### PR TITLE
ONNXToTosa: Fix integer division for != 32 bits

### DIFF
--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -206,9 +206,8 @@ Value TosaBuilder::mul(mlir::Value &lhs, mlir::Value &rhs, int32_t shift) {
 Value TosaBuilder::intdiv(mlir::Value &lhs, mlir::Value &rhs) {
   Type lhsElementType = lhs.getType().cast<ShapedType>().getElementType();
   Type rhsElementType = rhs.getType().cast<ShapedType>().getElementType();
-  assert((lhsElementType.isSignlessInteger(32) &&
-             rhsElementType.isSignlessInteger(32)) &&
-         "Tosa DivOp needs 32-bit signless integer inputs");
+  assert(lhsElementType == rhsElementType &&
+         "Tosa DivOp needs matching element types on lhs and rhs");
 
   if (needsRankBroadcast({lhs, rhs})) {
     llvm::SmallVector<Value, 4> valueVec = equalizeRanks({lhs, rhs});

--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -476,14 +476,13 @@ public:
 
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
 
-    if (resultElementType.isSignlessInteger(32)) {
-      // tosa::DivOp takes 32-but signless integers as inputs
+    if (isa<IntegerType>(resultElementType)) {
       Value divOp = tosaBuilder.intdiv(lhs, rhs);
       rewriter.replaceOp(op, {divOp});
       return success();
     }
-    // If it is not a 32-bit signless integer, decompose ONNXDivOp into
-    // tosa::ReciprocalOp and tosa::MulOp
+    // For floating point types, decompose ONNXDivOp into
+    // tosa::ReciprocalOp and tosa::MulOp.
     Value reciprocalOp = tosaBuilder.unaryOp<mlir::tosa::ReciprocalOp>(rhs);
     Value mulOp = tosaBuilder.mul(lhs, reciprocalOp);
     rewriter.replaceOp(op, {mulOp});

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -170,6 +170,16 @@ func.func @test_div(%arg0: tensor<13x21x1xi32>, %arg1: tensor<13x21x1xi32>) -> t
 
 // -----
 
+func.func @test_div_unsigned(%arg0: tensor<13x21x1xui8>, %arg1: tensor<13x21x1xui8>) -> tensor<13x21x1xui8> {
+  %0 = "onnx.Div"(%arg0, %arg1) : (tensor<13x21x1xui8>, tensor<13x21x1xui8>) -> tensor<13x21x1xui8>
+  "func.return"(%0) : (tensor<13x21x1xui8>) -> ()
+// CHECK-LABEL:  func @test_div_unsigned
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xui8>, [[PARAM_1_:%.+]]: tensor<13x21x1xui8>) -> tensor<13x21x1xui8> {
+// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.div [[PARAM_0_]], [[PARAM_1_]] : (tensor<13x21x1xui8>, tensor<13x21x1xui8>) -> tensor<13x21x1xui8>
+}
+
+// -----
+
 func.func @test_div_broadcast(%arg0: tensor<13x21x1xi32>, %arg1: tensor<1xi32>) -> tensor<13x21x1xi32> {
   %0 = "onnx.Div"(%arg0, %arg1) : (tensor<13x21x1xi32>, tensor<1xi32>) -> tensor<13x21x1xi32>
   "func.return"(%0) : (tensor<13x21x1xi32>) -> ()


### PR DESCRIPTION
We don't need to be strict in the lowering as the TOSA dialect was extended to allow all integer types.