### PR TITLE
Fix crash in ReshapeOp inference when an input to the previous concat is empty

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -487,11 +487,6 @@ bool areDims(Value val) {
   if (!(isRankedShapedType(vType) && (getRank(vType) == 1)))
     return false;
 
-  // Base case.
-  // A dimension must be a 1D tensor of one i64 element.
-  if ((getShape(vType)[0] == 1) && getElementType(vType).isSignlessInteger(64))
-    return true;
-
   // Recursion case.
   if (definedBy<ONNXConcatOp>(val)) {
     // Recursively check.
@@ -500,6 +495,11 @@ bool areDims(Value val) {
         return false;
     return true;
   }
+
+  // Base case.
+  // A dimension must be a 1D tensor of one i64 element.
+  if ((getShape(vType)[0] == 1) && getElementType(vType).isSignlessInteger(64))
+    return true;
 
   // Not Dim/Constant/Cast/Concat.
   return false;

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Reshape.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Reshape.cpp
@@ -36,7 +36,8 @@ LogicalResult ONNXReshapeOpShapeHelper::computeShape() {
   // Get info about shape operand.
   Value shape = operandAdaptor.getShape();
   int64_t outputRank = createIE->getShape(shape, 0);
-  assert(outputRank != -1 && "Shape tensor must have constant shape");
+  assert(outputRank != ShapedType::kDynamic &&
+         "Shape tensor must have constant shape");
 
   // Initialize context and results.
   outputDims.resize(outputRank);

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -932,6 +932,24 @@ func.func @test_reshape_dynamic(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<4xi
 
 // -----
 
+//===----------------------------------------------------------------------===//
+/// Test the reshape op rank inference when an input is empty 
+//===----------------------------------------------------------------------===//
+
+func.func @test_reshape_concat_0(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
+  %0 = onnx.Constant dense<> : tensor<0xi64>
+  %1 = onnx.Constant dense<-1> : tensor<1xi64>
+  %2 = "onnx.Concat" (%0, %1) {axis = 0 : si64 }: ( tensor<0xi64>, tensor<1xi64>) ->  tensor<*xi64>
+  %3 = "onnx.Reshape"(%arg0, %2) : (tensor<5x5x1x32xf32>, tensor<*xi64>) -> tensor<*xf32>
+  "onnx.Return"(%3) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: test_reshape_concat_0
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, %2) {allowzero = 0 : si64} : (tensor<5x5x1x32xf32>, tensor<1xi64>) -> tensor<?xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<?xf32>
+}
+
+// -----
+
 func.func @test_reshape_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[5, 5, 16, 2]> : tensor<4xi64>
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>


### PR DESCRIPTION
The problem was that the check:
```
if ((getShape(vType)[0] == 1) && getElementType(vType).isSignlessInteger(64))
    return true;
```
can succeed even if `areDims(Value val)` is not true for all operands of Concat. 

I think this should be upstreamed