### PR TITLE
[FXML-4819] Clamp QuantizeLinear to integers

### DIFF
--- a/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
@@ -15,7 +15,8 @@ func.func @test_quantizeLinear(%arg0 : tensor<32x3x224x224xf32>) -> tensor<32x3x
 // CHECK-DAG:    %[[MUL_CAST:.*]] = tosa.cast %[[MUL]] : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi32>
 // CHECK-DAG:    %[[ZPCAST:.*]] = tosa.cast %[[ZP]] : (tensor<1x1x1x1xi8>) -> tensor<1x1x1x1xi32>
 // CHECK-DAG:    %[[ADD:.*]] = tosa.add %[[MUL_CAST]], %[[ZPCAST]] : (tensor<32x3x224x224xi32>, tensor<1x1x1x1xi32>) -> tensor<32x3x224x224xi32>
-// CHECK-DAG:    %[[CAST:.*]]  = tosa.cast %[[ADD]] : (tensor<32x3x224x224xi32>) -> tensor<32x3x224x224xi8>
+// CHECK-DAG:    %[[CLAMP:.*]] = tosa.clamp %[[ADD]] {max_fp = 1.270000e+02 : f32, max_int = 127 : i64, min_fp = -1.280000e+02 : f32, min_int = -128 : i64} : (tensor<32x3x224x224xi32>) -> tensor<32x3x224x224xi32>
+// CHECK-DAG:    %[[CAST:.*]]  = tosa.cast %[[CLAMP]] : (tensor<32x3x224x224xi32>) -> tensor<32x3x224x224xi8>
 // CHECK-DAG:    return %[[CAST]] : tensor<32x3x224x224xi8>
 
 // -----
@@ -55,7 +56,8 @@ func.func @test_quantizeLinear_per_axis(%arg0: tensor<8x2xf32>) -> tensor<8x2xi8
 // CHECK:           %[[ZP:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 1]]> : tensor<1x2xi8>}> : () -> tensor<1x2xi8>
 // CHECK:           %[[ZPCAST:.*]] = tosa.cast %[[ZP]] : (tensor<1x2xi8>) -> tensor<1x2xi32>
 // CHECK:           %[[ADD:.*]] = tosa.add %[[MUL_CAST]], %[[ZPCAST]] : (tensor<8x2xi32>, tensor<1x2xi32>) -> tensor<8x2xi32>
-// CHECK:           %[[CAST:.*]] = tosa.cast %[[ADD]] : (tensor<8x2xi32>) -> tensor<8x2xi8>
+// CHECK:           %[[CLAMP:.*]] = tosa.clamp %[[ADD]] {max_fp = 1.270000e+02 : f32, max_int = 127 : i64, min_fp = -1.280000e+02 : f32, min_int = -128 : i64} : (tensor<8x2xi32>) -> tensor<8x2xi32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[CLAMP]] : (tensor<8x2xi32>) -> tensor<8x2xi8>
 // CHECK:           return %[[CAST]] : tensor<8x2xi8>
 // CHECK:         }
 
@@ -71,6 +73,27 @@ func.func @test_quantizeLinear_negative_axis(%arg0: tensor<8x2xf32>) -> tensor<8
 }
 // CHECK-LABEL: test_quantizeLinear_negative_axis
 // CHECK: "tosa.const"() {{.*}} : tensor<8x1xi8>
+
+// -----
+
+func.func @test_quantizeLinear_ui8(%arg0 : tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xui8> {
+  %0 = onnx.Constant dense<3.125000e-02> : tensor<f32>                       
+  %1 = onnx.Constant dense<0> : tensor<ui8>                                   
+  %2 = "onnx.QuantizeLinear"(%arg0, %0, %1) {axis = 1 : si64} : (tensor<32x3x224x224xf32>, tensor<f32>, tensor<ui8>) -> tensor<32x3x224x224xui8>
+  "func.return"(%2) : (tensor<32x3x224x224xui8>) -> ()
+}
+// CHECK-LABEL:  @test_quantizeLinear_ui8
+// CHECK-SAME: (%[[ARG_0:.*]]: tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xui8>
+// CHECK-DAG:    %[[ZP:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1x1x1xui8>}> : () -> tensor<1x1x1x1xui8>
+// CHECK-DAG:    %[[SCALE:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK-DAG:    %[[REC:.*]] = tosa.reciprocal %[[SCALE]] : (tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:    %[[MUL:.*]] = tosa.mul %[[ARG_0]], %[[REC]] {shift = 0 : i8} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
+// CHECK-DAG:    %[[MUL_CAST:.*]] = tosa.cast %[[MUL]] : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi32>
+// CHECK-DAG:    %[[ZPCAST:.*]] = tosa.cast %[[ZP]] : (tensor<1x1x1x1xui8>) -> tensor<1x1x1x1xi32>
+// CHECK-DAG:    %[[ADD:.*]] = tosa.add %[[MUL_CAST]], %[[ZPCAST]] : (tensor<32x3x224x224xi32>, tensor<1x1x1x1xi32>) -> tensor<32x3x224x224xi32>
+// CHECK-DAG:    %[[CLAMP:.*]] = tosa.clamp %[[ADD]] {max_fp = 2.550000e+02 : f32, max_int = 255 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<32x3x224x224xi32>) -> tensor<32x3x224x224xi32>
+// CHECK-DAG:    %[[CAST:.*]]  = tosa.cast %[[CLAMP]] : (tensor<32x3x224x224xi32>) -> tensor<32x3x224x224xui8>
+// CHECK-DAG:    return %[[CAST]] : tensor<32x3x224x224xui8>
 
 // -----
 


### PR DESCRIPTION
Per ONNX doc:

> The quantization formula is y = saturate((x / y_scale) + y_zero_point).

This commit introduces the saturation for integer types. Computations are performed using 32 bits (wider than all supported integer types), so we can introduce a clamp before the cast to the destination type is performed.