### PR TITLE
feat: make dtype a required argument of TosaBuilder::getSplattedConst.

### DIFF
--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -90,8 +90,8 @@ struct TosaBuilder : DialectBuilder {
   // The tensor will have the same rank as shape but all dimensions will
   // have size 1 (differs from tensorflow impl.)
   // If dtype is provided, it also cast the value to the appropriate dtype.
-  mlir::Value getSplattedConst(float val, llvm::ArrayRef<int64_t> shape = {},
-      std::optional<mlir::Type> dtype = {});
+  mlir::Value getSplattedConst(
+      float val, mlir::Type dtype, llvm::ArrayRef<int64_t> shape = {});
 
   // Creates a constant of shape <1x1x...x1> of rank `rank` with all values set
   // to `value`.

--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -231,7 +231,7 @@ static LogicalResult legalizeFloatingPointPrelu(Operation *op,
   auto loc = op->getLoc();
   TosaBuilder tosaBuilder(rewriter, loc);
   Value constZero = tosaBuilder.getSplattedConst(
-      0.0, outputType.getShape(), outputType.getElementType());
+      0.0, outputType.getElementType(), outputType.getShape());
 
   auto mul = tosaBuilder.mul(input, alphaOrSlope);
   auto greaterEqual = tosaBuilder.greaterEqual(input, constZero);
@@ -266,7 +266,7 @@ public:
     TosaBuilder tosaBuilder(rewriter, loc);
     return legalizeFloatingPointPrelu(op, rewriter, adaptor.getX(),
         tosaBuilder.getSplattedConst(
-            alpha, outputType.getShape(), outputType.getElementType()),
+            alpha, outputType.getElementType(), outputType.getShape()),
         outputType);
   }
 };
@@ -386,7 +386,8 @@ public:
       // ceil for negative ones. Conversion to boolean works the same between
       // onnx.Cast and tosa.cast.
       if (resultTy.getElementType().getIntOrFloatBitWidth() != 1) {
-        auto zero = tosaBuilder.getSplattedConst(0.0f, resultTy.getRank());
+        auto zero = tosaBuilder.getSplattedConst(
+            0.0f, inputTy.getElementType(), resultTy.getShape());
         auto positive = tosaBuilder.greaterEqual(input, zero);
 
         auto floor = tosaBuilder.unaryOp<mlir::tosa::FloorOp>(input);
@@ -465,12 +466,12 @@ public:
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
 
     Value one = tosaBuilder.getSplattedConst(
-        1.0, resultTensorType.getShape(), resultTensorType.getElementType());
+        1.0, resultTensorType.getElementType(), resultTensorType.getShape());
     Value alpha =
         tosaBuilder.getSplattedConst(adaptor.getAlpha().convertToDouble(),
-            resultTensorType.getShape(), resultTensorType.getElementType());
+            resultTensorType.getElementType(), resultTensorType.getShape());
     Value constZero = tosaBuilder.getSplattedConst(
-        0.0, resultTensorType.getShape(), resultTensorType.getElementType());
+        0.0, resultTensorType.getElementType(), resultTensorType.getShape());
 
     Value exp = tosaBuilder.unaryOp<mlir::tosa::ExpOp>(input);
     Value expMinusOne = tosaBuilder.binaryOp<mlir::tosa::SubOp>(exp, one);
@@ -511,9 +512,9 @@ public:
 
     Value constBetaOverAlpha =
         tosaBuilder.getSplattedConst(betaOverAlpha.convertToDouble(),
-            resultType.getShape(), resultElementType);
+            resultElementType, resultType.getShape());
     Value constAlpha = tosaBuilder.getSplattedConst(
-        alpha.convertToDouble(), resultType.getShape(), resultElementType);
+        alpha.convertToDouble(), resultElementType, resultType.getShape());
 
     auto addOp =
         tosaBuilder.binaryOp<mlir::tosa::AddOp>(input, constBetaOverAlpha);
@@ -563,7 +564,7 @@ public:
 
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
     auto one = tosaBuilder.getSplattedConst(
-        1.0, outputType.getShape(), outputType.getElementType());
+        1.0, outputType.getElementType(), outputType.getShape());
 
     auto expOp = tosaBuilder.unaryOp<mlir::tosa::ExpOp>(input);
     auto expPlusOne = tosaBuilder.binaryOp<mlir::tosa::AddOp>(expOp, one);
@@ -590,12 +591,12 @@ public:
 
     Value alpha =
         tosaBuilder.getSplattedConst(adaptor.getAlpha().convertToDouble(),
-            outputType.getShape(), outputType.getElementType());
+            outputType.getElementType(), outputType.getShape());
     Value gamma =
         tosaBuilder.getSplattedConst(adaptor.getGamma().convertToDouble(),
-            outputType.getShape(), outputType.getElementType());
+            outputType.getElementType(), outputType.getShape());
     Value constZero = tosaBuilder.getSplattedConst(
-        0.0, outputType.getShape(), outputType.getElementType());
+        0.0, outputType.getElementType(), outputType.getShape());
 
     Value exp = tosaBuilder.unaryOp<mlir::tosa::ExpOp>(input);
     Value expTimesAlpha = tosaBuilder.mul(exp, alpha);
@@ -629,9 +630,9 @@ public:
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
     auto alpha =
         tosaBuilder.getSplattedConst(adaptor.getAlpha().convertToDouble(),
-            outputType.getShape(), outputType.getElementType());
+            outputType.getElementType(), outputType.getShape());
     auto zero = tosaBuilder.getSplattedConst(
-        0.0, outputType.getShape(), outputType.getElementType());
+        0.0, outputType.getElementType(), outputType.getShape());
 
     auto greater = tosaBuilder.greater(input, alpha);
     auto select = tosaBuilder.select(greater, input, zero);

--- a/src/Conversion/ONNXToTOSA/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Gemm.cpp
@@ -103,7 +103,7 @@ public:
     // A
     if (alpha && alpha.getValueAsDouble() != 1.) {
       Value splattedConstAlpha = tosaBuilder.getSplattedConst(
-          (float)alpha.getValueAsDouble(), newShapeA);
+          (float)alpha.getValueAsDouble(), AType.getElementType(), newShapeA);
       alphaMulResult = tosaBuilder.mul(splattedConstAlpha, A, 0);
     }
 
@@ -111,7 +111,7 @@ public:
     // a multiplication for beta * C
     if (beta && isCPresent && beta.getValueAsDouble() != 1.) {
       Value splattedConstBeta = tosaBuilder.getSplattedConst(
-          (float)beta.getValueAsDouble(), newShapeA);
+          (float)beta.getValueAsDouble(), AType.getElementType(), newShapeA);
       betaMulResult = tosaBuilder.mul(splattedConstBeta, C, 0);
     }
 

--- a/src/Conversion/ONNXToTOSA/Math/Reduce.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Reduce.cpp
@@ -181,7 +181,7 @@ LogicalResult reduceMeanLowering(ONNXReduceMeanOp op,
 
   TosaBuilder tosaBuilder(rewriter, op->getLoc());
   Value divConst = tosaBuilder.getSplattedConst(
-      divScale, outputType.getShape(), outputType.getElementType());
+      divScale, outputType.getElementType(), outputType.getShape());
   auto output = tosaBuilder.mul(val, divConst);
 
   if (!output) {

--- a/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
@@ -45,12 +45,13 @@ void handleIncludePadAttr(
           /*ceilMode*/ 0, {0, 1, 2, 3});
 
   // Create Padding and ConstPad tosa::ConstOp's
+  auto inputType = input.getType().cast<mlir::TensorType>();
   TosaBuilder tosaBuilder(rewriter, loc);
   Value padding = tosa::buildOnnxToTosaPaddingConstOp(
       rewriter, pads, loc, {0, 0, 0, 0}, {});
-  auto constTosaTensor = tosaBuilder.getSplattedConst(0.0);
+  auto constTosaTensor =
+      tosaBuilder.getSplattedConst(0.0, inputType.getElementType());
 
-  auto inputType = input.getType().cast<mlir::TensorType>();
   auto padOp = tosa::CreateOpAndInfer<mlir::tosa::PadOp>(rewriter, loc,
       mlir::RankedTensorType::get(
           llvm::SmallVector<int64_t, 4>(

--- a/src/Conversion/ONNXToTOSA/NN/BatchNorm.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/BatchNorm.cpp
@@ -60,7 +60,7 @@ public:
     // epsilon's shape: constant -> {1, 1, 1, ...}
     newShape[1] = 1;
     auto eps = tosaBuilder.getSplattedConst(op.getEpsilon().convertToFloat(),
-        newShape, outTensorType.getElementType());
+        outTensorType.getElementType(), newShape);
 
     // output = (input - mean) * scale * rsqrt(var + eps) + bias
     auto op1SubInputMean =

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.cpp
@@ -424,7 +424,7 @@ std::optional<Value> convertReduceMeanOp(PatternRewriter &rewriter,
 
   if (!input_is_qtype) {
     Value div_const = tosaBuilder.getSplattedConst(
-        div_scale, output_type.getShape(), output_type.getElementType());
+        div_scale, output_type.getElementType(), output_type.getShape());
     return tosaBuilder.mul(val.value(), div_const);
   }
 

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
@@ -236,7 +236,8 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
       "Expected either tosa::MaxPool2dOp or tosa::AvgPool2dOp");
   if constexpr (std::is_same<TOSAPoolOp, mlir::tosa::MaxPool2dOp>::value) {
     input = tosa::CreateOpAndInfer<TOSAPoolOp>(rewriter, loc, newResultType,
-        *resizedInput, newKernelShape, strides, newPads).getResult();
+        *resizedInput, newKernelShape, strides, newPads)
+                .getResult();
   } else if constexpr (std::is_same<TOSAPoolOp,
                            mlir::tosa::AvgPool2dOp>::value) {
     mlir::TypeAttr accType;
@@ -246,7 +247,7 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
       return mlir::failure();
     }
     input = tosa::CreateOpAndInfer<TOSAPoolOp>(rewriter, loc, newResultType,
-         *resizedInput, newKernelShape, strides, newPads, accType)
+        *resizedInput, newKernelShape, strides, newPads, accType)
                 .getResult();
   }
 

--- a/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
@@ -62,20 +62,13 @@ public:
     // element-wise.
 
     // Create an 1x..x1 constant containing the size of the gathered dimension.
-    auto dimSize =
-        tosaBuilder.getSplattedConst(inputShape[axis], indicesType.getRank());
-    if (!indicesType.getElementType().isInteger(64)) {
-      dimSize = tosaBuilder.castToNewTensorElementType(
-          dimSize, indicesType.getElementType());
-    }
+    auto dimSize = tosaBuilder.getSplattedConst(
+        inputShape[axis], indicesType.getElementType(), indicesType.getShape());
     auto indicesPlusDimSize =
         tosaBuilder.binaryOp<mlir::tosa::AddOp>(indices, dimSize);
 
-    auto zero = tosaBuilder.getSplattedConst((int64_t)0, indicesType.getRank());
-    if (!indicesType.getElementType().isInteger(64)) {
-      zero = tosaBuilder.castToNewTensorElementType(
-          zero, indicesType.getElementType());
-    }
+    auto zero = tosaBuilder.getSplattedConst(
+        (int64_t)0, indicesType.getElementType(), indicesType.getShape());
     auto indicesPositive = tosaBuilder.greaterEqual(indices, zero);
 
     auto newIndices =

--- a/src/Conversion/ONNXToTOSA/Tensor/PaddingOp.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/PaddingOp.cpp
@@ -83,7 +83,8 @@ public:
       float valueFloat = (*valueIt).cast<FloatAttr>().getValueAsDouble();
 
       TosaBuilder tosaBuilder(rewriter, loc);
-      Value constTosaTensor = tosaBuilder.getSplattedConst(valueFloat);
+      Value constTosaTensor =
+          tosaBuilder.getSplattedConst(valueFloat, valueAttr.getElementType());
 
       rewriter.replaceOpWithNewOp<mlir::tosa::PadOp>(
           op, resultType, data, padsList1, constTosaTensor);

--- a/src/Conversion/ONNXToTOSA/Tensor/Shrink.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Shrink.cpp
@@ -48,13 +48,13 @@ public:
     const float lambdAsFloat = lambd.getValue().convertToFloat();
     const float biasAsFloat = bias.getValue().convertToFloat();
     auto lambdConstOp = tosaBuilder.getSplattedConst(lambdAsFloat,
-        inputRankedTensorTy.getShape(), inputRankedTensorTy.getElementType());
+        inputRankedTensorTy.getElementType(), inputRankedTensorTy.getShape());
     auto negatedLambdConstOp = tosaBuilder.getSplattedConst(-lambdAsFloat,
-        inputRankedTensorTy.getShape(), inputRankedTensorTy.getElementType());
+        inputRankedTensorTy.getElementType(), inputRankedTensorTy.getShape());
     auto biasConstOp = tosaBuilder.getSplattedConst(biasAsFloat,
-        inputRankedTensorTy.getShape(), inputRankedTensorTy.getElementType());
+        inputRankedTensorTy.getElementType(), inputRankedTensorTy.getShape());
     auto zeroConstOp = tosaBuilder.getSplattedConst(0,
-        inputRankedTensorTy.getShape(), inputRankedTensorTy.getElementType());
+        inputRankedTensorTy.getElementType(), inputRankedTensorTy.getShape());
 
     // Formula to be implemented:
     // { x < -lambd, then y = x + bias

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -19,6 +19,23 @@ func.func @test_cast_f32_i8(%arg0: tensor<13x21x1xf32>) -> tensor<13x21x1xi8> {
 
 // -----
 
+func.func @test_cast_f16_i8(%arg0: tensor<13x21x1xf16>) -> tensor<13x21x1xi8> {
+  %0 = "onnx.Cast"(%arg0) {to = i8} : (tensor<13x21x1xf16>) -> tensor<13x21x1xi8>
+  "func.return"(%0) : (tensor<13x21x1xi8>) -> ()
+// CHECK-LABEL:   func.func @test_cast_f16_i8(
+// CHECK-SAME:                                %[[VAL_0:.*]]: tensor<13x21x1xf16>) -> tensor<13x21x1xi8> {
+// CHECK:           %[[VAL_1:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xf16>}> : () -> tensor<1x1x1xf16>
+// CHECK:           %[[VAL_2:.*]] = tosa.greater_equal %[[VAL_0]], %[[VAL_1]] : (tensor<13x21x1xf16>, tensor<1x1x1xf16>) -> tensor<13x21x1xi1>
+// CHECK:           %[[VAL_3:.*]] = tosa.floor %[[VAL_0]] : (tensor<13x21x1xf16>) -> tensor<13x21x1xf16>
+// CHECK:           %[[VAL_4:.*]] = tosa.ceil %[[VAL_0]] : (tensor<13x21x1xf16>) -> tensor<13x21x1xf16>
+// CHECK:           %[[VAL_5:.*]] = tosa.select %[[VAL_2]], %[[VAL_3]], %[[VAL_4]] : (tensor<13x21x1xi1>, tensor<13x21x1xf16>, tensor<13x21x1xf16>) -> tensor<13x21x1xf16>
+// CHECK:           %[[VAL_6:.*]] = tosa.cast %[[VAL_5]] : (tensor<13x21x1xf16>) -> tensor<13x21x1xi8>
+// CHECK:           return %[[VAL_6]] : tensor<13x21x1xi8>
+// CHECK:         }
+}
+
+// -----
+
 func.func @test_cast_i8_i1(%arg0: tensor<1x21x1x1xi8>) -> tensor<1x21x1x1xi1> {
   %0 = "onnx.Cast"(%arg0) {to = i1} : (tensor<1x21x1x1xi8>) -> tensor<1x21x1x1xi1>
   "func.return"(%0) : (tensor<1x21x1x1xi1>) -> ()

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
@@ -112,12 +112,10 @@ func.func @test_gather_dynamic_indices_i32(%arg0 : tensor<3x3xf32>, %indices: te
 // CHECK-LABEL:   func.func @test_gather_dynamic_indices_i32(
 // CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<3x3xf32>,
 // CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<1x2xi32>) -> tensor<3x1x2xf32> {
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_3:.*]] = tosa.cast %[[VAL_2]] : (tensor<1x1xi64>) -> tensor<1x1xi32>
-// CHECK:           %[[VAL_4:.*]] = tosa.add %[[VAL_1]], %[[VAL_3]] : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
-// CHECK:           %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_6:.*]] = tosa.cast %[[VAL_5]] : (tensor<1x1xi64>) -> tensor<1x1xi32>
-// CHECK:           %[[VAL_7:.*]] = tosa.greater_equal %[[VAL_1]], %[[VAL_6]] : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi1>
+// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK:           %[[VAL_4:.*]] = tosa.add %[[VAL_1]], %[[VAL_2]] : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+// CHECK:           %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK:           %[[VAL_7:.*]] = tosa.greater_equal %[[VAL_1]], %[[VAL_5]] : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi1>
 // CHECK:           %[[VAL_8:.*]] = tosa.select %[[VAL_7]], %[[VAL_1]], %[[VAL_4]] : (tensor<1x2xi1>, tensor<1x2xi32>, tensor<1x2xi32>) -> tensor<1x2xi32>
 // CHECK:           %[[VAL_9:.*]] = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}> : () -> tensor<2xi32>
 // CHECK:           %[[VAL_10:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_9]] : (tensor<3x3xf32>, tensor<2xi32>) -> tensor<3x3xf32>


### PR DESCRIPTION
It is safer to make `dtype` a required argument of `TosaBuilder::getSplattedConst` since we might miss to specify it in some cases.
This PR is specifically motivated by ONNXToTosa lowering of `onnx.Cast` where we weren't passing on the `dtype` and `onnx.cast` conversion for `f16` types were generating illegal code (`tosa.greater_than` was getting created with `f16` and `f32`).
So the intent of this change is so that we don't miss it anymore.