### PR TITLE
Add result type inference for onnx.EyeLike

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -2305,7 +2305,7 @@ def ONNXExpandOp:ONNX_Op<"Expand",
 }
 
 def ONNXEyeLikeOp:ONNX_Op<"EyeLike",
-  [Pure, OpVersionTrait<9>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  [Pure, OpVersionTrait<9>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>, DeclareOpInterfaceMethods<ResultTypeInferenceOpInterface>]> {
   let summary = "ONNX EyeLike operation";
   let description = [{
   Generate a 2D tensor (matrix) with ones on the diagonal and zeros everywhere else. Only 2D
@@ -2330,7 +2330,9 @@ def ONNXEyeLikeOp:ONNX_Op<"EyeLike",
     static std::vector<int> getTypeMap() {
       return {-1};
     }
-  }];
+
+    mlir::Type getResultElementType();
+    }];
   let extraClassDefinition = [{
     onnx_mlir::ONNXOpShapeHelper * $cppClass::getShapeHelper(mlir::Operation *op, llvm::ArrayRef<mlir::Value> oper,
         onnx_mlir::IndexExprBuilder *ieb, onnx_mlir::IndexExprScope *scope) {

--- a/src/Dialect/ONNX/ONNXOps/Tensor/EyeLike.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/EyeLike.cpp
@@ -44,7 +44,7 @@ LogicalResult ONNXEyeLikeOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 Type ONNXEyeLikeOp::getResultElementType() {
-  const auto inputType = getInput().getType().cast<TensorType>();
+  const auto inputType = cast<TensorType>(getInput().getType());
   if (getDtypeAttr()) {
     auto builder = OpBuilder(getContext());
     return convertONNXTypeToMLIRType(builder,
@@ -57,8 +57,7 @@ std::vector<Type> ONNXEyeLikeOp::resultTypeInference() {
   Type elementType = getResultElementType();
   std::vector<Type> resultTypes;
 
-  if (auto rankedInputType =
-          getInput().getType().dyn_cast<RankedTensorType>()) {
+  if (auto rankedInputType = dyn_cast<RankedTensorType>(getInput().getType())) {
     resultTypes.push_back(rankedInputType.clone(elementType));
   } else {
     resultTypes.push_back(UnrankedTensorType::get(elementType));

--- a/src/Dialect/ONNX/ONNXOps/Tensor/EyeLike.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/EyeLike.cpp
@@ -40,6 +40,39 @@ LogicalResult ONNXEyeLikeOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
+// Type Inference
+//===----------------------------------------------------------------------===//
+
+Type ONNXEyeLikeOp::getResultElementType() {
+  const auto inputType = getInput().getType().cast<TensorType>();
+  if (getDtypeAttr()) {
+    auto builder = OpBuilder(getContext());
+    return convertONNXTypeToMLIRType(builder,
+        (onnx::TensorProto_DataType)getDtypeAttr().getValue().getSExtValue());
+  }
+  Type elementType = inputType.getElementType();
+  if (elementType.isa<NoneType>()) {
+    auto builder = OpBuilder(getContext());
+    elementType = convertONNXTypeToMLIRType(
+        builder, onnx::TensorProto_DataType::TensorProto_DataType_FLOAT);
+  }
+  return elementType;
+}
+
+std::vector<Type> ONNXEyeLikeOp::resultTypeInference() {
+  Type elementType = getResultElementType();
+  std::vector<Type> resultTypes;
+
+  if (auto rankedInputType =
+          getInput().getType().dyn_cast<RankedTensorType>()) {
+    resultTypes.push_back(rankedInputType.clone(elementType));
+  } else {
+    resultTypes.push_back(UnrankedTensorType::get(elementType));
+  }
+  return resultTypes;
+}
+
+//===----------------------------------------------------------------------===//
 // Shape Inference
 //===----------------------------------------------------------------------===//
 
@@ -48,16 +81,7 @@ LogicalResult ONNXEyeLikeOp::inferShapes(
   if (!hasShapeAndRank(getInput()))
     return success();
 
-  RankedTensorType inputType = getInput().getType().cast<RankedTensorType>();
-  Type elementType;
-  if (getDtypeAttr()) {
-    auto builder = OpBuilder(getContext());
-    elementType = convertONNXTypeToMLIRType(builder,
-        (onnx::TensorProto_DataType)getDtypeAttr().getValue().getSExtValue());
-  } else {
-    elementType = inputType.getElementType();
-  }
-
+  Type elementType = getResultElementType();
   ONNXEyeLikeOpShapeHelper shapeHelper(getOperation(), {});
   return shapeHelper.computeShapeAndUpdateType(elementType);
 }

--- a/src/Dialect/ONNX/ONNXOps/Tensor/EyeLike.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/EyeLike.cpp
@@ -50,13 +50,7 @@ Type ONNXEyeLikeOp::getResultElementType() {
     return convertONNXTypeToMLIRType(builder,
         (onnx::TensorProto_DataType)getDtypeAttr().getValue().getSExtValue());
   }
-  Type elementType = inputType.getElementType();
-  if (elementType.isa<NoneType>()) {
-    auto builder = OpBuilder(getContext());
-    elementType = convertONNXTypeToMLIRType(
-        builder, onnx::TensorProto_DataType::TensorProto_DataType_FLOAT);
-  }
-  return elementType;
+  return inputType.getElementType();
 }
 
 std::vector<Type> ONNXEyeLikeOp::resultTypeInference() {

--- a/test/mlir/onnx/parse/eyelike.onnxtext
+++ b/test/mlir/onnx/parse/eyelike.onnxtext
@@ -1,0 +1,18 @@
+
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+<
+   ir_version: 4,
+   opset_import: ["" : 9]
+>
+test_eye_like (int64[2] shape) => (float[unknown_x, unknown_y] eye_like)
+{
+   constant_of_shape = ConstantOfShape <value: tensor = float[1] {0}> (shape)
+   eye_like = EyeLike (constant_of_shape)
+}
+
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2xi64>
+// CHECK-SAME:   tensor<?x?xf32>
+// CHECK:           [[VAR_0_:%.+]] = onnx.ConstantOfShape([[PARAM_0_]]) {value = dense<0.000000e+00> : tensor<1xf32>} : (tensor<2xi64>) -> tensor<?x?xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.EyeLike"([[VAR_0_]]) {k = 0 : si64} : (tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<?x?xf32>

--- a/test/mlir/onnx/parse/eyelike.onnxtext
+++ b/test/mlir/onnx/parse/eyelike.onnxtext
@@ -4,15 +4,14 @@
    ir_version: 4,
    opset_import: ["" : 9]
 >
-test_eye_like (int64[2] shape) => (float[unknown_x, unknown_y] eye_like)
+test_eye_like (float[] Mul_lhs, float[unk__a,unk__b] EyeLike_in) => (float[] Mul_res) 
 {
-   constant_of_shape = ConstantOfShape <value: tensor = float[1] {0}> (shape)
-   eye_like = EyeLike (constant_of_shape)
+   EyeLike_out = EyeLike (EyeLike_in)
+   Mul_res = Mul (Mul_lhs, EyeLike_out)
 }
 
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2xi64>
-// CHECK-SAME:   tensor<?x?xf32>
-// CHECK:           [[VAR_0_:%.+]] = onnx.ConstantOfShape([[PARAM_0_]]) {value = dense<0.000000e+00> : tensor<1xf32>} : (tensor<2xi64>) -> tensor<?x?xf32>
-// CHECK:           [[VAR_1_:%.+]] = "onnx.EyeLike"([[VAR_0_]]) {k = 0 : si64} : (tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:           onnx.Return [[VAR_1_]] : tensor<?x?xf32>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32> {onnx.dim_params = "0:unk__a,1:unk__b", onnx.name = "Mul_lhs"}, [[PARAM_1_:%.+]]: tensor<?x?xf32> {onnx.name = "EyeLike_in"}) -> (tensor<*xf32> {onnx.name = "Mul_res"}) {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.EyeLike"([[PARAM_1_]]) {k = 0 : si64} : (tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_0_]]) : (tensor<*xf32>, tensor<?x?xf32>) -> tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<*xf32>

--- a/test/mlir/onnx/parse/eyelike_dtype.onnxtext
+++ b/test/mlir/onnx/parse/eyelike_dtype.onnxtext
@@ -1,0 +1,15 @@
+
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+<
+   ir_version: 4,
+   opset_import: ["" : 9]
+>
+test_eye_like_dtype (float[unk__a,unk__b] EyeLike_in) => (uint16[] EyeLike_out) 
+{
+   EyeLike_out = EyeLike<dtype: int = 4> (EyeLike_in)
+}
+
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xf32> {onnx.dim_params = "0:unk__a,1:unk__b", onnx.name = "EyeLike_in"}) -> (tensor<?x?xui16> {onnx.dim_params = "0:unk__a,1:unk__b", onnx.name = "EyeLike_out"}) {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.EyeLike"([[PARAM_0_]]) {dtype = 4 : si64, k = 0 : si64} : (tensor<?x?xf32>) -> tensor<?x?xui16>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<?x?xui16>

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -447,8 +447,10 @@ OpsWithFolder = ["Constant", "Squeeze", "SqueezeV11"]
 OpsWithConstantLike = ["Constant"]
 
 # Op with Helper functions
-# Here the functions are for data flow analysis.
 OpsWithHelpers = {
+    "EyeLike": """
+    mlir::Type getResultElementType();
+  """,
     "Loop": """
     mlir::Operation::result_range v_final();
     mlir::Operation::result_range scan_outputs();
@@ -468,6 +470,7 @@ OpsWithResultTypeInference = [
     "Constant",
     "Cast",
     "ConstantOfShape",
+    "EyeLike",
     "If",
     "Loop",
     "RandomNormal",


### PR DESCRIPTION
This adds result type inference for onnx.EyeLike

The onnx standard is a bit unclear when it comes to the resulting type of `EyeLike`.
It states:

>  **dtype - INT :**
> 
> (Optional) The data type for the elements of the output tensor. If not specified,the data type of the input tensor T1 is used. If input tensor T1 is also notspecified, then type defaults to ‘float’.

But the input T1 is required, so it is unclear how/why the case that requires a defaulting to 'float' can happen. For this reason I did not add support for the defaulting to 'float'.

Without the changes in this PR, the `EyeLike` in the added test has an output type of  `none`. In a larger model this leads to an error in the verifier, but I was not able to reproduce this in a small test
