### PR TITLE
FXML-3616: Temporarily disable big grouped convolutions

### DIFF
--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -161,10 +161,15 @@ public:
       conv2D = tosa::CreateOpAndInfer<mlir::tosa::Conv2DOp>(rewriter,
           convOp->getLoc(), newConvOutputType, newInput, newWeight, bias,
           newPads, strides, dilations);
-    } else {
+    // FXML-3612: Temporary hardcoding to prevent test memory explosion
+    } else if (group <= 16) {
       conv2D = createConvInGroups(rewriter, convOp, tosaBuilder, resultType,
           weightShape, newInput, newWeight, bias, group, newPads, strides,
           dilations);
+    }
+    else {
+      return rewriter.notifyMatchFailure(
+          op, "grouped convolution too big to be decomposed.");
     }
 
     // Convert output [N,OH,OW,OC] -> [N,OC,OH,OW]


### PR DESCRIPTION
For the context, XOAH tests are breaking right now because we exhaust memory through group conv decomposition. This PR is just a temporary hack until we merge the real feature to keep it reasonable 