### PR TITLE
Don't crash when running the GAP rewrite on dynamic rank

### DIFF
--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -176,6 +176,12 @@ def IsStaticShapeTensor:
       "$_self.getType().cast<::mlir::ShapedType>().hasStaticShape()">,
     "hasStaticShape">;
 
+def HasRank:
+  Constraint<
+    CPred<
+      "$_self.getType().cast<::mlir::ShapedType>().hasRank()">,
+    "is a tensor of static rank">;
+
 def HasSpecifiedConstantShape: Constraint<
     CPred<"onnx_mlir::HasSpecifiedConstantShape($0, $1)">,
           "Has the specified constant shape">;
@@ -851,7 +857,8 @@ def SizeToConstantPattern: Pat<
 // Rewrite GlobalAveragePool using ReduceMean.
 def GlobalAveragePoolPattern: Pat<
   (ONNXGlobalAveragePoolOp $x),
-  (ONNXReduceMeanV13Op $x, (createArrayAttrOfTwoToRankOf $x), (GetNullAttr))
+  (ONNXReduceMeanV13Op $x, (createArrayAttrOfTwoToRankOf $x), (GetNullAttr)),
+  [(HasRank:$x)]
 >;
 
 // Rewrite GlobalMaxPool using ReduceMax.

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -397,6 +397,16 @@ func.func @test_global_average_pool_dyn_dims(%arg0: tensor<1x?x?x5xf32>) -> tens
 
 // -----
 
+// COM: Test that GlobalAveragePool with dynamic rank does not crash
+func.func @test_global_average_pool_dynamic_rank(%arg0: tensor<*xf32>) -> tensor<*xf32> {
+  %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
+  // CHECK-LABEL: test_global_average_pool_dynamic_rank
+  // CHECK: "onnx.GlobalAveragePool"
+  }
+
+// -----
+
 // COM: Test rewriting GlobalMaxPool into ReduceMaxV13
 func.func @test_global_average_pool(%arg0: tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32> {
   %0 = "onnx.GlobalMaxPool"(%arg0) : (tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32>


### PR DESCRIPTION
Don't crash the rewrite when the shapes are dynamic.