### PR TITLE
Fix Expand shape computation when one dim is bigger than its tiling

### DIFF
--- a/src/Conversion/ONNXToTOSA/Tensor/Expand.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Expand.cpp
@@ -151,7 +151,12 @@ private:
       const llvm::ArrayRef<int64_t> &shapeAttr) {
     llvm::SmallVector<int64_t> multipliesArray;
     for (size_t i = 0; i < inputShape.size(); ++i) {
-      multipliesArray.push_back(shapeAttr[i] / inputShape[i]);
+      int tile = shapeAttr[i] / inputShape[i];
+      if (tile == 0) {
+        multipliesArray.push_back(1);
+      } else {
+        multipliesArray.push_back(tile);
+      }
     }
     return DenseI64ArrayAttr::get(op.getContext(), multipliesArray);
   }

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Expand.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Expand.mlir
@@ -75,6 +75,16 @@ func.func @test_expand_no_tile(%arg0: tensor<128x16xf32>) -> tensor<1x1x128x16xf
 // CHECK-NEXT:    return %[[TILE]] : tensor<1x1x128x16xf32>
 
 // -----
+func.func @test_expand_tile_one_dim_big(%arg0: tensor<1x6x1x1xf32>) -> tensor<1x6x576x672xf32> {
+  %0 =  onnx.Constant dense<[1, 1, 576, 672]> : tensor<4xi64> 
+  %1 = "onnx.Expand"(%arg0, %0) {onnx_node_name = "Expand_1417"} : (tensor<1x6x1x1xf32>, tensor<4xi64>) -> tensor<1x6x576x672xf32>
+  return %1 : tensor<1x6x576x672xf32>
+}
+// CHECK-LABEL:  func.func @test_expand_tile_one_dim_big
+// CHECK:         %[[TILE:.*]] = tosa.tile %{{.*}} {multiples = array<i64: 1, 1, 576, 672>} : (tensor<1x6x1x1xf32>) -> tensor<1x6x576x672xf32>
+// CHECK:         return %[[TILE]] : tensor<1x6x576x672xf32>
+
+// -----
 
 func.func @test_expand_no_legalization(%arg0: tensor<1x64x1x1xf32>, %arg1: tensor<4xi64>) -> tensor<1x64x64x64xf32> {
   %0 = "onnx.Expand"(%arg0, %arg1) : (tensor<1x64x1x1xf32>, tensor<4xi64>) -> tensor<1x64x64x64xf32>

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Expand.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Expand.mlir
@@ -86,20 +86,35 @@ func.func @test_expand_tile_one_dim_big(%arg0: tensor<1x6x1x1xf32>) -> tensor<1x
 
 // -----
 
+func.func @test_expand_smaller_dims(%arg0: tensor<128x64x1x1xf32>) -> tensor<1x128x64x64x128xf32> {
+  %0 = "onnx.Constant"() {value = dense<[1, 64, 128]> : tensor<3xi64>} : () -> tensor<3xi64>
+  %1 = "onnx.Expand"(%arg0, %0) : (tensor<128x64x1x1xf32>, tensor<3xi64>) -> tensor<1x128x64x64x128xf32>
+  return %1 : tensor<1x128x64x64x128xf32>
+}
+
+// CHECK-LABEL:  func.func @test_expand_smaller_dims
+// CHECK:    %[[RES:.*]] = tosa.reshape {{.*}} {new_shape = array<i64: 1, 128, 64, 1, 1>} : (tensor<128x64x1x1xf32>) -> tensor<1x128x64x1x1xf32>
+// CHECK:    %[[TILE:.*]] = tosa.tile %[[RES]] {multiples = array<i64: 1, 1, 1, 64, 128>} : (tensor<1x128x64x1x1xf32>) -> tensor<1x128x64x64x128xf32>
+// CHECK:    return %[[TILE]] : tensor<1x128x64x64x128xf32>
+
+// -----
+
+func.func @test_expand_mixed_smaller(%arg0 : tensor<2x1x6x1xbf16>) -> tensor<2x7x6x5xbf16> {
+  %0 = "onnx.Constant"() {value = dense<[7, 1, 5]> : tensor<3xi64> } : () -> tensor<3xi64>
+  %1 = "onnx.Expand"(%arg0, %0) : (tensor<2x1x6x1xbf16>, tensor<3xi64>) -> tensor<2x7x6x5xbf16>
+  func.return %1 : tensor<2x7x6x5xbf16>
+}
+
+// CHECK-LABEL:   func.func @test_expand_mixed_smaller
+// CHECK:    %[[RES:.*]] = tosa.reshape {{.*}} {new_shape = array<i64: 2, 1, 6, 1>} : (tensor<2x1x6x1xbf16>) -> tensor<2x1x6x1xbf16>
+// CHECK:    %[[TILE:.*]] = tosa.tile %[[RES]] {multiples = array<i64: 1, 7, 1, 5>} : (tensor<2x1x6x1xbf16>) -> tensor<2x7x6x5xbf16>
+// CHECK:    return %[[TILE]] : tensor<2x7x6x5xbf16>
+
+// -----
+
 func.func @test_expand_no_legalization(%arg0: tensor<1x64x1x1xf32>, %arg1: tensor<4xi64>) -> tensor<1x64x64x64xf32> {
   %0 = "onnx.Expand"(%arg0, %arg1) : (tensor<1x64x1x1xf32>, tensor<4xi64>) -> tensor<1x64x64x64xf32>
   return %0 : tensor<1x64x64x64xf32>
 }
 // CHECK-LABEL:  func @test_expand_no_legalization
 // CHECK: onnx.Expand
-
-// -----
-
-func.func @test_expand_illegal_dims(%arg0: tensor<128x64x1x1xf32>) -> tensor<1x128x64xf32> {
-  %0 = "onnx.Constant"() {value = dense<[1, 128, 64]> : tensor<3xi64>} : () -> tensor<3xi64>
-  %1 = "onnx.Expand"(%arg0, %0) : (tensor<128x64x1x1xf32>, tensor<3xi64>) -> tensor<1x128x64xf32>
-  return %1 : tensor<1x128x64xf32>
-}
-
-// CHECK-LABEL:  func.func @test_expand_illegal_dims
-// CHECK:           onnx.Expand


### PR DESCRIPTION
This is the root cause of a bug seen in recent model runs `failed to materialize conversion for result #0 of operation onnx.X `

- [x] Check for shapes < input (ignore the dim in this case)