### PR TITLE
feat: allow Squeeze to infer shape of tensor with single dynamic dimension when axes is not provided.

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
@@ -219,8 +219,9 @@ LogicalResult ONNXOpShapeHelper::setOutputDimsFromTypeWithConstantShape(
 LogicalResult ONNXOpShapeHelper::computeShapeAndUpdateType(
     Type elementType, Attribute encoding) {
   // Invoke virtual compute shape.
-  if (failed(computeShape()))
-    return op->emitError("Failed to scan parameters successfully");
+  if (failed(computeShape())) {
+    return failure();
+  }
   assert((elementType.isa<VectorType>() || !elementType.isa<ShapedType>()) &&
          "element type cannot be a shaped type other than vector type");
   uint64_t resNum = op->getNumResults();

--- a/src/Dialect/ONNX/Transforms/ShapeInference.cpp
+++ b/src/Dialect/ONNX/Transforms/ShapeInference.cpp
@@ -10,6 +10,8 @@
 
 #include "ShapeInference.hpp"
 
+#define DEBUG_TYPE "onnx-shape-inference"
+
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/STLExtras.h"
 
@@ -75,7 +77,8 @@ LogicalResult inferShapes(
     OperationFingerPrint after(shapeInfOp);
     if (failed(outcome)) {
       assert(after == before && "op must be unchanged on failure");
-      return shapeInfOp.emitOpError("shape inference failed");
+      LLVM_DEBUG(llvm::errs() << "shape inference failed");
+      return failure();
     }
     // succeed only shapeInfOp or its result types changed
     return after == before ? failure() : success();

--- a/test/mlir/onnx/onnx_canonicalization_without_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_without_shape_inference.mlir
@@ -1,0 +1,117 @@
+// RUN: onnx-mlir-opt --canonicalize="test-convergence=true" %s -split-input-file | FileCheck %s
+
+// FIXME: This tests have issues when running shape-inference previous to canonicalize.
+
+// CHECK-LABEL: @test_gemm_add_fusion_rank3(%{{.*}}: tensor<128x128x256xf32>, %{{.*}}: tensor<128x128x256xf32>, %{{.*}}: tensor<256xf32>) -> tensor<*xf32> {
+func.func @test_gemm_add_fusion_rank3(%arg0: tensor<128x128x256xf32>, %arg1: tensor<128x128x256xf32>, %arg2: tensor<256xf32>) -> tensor<*xf32> {
+  %cst = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.Gemm"(%arg0, %arg1, %cst) : (tensor<128x128x256xf32>, tensor<128x128x256xf32>, none) -> tensor<*xf32>
+  %1 = "onnx.Add"(%0, %arg2) : (tensor<*xf32>, tensor<256xf32>) -> tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
+
+  // CHECK-NEXT: [[GEMM:%.+]] = "onnx.Gemm"(%{{.*}}, %{{.*}}, %{{.*}}) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<128x128x256xf32>, tensor<128x128x256xf32>, tensor<256xf32>) -> tensor<*xf32>
+  // onnx.Return [[GEMM]] : tensor<*xf32>
+}
+
+// -----
+
+//CHECK-LABEL: @test_gemm_add_fusion(%{{.*}}: tensor<128x128xf32>, %{{.*}}: tensor<128x128xf32>, %{{.*}}: tensor<128xf32>) -> tensor<*xf32> {
+func.func @test_gemm_add_fusion(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128xf32>) -> tensor<*xf32> {
+  %cst = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.Gemm"(%arg0, %arg1, %cst) : (tensor<128x128xf32>, tensor<128x128xf32>, none) -> tensor<*xf32>
+  %1 = "onnx.Add"(%0, %arg2) : (tensor<*xf32>, tensor<128xf32>) -> tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
+
+  // CHECK-NEXT: [[GEMM:%.+]] = "onnx.Gemm"(%{{.*}}, %{{.*}}, %{{.*}}) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128xf32>) -> tensor<*xf32>
+  // onnx.Return [[GEMM]] : tensor<*xf32>
+}
+
+// -----
+
+//CHECK-LABEL: @test_gemm_add_fusion_beta_zero(%{{.*}}: tensor<128x128xf32>, %{{.*}}: tensor<128x128xf32>, %{{.*}}: tensor<128xf32>) -> tensor<*xf32> {
+func.func @test_gemm_add_fusion_beta_zero(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128xf32>) -> tensor<*xf32> {
+  %cst = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.Gemm"(%arg0, %arg1, %cst) {beta = 0.0 : f32}: (tensor<128x128xf32>, tensor<128x128xf32>, none) -> tensor<*xf32>
+  %1 = "onnx.Add"(%0, %arg2) : (tensor<*xf32>, tensor<128xf32>) -> tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
+
+  // CHECK-NEXT: [[GEMM:%.+]] = "onnx.Gemm"(%{{.*}}, %{{.*}}, %{{.*}}) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128xf32>) -> tensor<*xf32>
+  // onnx.Return [[GEMM]] : tensor<*xf32>
+}
+
+// -----
+
+// Check deriving a new maximum trip count from the break condition of the loop.
+// In this test, the new maximum trip count is a constant.
+func.func @test_loop_derive_max_trip_count(%arg0: tensor<?x30xf32>) -> tensor<?x?x30xf32> {
+  %0 = onnx.Constant dense<9223372036854775807> : tensor<i64>
+  %1 = onnx.Constant dense<true> : tensor<i1>
+  %2 = onnx.Constant dense<0> : tensor<i32>
+  %3 = onnx.Constant dense<30> : tensor<i32>
+  %4:4 = "onnx.Loop"(%0, %1, %2, %3, %arg0) ({
+  ^bb0(%arg1: tensor<i64>, %arg2: tensor<i1>, %arg3: tensor<i32>, %arg4: tensor<i32>, %arg5: tensor<?x30xf32>):
+    %5 = onnx.Constant dense<4> : tensor<i32>
+    %6 = "onnx.Add"(%arg3, %5) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+    %7 = "onnx.Relu"(%arg5) : (tensor<?x30xf32>) -> tensor<?x30xf32>
+    %8 = "onnx.Less"(%6, %arg4) : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    onnx.Yield %8, %6, %arg4, %7 : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
+  }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
+  onnx.Return %4#3 : tensor<?x?x30xf32>
+// CHECK-LABEL:  func.func @test_loop_derive_max_trip_count
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x30xf32>) -> tensor<?x?x30xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<8> : tensor<i64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<4> : tensor<i32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<true> : tensor<i1>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<0> : tensor<i32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<30> : tensor<i32>
+// CHECK:           [[VAR_5_:%.+]]:4 = "onnx.Loop"([[VAR_0_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[PARAM_0_]]) ({
+// CHECK:           ^bb0([[arg1_:%.+]]: tensor<i64>, [[arg2_:%.+]]: tensor<i1>, [[arg3_:%.+]]: tensor<i32>, [[arg4_:%.+]]: tensor<i32>, [[arg5_:%.+]]: tensor<?x30xf32>):
+// CHECK-DAG:         [[VAR_6_:%.+]] = "onnx.Add"([[arg3_]], [[VAR_1_]]) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+// CHECK-DAG:         [[VAR_7_:%.+]] = "onnx.Relu"([[arg5_]]) : (tensor<?x30xf32>) -> tensor<?x30xf32>
+// CHECK:             onnx.Yield [[arg2_]], [[VAR_6_]], [[arg4_]], [[VAR_7_]] : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
+// CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
+// CHECK:           onnx.Return [[VAR_5_]]#3 : tensor<?x?x30xf32>
+
+}
+
+// -----
+
+// Check deriving a new maximum trip count from the break condition of the loop.
+// In this test, the new maximum trip count is not a constant.
+func.func @test_loop_derive_max_trip_count_non_constant_ub(%arg0: tensor<?x30xf32>, %arg1: tensor<i32>) -> tensor<?x?x30xf32> {
+  %0 = onnx.Constant dense<9223372036854775807> : tensor<i64>
+  %1 = onnx.Constant dense<true> : tensor<i1>
+  %2 = onnx.Constant dense<0> : tensor<i32>
+  %3:4 = "onnx.Loop"(%0, %1, %2, %arg1, %arg0) ({
+  ^bb0(%arg2: tensor<i64>, %arg3: tensor<i1>, %arg4: tensor<i32>, %arg5: tensor<i32>, %arg6: tensor<?x30xf32>):
+    %4 = onnx.Constant dense<1> : tensor<i32>
+    %5 = "onnx.Add"(%arg4, %4) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+    %6 = "onnx.Relu"(%arg6) : (tensor<?x30xf32>) -> tensor<?x30xf32>
+    %7 = "onnx.Less"(%5, %arg5) : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    onnx.Yield %7, %5, %arg5, %6 : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
+  }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
+  onnx.Return %3#3 : tensor<?x?x30xf32>
+// CHECK-LABEL:  func @test_loop_derive_max_trip_count_non_constant_ub
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x30xf32>, [[PARAM_1_:%.+]]: tensor<i32>) -> tensor<?x?x30xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1> : tensor<i32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<9223372036854775807> : tensor<i64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<true> : tensor<i1>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<0> : tensor<i32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Cast"([[PARAM_1_]]) {saturate = 1 : si64, to = i64} : (tensor<i32>) -> tensor<i64>
+// CHECK:           [[VAR_5_:%.+]] = "onnx.Cast"([[VAR_3_]]) {saturate = 1 : si64, to = i64} : (tensor<i32>) -> tensor<i64>
+// CHECK:           [[VAR_6_:%.+]] = "onnx.Sub"([[VAR_4_]], [[VAR_5_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Cast"([[VAR_6_]]) {saturate = 1 : si64, to = f32} : (tensor<i64>) -> tensor<f32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = "onnx.Cast"([[VAR_0_]]) {saturate = 1 : si64, to = f32} : (tensor<i32>) -> tensor<f32>
+// CHECK:           [[VAR_9_:%.+]] = "onnx.Div"([[VAR_7_]], [[VAR_8_]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+// CHECK:           [[VAR_10_:%.+]] = "onnx.Ceil"([[VAR_9_]]) : (tensor<f32>) -> tensor<f32>
+// CHECK:           [[VAR_11_:%.+]] = "onnx.Cast"([[VAR_10_]]) {saturate = 1 : si64, to = i64} : (tensor<f32>) -> tensor<i64>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.Min"([[VAR_1_]], [[VAR_1_]]1) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK:           [[VAR_13_:%.+]]:4 = "onnx.Loop"([[VAR_12_]], [[VAR_2_]], [[VAR_3_]], [[PARAM_1_]], [[PARAM_0_]]) ({
+// CHECK:           ^bb0([[arg2_:%.+]]: tensor<i64>, [[arg3_:%.+]]: tensor<i1>, [[arg4_:%.+]]: tensor<i32>, [[arg5_:%.+]]: tensor<i32>, [[arg6_:%.+]]: tensor<?x30xf32>):
+// CHECK-DAG:         [[VAR_14_:%.+]] = "onnx.Add"([[arg4_]], [[VAR_0_]]) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+// CHECK-DAG:         [[VAR_15_:%.+]] = "onnx.Relu"([[arg6_]]) : (tensor<?x30xf32>) -> tensor<?x30xf32>
+// CHECK:             onnx.Yield [[arg3_]], [[VAR_14_]], [[arg5_]], [[VAR_15_]] : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
+// CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
+// CHECK:           onnx.Return [[VAR_13_]]#3 : tensor<?x?x30xf32>
+
+}

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -1597,6 +1597,20 @@ func.func private @test_squeezev11_empty_axes(%arg0 : tensor<16x1x32x1x64xf32>) 
 
 // -----
 
+func.func private @test_squeeze_dyn_dimension_empty_axes_only_known_ones(%arg0 : tensor<1x?x1xf32>) -> tensor<*xf32> {
+  %cst = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none
+  %0 = "onnx.Squeeze"(%arg0, %cst) : (tensor<1x?x1xf32>, none) -> (tensor<*xf32>)
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+
+// CHECK-LABEL: test_squeeze_dyn_dimension_empty_axes_only_known_ones
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x?x1xf32>) -> tensor<?xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Squeeze"([[PARAM_0_]], [[VAR_0_]]) : (tensor<1x?x1xf32>, tensor<2xi64>) -> tensor<?xf32>
+// CHECK:           return [[VAR_1_]] : tensor<?xf32>
+}
+
+// -----
+
 func.func @test_unsqueeze(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[1]> : tensor<1xi64>
   %1 = "onnx.Unsqueeze"(%arg0, %0) : (tensor<16x32x64xf32>, tensor<1xi64>) -> (tensor<*xf32>)

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -1595,18 +1595,30 @@ func.func private @test_squeezev11_empty_axes(%arg0 : tensor<16x1x32x1x64xf32>) 
   // CHECK: onnx.Return [[RES]] : tensor<16x32x64xf32>
 }
 
+
 // -----
 
-func.func private @test_squeeze_dyn_dimension_empty_axes_only_known_ones(%arg0 : tensor<1x?x1xf32>) -> tensor<*xf32> {
+func.func @test_squeeze_dyn_dimension_empty_axes_diff_known_dims2(%arg0 : tensor<1x?x1x?xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none
-  %0 = "onnx.Squeeze"(%arg0, %cst) : (tensor<1x?x1xf32>, none) -> (tensor<*xf32>)
+  %0 = "onnx.Squeeze"(%arg0, %cst) : (tensor<1x?x1x?xf32>, none) -> (tensor<*xf32>)
   "func.return"(%0) : (tensor<*xf32>) -> ()
 
-// CHECK-LABEL: test_squeeze_dyn_dimension_empty_axes_only_known_ones
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x?x1xf32>) -> tensor<?xf32> {
-// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
-// CHECK:           [[VAR_1_:%.+]] = "onnx.Squeeze"([[PARAM_0_]], [[VAR_0_]]) : (tensor<1x?x1xf32>, tensor<2xi64>) -> tensor<?xf32>
-// CHECK:           return [[VAR_1_]] : tensor<?xf32>
+  // CHECK-LABEL: test_squeeze_dyn_dimension_empty_axes_diff_known_dims2
+  // CHECK: [[RES:%.+]] = "onnx.Squeeze"
+  // CHECK-SAME: tensor<*xf32>
+}
+
+
+// -----
+
+func.func @test_squeeze_dyn_dimension_empty_axes_diff_known_dims(%arg0 : tensor<1x?x1x2xf32>) -> tensor<*xf32> {
+  %cst = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none
+  %0 = "onnx.Squeeze"(%arg0, %cst) : (tensor<1x?x1x2xf32>, none) -> (tensor<*xf32>)
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: test_squeeze_dyn_dimension_empty_axes_diff_known_dims
+  // CHECK: [[RES:%.+]] = "onnx.Squeeze"
+  // CHECK-SAME: tensor<*xf32>
 }
 
 // -----

--- a/test/mlir/onnx/onnx_shape_inference_error.mlir
+++ b/test/mlir/onnx/onnx_shape_inference_error.mlir
@@ -56,9 +56,7 @@ func.func @test_reshape_2D_shape(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<1x
 
 func.func @test_lstm_not_3D_input(%arg0: tensor<4x3xf32>, %arg1: tensor<1x12x2xf32>, %arg2: tensor<1x12x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
-  // expected-error @+3 {{The first input tensor must have rank 3}}
-  // expected-error @+2 {{Failed to scan parameters successfully}}
-  // expected-error @+1 {{shape inference failed}}
+  // expected-error @+1 {{The first input tensor must have rank 3}}
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
   onnx.Return %Y_h : tensor<*xf32>
 }
@@ -67,9 +65,7 @@ func.func @test_lstm_not_3D_input(%arg0: tensor<4x3xf32>, %arg1: tensor<1x12x2xf
 
 func.func @test_lstm_not_3D_weight(%arg0: tensor<4x3x2xf32>, %arg1: tensor<12x2xf32>, %arg2: tensor<1x12x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
-  // expected-error @+3 {{The second input tensor must have rank 3}}
-  // expected-error @+2 {{Failed to scan parameters successfully}}
-  // expected-error @+1 {{shape inference failed}}
+  // expected-error @+1 {{The second input tensor must have rank 3}}
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
   onnx.Return %Y_h : tensor<*xf32>
 }
@@ -78,9 +74,7 @@ func.func @test_lstm_not_3D_weight(%arg0: tensor<4x3x2xf32>, %arg1: tensor<12x2x
 
 func.func @test_lstm_not_3D_recurrent(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x12x2xf32>, %arg2: tensor<12x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
-  // expected-error @+3 {{The third input tensor must have rank 3}}
-  // expected-error @+2 {{Failed to scan parameters successfully}}
-  // expected-error @+1 {{shape inference failed}}
+  // expected-error @+1 {{The third input tensor must have rank 3}}
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
   onnx.Return %Y_h : tensor<*xf32>
 }
@@ -89,9 +83,7 @@ func.func @test_lstm_not_3D_recurrent(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x
 
 func.func @test_lstm_wrong_direction(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x12x2xf32>, %arg2: tensor<1x12x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
-  // expected-error @+3 {{direction attribute must be one of the strings: forward, reverse, and bidirectional}}
-  // expected-error @+2 {{Failed to scan parameters successfully}}
-  // expected-error @+1 {{shape inference failed}}
+  // expected-error @+1 {{direction attribute must be one of the strings: forward, reverse, and bidirectional}}
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64, direction="forwadr"} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
   onnx.Return %Y_h : tensor<*xf32>
 }
@@ -114,26 +106,4 @@ func.func @test_category_mapper_diff_size_attrs (%arg0: tensor<20x1xi32>) -> ten
   // expected-error @+1 {{'onnx.CategoryMapper' op operand #0 must be tensor of string type values or tensor of 64-bit signless integer values, but got 'tensor<20x1xi32>'}}      
   %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1], cats_strings = ["cat"]} : (tensor<20x1xi32>) -> tensor<*x!onnx.String>
   "onnx.Return"(%0) : (tensor<*x!onnx.String>) -> ()
-}
-
-// -----
-
-func.func @test_squeeze_dyn_dimension_empty_axes_diff_known_dims2(%arg0 : tensor<1x?x1x?xf32>) -> tensor<*xf32> {
-  %cst = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none
-  // expected-error @+3 {{Can not squeeze multiple dynamic dimensions at this time}}
-  // expected-error @+2 {{Failed to scan parameters successfully}}
-  // expected-error @+1 {{shape inference failed}}
-  %0 = "onnx.Squeeze"(%arg0, %cst) : (tensor<1x?x1x?xf32>, none) -> (tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
-}
-
-// -----
-
-func.func @test_squeeze_dyn_dimension_empty_axes_diff_known_dims(%arg0 : tensor<1x?x1x2xf32>) -> tensor<*xf32> {
-  %cst = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none
-  // expected-error @+3 {{Can only squeeze single dynamic dimension when others are one.}}
-  // expected-error @+2 {{Failed to scan parameters successfully}}
-  // expected-error @+1 {{shape inference failed}}
-  %0 = "onnx.Squeeze"(%arg0, %cst) : (tensor<1x?x1x2xf32>, none) -> (tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
 }

--- a/test/mlir/onnx/onnx_shape_inference_error.mlir
+++ b/test/mlir/onnx/onnx_shape_inference_error.mlir
@@ -117,3 +117,23 @@ func.func @test_category_mapper_diff_size_attrs (%arg0: tensor<20x1xi32>) -> ten
 }
 
 // -----
+
+func.func @test_squeeze_dyn_dimension_empty_axes_diff_known_dims2(%arg0 : tensor<1x?x1x?xf32>) -> tensor<*xf32> {
+  %cst = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none
+  // expected-error @+3 {{Can not squeeze multiple dynamic dimensions at this time}}
+  // expected-error @+2 {{Failed to scan parameters successfully}}
+  // expected-error @+1 {{shape inference failed}}
+  %0 = "onnx.Squeeze"(%arg0, %cst) : (tensor<1x?x1x?xf32>, none) -> (tensor<*xf32>)
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+}
+
+// -----
+
+func.func @test_squeeze_dyn_dimension_empty_axes_diff_known_dims(%arg0 : tensor<1x?x1x2xf32>) -> tensor<*xf32> {
+  %cst = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none
+  // expected-error @+3 {{Can only squeeze single dynamic dimension when others are one.}}
+  // expected-error @+2 {{Failed to scan parameters successfully}}
+  // expected-error @+1 {{shape inference failed}}
+  %0 = "onnx.Squeeze"(%arg0, %cst) : (tensor<1x?x1x2xf32>, none) -> (tensor<*xf32>)
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+}


### PR DESCRIPTION
As a reminder, `If axes is not provided, all the single dimensions will be removed from the shape.`.
THis PR also decouples shape inference for Squeeze from folding, and I had to make changes on the tests to cope with that: changing some LIT tests to get the right shapes inferred, and separated some other tests that were failing or giving wrong shape inference.