### PR TITLE
Include op version in additional ops that have one

### DIFF
--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -369,7 +369,7 @@ def ONNXYieldOp : ONNX_Op<"Yield", [Pure, ReturnLike, Terminator]> {
 //===----------------------------------------------------------------------===//
 // BatchNorm in Inference mode.
 def ONNXBatchNormalizationInferenceModeOp: ONNX_Op<"BatchNormalizationInferenceMode",
-    [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>,
+    [Pure, OpVersionTrait<15>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>,
     DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
   let summary = "ONNX BatchNormalization operation in test mode";
   let description = [{
@@ -421,7 +421,8 @@ def ONNXBatchNormalizationInferenceModeOp: ONNX_Op<"BatchNormalizationInferenceM
 //===----------------------------------------------------------------------===//
 // MaxPoolSingleOutOp
 def ONNXMaxPoolSingleOutOp: ONNX_Op<"MaxPoolSingleOut",
-    [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>,
+    [Pure,  OpVersionTrait<12>,
+    DeclareOpInterfaceMethods<ShapeInferenceOpInterface>,
     DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
   let summary = "ONNX MaxPool operation with a single output.";
   let description = [{


### PR DESCRIPTION
Two ONNX-MLIR ops correspond to special cases of existing ops:

* ONNXMaxPoolSingleOutOp
* ONNXBatchNormalizationInferenceModeOp

This PR gives version number to these ops matching the version numbers of the op they're a special case of. Drawback: these need to be manually updated each time the opset is re-generated...