### PR TITLE
Lower cos and sin to tosa::SinOp/CosOp instead of tosa::CustomOp

### DIFF
--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -99,43 +99,6 @@ LogicalResult checkBasicTosaRequirementsForBinaryOps(
   return success();
 }
 
-// Element-wise unary ops lowering to custom op of TOSA dialect.
-//===----------------------------------------------------------------------===//
-template <typename ONNXOp>
-class ConvertONNXUnaryOpToTosaCustomOp : public OpConversionPattern<ONNXOp> {
-public:
-  using OpConversionPattern<ONNXOp>::OpConversionPattern;
-  using OpAdaptor = typename ONNXOp::Adaptor;
-
-  ConvertONNXUnaryOpToTosaCustomOp(TypeConverter &typeConverter,
-      MLIRContext *context, std::string opName,
-      std::string implementedWithOpAttr = "UNDEF")
-      : OpConversionPattern<ONNXOp>(typeConverter, context),
-        opName(std::move(opName)),
-        implementedWithOpAttr(std::move(implementedWithOpAttr)) {}
-
-  LogicalResult matchAndRewrite(ONNXOp op, OpAdaptor adaptor,
-      ConversionPatternRewriter &rewriter) const override {
-
-    // Set tosa.custom_op attributes.
-    // Only identifier needs to be known. Other attributes are not used.
-    auto *ctx = op->getContext();
-    auto identifier = StringAttr::get(ctx, opName);
-    auto implementAttr = StringAttr::get(ctx, implementedWithOpAttr);
-    auto config = StringAttr::get(ctx, "UNDEF");
-
-    rewriter.replaceOpWithNewOp<mlir::tosa::CustomOp>(op,
-        TypeRange{OpConversionPattern<ONNXOp>::getTypeConverter()->convertType(
-            op.getType())},
-        identifier, config, implementAttr, adaptor.getOperands());
-    return success();
-  }
-
-private:
-  std::string opName;
-  std::string implementedWithOpAttr;
-};
-
 // Element-wise unary ops lowering to TOSA dialect.
 //===----------------------------------------------------------------------===//
 template <typename ElementwiseUnaryOpONNX, typename ElementwiseUnaryOpTOSA,
@@ -720,19 +683,11 @@ static void populateLoweringONNXElementwiseUnaryTemplateOpToTOSAPattern(
       ONNXElementwiseUnaryOpLoweringToTOSA<ONNXAbsOp, mlir::tosa::AbsOp,
           IsIntOrFloat, IsIntOrFloat>,
       ONNXElementwiseUnaryOpLoweringToTOSA<ONNXErfOp, mlir::tosa::ErfOp,
+          IsFloat, IsFloat>,
+      ONNXElementwiseUnaryOpLoweringToTOSA<ONNXSinOp, mlir::tosa::SinOp,
+          IsFloat, IsFloat>,
+      ONNXElementwiseUnaryOpLoweringToTOSA<ONNXCosOp, mlir::tosa::CosOp,
           IsFloat, IsFloat>>(typeConverter, ctx);
-
-// Tosa custom ops
-#define INSERT_ONNX_UNARY_TO_TOSA_CUSTOMOP_PATTERN(                            \
-    ONNXOp, opName, implementedWith)                                           \
-  patterns.add<ConvertONNXUnaryOpToTosaCustomOp<ONNXOp>>(                      \
-      typeConverter, ctx, opName, implementedWith);
-
-  INSERT_ONNX_UNARY_TO_TOSA_CUSTOMOP_PATTERN(
-      ONNXSinOp, "math.sin", "linalg.generic");
-  INSERT_ONNX_UNARY_TO_TOSA_CUSTOMOP_PATTERN(
-      ONNXCosOp, "math.cos", "linalg.generic");
-#undef INSERT_ONNX_UNARY_TO_TOSA_CUSTOMOP_PATTERN
 }
 
 void populateLoweringONNXElementwiseOpToTOSAPattern(ConversionTarget &target,

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -870,7 +870,7 @@ func.func @test_sin(%arg0 : tensor<10x10xf32>) -> tensor<10x10xf32> {
   "func.return"(%0) : (tensor<10x10xf32>) -> ()
 // CHECK-LABEL:  func @test_sin
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x10xf32>) -> tensor<10x10xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.custom [[PARAM_0_]] {domain_name = "UNDEF", implementation_attrs = "linalg.generic", operator_name = "math.sin"} : (tensor<10x10xf32>) -> tensor<10x10xf32>
+// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.sin [[PARAM_0_]] : (tensor<10x10xf32>) -> tensor<10x10xf32>
 // CHECK-NEXT:      return [[VAR_0_]] : tensor<10x10xf32>
 // CHECK-NEXT:    }
 }
@@ -882,7 +882,7 @@ func.func @test_sin_dynamic(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   "func.return"(%0) : (tensor<*xf32>) -> ()
 // CHECK-LABEL:  func @test_sin_dynamic
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x10xf32>) -> tensor<?x10xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.custom [[PARAM_0_]] {domain_name = "UNDEF", implementation_attrs = "linalg.generic", operator_name = "math.sin"} : (tensor<?x10xf32>) -> tensor<?x10xf32>
+// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.sin [[PARAM_0_]]  : (tensor<?x10xf32>) -> tensor<?x10xf32>
 // CHECK-NEXT:      return [[VAR_0_]] : tensor<?x10xf32>
 // CHECK-NEXT:    }
 }
@@ -894,7 +894,7 @@ func.func @test_cos(%arg0 : tensor<10x10xf32>) -> tensor<10x10xf32> {
   "func.return"(%0) : (tensor<10x10xf32>) -> ()
 // CHECK-LABEL:  func @test_cos
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x10xf32>) -> tensor<10x10xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.custom [[PARAM_0_]] {domain_name = "UNDEF", implementation_attrs = "linalg.generic", operator_name = "math.cos"} : (tensor<10x10xf32>) -> tensor<10x10xf32>
+// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.cos [[PARAM_0_]] : (tensor<10x10xf32>) -> tensor<10x10xf32>
 // CHECK-NEXT:      return [[VAR_0_]] : tensor<10x10xf32>
 // CHECK-NEXT:    }
 }
@@ -906,7 +906,7 @@ func.func @test_cos_dynamic(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   "func.return"(%0) : (tensor<*xf32>) -> ()
 // CHECK-LABEL:  func @test_cos_dynamic
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x10xf32>) -> tensor<?x10xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.custom [[PARAM_0_]] {domain_name = "UNDEF", implementation_attrs = "linalg.generic", operator_name = "math.cos"} : (tensor<?x10xf32>) -> tensor<?x10xf32>
+// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.cos [[PARAM_0_]] : (tensor<?x10xf32>) -> tensor<?x10xf32>
 // CHECK-NEXT:      return [[VAR_0_]] : tensor<?x10xf32>
 // CHECK-NEXT:    }
 }


### PR DESCRIPTION
The TOSA MLIR bindings have [Sin](https://mlir.llvm.org/docs/Dialects/TOSA/#tosasin-mlirtosasinop) and [Cos](https://mlir.llvm.org/docs/Dialects/TOSA/#tosacos-mlirtosacosop) operations, so lower to them instead of `CustomOp`