### PR TITLE
Import ONNX models where some dimensions have zero size

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -306,12 +306,10 @@ private:
     }
     auto shape_proto = tensor_type.shape();
     for (int i = 0; i < shape_proto.dim_size(); i++) {
-      if (shape_proto.dim()[i].dim_value()) {
+      if (shape_proto.dim()[i].has_dim_value()) {
         // Dim is a constant value.
         int dim_numeric_size = shape_proto.dim()[i].dim_value();
-        assert(dim_numeric_size != 0 &&
-               "Parsed an tensor with a dimension size of zero");
-        if (dim_numeric_size > 0) {
+        if (dim_numeric_size >= 0) {
           dims.push_back(dim_numeric_size);
         } else {
           // If dim_value < 0, then dim is parametric.

--- a/test/mlir/onnx/parse/test_dim_zero.onnxtext
+++ b/test/mlir/onnx/parse/test_dim_zero.onnxtext
@@ -1,0 +1,13 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+
+<
+   ir_version: 9,
+   opset_import: ["" : 19]
+>
+identity (float[0] x) => (float[0] y) {
+   y = Identity(x)
+}
+
+// CHECK-LABEL:   func.func @main_graph
+// CHECK-SAME:     ([[PARAM_0_:%.+]]: tensor<0xf32> {onnx.name = "x"}) -> (tensor<0xf32> {onnx.name = "y"}) {
+


### PR DESCRIPTION
ONNX allows dimensions to have zero size. Before this PR, those were imported as dynamic dimensions, but they must be imported as static.