### PR TITLE
feat: Constant propagation for ONNXAbsOp and ONNXRoundOp.

### DIFF
--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -455,6 +455,23 @@ struct ElementWiseUnaryOpImpl<ONNXBitwiseNotOp, T, EnableInteger<T>> {
 };
 
 template <typename T>
+struct ElementWiseUnaryOpImpl<ONNXAbsOp, T, EnableNotBool<T>> {
+  static T eval(T val) {
+    if constexpr (std::is_integral_v<T>) {
+      // Cast to int64_t to disambiguate abs if T is signed.
+      // Otherwise, just return the value.
+      if constexpr (std::is_signed_v<T>) {
+        return std::abs(static_cast<int64_t>(val));
+      } else {
+        return val;
+      }
+    } else {
+      return std::fabs(val);
+    };
+  }
+};
+
+template <typename T>
 struct ElementWiseUnaryOpImpl<ONNXCeilOp, T, EnableNotBool<T>> {
   static T eval(T val) { return ceil(val); }
 };
@@ -468,7 +485,6 @@ template <typename T>
 struct ElementWiseUnaryOpImpl<ONNXErfOp, T, EnableNotBool<T>> {
   static T eval(T val) { return std::erf(val); }
 };
-
 template <typename T>
 struct ElementWiseUnaryOpImpl<ONNXExpOp, T, EnableFloatingPoint<T>> {
   static T eval(T val) { return std::exp(val); }
@@ -512,6 +528,22 @@ struct ElementWiseUnaryOpImpl<ONNXReluOp, T, EnableNotBool<T>> {
 template <typename T>
 struct ElementWiseUnaryOpImpl<ONNXReciprocalOp, T, EnableFloatingPoint<T>> {
   static T eval(T val) { return 1 / val; }
+};
+
+template <typename T>
+struct ElementWiseUnaryOpImpl<ONNXRoundOp, T, EnableNotBool<T>> {
+  static T eval(T val) {
+    // OnnxRoundOp implements roundeven.
+    double intPart;
+    double fracPart = std::modf(val, &intPart);
+    if (std::abs(fracPart) == 0.5) {
+      if (static_cast<int>(intPart) % 2 == 0) {
+        return intPart;
+      }
+      return intPart > 0 ? intPart + 1.0 : intPart - 1.0;
+    }
+    return std::round(val);
+  }
 };
 
 template <typename ElementwiseUnaryOp>

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -532,18 +532,7 @@ struct ElementWiseUnaryOpImpl<ONNXReciprocalOp, T, EnableFloatingPoint<T>> {
 
 template <typename T>
 struct ElementWiseUnaryOpImpl<ONNXRoundOp, T, EnableNotBool<T>> {
-  static T eval(T val) {
-    // OnnxRoundOp implements roundeven.
-    double intPart;
-    double fracPart = std::modf(val, &intPart);
-    if (std::abs(fracPart) == 0.5) {
-      if (static_cast<int>(intPart) % 2 == 0) {
-        return intPart;
-      }
-      return intPart > 0 ? intPart + 1.0 : intPart - 1.0;
-    }
-    return std::round(val);
-  }
+  static T eval(T val) { return std::nearbyint(val); }
 };
 
 template <typename ElementwiseUnaryOp>

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -142,6 +142,9 @@ def CreateSubOfTwoConst :
 def CreateCastOfConst :
    NativeCodeCall<"ConstPropCast($_builder, $0, $1, $2, $3)">;
 
+def CreateAbsOfConst :
+   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXAbsOp>($_builder, $0, $1)">;
+
 def CreateBitwiseNotOfConst :
    NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXBitwiseNotOp>($_builder, $0, $1)">;
 
@@ -180,6 +183,9 @@ def CreateReluOfConst :
 
 def CreateReciprocalOfConst :
    NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXReciprocalOp>($_builder, $0, $1)">;
+
+def CreateRoundOfConst :
+   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXRoundOp>($_builder, $0, $1)">;
 
 def CreateMaxOfConst :
    NativeCodeCall<"ConstPropVariadicElementwiseBinary<mlir::ONNXMaxOp>($_builder, $0, $1)">;
@@ -411,6 +417,12 @@ def CastofConst : NamedPat<"CastofConst",
     (CreateCastOfConst $castOp, $input, $saturate, $to),
     [(IsFromDenseONNXConstantOp:$input)]>;
 
+// Constant Propagation for Abs
+def AbsConstProp : NamedPat<"AbsofConst",
+    (ONNXAbsOp:$absOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    (CreateAbsOfConst $absOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
 // Constant Propagation for BitwiseNot
 def BitwiseNotConstProp : NamedPat<"BitwiseNotofConst",
     // From bitwise_not(c).
@@ -497,6 +509,14 @@ def ReciprocalConstProp : NamedPat<"ReciprocalofConst",
     (ONNXReciprocalOp:$reciprocalOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateReciprocalOfConst $reciprocalOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
+// Constant Propagation for Round
+def RoundConstProp : NamedPat<"RoundofConst",
+    // From round(c)
+    (ONNXRoundOp:$roundOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To new_c.
+    (CreateRoundOfConst $roundOp, $input),
     [(IsFromDenseONNXConstantOp:$input)]>;
 
 // Change a subtraction of a constant c by an addition of -c. Helpfull to combine

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -320,6 +320,40 @@ func.func @test_neg_3(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
 
 // -----
 
+// CHECK-LABEL: @test_abs() -> tensor<4x2xbf16>
+func.func @test_abs() -> tensor<4x2xbf16> {
+  // Test Positive, Negative, Zero, -Zero, +Inf, -Inf, NaN, -NaN
+  %0 = onnx.Constant dense<[[12.5, -12.5], [0.0, -0.0], [0x7F80, 0xFF80], [0xFFC0, 0x7FC0]]> : tensor<4x2xbf16>
+  %1 = "onnx.Abs"(%0) : (tensor<4x2xbf16>) -> tensor<4x2xbf16>
+  "onnx.Return"(%1) : (tensor<4x2xbf16>) -> ()
+  // CHECK: onnx.Constant dense<{{.}}[1.250000e+01, 1.250000e+01], [0.000000e+00, 0.000000e+00], [0x7F80, 0x7F80], [0x7FC0, 0x7FC0]]>
+  // CHECK-NOT: "onnx.Abs"
+}
+
+// -----
+
+// CHECK-LABEL: @test_abs2() -> tensor<2x2xi32>
+func.func @test_abs2() -> tensor<2x2xi32> {
+  %0 = onnx.Constant dense<[[12, -12], [0, -1000]]> : tensor<2x2xi32>
+  %1 = "onnx.Abs"(%0) : (tensor<2x2xi32>) -> tensor<2x2xi32>
+  "onnx.Return"(%1) : (tensor<2x2xi32>) -> ()
+  // CHECK: onnx.Constant dense<{{.}}[12, 12], [0, 1000]]>
+  // CHECK-NOT: "onnx.Abs"
+}
+
+// -----
+
+// CHECK-LABEL: @test_abs3() -> tensor<1x2xui64>
+func.func @test_abs3() -> tensor<1x2xui64> {
+  %0 = onnx.Constant dense<[[18446744073709551615, 18446744073709551614]]> : tensor<1x2xui64>
+  %1 = "onnx.Abs"(%0) : (tensor<1x2xui64>) -> tensor<1x2xui64>
+  "onnx.Return"(%1) : (tensor<1x2xui64>) -> ()
+  // CHECK: onnx.Constant dense<{{.}}[18446744073709551615, 18446744073709551614]]>
+  // CHECK-NOT: "onnx.Abs"
+}
+
+// -----
+
 // CHECK-LABEL: @test_ceil() -> tensor<3x2xbf16>
 func.func @test_ceil() -> tensor<3x2xbf16> {
   // Test Positive, Negative, Zero, NaN, +Inf, -Inf
@@ -413,7 +447,18 @@ func.func @test_reciprocal() -> tensor<3x2xbf16> {
   %1 = "onnx.Reciprocal"(%0) : (tensor<3x2xbf16>) -> tensor<3x2xbf16>
   "onnx.Return"(%1) : (tensor<3x2xbf16>) -> ()
   // CHECK: onnx.Constant dense<{{.}}[4.000000e+00, -4.000000e+00], [0x7F80, 0x7FC0], [0.000000e+00, -0.000000e+00]]>
-  // CHECK-NOT: "onnx.Sin"
+  // CHECK-NOT: "onnx.Reciprocal"
+}
+
+// -----
+
+// CHECK-LABEL: @test_round() -> tensor<5x2xbf16>
+func.func @test_round() -> tensor<5x2xbf16> {
+  %0 = onnx.Constant dense<[[0.9, 2.5], [2.3, 1.5], [-4.5, -3.5], [-2.6, 0x7FC0],[0x7F80, 0xFF80]]> : tensor<5x2xbf16>
+  %1 = "onnx.Round"(%0) : (tensor<5x2xbf16>) -> tensor<5x2xbf16>
+  "onnx.Return"(%1) : (tensor<5x2xbf16>) -> ()
+  // CHECK: onnx.Constant dense<{{.}}[1.000000e+00, 2.000000e+00], [2.000000e+00, 2.000000e+00], [-4.000000e+00, -4.000000e+00], [-3.000000e+00, 0x7FC0], [0x7F80, 0xFF80]]>
+  // CHECK-NOT: "onnx.Round"
 }
 
 // -----


### PR DESCRIPTION
`Abs` requires a disambiguation of the `std::abs` function for integer types, otherwise the compiler doesn't know which function to use.
`Round` implements `roundeven`, which isn't part of the C++ std, but only from C23. Therefore, it isn't a one-to-one translation of `std::round`.