### PR TITLE
fix: do not fail when using dynamic types in Binary ElemWise and Gather.

### DIFF
--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -13,6 +13,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -98,7 +99,7 @@ struct FrontendToTosaLoweringPass
       : PassWrapper<FrontendToTosaLoweringPass, OperationPass<ModuleOp>>() {}
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<mlir::tosa::TosaDialect>();
+    registry.insert<mlir::tosa::TosaDialect, mlir::shape::ShapeDialect>();
   }
   void runOnOperation() final;
 
@@ -135,7 +136,7 @@ void FrontendToTosaLoweringPass::runOnOperation() {
 
   // Define legal dialects and operations
   target.addLegalDialect<mlir::tosa::TosaDialect, func::FuncDialect,
-      mlir::arith::ArithDialect>();
+      mlir::arith::ArithDialect, mlir::shape::ShapeDialect>();
 
   // Define patterns
   populateONNXToTOSAConversionPattern(

--- a/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
@@ -45,6 +45,10 @@ public:
     auto inputType = input.getType();
     if (!onnx_mlir::isRankedShapedType(inputType))
       return rewriter.notifyMatchFailure(op, "input is not a ranked tensor");
+
+    if (!hasStaticShape(result.getType()))
+      return rewriter.notifyMatchFailure(op, "dynamic shapes not supported");
+
     int64_t inputRank = onnx_mlir::getRank(inputType);
 
     // onnx allows values beetween [-r, r-1] where r is the rank

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -145,6 +145,20 @@ func.func @test_add_f64(%arg0: tensor<13x21x1xf64>, %arg1: tensor<13x21x1xf64>) 
 
 // -----
 
+func.func @test_add_dyn_shape_and_const(%arg0: tensor<?x1xi64>) -> tensor<?x1xi64> {
+  %0 = onnx.Constant dense<8400> : tensor<1xi64>
+  %1 = "onnx.Add"(%arg0, %0) : (tensor<?x1xi64>, tensor<1xi64>) -> tensor<?x1xi64>
+  "func.return"(%1) : (tensor<?x1xi64>) -> ()
+// CHECK-LABEL:  test_add_dyn_shape_and_const
+// CHECK:   ([[PARAM_0_:%.+]]: tensor<?x1xi64>) -> tensor<?x1xi64> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<8400> : tensor<1xi64>}> : () -> tensor<1xi64>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 1, 1>} : (tensor<1xi64>) -> tensor<1x1xi64>
+// CHECK:           [[VAR_2_:%.+]] = tosa.add [[PARAM_0_]], [[VAR_1_]] : (tensor<?x1xi64>, tensor<1x1xi64>) -> tensor<?x1xi64>
+// CHECK:           return [[VAR_2_]] : tensor<?x1xi64>
+}
+
+// -----
+
 func.func @test_sub(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x1xf32>) -> tensor<13x21x1xf32> {
   %0 = "onnx.Sub"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
@@ -127,3 +127,12 @@ func.func @test_gather_dynamic_indices_i32(%arg0 : tensor<3x3xf32>, %indices: te
 // CHECK:           %[[VAL_16:.*]] = tosa.transpose %[[VAL_14]], %[[VAL_15]] : (tensor<1x2x3xf32>, tensor<3xi32>) -> tensor<3x1x2xf32>
 // CHECK:           return %[[VAL_16]] : tensor<3x1x2xf32>
 }
+
+// -----
+
+func.func @test_gather_dynamic_type_indices_i32(%arg0 : tensor<?x4xf32>, %indices: tensor<?xi64>) -> tensor<?x4xf32> {
+  %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<?x4xf32>, tensor<?xi64>) -> tensor<?x4xf32>
+  "func.return"(%0) : (tensor<?x4xf32>) -> ()
+// CHECK-LABEL: test_gather_dynamic_type_indices_i32
+// CHECK: onnx.Gather
+}

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
@@ -130,9 +130,9 @@ func.func @test_gather_dynamic_indices_i32(%arg0 : tensor<3x3xf32>, %indices: te
 
 // -----
 
-func.func @test_gather_dynamic_type_indices_i32(%arg0 : tensor<?x4xf32>, %indices: tensor<?xi64>) -> tensor<?x4xf32> {
+func.func @test_gather_dynamic_shape_indices_i32(%arg0 : tensor<?x4xf32>, %indices: tensor<?xi64>) -> tensor<?x4xf32> {
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<?x4xf32>, tensor<?xi64>) -> tensor<?x4xf32>
   "func.return"(%0) : (tensor<?x4xf32>) -> ()
-// CHECK-LABEL: test_gather_dynamic_type_indices_i32
+// CHECK-LABEL: test_gather_dynamic_shape_indices_i32
 // CHECK: onnx.Gather
 }


### PR DESCRIPTION
Lowering to tosa was failing when Elementwise binary had dynamic type saying that `shape` dialect was not loaded. The pass must add `ShapeDialect` as its dependent dialects.
Also, Gather shouldn't fail when indices are dynamic type. For now, no lower to TOSA is done.