### PR TITLE
feat: add a threshold to control when to decompose a grouped convolution.

### DIFF
--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -96,7 +96,8 @@ public:
   Option<int64_t> groupedConvThreshold{*this, "grouped-conv-threshold",
       llvm::cl::desc("The threshold used to decompose grouped convolution "
                      "into a concatenation of tosa.conv2d operations"),
-      llvm::cl::ZeroOrMore};
+      llvm::cl::ZeroOrMore,
+      llvm::cl::init(std::numeric_limits<int64_t>::max())};
 };
 
 void FrontendToTosaLoweringPass::runOnOperation() {

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -336,7 +336,8 @@ void populateLoweringONNXSoftmaxOpToTOSAPattern(mlir::ConversionTarget &,
 void populateLoweringONNXReduceMeanOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXConvOpToTOSAPattern(mlir::ConversionTarget &,
-    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *,
+    int64_t);
 void populateLoweringONNXReduceMeanOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 // `NN` directory methods:


### PR DESCRIPTION
Some networks may have group convolutions where the group is small, so we'd like to be able to control when to decompose those into `tosa.conv2d` and when not to.