### PR TITLE
Fix QuantizeLinear for two cases

### DIFF
--- a/src/Conversion/ONNXToTOSA/NN/QuantizeLinear.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/QuantizeLinear.cpp
@@ -43,13 +43,13 @@ public:
     }
 
     if (auto zpTy = dyn_cast<ShapedType>(adaptor.getYZeroPoint().getType());
-        !zpTy.hasStaticShape()) {
+        zpTy && !zpTy.hasStaticShape()) {
       return rewriter.notifyMatchFailure(
           loc, "expected zero point to have static shape");
     }
 
     if (auto zpTy = dyn_cast<ShapedType>(adaptor.getYScale().getType());
-        !zpTy.hasStaticShape()) {
+        zpTy && !zpTy.hasStaticShape()) {
       return rewriter.notifyMatchFailure(
           loc, "expected scale to have static shape");
     }
@@ -68,39 +68,75 @@ public:
     if (axis < 0)
       axis += resultType.getRank();
 
-    // Since tosa.add and tosa.mul don't allow different ranks, get the value
-    // from the constants, and create a new constant of the same rank as the
-    // input out of it in order to have a correct add and mul.
-    auto zpConst = tosa::expandShape(
-        rewriter, loc, adaptor.getYZeroPoint(), axis, resultType.getRank());
-    auto scaleFactorConst = tosa::expandShape(
-        rewriter, loc, adaptor.getYScale(), axis, resultType.getRank());
-
     Value x = adaptor.getX();
     Type xType = x.getType();
 
-    // Quantization formula is ((x / y_scale) + y_zero_point)
+    // Quantization formula is saturate((x / y_scale) + y_zero_point)
+    // tosa.mul doesn't allow different ranks
+    auto expandedScaleFactorConst = tosa::expandShape(
+        rewriter, loc, adaptor.getYScale(), axis, resultType.getRank());
     // Replace the division by a reciprocal followed by a mul
-    Value recOp = tosa::CreateOpAndInfer<mlir::tosa::ReciprocalOp>(
-        rewriter, loc, scaleFactorConst.getType(), scaleFactorConst)
+    Value recOp = tosa::CreateOpAndInfer<mlir::tosa::ReciprocalOp>(rewriter,
+        loc, expandedScaleFactorConst.getType(), expandedScaleFactorConst)
                       .getResult();
-    Value mulOp = tosa::CreateOpAndInfer<mlir::tosa::MulOp>(
+    Value scaledResult = tosa::CreateOpAndInfer<mlir::tosa::MulOp>(
         rewriter, loc, xType, x, recOp, 0)
-                      .getResult();
-    // zpConst has the same type as the result of QLinear which is always
-    // smaller than the input type. Cast it to the input type.
-    Value castZp = tosa::CreateOpAndInfer<mlir::tosa::CastOp>(
-        rewriter, loc, scaleFactorConst.getType(), zpConst)
-                       .getResult();
+                             .getResult();
+
+    Value expandedZpConst;
+    if (isa<ShapedType>(adaptor.getYZeroPoint().getType())) {
+      expandedZpConst = tosa::expandShape(
+          rewriter, loc, adaptor.getYZeroPoint(), axis, resultType.getRank());
+    }
+
+    // Quantization to i4//i8/16/ is particular since the intermediate result of
+    // (x / y_scale) must round to the nearest even. This is particularly
+    // important if the intermediate result is e.g. 8.5. If we don't round to
+    // the nearest even and add 1, we would end up with 10 instead of 9.
+    bool quantizingToInt = isa<IntegerType>(resultType.getElementType());
+    if (quantizingToInt) {
+      // Convert the scaled result to a safe bitwith (i32) that avoids
+      // underflows/overflows
+      scaledResult = tosa::CreateOpAndInfer<mlir::tosa::CastOp>(rewriter, loc,
+          resultType.cloneWith({}, rewriter.getI32Type()), scaledResult)
+                         .getResult();
+    }
+
+    // If there is no zero point, we are done
+    if (!expandedZpConst) {
+      Value result = tosa::CreateOpAndInfer<mlir::tosa::CastOp>(
+          rewriter, loc, resultType, scaledResult)
+                         .getResult();
+      rewriter.replaceOp(op, result);
+      return success();
+    }
+
+    // Cast the expandedZpConst to have the same rank and element type as
+    // the scaledResult. tosa.add doesn't allow different ranks
+    Value castedZp;
+    if (quantizingToInt) {
+      castedZp = tosa::CreateOpAndInfer<mlir::tosa::CastOp>(rewriter, loc,
+          cast<ShapedType>(expandedZpConst.getType())
+              .cloneWith({}, rewriter.getI32Type()),
+          expandedZpConst)
+                     .getResult();
+    } else {
+      // zpConst has the same type as the result of QLinear which is always
+      // smaller than the input type. Cast it to the input type.
+      castedZp = tosa::CreateOpAndInfer<mlir::tosa::CastOp>(
+          rewriter, loc, expandedScaleFactorConst.getType(), expandedZpConst)
+                     .getResult();
+    }
+
     Value addOp = tosa::CreateOpAndInfer<mlir::tosa::AddOp>(
-        rewriter, loc, xType, mulOp, castZp)
+        rewriter, loc, scaledResult.getType(), scaledResult, castedZp)
                       .getResult();
     // Cast into the result type
-    Value castOp = tosa::CreateOpAndInfer<mlir::tosa::CastOp>(
+    Value result = tosa::CreateOpAndInfer<mlir::tosa::CastOp>(
         rewriter, loc, resultType, addOp)
                        .getResult();
 
-    rewriter.replaceOp(op, castOp);
+    rewriter.replaceOp(op, result);
     return success();
   }
 };

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
@@ -63,7 +63,7 @@ mlir::Value expandShape(mlir::PatternRewriter &rewriter, mlir::Location loc,
 // op. This allows shape inference during the framework to TOSA lowering.
 template <typename TosaOp, typename... Args>
 TosaOp CreateOpAndInfer(mlir::PatternRewriter &rewriter, mlir::Location loc,
-    mlir::Type result_ty, Args &&... args) {
+    mlir::Type result_ty, Args &&...args) {
   auto op = rewriter.create<TosaOp>(loc, result_ty, args...);
 
   mlir::InferShapedTypeOpInterface shapeInterface =
@@ -92,7 +92,7 @@ TosaOp CreateOpAndInfer(mlir::PatternRewriter &rewriter, mlir::Location loc,
 
 template <typename TosaOp, typename... Args>
 void CreateReplaceOpAndInfer(mlir::PatternRewriter &rewriter,
-    mlir::Operation *op, mlir::Type result_ty, Args &&... args) {
+    mlir::Operation *op, mlir::Type result_ty, Args &&...args) {
   auto result =
       CreateOpAndInfer<TosaOp>(rewriter, op->getLoc(), result_ty, args...);
   rewriter.replaceOp(op, result->getResults());

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
@@ -63,7 +63,7 @@ mlir::Value expandShape(mlir::PatternRewriter &rewriter, mlir::Location loc,
 // op. This allows shape inference during the framework to TOSA lowering.
 template <typename TosaOp, typename... Args>
 TosaOp CreateOpAndInfer(mlir::PatternRewriter &rewriter, mlir::Location loc,
-    mlir::Type result_ty, Args &&...args) {
+    mlir::Type result_ty, Args &&... args) {
   auto op = rewriter.create<TosaOp>(loc, result_ty, args...);
 
   mlir::InferShapedTypeOpInterface shapeInterface =
@@ -92,7 +92,7 @@ TosaOp CreateOpAndInfer(mlir::PatternRewriter &rewriter, mlir::Location loc,
 
 template <typename TosaOp, typename... Args>
 void CreateReplaceOpAndInfer(mlir::PatternRewriter &rewriter,
-    mlir::Operation *op, mlir::Type result_ty, Args &&...args) {
+    mlir::Operation *op, mlir::Type result_ty, Args &&... args) {
   auto result =
       CreateOpAndInfer<TosaOp>(rewriter, op->getLoc(), result_ty, args...);
   rewriter.replaceOp(op, result->getResults());

--- a/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
@@ -51,8 +51,8 @@ func.func @test_quantizeLinear_per_axis(%arg0: tensor<8x2xf32>) -> tensor<8x2xi8
 // CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<{{\[\[}}1.000000e+00, 2.000000e+00]]> : tensor<1x2xf32>}> : () -> tensor<1x2xf32>
 // CHECK:           %[[REC:.*]] = tosa.reciprocal %[[VAL_2]] : (tensor<1x2xf32>) -> tensor<1x2xf32>
 // CHECK:           %[[MUL:.*]] = tosa.mul %[[VAL_0]], %[[REC]] {shift = 0 : i8} : (tensor<8x2xf32>, tensor<1x2xf32>) -> tensor<8x2xf32>
-// CHECK:           %[[ZP:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 1]]> : tensor<1x2xi8>}> : () -> tensor<1x2xi8>
 // CHECK:           %[[MUL_CAST:.*]] = tosa.cast %[[MUL]] : (tensor<8x2xf32>) -> tensor<8x2xi32>
+// CHECK:           %[[ZP:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 1]]> : tensor<1x2xi8>}> : () -> tensor<1x2xi8>
 // CHECK:           %[[ZPCAST:.*]] = tosa.cast %[[ZP]] : (tensor<1x2xi8>) -> tensor<1x2xi32>
 // CHECK:           %[[ADD:.*]] = tosa.add %[[MUL_CAST]], %[[ZPCAST]] : (tensor<8x2xi32>, tensor<1x2xi32>) -> tensor<8x2xi32>
 // CHECK:           %[[CAST:.*]] = tosa.cast %[[ADD]] : (tensor<8x2xi32>) -> tensor<8x2xi8>

--- a/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
@@ -12,10 +12,29 @@ func.func @test_quantizeLinear(%arg0 : tensor<32x3x224x224xf32>) -> tensor<32x3x
 // CHECK-DAG:    %[[SCALE:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
 // CHECK-DAG:    %[[REC:.*]] = tosa.reciprocal %[[SCALE]] : (tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
 // CHECK-DAG:    %[[MUL:.*]] = tosa.mul %[[ARG_0]], %[[REC]] {shift = 0 : i8} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
-// CHECK-DAG:    %[[ZPCAST:.*]] = tosa.cast %[[ZP]] : (tensor<1x1x1x1xi8>) -> tensor<1x1x1x1xf32>
-// CHECK-DAG:    %[[ADD:.*]] = tosa.add %3, %[[ZPCAST]] : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
-// CHECK-DAG:    %[[CAST:.*]]  = tosa.cast %[[ADD]] : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi8>
+// CHECK-DAG:    %[[MUL_CAST:.*]] = tosa.cast %[[MUL]] : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi32>
+// CHECK-DAG:    %[[ZPCAST:.*]] = tosa.cast %[[ZP]] : (tensor<1x1x1x1xi8>) -> tensor<1x1x1x1xi32>
+// CHECK-DAG:    %[[ADD:.*]] = tosa.add %[[MUL_CAST]], %[[ZPCAST]] : (tensor<32x3x224x224xi32>, tensor<1x1x1x1xi32>) -> tensor<32x3x224x224xi32>
+// CHECK-DAG:    %[[CAST:.*]]  = tosa.cast %[[ADD]] : (tensor<32x3x224x224xi32>) -> tensor<32x3x224x224xi8>
 // CHECK-DAG:    return %[[CAST]] : tensor<32x3x224x224xi8>
+
+// -----
+
+func.func @test_quantizeLinear_none(%arg0 : tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi8> {
+  %0 = onnx.Constant dense<3.125000e-02> : tensor<f32>                       
+  %1 = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none                              
+  %2 = "onnx.QuantizeLinear"(%arg0, %0, %1) {axis = 1 : si64} : (tensor<32x3x224x224xf32>, tensor<f32>, none) -> tensor<32x3x224x224xi8>
+  "func.return"(%2) : (tensor<32x3x224x224xi8>) -> ()
+}
+
+// CHECK-LABEL: @test_quantizeLinear_none
+// CHECK-SAME:    (%[[ARG_0:.*]]: tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xui8>
+// CHECK-DAG:   %[[SCALE:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK-DAG:   %[[REC:.*]] = tosa.reciprocal %[[SCALE]] : (tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:   %[[MUL:.*]] = tosa.mul %[[ARG_0]], %[[REC]] {shift = 0 : i8} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
+// CHECK-DAG:   %[[MUL_CAST:.*]] = tosa.cast %[[MUL]] : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi32>
+// CHECK-DAG:   %[[CAST:.*]] = tosa.cast %[[MUL_CAST]] : (tensor<32x3x224x224xi32>) -> tensor<32x3x224x224xui8>
+// CHECK-DAG:   return %[[CAST]] : tensor<32x3x224x224xui8>
 
 // -----
 
@@ -29,13 +48,14 @@ func.func @test_quantizeLinear_per_axis(%arg0: tensor<8x2xf32>) -> tensor<8x2xi8
 }
 // CHECK-LABEL:   func.func @test_quantizeLinear_per_axis(
 // CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<8x2xf32>) -> tensor<8x2xi8> {
-// CHECK:           %[[VAL_1:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 1]]> : tensor<1x2xi8>}> : () -> tensor<1x2xi8>
 // CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<{{\[\[}}1.000000e+00, 2.000000e+00]]> : tensor<1x2xf32>}> : () -> tensor<1x2xf32>
 // CHECK:           %[[REC:.*]] = tosa.reciprocal %[[VAL_2]] : (tensor<1x2xf32>) -> tensor<1x2xf32>
 // CHECK:           %[[MUL:.*]] = tosa.mul %[[VAL_0]], %[[REC]] {shift = 0 : i8} : (tensor<8x2xf32>, tensor<1x2xf32>) -> tensor<8x2xf32>
-// CHECK:           %[[ZPCAST:.*]] = tosa.cast %[[VAL_1]] : (tensor<1x2xi8>) -> tensor<1x2xf32>
-// CHECK:           %[[ADD:.*]] = tosa.add %[[MUL]], %[[ZPCAST]] : (tensor<8x2xf32>, tensor<1x2xf32>) -> tensor<8x2xf32>
-// CHECK:           %[[CAST:.*]] = tosa.cast %[[ADD]] : (tensor<8x2xf32>) -> tensor<8x2xi8>
+// CHECK:           %[[ZP:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 1]]> : tensor<1x2xi8>}> : () -> tensor<1x2xi8>
+// CHECK:           %[[MUL_CAST:.*]] = tosa.cast %[[MUL]] : (tensor<8x2xf32>) -> tensor<8x2xi32>
+// CHECK:           %[[ZPCAST:.*]] = tosa.cast %[[ZP]] : (tensor<1x2xi8>) -> tensor<1x2xi32>
+// CHECK:           %[[ADD:.*]] = tosa.add %[[MUL_CAST]], %[[ZPCAST]] : (tensor<8x2xi32>, tensor<1x2xi32>) -> tensor<8x2xi32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[ADD]] : (tensor<8x2xi32>) -> tensor<8x2xi8>
 // CHECK:           return %[[CAST]] : tensor<8x2xi8>
 // CHECK:         }
 


### PR DESCRIPTION
- If the zero point is of NoneType avoid doing the add
- If the resulting type is integer the intermediate computation needs to be rounded before adding the zero point