### PR TITLE
Avoid converting to TOSA if the invariants are not respected

### DIFF
--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -94,12 +94,8 @@ LogicalResult checkBasicTosaRequirementsForBinaryOps(
 
   if (TosaOpT::template hasTrait<
           ::mlir::OpTrait::SameOperandsAndResultElementType>()) {
-    auto lhsElementType =
-        lhs.getType().template cast<TensorType>().getElementType();
-    auto rhsElementType =
-        rhs.getType().template cast<TensorType>().getElementType();
-    if (lhsElementType != rhsElementType ||
-        lhsElementType != resultElementType) {
+    if (lhsType.getElementType() != rhsType.getElementType() ||
+        lhsType.getElementType() != resultElementType) {
       return rewriter.notifyMatchFailure(
           op, "lhs, rhs and result must have the same type");
     }

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -513,6 +513,16 @@ func.func @test_pow_f64(%arg0: tensor<13x21x1xf64>, %arg1: tensor<13x21x1xf64>) 
 
 // -----
 
+func.func @main_graph(%arg0: tensor<3xf32>, %arg1: tensor<3xi32>) -> (tensor<3xf32>) {
+  // CHECK-LABEL:  func @main_graph
+  // CHECK-SAME:   ([[PARAM_0:%.*]]: tensor<3xf32>, [[PARAM_1:%.*]]: tensor<3xi32>) -> tensor<3xf32> 
+  // CHECK: %{{.*}} = "onnx.Pow"([[PARAM_0]], [[PARAM_1]]) {onnx_node_name = "onnx.Pow_0"} : (tensor<3xf32>, tensor<3xi32>) -> tensor<3xf32>
+  %0 = "onnx.Pow"(%arg0, %arg1) {onnx_node_name = "onnx.Pow_0"} : (tensor<3xf32>, tensor<3xi32>) -> tensor<3xf32>
+  return %0 : tensor<3xf32>
+}
+
+// -----
+
 func.func @test_sqrt(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %0 = "onnx.Sqrt"(%arg0) : (tensor<3xf32>) -> tensor<3xf32>
   return %0 : tensor<3xf32>

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -513,10 +513,10 @@ func.func @test_pow_f64(%arg0: tensor<13x21x1xf64>, %arg1: tensor<13x21x1xf64>) 
 
 // -----
 
-func.func @main_graph(%arg0: tensor<3xf32>, %arg1: tensor<3xi32>) -> (tensor<3xf32>) {
-  // CHECK-LABEL:  func @main_graph
+func.func @test_pow_mixed_types(%arg0: tensor<3xf32>, %arg1: tensor<3xi32>) -> (tensor<3xf32>) {
+  // CHECK-LABEL:  func @test_pow_mixed_types
   // CHECK-SAME:   ([[PARAM_0:%.*]]: tensor<3xf32>, [[PARAM_1:%.*]]: tensor<3xi32>) -> tensor<3xf32> 
-  // CHECK: %{{.*}} = "onnx.Pow"([[PARAM_0]], [[PARAM_1]]) {onnx_node_name = "onnx.Pow_0"} : (tensor<3xf32>, tensor<3xi32>) -> tensor<3xf32>
+  // CHECK: "onnx.Pow"([[PARAM_0]], [[PARAM_1]]) {onnx_node_name = "onnx.Pow_0"} : (tensor<3xf32>, tensor<3xi32>) -> tensor<3xf32>
   %0 = "onnx.Pow"(%arg0, %arg1) {onnx_node_name = "onnx.Pow_0"} : (tensor<3xf32>, tensor<3xi32>) -> tensor<3xf32>
   return %0 : tensor<3xf32>
 }


### PR DESCRIPTION
Employ the `SameOperandsAndResultElementType` before the operator is created. Unfortunately, I can employ `verifySameOperandsAndResultElementType` since the operator hasn't been created.