### PR TITLE
Fix macos build by pinning version

### DIFF
--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
The macos-latest version is macos 14 that removed python 3.10, so it failed to install protobuf 4.21.12 using python 3.11 or 3.12 in macos 14.

Picked from https://github.com/onnx/onnx-mlir/pull/2816