### PR TITLE
fix: align decomposition of Hardswish with torch-mlir implementation.

### DIFF
--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -571,7 +571,7 @@ struct DecomposeHardSwishPattern : public ConversionPattern {
         hardSwishOp.getType(), input, rewriter.getF32FloatAttr(1.0 / 6.0),
         rewriter.getF32FloatAttr(0.5));
     rewriter.replaceOpWithNewOp<ONNXMulOp>(
-        op, hardSwishOp.getType(), input, hardSigmoid);
+        op, hardSwishOp.getType(), hardSigmoid, input);
     return success();
   }
 };

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -489,6 +489,6 @@ func.func @test_hardswish_f32(%arg0: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
 // CHECK-LABEL:  func @test_hardswish_f32
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
 // CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]]) {alpha = 0.166666672 : f32, beta = 5.000000e-01 : f32} : (tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-// CHECK:           [[VAR_1_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_0_]]) : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Mul"([[VAR_0_]], [[PARAM_0_]]) : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
 // CHECK:           return [[VAR_1_]] : tensor<?x?x?xf32>
 }


### PR DESCRIPTION
This is a minor change to align the decomposition of Hardswish with `torch-mlir`.