### PR TITLE
Output warnings/errors to stderr

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -165,7 +165,7 @@ public:
     in_model_functions_ = GetModelLocalFunctions(model);
     importGraph(model.graph());
     if (options_.verboseOutput) {
-      llvm::outs()
+      llvm::errs()
           << "The ONNX model has " << num_of_parameters_
           << " elements in its initializers. This value would be close to and "
              "greater than the number of parameters in the model. Because "
@@ -1115,7 +1115,7 @@ private:
     if (node.domain().compare("ai.onnx.ml") != 0 &&
         current_opset < opset_list.back() &&
         current_opset < MINIMUM_SUPPORTED_OPSET)
-      llvm::outs() << "Warning: ONNX " << node.op_type()
+      llvm::errs() << "Warning: ONNX " << node.op_type()
                    << " in your model is using Opset " << current_opset
                    << ", which is quite old. Please consider regenerating your "
                       "model with a newer Opset.\n";
@@ -1490,7 +1490,7 @@ bool ImportFrontendModelInternal(onnx::ModelProto &model, MLIRContext &context,
 
   if (options.allowSorting && !IsTopologicallySorted(model.graph())) {
     if (!SortGraph(model.mutable_graph())) {
-      llvm::outs() << "The graph is not topologically sortable.\n";
+      llvm::errs() << "The graph is not topologically sortable.\n";
       return false;
     }
   }

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
@@ -114,13 +114,13 @@ static void refineDims(Operation *op, DimsExpr &inferredDims, Value output) {
     assert(inferredDims[i].isLiteral() && "isLiteral failed");
     if (existingDims[i] != inferredDims[i].getLiteral()) {
       if (op)
-        llvm::outs() << "Warning for operation " << op->getName()
+        llvm::errs() << "Warning for operation " << op->getName()
                      << ": [Shape inference, dim " << i
                      << "] the inferred dim (" << inferredDims[i].getLiteral()
                      << ") is different from the existing dim ("
                      << existingDims[i] << "). Use the existing dim instead.\n";
       else
-        llvm::outs() << "Warning: [Shape inference, dim " << i
+        llvm::errs() << "Warning: [Shape inference, dim " << i
                      << "] the inferred dim (" << inferredDims[i].getLiteral()
                      << ") is different from the existing dim ("
                      << existingDims[i] << "). Use the existing dim instead.\n";

--- a/src/Dialect/ONNX/Transforms/SetONNXNodeName.cpp
+++ b/src/Dialect/ONNX/Transforms/SetONNXNodeName.cpp
@@ -70,7 +70,7 @@ void SetONNXNodeNamePass::runOnOperation() {
       std::string s = nodeName.getValue().str();
       bool succeeded = nodeNames.insert(s).second;
       if (!succeeded) {
-        llvm::outs() << "Duplicated " << nodeNameAttr << ": " << s
+        llvm::errs() << "Duplicated " << nodeNameAttr << ": " << s
                      << ". It will be updated with a new string.\n";
         opsNeedNodeName.insert(op);
       }


### PR DESCRIPTION
Because we use stdout to print the IR bytecode. Otherwise the bytecode gets mixed with warning messages and causes the parsing of the byte code to crash.