### PR TITLE
[FXML-4790] Simplify some gathers to slices

### DIFF
--- a/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
@@ -42,15 +42,34 @@ public:
 
     auto result = op.getResult();
 
-    auto inputType = input.getType();
+    auto inputType = dyn_cast<TensorType>(input.getType());
     if (!onnx_mlir::isRankedShapedType(inputType))
       return rewriter.notifyMatchFailure(op, "input is not a ranked tensor");
+    auto resultTy = dyn_cast<TensorType>(op.getType());
+    if (!onnx_mlir::isRankedShapedType(resultTy))
+      return rewriter.notifyMatchFailure(op, "result is not a ranked tensor");
     int64_t inputRank = onnx_mlir::getRank(inputType);
 
     // onnx allows values beetween [-r, r-1] where r is the rank
     axis = tosa::convertNegativeAxis(axis, inputRank);
 
     auto indicesType = indices.getType().cast<ShapedType>();
+
+    APInt indicesVal;
+    /*std::cout << "indicesType.getRank():"<< indicesType.getRank() 
+    << " matchPattern(indices, m_ConstantInt(&indicesVal):" << matchPattern(indices, m_ConstantInt(&indicesVal))
+    << " indicesVal.getSExtValue():" << indicesVal.getSExtValue() << "\n";*/
+    if(indicesType.getRank() == 0 && matchPattern(indices, m_ConstantInt(&indicesVal)) && indicesVal.getSExtValue() >= 0) {
+      llvm::SmallVector<int64_t, 4> starts(inputType.getRank(), 0);
+      llvm::SmallVector<int64_t, 4> size{inputType.getShape()};
+      starts[axis] = indicesVal.getSExtValue();
+      size[axis] = 1;
+      Value sliceOp = tosaBuilder.slice(input, size, starts);
+      auto reshape = tosaBuilder.reshape(sliceOp, resultTy.getShape());
+      rewriter.replaceOp(op, reshape);
+      return success();
+    }
+
     SmallVector<int32_t, 4> newIndicesValues;
     newIndicesValues.resize(indicesType.getNumElements());
 

--- a/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
@@ -56,10 +56,9 @@ public:
     auto indicesType = indices.getType().cast<ShapedType>();
 
     APInt indicesVal;
-    /*std::cout << "indicesType.getRank():"<< indicesType.getRank() 
-    << " matchPattern(indices, m_ConstantInt(&indicesVal):" << matchPattern(indices, m_ConstantInt(&indicesVal))
-    << " indicesVal.getSExtValue():" << indicesVal.getSExtValue() << "\n";*/
-    if(indicesType.getRank() == 0 && matchPattern(indices, m_ConstantInt(&indicesVal)) && indicesVal.getSExtValue() >= 0) {
+    if (indicesType.getRank() == 0 &&
+        matchPattern(indices, m_ConstantInt(&indicesVal)) &&
+        indicesVal.getSExtValue() >= 0) {
       llvm::SmallVector<int64_t, 4> starts(inputType.getRank(), 0);
       llvm::SmallVector<int64_t, 4> size{inputType.getShape()};
       starts[axis] = indicesVal.getSExtValue();

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
@@ -129,3 +129,30 @@ func.func @test_gather_dynamic_indices_i32(%arg0 : tensor<3x3xf32>, %indices: te
 // CHECK:           %[[VAL_16:.*]] = tosa.transpose %[[VAL_14]], %[[VAL_15]] : (tensor<1x2x3xf32>, tensor<3xi32>) -> tensor<3x1x2xf32>
 // CHECK:           return %[[VAL_16]] : tensor<3x1x2xf32>
 }
+
+// -----
+
+func.func @test_gather_like_slice(%arg0 : tensor<3x3xf32>) -> tensor<3xf32> {
+  %indices = onnx.Constant dense<0> : tensor<i64>
+  %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
+  "func.return"(%0) : (tensor<3xf32>) -> ()
+// CHECK-LABEL:   func.func @test_gather_like_slice(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: tensor<3x3xf32>) -> tensor<3x1x2xf32> {
+// CHECK:           %[[VAL_1:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 2]]> : tensor<1x2xi64>}> : () -> tensor<1x2xi64>
+// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK:           %[[VAL_3:.*]] = tosa.add %[[VAL_1]], %[[VAL_2]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi64>
+// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK:           %[[VAL_5:.*]] = tosa.greater_equal %[[VAL_1]], %[[VAL_4]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi1>
+// CHECK:           %[[VAL_6:.*]] = tosa.select %[[VAL_5]], %[[VAL_1]], %[[VAL_3]] : (tensor<1x2xi1>, tensor<1x2xi64>, tensor<1x2xi64>) -> tensor<1x2xi64>
+// CHECK:           %[[VAL_7:.*]] = tosa.cast %[[VAL_6]] : (tensor<1x2xi64>) -> tensor<1x2xi32>
+// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}> : () -> tensor<2xi32>
+// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_8]] : (tensor<3x3xf32>, tensor<2xi32>) -> tensor<3x3xf32>
+// CHECK:           %[[VAL_10:.*]] = tosa.reshape %[[VAL_9]] {new_shape = array<i64: 1, 3, 3>} : (tensor<3x3xf32>) -> tensor<1x3x3xf32>
+// CHECK:           %[[VAL_11:.*]] = tosa.reshape %[[VAL_7]] {new_shape = array<i64: 1, 2>} : (tensor<1x2xi32>) -> tensor<1x2xi32>
+// CHECK:           %[[VAL_12:.*]] = tosa.gather %[[VAL_10]], %[[VAL_11]] : (tensor<1x3x3xf32>, tensor<1x2xi32>) -> tensor<1x2x3xf32>
+// CHECK:           %[[VAL_13:.*]] = tosa.reshape %[[VAL_12]] {new_shape = array<i64: 1, 2, 3>} : (tensor<1x2x3xf32>) -> tensor<1x2x3xf32>
+// CHECK:           %[[VAL_14:.*]] = "tosa.const"() <{value = dense<[2, 0, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK:           %[[VAL_15:.*]] = tosa.transpose %[[VAL_13]], %[[VAL_14]] : (tensor<1x2x3xf32>, tensor<3xi32>) -> tensor<3x1x2xf32>
+// CHECK:           return %[[VAL_15]] : tensor<3x1x2xf32>
+// CHECK:         }
+}

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
@@ -136,23 +136,22 @@ func.func @test_gather_like_slice(%arg0 : tensor<3x3xf32>) -> tensor<3xf32> {
   %indices = onnx.Constant dense<0> : tensor<i64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
   "func.return"(%0) : (tensor<3xf32>) -> ()
-// CHECK-LABEL:   func.func @test_gather_like_slice(
-// CHECK-SAME:                                 %[[VAL_0:.*]]: tensor<3x3xf32>) -> tensor<3x1x2xf32> {
-// CHECK:           %[[VAL_1:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 2]]> : tensor<1x2xi64>}> : () -> tensor<1x2xi64>
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_3:.*]] = tosa.add %[[VAL_1]], %[[VAL_2]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi64>
-// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_5:.*]] = tosa.greater_equal %[[VAL_1]], %[[VAL_4]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi1>
-// CHECK:           %[[VAL_6:.*]] = tosa.select %[[VAL_5]], %[[VAL_1]], %[[VAL_3]] : (tensor<1x2xi1>, tensor<1x2xi64>, tensor<1x2xi64>) -> tensor<1x2xi64>
-// CHECK:           %[[VAL_7:.*]] = tosa.cast %[[VAL_6]] : (tensor<1x2xi64>) -> tensor<1x2xi32>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}> : () -> tensor<2xi32>
-// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_8]] : (tensor<3x3xf32>, tensor<2xi32>) -> tensor<3x3xf32>
-// CHECK:           %[[VAL_10:.*]] = tosa.reshape %[[VAL_9]] {new_shape = array<i64: 1, 3, 3>} : (tensor<3x3xf32>) -> tensor<1x3x3xf32>
-// CHECK:           %[[VAL_11:.*]] = tosa.reshape %[[VAL_7]] {new_shape = array<i64: 1, 2>} : (tensor<1x2xi32>) -> tensor<1x2xi32>
-// CHECK:           %[[VAL_12:.*]] = tosa.gather %[[VAL_10]], %[[VAL_11]] : (tensor<1x3x3xf32>, tensor<1x2xi32>) -> tensor<1x2x3xf32>
-// CHECK:           %[[VAL_13:.*]] = tosa.reshape %[[VAL_12]] {new_shape = array<i64: 1, 2, 3>} : (tensor<1x2x3xf32>) -> tensor<1x2x3xf32>
-// CHECK:           %[[VAL_14:.*]] = "tosa.const"() <{value = dense<[2, 0, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
-// CHECK:           %[[VAL_15:.*]] = tosa.transpose %[[VAL_13]], %[[VAL_14]] : (tensor<1x2x3xf32>, tensor<3xi32>) -> tensor<3x1x2xf32>
-// CHECK:           return %[[VAL_15]] : tensor<3x1x2xf32>
-// CHECK:         }
+// CHECK-LABEL:   test_gather_like_slice
+// CHECK-SAME:    (%[[ARG:.*]]: tensor<3x3xf32>)
+// CHECK:         %[[VAL_1:.*]] = tosa.slice %[[ARG]] {size = array<i64: 3, 1>, start = array<i64: 0, 0>} : (tensor<3x3xf32>) -> tensor<3x1xf32>
+// CHECK:         %[[VAL_2:.*]] = tosa.reshape %[[VAL_1]] {{.*}} -> tensor<3xf32>
+// CHECK:         return %[[VAL_2]]
+}
+
+// -----
+
+func.func @test_gather_like_slice_non_zero(%arg0 : tensor<3x3xf32>) -> tensor<3xf32> {
+  %indices = onnx.Constant dense<2> : tensor<i64>
+  %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
+  "func.return"(%0) : (tensor<3xf32>) -> ()
+// CHECK-LABEL:   test_gather_like_slice
+// CHECK-SAME:    (%[[ARG:.*]]: tensor<3x3xf32>)
+// CHECK:         %[[VAL_1:.*]] = tosa.slice %[[ARG]] {size = array<i64: 1, 3>, start = array<i64: 2, 0>} : (tensor<3x3xf32>) -> tensor<1x3xf32>
+// CHECK:         %[[VAL_2:.*]] = tosa.reshape %[[VAL_1]] {{.*}} -> tensor<3xf32>
+// CHECK:         return %[[VAL_2]]
 }


### PR DESCRIPTION
This simplifies the special case where you gather one specific row/column/..., i.e., effectively dropping everything else in a dimension (making it redundant/1). Since a slice in TOSA is rank-preserving, we generate it with the 1-dimension, and add a reshape afterwards to get rid of it. See the added tests for examples.