### PR TITLE
Compiler: Allow to emit IR as bytecode

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -166,6 +166,7 @@ add_onnx_mlir_library(OMCompilerUtils
   ${ONNX_MLIR_SRC_ROOT}/include
 
   LINK_LIBS PUBLIC
+  MLIRBytecodeWriter
   OMCompilerDialects
   OMCompilerPasses
   OMAccelerator

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -45,6 +45,7 @@ EmissionTargetType emissionTarget;                     // onnx-mlir only
 bool invokeOnnxVersionConverter;                       // onnx-mlir only
 bool preserveLocations;                                // onnx-mlir only
 bool printIR;                                          // onnx-mlir only
+bool printBytecode;                                    // onnx-mlir only
 bool preserveBitcode;                                  // onnx-mlir only
 bool preserveLLVMIR;                                   // onnx-mlir only
 bool preserveMLIR;                                     // onnx-mlir only
@@ -240,6 +241,11 @@ static llvm::cl::opt<bool, true> preserveLocationsOpt("preserveLocations",
 static llvm::cl::opt<bool, true> printIROpt("printIR",
     llvm::cl::desc("print the IR to stdout:"), llvm::cl::location(printIR),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
+
+static llvm::cl::opt<bool, true> printBytecodeOpt("printBytecode",
+    llvm::cl::desc("print bytecode to stdout:"),
+    llvm::cl::location(printBytecode), llvm::cl::init(false),
+    llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<bool, true> preserveBitcodeOpt("preserveBitcode",
     llvm::cl::desc(

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -88,6 +88,7 @@ extern EmissionTargetType emissionTarget;                     // onnx-mlir only
 extern bool invokeOnnxVersionConverter;                       // onnx-mlir only
 extern bool preserveLocations;                                // onnx-mlir only
 extern bool printIR;                                          // onnx-mlir only
+extern bool printBytecode;                                    // onnx-mlir only
 extern bool preserveBitcode;                                  // onnx-mlir only
 extern bool preserveLLVMIR;                                   // onnx-mlir only
 extern bool preserveMLIR;                                     // onnx-mlir only

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -871,6 +871,12 @@ static int emitOutput(mlir::OwningOpRef<ModuleOp> &module,
     outputModule(module, llvm::outs());
     return CompilerSuccess;
   }
+  if (printBytecode) {
+    if (failed(mlir::writeBytecodeToFile(*module, llvm::outs()))) {
+      return CompilerFailure;
+    }
+    return CompilerSuccess;
+  }
   return emitOutputFiles(outputNameNoExt, emissionTarget, context, module);
 }
 

--- a/test/mlir/driver/bytecode.mlir
+++ b/test/mlir/driver/bytecode.mlir
@@ -1,0 +1,5 @@
+// RUN: onnx-mlir --tag="encoder_model" --printBytecode %s | onnx-mlir-opt | FileCheck %s
+
+// CHECK: module attributes {{{.*}}"onnx-mlir.symbol-postfix" = "encoder_model"}
+module {
+}


### PR DESCRIPTION
This improves speed and reduces the size.