### PR TITLE
ONNXToTOSA: Support Squeeze/Unsqueeze with runtime shape operand

### DIFF
--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -179,7 +179,7 @@ std::optional<Value> TosaBuilder::gather(Value resultValue, Value inputValue,
   return tosa::convertGatherOp(rewriter(), loc(), resultValue, inputValue,
       indicesValue, batchDims, axis);
 };
-Value TosaBuilder::reshape(mlir::Value &value, llvm::ArrayRef<int64_t> shape) {
+Value TosaBuilder::reshape(mlir::Value value, llvm::ArrayRef<int64_t> shape) {
   auto shapeAttr = rewriter().getDenseI64ArrayAttr(shape);
   auto valueType = value.getType().cast<ShapedType>();
   Type newValueType = RankedTensorType::get(

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -48,7 +48,7 @@ struct TosaBuilder : DialectBuilder {
   mlir::Value transpose(mlir::Value &value, llvm::ArrayRef<int32_t> perm);
   mlir::Value slice(mlir::Value &inputConst, llvm::ArrayRef<int64_t> size,
       llvm::ArrayRef<int64_t> start);
-  mlir::Value reshape(mlir::Value &value, llvm::ArrayRef<int64_t> shape);
+  mlir::Value reshape(mlir::Value value, llvm::ArrayRef<int64_t> shape);
 
   template <typename T>
   mlir::Value unaryOp(mlir::Value &input);

--- a/src/Conversion/ONNXToTOSA/Tensor/Squeeze.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Squeeze.cpp
@@ -12,13 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Dialect/Tosa/IR/TosaOps.h"
-#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
-#include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
-#include "llvm/ADT/SmallVector.h"
 
 using namespace mlir;
 

--- a/src/Conversion/ONNXToTOSA/Tensor/Squeeze.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Squeeze.cpp
@@ -40,7 +40,8 @@ public:
     }
 
     TosaBuilder tosaBuilder(rewriter, loc);
-    rewriter.replaceOp(op, tosaBuilder.reshape(adaptor.getData(), resultTy.getShape()));
+    rewriter.replaceOp(
+        op, tosaBuilder.reshape(adaptor.getData(), resultTy.getShape()));
     return success();
   }
 };

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Squeeze.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Squeeze.mlir
@@ -27,6 +27,6 @@ func.func @test_squeeze_unknown_dimensions(%arg0 : tensor<1x1x32x1x64xf32>) -> t
 func.func @squeeze_dynamic(%arg0: tensor<1x3x4x5xf32> , %arg1: tensor<1xi64> ) -> tensor<3x4x5xf32> {
   %0 = "onnx.Squeeze"(%arg0, %arg1) : (tensor<1x3x4x5xf32>, tensor<1xi64>) -> tensor<3x4x5xf32>
   return %0 : tensor<3x4x5xf32>
-// CHECK-LABEL:  func.func @squeeze_dynamic
-// CHECK: onnx.Squeeze
+// CHECK-LABEL: squeeze_dynamic
+// CHECK: tosa.reshape {{.*}} {new_shape = array<i64: 3, 4, 5>} : (tensor<1x3x4x5xf32>) -> tensor<3x4x5xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Squeeze.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Squeeze.mlir
@@ -24,9 +24,18 @@ func.func @test_squeeze_unknown_dimensions(%arg0 : tensor<1x1x32x1x64xf32>) -> t
 
 // -----
 
-func.func @squeeze_dynamic(%arg0: tensor<1x3x4x5xf32> , %arg1: tensor<1xi64> ) -> tensor<3x4x5xf32> {
+func.func @squeeze_runtime(%arg0: tensor<1x3x4x5xf32> , %arg1: tensor<1xi64> ) -> tensor<3x4x5xf32> {
   %0 = "onnx.Squeeze"(%arg0, %arg1) : (tensor<1x3x4x5xf32>, tensor<1xi64>) -> tensor<3x4x5xf32>
   return %0 : tensor<3x4x5xf32>
-// CHECK-LABEL: squeeze_dynamic
+// CHECK-LABEL: squeeze_runtime
 // CHECK: tosa.reshape {{.*}} {new_shape = array<i64: 3, 4, 5>} : (tensor<1x3x4x5xf32>) -> tensor<3x4x5xf32>
+}
+
+// -----
+
+func.func @squeeze_dynamic(%arg0: tensor<1x3x4x5xf32> , %arg1: tensor<1xi64> ) -> tensor<?x?x?xf32> {
+  %0 = "onnx.Squeeze"(%arg0, %arg1) : (tensor<1x3x4x5xf32>, tensor<1xi64>) -> tensor<?x?x?xf32>
+  return %0 : tensor<?x?x?xf32>
+// CHECK-LABEL: squeeze_dynamic
+// CHECK: onnx.Squeeze
 }

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Unsqueeze.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Unsqueeze.mlir
@@ -32,3 +32,20 @@ func.func @test_unsqueeze_mix(%arg0 : tensor<16x32x64xf32>) -> tensor<16x1x32x1x
 // CHECK:           return %[[VAL_1]] : tensor<16x1x32x1x64xf32>
 // CHECK:         }
 }
+
+// -----
+
+func.func @unsqueeze_runtime(%arg0: tensor<3x4x5xf32> , %arg1: tensor<1xi64> ) -> tensor<3x4x1x5xf32> {
+  %0 = "onnx.Unsqueeze"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<1xi64>) -> tensor<3x4x1x5xf32>
+  return %0 : tensor<3x4x1x5xf32>
+// CHECK-LABEL: unsqueeze_runtime
+// CHECK: tosa.reshape {{.*}} {new_shape = array<i64: 3, 4, 1, 5>} : (tensor<3x4x5xf32>) -> tensor<3x4x1x5xf32>
+}
+// -----
+
+func.func @unsqueeze_dynamic(%arg0: tensor<1x3x4x5xf32> , %arg1: tensor<1xi64> ) -> tensor<?x?x?xf32> {
+  %0 = "onnx.Unsqueeze"(%arg0, %arg1) : (tensor<1x3x4x5xf32>, tensor<1xi64>) -> tensor<?x?x?xf32>
+  return %0 : tensor<?x?x?xf32>
+// CHECK-LABEL: unsqueeze_dynamic
+// CHECK: onnx.Unsqueeze
+}


### PR DESCRIPTION
While we were talking about it, I realized that we can do the reshape trick here, too.