### PR TITLE
Add ccache / don't run action twice on pull_requests

### DIFF
--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -1,6 +1,9 @@
 name: GitHub Action MacOS amd64
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ main, feature/onnx-to-tosa ]
 
 jobs:
   build:

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -66,7 +66,8 @@ jobs:
       run: |
         cd ~/work/onnx-mlir
         sh ~/work/onnx-mlir/onnx-mlir/utils/check-unittest.sh
-    - name: run onnx-mlir backend and numerical tests
-      run: |
-        cd ~/work/onnx-mlir
-        sh ~/work/onnx-mlir/onnx-mlir/utils/check-onnx-backend-numerical.sh
+    # Those tests are not relevant to the work on the xilinx fork, but take 40 min
+    #    - name: run onnx-mlir backend and numerical tests
+    #  run: |
+    #    cd ~/work/onnx-mlir
+    #    sh ~/work/onnx-mlir/onnx-mlir/utils/check-onnx-backend-numerical.sh

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -66,8 +66,10 @@ jobs:
       run: |
         cd ~/work/onnx-mlir
         sh ~/work/onnx-mlir/onnx-mlir/utils/check-unittest.sh
-    # Those tests are not relevant to the work on the xilinx fork, but take 40 min
-    #    - name: run onnx-mlir backend and numerical tests
-    #  run: |
-    #    cd ~/work/onnx-mlir
-    #    sh ~/work/onnx-mlir/onnx-mlir/utils/check-onnx-backend-numerical.sh
+    - name: run onnx-mlir backend and numerical tests
+      # Those tests are not relevant to the work on the xilinx fork, but take
+      # 40 min. Don't run them on PRs.
+      if: github.event_name != 'pull_request'
+      run: |
+        cd ~/work/onnx-mlir
+        sh ~/work/onnx-mlir/onnx-mlir/utils/check-onnx-backend-numerical.sh

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -21,6 +21,12 @@ jobs:
     - name: install tools that are needed for compilation
       run: |
         brew install automake ninja pybind11
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        # Create symlinks to intercept compiler calls without modifying the cmake invocation
+        create-symlink: true
+        key: ${{ runner.os }}-ccache
     - name: install protobuf
       run: |
         cd ~/work

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -55,6 +55,7 @@ jobs:
         python3 -m pip install -v .
     - name: build onnx-mlir
       run: |
+        export EXTRA_CMAKE_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
         cd ~/work/onnx-mlir
         sh ~/work/onnx-mlir/onnx-mlir/utils/install-onnx-mlir.sh
     - name: build and run docs/doc_example tests

--- a/utils/install-onnx-mlir.sh
+++ b/utils/install-onnx-mlir.sh
@@ -5,12 +5,14 @@ if [[ -z "$pythonLocation" ]]; then
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
         -DMLIR_DIR=${MLIR_DIR} \
+        $EXTRA_CMAKE_ARGS \
         ..
 else
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
         -DPython3_ROOT_DIR=$pythonLocation \
         -DMLIR_DIR=${MLIR_DIR} \
+        $EXTRA_CMAKE_ARGS \
         ..
 fi
 cmake --build .


### PR DESCRIPTION
Brings the CI time to 10 minutes.

Only build on pushes to the main/feature branch. Otherwise every PR sees two builds because pushing to the PR branch and changing the pull_request both trigger it separate builds.

Introduce ccache to speed-up onnx-mlir builds.