### PR TITLE
ONNXToTosa: Allow unsigned integers

### DIFF
--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -120,7 +120,7 @@ void FrontendToTosaLoweringPass::runOnOperation() {
   // conversion failures. Quantized types are not supported right now.
   TypeConverter typeConverter;
   typeConverter.addConversion([](Type type) -> std::optional<Type> {
-    if (isTOSASignedInt(type) || isTOSAFloat(type) || type.isa<NoneType>() ||
+    if (isTOSAInt(type) || isTOSAFloat(type) || type.isa<NoneType>() ||
         isTOSABool(type))
       return type;
     return std::nullopt;

--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -60,7 +60,7 @@ struct ErfIOSupportedTypes {
 struct IsAnyLegalType {
   static LogicalResult checkType(
       ConversionPatternRewriter &rewriter, Type scalarType, Operation *op) {
-    if (!isTOSAFloat(scalarType) && !isTOSASignedInt(scalarType) &&
+    if (!isTOSAFloat(scalarType) && !isTOSAInt(scalarType) &&
         !isTOSABool(scalarType)) {
       return rewriter.notifyMatchFailure(
           op, "this operation only supports signed integer or float types");
@@ -72,7 +72,7 @@ struct IsAnyLegalType {
 struct IsIntOrFloat {
   static LogicalResult checkType(
       ConversionPatternRewriter &rewriter, Type scalarType, Operation *op) {
-    if (!isTOSAFloat(scalarType) && !isTOSASignedInt(scalarType)) {
+    if (!isTOSAFloat(scalarType) && !isTOSAInt(scalarType)) {
       return rewriter.notifyMatchFailure(
           op, "this operation only supports signed integer or float types");
     }
@@ -83,7 +83,7 @@ struct IsIntOrFloat {
 struct IsInt {
   static LogicalResult checkType(
       ConversionPatternRewriter &rewriter, Type scalarType, Operation *op) {
-    if (!isTOSASignedInt(scalarType)) {
+    if (!isTOSAInt(scalarType)) {
       return rewriter.notifyMatchFailure(
           op, "this operation only supports int types");
     }

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -90,10 +90,10 @@ inline bool isTOSABool(mlir::Type type) {
   return intType && intType.isSignless() && intType.getWidth() == 1;
 }
 
-inline bool isTOSASignedInt(mlir::Type type) {
+inline bool isTOSAInt(mlir::Type type) {
   mlir::IntegerType intType = type.dyn_cast<mlir::IntegerType>();
   std::set<unsigned> intWidth{8, 16, 32, 48, 64};
-  return intType && intType.isSignless() &&
+  return intType && (intType.isSignless() || intType.isUnsignedInteger()) &&
          (intWidth.find(intType.getWidth()) != intWidth.end());
 }
 

--- a/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
@@ -203,7 +203,7 @@ public:
     }
 
     auto elementType = inputType.getElementType();
-    if (!(isTOSAFloat(elementType) || isTOSASignedInt(elementType))) {
+    if (!(isTOSAFloat(elementType) || isTOSAInt(elementType))) {
       return rewriter.notifyMatchFailure(
           resizeOp, "Element type is not supported by TOSA.");
     }

--- a/src/Conversion/ONNXToTOSA/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Transpose.cpp
@@ -53,7 +53,7 @@ public:
 
     Type inputElementType = inputType.getElementType();
 
-    if (!isTOSAFloat(inputElementType) && !isTOSASignedInt(inputElementType) &&
+    if (!isTOSAFloat(inputElementType) && !isTOSAInt(inputElementType) &&
         !inputElementType.isInteger(1)) {
       return rewriter.notifyMatchFailure(
           op, "input element type not supported");

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -87,6 +87,18 @@ func.func @test_add_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1xf32>) 
 
 // -----
 
+func.func @test_add_ui32(%arg0: tensor<13x21x1xui32>, %arg1: tensor<13x21x1xui32>) -> tensor<13x21x1xui32> {
+  %0 = "onnx.Add"(%arg0, %arg1) : (tensor<13x21x1xui32>, tensor<13x21x1xui32>) -> tensor<13x21x1xui32>
+  "func.return"(%0) : (tensor<13x21x1xui32>) -> ()
+// CHECK-LABEL:  func.func @test_add_ui32
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xui32>, [[PARAM_1_:%.+]]: tensor<13x21x1xui32>) -> tensor<13x21x1xui32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.add [[PARAM_0_]], [[PARAM_1_]] : (tensor<13x21x1xui32>, tensor<13x21x1xui32>) -> tensor<13x21x1xui32>
+// CHECK:           return [[VAR_0_]] : tensor<13x21x1xui32>
+}
+
+
+// -----
+
 func.func @test_sub(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x1xf32>) -> tensor<13x21x1xf32> {
   %0 = "onnx.Sub"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/xilinx/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout b2cdf3cc4c08729d0ff582d55e40793a20bbcdcc && cd ..
+cd llvm-project && git checkout 3a2d92bdaa75 && cd ..


### PR DESCRIPTION
Those are not allowed by the TOSA spec, but they are allowed by the TOSA dialect.
And ONNX allows them, so we need to lower them somehow.