### PR TITLE
Allow Group and Instance Normalization after Decomposition

### DIFF
--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -1013,10 +1013,12 @@ void DecomposeONNXToONNXPass::runOnOperation() {
   target.addIllegalOp<ONNXClipV12Op>();
   target.addIllegalOp<ONNXClipV6Op>();
   target.addIllegalOp<ONNXConstantOfShapeOp>();
-  // In some instances the decompisition does not trigger and we are left these
-  // operations till. We need to see if these examples can be fixed upstream.
-  // However, for now allow these operations to pass and open a corresponding
-  // issue.
+  // In some instances the decomposition does not trigger and we are left these
+  // operations. One reason is the input to the operation has unknown shapes.
+  // However, the decompose pass is executed multiple times in the pipeline and
+  // between the executions shape inference is called resolving the issue. That
+  // is why GroupNormalization and InstanceNormalization will be marked as
+  // dynamically legal.
   target.addDynamicallyLegalOp<ONNXGroupNormalizationOp>(
       [](ONNXGroupNormalizationOp op) {
         return !GroupNormIntoLayerNormPattern::isDecomposable(op);

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -534,12 +534,8 @@ func.func @test_groupnorm(%arg0: tensor<3x4x2x2xf32>, %arg1: tensor<2xf32>, %arg
 func.func @test_groupnorm_dynamic(%arg0: tensor<*xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>) -> tensor<*xf32> {
   %0 = "onnx.GroupNormalization"(%arg0, %arg1, %arg2) {epsilon = 0.00999999977 : f32, num_groups = 2 : si64} : (tensor<*xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<*xf32>
   onnx.Return %0 : tensor<*xf32>
-// mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_groupnorm_dynamic
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<2xf32>, [[PARAM_2_:%.+]]: tensor<2xf32>) -> tensor<*xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.GroupNormalization"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]]) {epsilon = 0.00999999977 : f32, num_groups = 2 : si64} : (tensor<*xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<*xf32>
-// CHECK:           onnx.Return [[VAR_0_]] : tensor<*xf32>
-// CHECK:         }
+// CHECK:           onnx.GroupNormalization
 }
 // -----
 
@@ -586,12 +582,8 @@ func.func @test_instancenorm(%arg0: tensor<2x3x4x5x6xf32>, %arg1: tensor<3xf32>,
 func.func @test_instancenorm_dynamic(%arg0: tensor<*xf32>, %arg1: tensor<4xf32>, %arg2: tensor<4xf32>) -> tensor<*xf32> {
   %0 = "onnx.InstanceNormalization"(%arg0, %arg1, %arg2) {epsilon = 0.00999999977 : f32} : (tensor<*xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<*xf32>
   onnx.Return %0 : tensor<*xf32>
-// mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_instancenorm_dynamic
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<4xf32>, [[PARAM_2_:%.+]]: tensor<4xf32>) -> tensor<*xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.InstanceNormalization"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]]) {epsilon = 0.00999999977 : f32} : (tensor<*xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<*xf32>
-// CHECK:           onnx.Return [[VAR_0_]] : tensor<*xf32>
-// CHECK:         }
+// CHECK:           onnx.InstanceNormalization
 }
 
 // -----

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -528,6 +528,19 @@ func.func @test_groupnorm(%arg0: tensor<3x4x2x2xf32>, %arg1: tensor<2xf32>, %arg
 // CHECK:           onnx.Return [[VAR_10_]] : tensor<3x4x2x2xf32>
 // CHECK:         }
 }
+
+// -----
+
+func.func @test_groupnorm_dynamic(%arg0: tensor<*xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>) -> tensor<*xf32> {
+  %0 = "onnx.GroupNormalization"(%arg0, %arg1, %arg2) {epsilon = 0.00999999977 : f32, num_groups = 2 : si64} : (tensor<*xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @test_groupnorm_dynamic
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<2xf32>, [[PARAM_2_:%.+]]: tensor<2xf32>) -> tensor<*xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.GroupNormalization"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]]) {epsilon = 0.00999999977 : f32, num_groups = 2 : si64} : (tensor<*xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<*xf32>
+// CHECK:         }
+}
 // -----
 
 func.func @group_norm5d(%arg0: tensor<3x4x6x8x16xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>) -> tensor<3x4x6x8x16xf32> {
@@ -565,6 +578,19 @@ func.func @test_instancenorm(%arg0: tensor<2x3x4x5x6xf32>, %arg1: tensor<3xf32>,
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[Y_:%.+]], [[Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[VAR_1_]], [[VAR_2_]]) {axis = 2 : si64, epsilon = 0.00999999977 : f32, stash_type = 1 : si64} : (tensor<2x3x4x5x6xf32>, tensor<3x1x1x1xf32>, tensor<3x1x1x1xf32>) -> (tensor<2x3x4x5x6xf32>, none, none)
 // CHECK:           onnx.Return [[Y_]] : tensor<2x3x4x5x6xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_instancenorm_dynamic(%arg0: tensor<*xf32>, %arg1: tensor<4xf32>, %arg2: tensor<4xf32>) -> tensor<*xf32> {
+  %0 = "onnx.InstanceNormalization"(%arg0, %arg1, %arg2) {epsilon = 0.00999999977 : f32} : (tensor<*xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @test_instancenorm_dynamic
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<4xf32>, [[PARAM_2_:%.+]]: tensor<4xf32>) -> tensor<*xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.InstanceNormalization"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]]) {epsilon = 0.00999999977 : f32} : (tensor<*xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<*xf32>
 // CHECK:         }
 }
 


### PR DESCRIPTION
In some of our examples we have group and instance normalization fail the decomposition due to unknown shapes at the time of decomposition. But due to the onnx-mlir pipeline and the iterative execution of passes, we can allow the operations after decomposition.

Meaning that during the next execution of the decomposition pass we can decompose the operations as shape inference has executed and resolved the input shapes as static.