### PR TITLE
FrontendDialectTransformer: Don't crash when importing Cast with saturate attribute

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -875,7 +875,8 @@ private:
         Attribute mlirAttr = TypeAttr::get(mlir_type);
         attributes.push_back(builder_.getNamedAttr(attr.name(), mlirAttr));
       } else {
-        attributes.push_back(convertOnnxAttributeProtoToMlirNamedAttribute(attr));
+        attributes.push_back(
+            convertOnnxAttributeProtoToMlirNamedAttribute(attr));
       }
     }
 

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -868,10 +868,14 @@ private:
     std::vector<NamedAttribute> attributes;
     for (int i = 0; i < node.attribute_size(); ++i) {
       auto attr = node.attribute(i);
-      auto mlir_type = convertONNXTypeToMLIRType(
-          builder_, static_cast<onnx::TensorProto_DataType>(attr.i()));
-      Attribute mlirAttr = TypeAttr::get(mlir_type);
-      attributes.push_back(builder_.getNamedAttr(attr.name(), mlirAttr));
+      if (attr.name() == "to") {
+        auto mlir_type = convertONNXTypeToMLIRType(
+            builder_, static_cast<onnx::TensorProto_DataType>(attr.i()));
+        Attribute mlirAttr = TypeAttr::get(mlir_type);
+        attributes.push_back(builder_.getNamedAttr(attr.name(), mlirAttr));
+      } else {
+        attributes.push_back(convertOnnxAttributeProtoToMlirNamedAttribute(attr));
+      }
     }
 
     // If the node has a name, then import it.

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -868,6 +868,7 @@ private:
     std::vector<NamedAttribute> attributes;
     for (int i = 0; i < node.attribute_size(); ++i) {
       auto attr = node.attribute(i);
+      // The 'to' attribute is an integer in ONNX that represents a type.
       if (attr.name() == "to") {
         auto mlir_type = convertONNXTypeToMLIRType(
             builder_, static_cast<onnx::TensorProto_DataType>(attr.i()));

--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -435,7 +435,7 @@ public:
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
 
     auto resultTy =
-        dyn_cast<ShapedType>(getTypeConverter()->convertType(op.getType()));
+        dyn_cast_if_present<ShapedType>(getTypeConverter()->convertType(op.getType()));
     if (!resultTy) {
       return rewriter.notifyMatchFailure(op, "expected valid result type");
     }

--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -435,7 +435,7 @@ public:
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
 
     auto resultTy =
-        dyn_cast_if_present<ShapedType>(getTypeConverter()->convertType(op.getType()));
+        dyn_cast<ShapedType>(getTypeConverter()->convertType(op.getType()));
     if (!resultTy) {
       return rewriter.notifyMatchFailure(op, "expected valid result type");
     }

--- a/test/mlir/onnx/parse/cast_with_saturate.onnxtext
+++ b/test/mlir/onnx/parse/cast_with_saturate.onnxtext
@@ -1,0 +1,15 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+
+<
+   ir_version: 9,
+   opset_import: ["" : 19],
+   producer_name: "backend-test"
+>
+test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ (float16[3,4] input) => (float8e4m3fnuz[3,4] output) {
+   output = Cast <saturate = 0, to = 18> (input)
+}
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf16> {onnx.name = "input"}) -> (tensor<3x4xf8E4M3FNUZ> {onnx.name = "output"}) {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {saturate = 0 : si64, to = f8E4M3FNUZ} : (tensor<3x4xf16>) -> tensor<3x4xf8E4M3FNUZ>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<3x4xf8E4M3FNUZ>
+// CHECK:         }

--- a/test/mlir/onnx/parse/cast_with_saturate.onnxtext
+++ b/test/mlir/onnx/parse/cast_with_saturate.onnxtext
@@ -1,5 +1,4 @@
 // RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
-
 <
    ir_version: 9,
    opset_import: ["" : 19],
@@ -9,7 +8,6 @@ test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ (float16[3,4] input) => (float8e
    output = Cast <saturate = 0, to = 18> (input)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf16> {onnx.name = "input"}) -> (tensor<3x4xf8E4M3FNUZ> {onnx.name = "output"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf16> {onnx.name = "input"}) -> (tensor<3x4xf8E4M3FNUZ> {onnx.name = "output"})
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {saturate = 0 : si64, to = f8E4M3FNUZ} : (tensor<3x4xf16>) -> tensor<3x4xf8E4M3FNUZ>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x4xf8E4M3FNUZ>
-// CHECK:         }


### PR DESCRIPTION
While investigating why some test case don't have error messages, I found a fix for this crash.

The Cast op got a new attribute `saturate`, but the ONNX to onnx-mlir parse assumed that all attributes on the Cast op are data types (and not a boolean like for saturate).