### PR TITLE
QLinear saturate last

### DIFF
--- a/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
@@ -39,7 +39,6 @@ func.func @test_quantizeLinear_per_axis(%arg0: tensor<8x2xf32>) -> tensor<8x2xi8
 // CHECK:           return %[[CAST]] : tensor<8x2xi8>
 // CHECK:         }
 
-
 // -----
 
 func.func @test_quantizeLinear_negative_axis(%arg0: tensor<8x2xf32>) -> tensor<8x2xi8> {

--- a/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
@@ -6,14 +6,16 @@ func.func @test_quantizeLinear(%arg0 : tensor<32x3x224x224xf32>) -> tensor<32x3x
   %2 = "onnx.QuantizeLinear"(%arg0, %0, %1) {axis = 1 : si64} : (tensor<32x3x224x224xf32>, tensor<f32>, tensor<i8>) -> tensor<32x3x224x224xi8>
   "func.return"(%2) : (tensor<32x3x224x224xi8>) -> ()
 }
-// CHECK-LABEL:  @test_quantizeLinear(%arg0: tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi8>
-// CHECK-DAG:    %[[SCALE:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK-LABEL:  @test_quantizeLinear
+// CHECK-SAME: (%[[ARG_0:.*]]: tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi8>
 // CHECK-DAG:    %[[ZP:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1x1x1xi8>}> : () -> tensor<1x1x1x1xi8>
+// CHECK-DAG:    %[[SCALE:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
 // CHECK-DAG:    %[[REC:.*]] = tosa.reciprocal %[[SCALE]] : (tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
-// CHECK-DAG:    %[[MUL:.*]] = tosa.mul %arg0, %[[REC]] {shift = 0 : i8} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
-// CHECK-DAG:    %[[CAST:.*]] = tosa.cast %[[MUL]] : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi8>
-// CHECK-DAG:    %[[ADD:.*]] = tosa.add %[[CAST]], %[[ZP]] : (tensor<32x3x224x224xi8>, tensor<1x1x1x1xi8>) -> tensor<32x3x224x224xi8>
-// CHECK-DAG:    return %[[ADD]] : tensor<32x3x224x224xi8>
+// CHECK-DAG:    %[[MUL:.*]] = tosa.mul %[[ARG_0]], %[[REC]] {shift = 0 : i8} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
+// CHECK-DAG:    %[[ZPCAST:.*]] = tosa.cast %[[ZP]] : (tensor<1x1x1x1xi8>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:    %[[ADD:.*]] = tosa.add %3, %[[ZPCAST]] : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
+// CHECK-DAG:    %[[CAST:.*]]  = tosa.cast %[[ADD]] : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi8>
+// CHECK-DAG:    return %[[CAST]] : tensor<32x3x224x224xi8>
 
 // -----
 
@@ -29,12 +31,14 @@ func.func @test_quantizeLinear_per_axis(%arg0: tensor<8x2xf32>) -> tensor<8x2xi8
 // CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<8x2xf32>) -> tensor<8x2xi8> {
 // CHECK:           %[[VAL_1:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 1]]> : tensor<1x2xi8>}> : () -> tensor<1x2xi8>
 // CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<{{\[\[}}1.000000e+00, 2.000000e+00]]> : tensor<1x2xf32>}> : () -> tensor<1x2xf32>
-// CHECK:           %[[VAL_3:.*]] = tosa.reciprocal %[[VAL_2]] : (tensor<1x2xf32>) -> tensor<1x2xf32>
-// CHECK:           %[[VAL_4:.*]] = tosa.mul %[[VAL_0]], %[[VAL_3]] {shift = 0 : i8} : (tensor<8x2xf32>, tensor<1x2xf32>) -> tensor<8x2xf32>
-// CHECK:           %[[VAL_5:.*]] = tosa.cast %[[VAL_4]] : (tensor<8x2xf32>) -> tensor<8x2xi8>
-// CHECK:           %[[VAL_6:.*]] = tosa.add %[[VAL_5]], %[[VAL_1]] : (tensor<8x2xi8>, tensor<1x2xi8>) -> tensor<8x2xi8>
-// CHECK:           return %[[VAL_6]] : tensor<8x2xi8>
+// CHECK:           %[[REC:.*]] = tosa.reciprocal %[[VAL_2]] : (tensor<1x2xf32>) -> tensor<1x2xf32>
+// CHECK:           %[[MUL:.*]] = tosa.mul %[[VAL_0]], %[[REC]] {shift = 0 : i8} : (tensor<8x2xf32>, tensor<1x2xf32>) -> tensor<8x2xf32>
+// CHECK:           %[[ZPCAST:.*]] = tosa.cast %[[VAL_1]] : (tensor<1x2xi8>) -> tensor<1x2xf32>
+// CHECK:           %[[ADD:.*]] = tosa.add %[[MUL]], %[[ZPCAST]] : (tensor<8x2xf32>, tensor<1x2xf32>) -> tensor<8x2xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[ADD]] : (tensor<8x2xf32>) -> tensor<8x2xi8>
+// CHECK:           return %[[CAST]] : tensor<8x2xi8>
 // CHECK:         }
+
 
 // -----
 


### PR DESCRIPTION
Converting the IR from doing 

`y = saturate((x / y_scale)) + y_zero_point`

to do

`y = saturate((x / y_scale) + y_zero_point)`

as stated in the [doc](https://onnx.ai/onnx/operators/onnx__QuantizeLinear.html)