### PR TITLE
fix: don't lower Conv2D and Flatten with dynamic shapes.

### DIFF
--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -100,6 +100,12 @@ public:
     auto inputType = input.getType().cast<TensorType>();
     auto weightType = weights.getType().cast<ShapedType>();
 
+    if (!inputType || !weightType || !inputType.hasStaticShape() ||
+        !weightType.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(
+          op, "only ranked tensor types are supported");
+    }
+
     // Get shapehelper for autopad attributes
     IndexExprBuilderForTosa createTosaIE(rewriter, convOp->getLoc());
     ONNXConvOpShapeHelper shapeHelper(op, operands, &createTosaIE);

--- a/src/Conversion/ONNXToTOSA/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/MatMul.cpp
@@ -114,7 +114,7 @@ public:
     if (!lhsTy || !rhsTy || !lhsTy.hasStaticShape() ||
         !rhsTy.hasStaticShape()) {
       return rewriter.notifyMatchFailure(
-          op, "only ranked tensor types are supproted");
+          op, "only ranked tensor types are supported");
     }
 
     auto lhsRank = lhsTy.getRank();

--- a/src/Conversion/ONNXToTOSA/Tensor/Flatten.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Flatten.cpp
@@ -33,10 +33,16 @@ public:
   LogicalResult matchAndRewrite(ONNXFlattenOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
 
+    Value input = adaptor.getInput();
+
+    // tosa.reshape does not allow a dynamic entry in the new_shape attribute
+    if (!hasStaticShape(input.getType()))
+      return rewriter.notifyMatchFailure(
+          op, "only static shapes are supported");
+
     auto loc = op->getLoc();
     TosaBuilder tosaBuilder(rewriter, loc);
 
-    Value input = adaptor.getInput();
     int64_t axis = adaptor.getAxis();
     auto inputType = input.getType().cast<ShapedType>();
 

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -171,3 +171,21 @@ func.func @test_onnx_conv2d_group_to_depthwise_integer_multiple(%arg0: tensor<32
 // CHECK:           [[VAR_7_:%.+]] = tosa.transpose [[VAR_5_]], [[VAR_6_]] : (tensor<32x112x112x48xf32>, tensor<4xi32>) -> tensor<32x48x112x112xf32>
 // CHECK:           return [[VAR_7_]] : tensor<32x48x112x112xf32>
 }
+
+// -----
+
+func.func @test_onnx_conv2d_dyn_shapes(%arg0: tensor<?x?x?x?xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<?x?x?x?xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<?x?x?x?xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) ->  tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+// CHECK-LABEL:  func.func @test_onnx_conv2d_dyn_shapes
+// CHECK: onnx.Conv
+}
+
+// -----
+
+func.func @test_onnx_conv2d_dyn_shapes_with_shape_inference(%arg0: tensor<5x3x256x256xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<?x?x?x?xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<5x3x256x256xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) ->  tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+// CHECK-LABEL:  func.func @test_onnx_conv2d_dyn_shapes_with_shape_inference
+// CHECK: tosa.conv
+}

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Flatten.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Flatten.mlir
@@ -33,3 +33,10 @@ func.func @test_flatten_axes_equals_rank(%arg0: tensor<32x51x1x3xf32>) -> tensor
   return %0 : tensor<4896x1xf32>
   //CHECK:  {{%.+}} = tosa.reshape %arg0 {new_shape = array<i64: 4896, 1>} : (tensor<32x51x1x3xf32>) -> tensor<4896x1xf32>
 }
+
+// -----
+func.func @test_flatten_dyn_shape(%arg0: tensor<?x?x?x?xf32>) -> tensor<?x1xf32> {
+  %0 = "onnx.Flatten"(%arg0) {axis = 4 : si64} : (tensor<?x?x?x?xf32>) -> tensor<?x1xf32>
+  return %0 : tensor<?x1xf32>
+  //CHECK:  onnx.Flatten
+}


### PR DESCRIPTION
We should avoid trying to convert onnx to tosa when dyn shapes for Flatten and Conv2d.