### PR TITLE
ONNXToTOSA: Use numerical stable lowering of Softmax

### DIFF
--- a/test/mlir/conversion/onnx_to_tosa/Math/Softmax.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Softmax.mlir
@@ -4,7 +4,9 @@ func.func @test_softmax_v13(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   %2 = "onnx.Softmax"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   func.return %2 : tensor<13x21x3xf32>
 // CHECK: test_softmax_v13(%[[VAL_0:.*]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
-// CHECK: %[[VAL_1:.*]] = tosa.exp %[[VAL_0]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[MAX:.*]] = tosa.reduce_max %[[VAL_0]] {axis = 2 : i32}
+// CHECK: %[[SUB:.*]] = tosa.sub %[[VAL_0]], %[[MAX]]
+// CHECK: %[[VAL_1:.*]] = tosa.exp %[[SUB]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
 // CHECK: %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 2 : i32} : (tensor<13x21x3xf32>) -> tensor<13x21x1xf32>
 // CHECK: %[[VAL_3:.*]] = tosa.reciprocal %[[VAL_2]] : (tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
 // CHECK: %[[VAL_4:.*]] = tosa.mul %[[VAL_1]], %[[VAL_3]] {shift = 0 : i8} : (tensor<13x21x3xf32>, tensor<13x21x1xf32>) -> tensor<13x21x3xf32>
@@ -16,7 +18,9 @@ func.func @test_softmax_v13_axis_one(%arg0: tensor<13x21x3xf32>) -> tensor<13x21
   %2 = "onnx.Softmax"(%arg0) {axis = 1 : si64} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   func.return %2 : tensor<13x21x3xf32>
 // CHECK: test_softmax_v13_axis_one(%[[VAL_0:.*]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
-// CHECK: %[[VAL_1:.*]] = tosa.exp %[[VAL_0]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[MAX:.*]] = tosa.reduce_max %[[VAL_0]] {axis = 1 : i32}
+// CHECK: %[[SUB:.*]] = tosa.sub %[[VAL_0]], %[[MAX]]
+// CHECK: %[[VAL_1:.*]] = tosa.exp %[[SUB]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
 // CHECK: %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 1 : i32} : (tensor<13x21x3xf32>) -> tensor<13x1x3xf32>
 // CHECK: %[[VAL_3:.*]] = tosa.reciprocal %[[VAL_2]] : (tensor<13x1x3xf32>) -> tensor<13x1x3xf32>
 // CHECK: %[[VAL_4:.*]] = tosa.mul %[[VAL_1]], %[[VAL_3]] {shift = 0 : i8} : (tensor<13x21x3xf32>, tensor<13x1x3xf32>) -> tensor<13x21x3xf32>
@@ -28,7 +32,10 @@ func.func @test_softmax_before_v13(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3
   %2 = "onnx.SoftmaxV11"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   func.return %2 : tensor<13x21x3xf32>
 // CHECK: test_softmax_before_v13(%[[VAL_0:.*]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
-// CHECK: %[[VAL_1:.*]] = tosa.exp %[[VAL_0]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[MAX:.*]] = tosa.reduce_max %[[VAL_0]] {axis = 1 : i32}
+// CHECK: %[[MAX2:.*]] = tosa.reduce_max %[[MAX]] {axis = 2 : i32}
+// CHECK: %[[SUB:.*]] = tosa.sub %[[VAL_0]], %[[MAX2]]
+// CHECK: %[[VAL_1:.*]] = tosa.exp %[[SUB]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
 // CHECK: %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 1 : i32} : (tensor<13x21x3xf32>) -> tensor<13x1x3xf32>
 // CHECK: %[[VAL_3:.*]] = tosa.reduce_sum %[[VAL_2]] {axis = 2 : i32} : (tensor<13x1x3xf32>) -> tensor<13x1x1xf32>
 // CHECK: %[[VAL_4:.*]] = tosa.reciprocal %[[VAL_3]] : (tensor<13x1x1xf32>) -> tensor<13x1x1xf32>
@@ -41,7 +48,11 @@ func.func @test_softmax_before_v13_axis_zero(%arg0: tensor<13x21x3xf32>) -> tens
   %2 = "onnx.SoftmaxV11"(%arg0) {axis = 0 : si64}: (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   func.return %2 : tensor<13x21x3xf32>
 // CHECK: test_softmax_before_v13_axis_zero(%[[VAL_0:.*]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
-// CHECK: %[[VAL_1:.*]] = tosa.exp %[[VAL_0]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[MAX:.*]] = tosa.reduce_max %[[VAL_0]] {axis = 0 : i32}
+// CHECK: %[[MAX2:.*]] = tosa.reduce_max %[[MAX]] {axis = 1 : i32}
+// CHECK: %[[MAX3:.*]] = tosa.reduce_max %[[MAX2]] {axis = 2 : i32}
+// CHECK: %[[SUB:.*]] = tosa.sub %[[VAL_0]], %[[MAX3]]
+// CHECK: %[[VAL_1:.*]] = tosa.exp %[[SUB]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
 // CHECK: %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 0 : i32} : (tensor<13x21x3xf32>) -> tensor<1x21x3xf32>
 // CHECK: %[[VAL_3:.*]] = tosa.reduce_sum %[[VAL_2]] {axis = 1 : i32} : (tensor<1x21x3xf32>) -> tensor<1x1x3xf32>
 // CHECK: %[[VAL_4:.*]] = tosa.reduce_sum %[[VAL_3]] {axis = 2 : i32} : (tensor<1x1x3xf32>) -> tensor<1x1x1xf32>


### PR DESCRIPTION
Both versions are identical for small inputs, but the new version avoids overflow for large input tensor values.
See https://stackoverflow.com/a/34969389/20356323