### PR TITLE
[AutoBump] Merge with fixes of 693ba938 (Jun 17) (10) (needs LLVM bump Jun 11)

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -15,7 +15,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 765206e050453018e861637a08a4520f29238074 && cd ..
+cd llvm-project && git checkout c012e487b7246239c31bd378ab074fb110631186 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -52,7 +52,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 765206e050453018e861637a08a4520f29238074 && cd ..
+cd llvm-project && git checkout c012e487b7246239c31bd378ab074fb110631186 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -4,7 +4,7 @@
 
 //===----------------IndexExpr.cpp - Index expression---------------------=== //
 //
-// copyright 2020-2023 The IBM Research Authors.
+// copyright 2020-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -22,11 +22,11 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Support/LLVM.h"
-#include "mlir/Support/MathExtras.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
 
 #define DEBUG_TYPE "index-expr"
 
@@ -947,7 +947,7 @@ IndexExpr IndexExpr::ceilDiv(IndexExpr const b) const {
 // Int operator
 IndexExpr IndexExpr::operator%(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    int64_t rval = mlir::mod(aa.getLiteral(), bb.getLiteral());
+    int64_t rval = llvm::mod(aa.getLiteral(), bb.getLiteral());
     return LiteralIndexExpr(rval);
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {

--- a/src/Dialect/Mlir/IndexExprDetail.cpp
+++ b/src/Dialect/Mlir/IndexExprDetail.cpp
@@ -5,7 +5,7 @@
 //===---------------IndexExprDetail.hpp - Index expression details---------===
 ////
 //
-// Copyright 2020-2023 The IBM Research Authors.
+// Copyright 2020-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -19,7 +19,6 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Support/LLVM.h"
-#include "mlir/Support/MathExtras.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/TypeSwitch.h"

--- a/test/mlir/conversion/krnl_to_llvm/constants_to_file/big_endian/symbol-postfix.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/constants_to_file/big_endian/symbol-postfix.mlir
@@ -72,15 +72,12 @@ module attributes {"onnx-mlir.symbol-postfix" = "tag_symbols"} {
 // CHECK:           [[VAR_7_1_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_6_3_]], [[VAR_4_3_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_8_1_:%.+]] = llvm.icmp "eq" [[VAR_7_1_]], [[VAR_5_4_]] : i32
 // CHECK:           llvm.cond_br [[VAR_8_1_]], ^bb1([[VAR_3_5_]] : !llvm.ptr), ^bb2
-// CHECK:         ^bb1([[VAR_9_:%.+]]: !llvm.ptr):  // 2 preds: ^bb0, ^bb2
+// CHECK:         ^bb1([[VAR_9_:%.+]]: !llvm.ptr):  // 3 preds: ^bb0, ^bb2, ^bb2
 // CHECK:           llvm.return [[VAR_9_]] : !llvm.ptr
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_10_1_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_2_5_]], [[VAR_1_5_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_11_1_:%.+]] = llvm.icmp "eq" [[VAR_10_1_]], [[VAR_5_4_]] : i32
-// CHECK:           llvm.cond_br [[VAR_11_1_]], ^bb1([[VAR_0_7_]] : !llvm.ptr), ^bb3
-// CHECK:         ^bb3:  // pred: ^bb2
-// CHECK:           [[VAR_12_1_:%.+]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:           llvm.return [[VAR_12_1_]] : !llvm.ptr
+// CHECK:           llvm.cond_br [[VAR_11_1_]], ^bb1([[VAR_0_7_]] : !llvm.ptr)
 // CHECK:         }
 
 // CHECK:         llvm.func @omInputSignature([[arg0_:%.+]]: !llvm.ptr) -> !llvm.ptr {
@@ -99,15 +96,12 @@ module attributes {"onnx-mlir.symbol-postfix" = "tag_symbols"} {
 // CHECK:           [[VAR_7_2_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_6_4_]], [[VAR_4_4_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_8_2_:%.+]] = llvm.icmp "eq" [[VAR_7_2_]], [[VAR_5_5_]] : i32
 // CHECK:           llvm.cond_br [[VAR_8_2_]], ^bb1([[VAR_3_6_]] : !llvm.ptr), ^bb2
-// CHECK:         ^bb1([[VAR_9_]]: !llvm.ptr):  // 2 preds: ^bb0, ^bb2
+// CHECK:         ^bb1([[VAR_9_]]: !llvm.ptr):  // 3 preds: ^bb0, ^bb2, ^bb2
 // CHECK:           llvm.return [[VAR_9_]] : !llvm.ptr
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_10_2_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_2_6_]], [[VAR_1_6_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_11_2_:%.+]] = llvm.icmp "eq" [[VAR_10_2_]], [[VAR_5_5_]] : i32
-// CHECK:           llvm.cond_br [[VAR_11_2_]], ^bb1([[VAR_0_9_]] : !llvm.ptr), ^bb3
-// CHECK:         ^bb3:  // pred: ^bb2
-// CHECK:           [[VAR_12_2_:%.+]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:           llvm.return [[VAR_12_2_]] : !llvm.ptr
+// CHECK:           llvm.cond_br [[VAR_11_2_]], ^bb1([[VAR_0_9_]] : !llvm.ptr)
 // CHECK:         }
 // CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr) -> !llvm.ptr {
 // CHECK:           [[VAR_0_9_:%.+]] = llvm.call @omOutputSignature_tag_symbols([[arg0_]]) : (!llvm.ptr) -> !llvm.ptr

--- a/test/mlir/conversion/krnl_to_llvm/constants_to_file/litte_endian/symbol-postfix.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/constants_to_file/litte_endian/symbol-postfix.mlir
@@ -72,15 +72,12 @@ module attributes {"onnx-mlir.symbol-postfix" = "tag_symbols"} {
 // CHECK:           [[VAR_7_1_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_6_3_]], [[VAR_4_3_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_8_1_:%.+]] = llvm.icmp "eq" [[VAR_7_1_]], [[VAR_5_4_]] : i32
 // CHECK:           llvm.cond_br [[VAR_8_1_]], ^bb1([[VAR_3_5_]] : !llvm.ptr), ^bb2
-// CHECK:         ^bb1([[VAR_9_:%.+]]: !llvm.ptr):  // 2 preds: ^bb0, ^bb2
+// CHECK:         ^bb1([[VAR_9_:%.+]]: !llvm.ptr):  // 3 preds: ^bb0, ^bb2, ^bb2
 // CHECK:           llvm.return [[VAR_9_]] : !llvm.ptr
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_10_1_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_2_5_]], [[VAR_1_5_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_11_1_:%.+]] = llvm.icmp "eq" [[VAR_10_1_]], [[VAR_5_4_]] : i32
-// CHECK:           llvm.cond_br [[VAR_11_1_]], ^bb1([[VAR_0_7_]] : !llvm.ptr), ^bb3
-// CHECK:         ^bb3:  // pred: ^bb2
-// CHECK:           [[VAR_12_1_:%.+]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:           llvm.return [[VAR_12_1_]] : !llvm.ptr
+// CHECK:           llvm.cond_br [[VAR_11_1_]], ^bb1([[VAR_0_7_]] : !llvm.ptr)
 // CHECK:         }
 
 // CHECK:         llvm.func @omInputSignature([[arg0_:%.+]]: !llvm.ptr) -> !llvm.ptr {
@@ -99,15 +96,12 @@ module attributes {"onnx-mlir.symbol-postfix" = "tag_symbols"} {
 // CHECK:           [[VAR_7_2_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_6_4_]], [[VAR_4_4_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_8_2_:%.+]] = llvm.icmp "eq" [[VAR_7_2_]], [[VAR_5_5_]] : i32
 // CHECK:           llvm.cond_br [[VAR_8_2_]], ^bb1([[VAR_3_6_]] : !llvm.ptr), ^bb2
-// CHECK:         ^bb1([[VAR_9_]]: !llvm.ptr):  // 2 preds: ^bb0, ^bb2
+// CHECK:         ^bb1([[VAR_9_]]: !llvm.ptr):  // 3 preds: ^bb0, ^bb2, ^bb2
 // CHECK:           llvm.return [[VAR_9_]] : !llvm.ptr
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_10_2_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_2_6_]], [[VAR_1_6_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_11_2_:%.+]] = llvm.icmp "eq" [[VAR_10_2_]], [[VAR_5_5_]] : i32
-// CHECK:           llvm.cond_br [[VAR_11_2_]], ^bb1([[VAR_0_9_]] : !llvm.ptr), ^bb3
-// CHECK:         ^bb3:  // pred: ^bb2
-// CHECK:           [[VAR_12_2_:%.+]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:           llvm.return [[VAR_12_2_]] : !llvm.ptr
+// CHECK:           llvm.cond_br [[VAR_11_2_]], ^bb1([[VAR_0_9_]] : !llvm.ptr)
 // CHECK:         }
 // CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr) -> !llvm.ptr {
 // CHECK:           [[VAR_0_9_:%.+]] = llvm.call @omOutputSignature_tag_symbols([[arg0_]]) : (!llvm.ptr) -> !llvm.ptr

--- a/test/mlir/conversion/krnl_to_llvm/entry_point.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/entry_point.mlir
@@ -18,12 +18,12 @@ module {
 // CHECK:           {{.*}} = llvm.call @omTensorListGetOmtArray([[ARG0]]) : (!llvm.ptr) -> !llvm.ptr
 
 // CHECK:         llvm.mlir.global internal constant @_entry_point_arrays() {addr_space = 0 : i32} : !llvm.array<2 x ptr> {
+// CHECK-DAG:       [[VAR_0:%.+]] = llvm.mlir.zero : !llvm.ptr
 // CHECK-DAG:       [[VAR_0_3_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr
 // CHECK-DAG:       [[VAR_1_3_:%.+]] = llvm.mlir.undef : !llvm.array<2 x ptr>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_2_3_:%.+]] = llvm.insertvalue [[VAR_0_3_]], [[VAR_1_3_]][0] : !llvm.array<2 x ptr>
-// CHECK-DAG:       [[VAR_3_3_:%.+]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:           [[VAR_4_2_:%.+]] = llvm.insertvalue [[VAR_3_3_]], [[VAR_2_3_]][1] : !llvm.array<2 x ptr>
+// CHECK:           [[VAR_4_2_:%.+]] = llvm.insertvalue [[VAR_0]], [[VAR_2_3_]][1] : !llvm.array<2 x ptr>
 // CHECK:           llvm.return [[VAR_4_2_]] : !llvm.array<2 x ptr>
 // CHECK:         }
 
@@ -41,32 +41,28 @@ module {
 // CHECK:         }
 
 // CHECK:         llvm.func @omInputSignature([[arg0_:%.+]]: !llvm.ptr) -> !llvm.ptr {
+// CHECK-DAG:       [[VAR_0:%.+]] = llvm.mlir.zero : !llvm.ptr
 // CHECK-DAG:       [[VAR_0_5_:%.+]] = llvm.mlir.addressof @_entry_point_0_in_sig : !llvm.ptr
 // CHECK-DAG:       [[VAR_1_5_:%.+]] = llvm.mlir.constant(15 : i64) : i64
 // CHECK-DAG:       [[VAR_2_5_:%.+]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:       [[VAR_3_5_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr
 // CHECK:           [[VAR_4_3_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_3_5_]], [[VAR_1_5_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_5_3_:%.+]] = llvm.icmp "eq" [[VAR_4_3_]], [[VAR_2_5_]] : i32
-// CHECK:           llvm.cond_br [[VAR_5_3_]], ^bb1, ^bb2
-// CHECK:         ^bb1:  // pred: ^bb0
-// CHECK:           llvm.return [[VAR_0_5_]] : !llvm.ptr
-// CHECK:         ^bb2:  // pred: ^bb0
-// CHECK:           [[VAR_6_2_:%.+]] = llvm.mlir.zero : !llvm.ptr
+// CHECK:           llvm.cond_br [[VAR_5_3_]], ^bb1([[VAR_0_5_]] : !llvm.ptr), ^bb1([[VAR_0]] : !llvm.ptr)
+// CHECK:         ^bb1([[VAR_6_2_:%.+]]: !llvm.ptr):  // 2 preds: ^bb0, ^bb0
 // CHECK:           llvm.return [[VAR_6_2_]] : !llvm.ptr
 // CHECK:         }
 
 // CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr) -> !llvm.ptr {
+// CHECK-DAG:       [[VAR_0:%.+]] = llvm.mlir.zero : !llvm.ptr
 // CHECK-DAG:       [[VAR_0_6_:%.+]] = llvm.mlir.addressof @_entry_point_0_out_sig : !llvm.ptr
 // CHECK-DAG:       [[VAR_1_6_:%.+]] = llvm.mlir.constant(15 : i64) : i64
 // CHECK-DAG:       [[VAR_2_6_:%.+]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:       [[VAR_3_6_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr
 // CHECK:           [[VAR_4_4_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_3_6_]], [[VAR_1_6_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_5_4_:%.+]] = llvm.icmp "eq" [[VAR_4_4_]], [[VAR_2_6_]] : i32
-// CHECK:           llvm.cond_br [[VAR_5_4_]], ^bb1, ^bb2
-// CHECK:         ^bb1:  // pred: ^bb0
-// CHECK:           llvm.return [[VAR_0_6_]] : !llvm.ptr
-// CHECK:         ^bb2:  // pred: ^bb0
-// CHECK:           [[VAR_6_3_:%.+]] = llvm.mlir.zero : !llvm.ptr
+// CHECK:           llvm.cond_br [[VAR_5_4_]], ^bb1([[VAR_0_6_]] : !llvm.ptr), ^bb1([[VAR_0]] : !llvm.ptr)
+// CHECK:         ^bb1([[VAR_6_3_:%.+]]: !llvm.ptr):  // 2 preds: ^bb0, ^bb0
 // CHECK:           llvm.return [[VAR_6_3_]] : !llvm.ptr
 // CHECK:         }
 }
@@ -99,13 +95,13 @@ module {
 // CHECK:           {{.*}} = llvm.call @omTensorListGetOmtArray([[ARG0]]) : (!llvm.ptr) -> !llvm.ptr
 
 // CHECK:         llvm.mlir.global internal constant @_entry_point_arrays() {addr_space = 0 : i32} : !llvm.array<3 x ptr> {
+// CHECK-DAG:       [[VAR_0:%.+]] = llvm.mlir.zero : !llvm.ptr
 // CHECK-DAG:       [[VAR_0_11_:%.+]] = llvm.mlir.addressof @_entry_point_1 : !llvm.ptr
 // CHECK-DAG:       [[VAR_1_13_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr
 // CHECK-DAG:       [[VAR_2_13_:%.+]] = llvm.mlir.undef : !llvm.array<3 x ptr>
 // CHECK:           [[VAR_3_13_:%.+]] = llvm.insertvalue [[VAR_1_13_]], [[VAR_2_13_]][0] : !llvm.array<3 x ptr>
 // CHECK-DAG:       [[VAR_4_9_:%.+]] = llvm.insertvalue [[VAR_0_11_]], [[VAR_3_13_]][1] : !llvm.array<3 x ptr>
-// CHECK-DAG:       [[VAR_5_11_:%.+]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:           [[VAR_6_8_:%.+]] = llvm.insertvalue [[VAR_5_11_]], [[VAR_4_9_]][2] : !llvm.array<3 x ptr>
+// CHECK:           [[VAR_6_8_:%.+]] = llvm.insertvalue [[VAR_0]], [[VAR_4_9_]][2] : !llvm.array<3 x ptr>
 // CHECK:           llvm.return [[VAR_6_8_]] : !llvm.array<3 x ptr>
 // CHECK:         }
 
@@ -123,6 +119,7 @@ module {
 // CHECK:         }
 
 // CHECK:         llvm.func @omInputSignature([[arg0_:%.+]]: !llvm.ptr) -> !llvm.ptr {
+// CHECK-DAG:       [[VAR_0:%.+]] = llvm.mlir.zero : !llvm.ptr
 // CHECK-DAG:       [[VAR_0_13_:%.+]] = llvm.mlir.addressof @_entry_point_1_in_sig : !llvm.ptr
 // CHECK-DAG:       [[VAR_1_15_:%.+]] = llvm.mlir.constant(17 : i64) : i64
 // CHECK-DAG:       [[VAR_2_15_:%.+]] = llvm.mlir.addressof @_entry_point_1 : !llvm.ptr
@@ -133,18 +130,16 @@ module {
 // CHECK:           [[VAR_7_3_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_6_9_]], [[VAR_4_10_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_8_3_:%.+]] = llvm.icmp "eq" [[VAR_7_3_]], [[VAR_5_12_]] : i32
 // CHECK:           llvm.cond_br [[VAR_8_3_]], ^bb1([[VAR_3_15_]] : !llvm.ptr), ^bb2
-// CHECK:         ^bb1([[VAR_9_2_:%.+]]: !llvm.ptr):  // 2 preds: ^bb0, ^bb2
+// CHECK:         ^bb1([[VAR_9_2_:%.+]]: !llvm.ptr):  // 3 preds: ^bb0, ^bb2, ^bb2
 // CHECK:           llvm.return [[VAR_9_2_]] : !llvm.ptr
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_10_3_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_2_15_]], [[VAR_1_15_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_11_3_:%.+]] = llvm.icmp "eq" [[VAR_10_3_]], [[VAR_5_12_]] : i32
-// CHECK:           llvm.cond_br [[VAR_11_3_]], ^bb1([[VAR_0_13_]] : !llvm.ptr), ^bb3
-// CHECK:         ^bb3:  // pred: ^bb2
-// CHECK:           [[VAR_12_3_:%.+]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:           llvm.return [[VAR_12_3_]] : !llvm.ptr
+// CHECK:           llvm.cond_br [[VAR_11_3_]], ^bb1([[VAR_0_13_]] : !llvm.ptr), ^bb1([[VAR_0]] : !llvm.ptr)
 // CHECK:         }
 
 // CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr) -> !llvm.ptr {
+// CHECK-DAG:       [[VAR_0:%.+]] = llvm.mlir.zero : !llvm.ptr
 // CHECK-DAG:       [[VAR_0_14_:%.+]] = llvm.mlir.addressof @_entry_point_1_out_sig : !llvm.ptr
 // CHECK-DAG:       [[VAR_1_16_:%.+]] = llvm.mlir.constant(17 : i64) : i64
 // CHECK-DAG:       [[VAR_2_16_:%.+]] = llvm.mlir.addressof @_entry_point_1 : !llvm.ptr
@@ -155,15 +150,12 @@ module {
 // CHECK:           [[VAR_7_4_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_6_10_]], [[VAR_4_11_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_8_4_:%.+]] = llvm.icmp "eq" [[VAR_7_4_]], [[VAR_5_13_]] : i32
 // CHECK:           llvm.cond_br [[VAR_8_4_]], ^bb1([[VAR_3_16_]] : !llvm.ptr), ^bb2
-// CHECK:         ^bb1([[VAR_9_2_:%.+]]: !llvm.ptr):  // 2 preds: ^bb0, ^bb2
+// CHECK:         ^bb1([[VAR_9_2_:%.+]]: !llvm.ptr):  // 3 preds: ^bb0, ^bb2, ^bb2
 // CHECK:           llvm.return [[VAR_9_2_]] : !llvm.ptr
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_10_4_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_2_16_]], [[VAR_1_16_]]) : (!llvm.ptr, !llvm.ptr, i64) -> i32
 // CHECK:           [[VAR_11_4_:%.+]] = llvm.icmp "eq" [[VAR_10_4_]], [[VAR_5_13_]] : i32
-// CHECK:           llvm.cond_br [[VAR_11_4_]], ^bb1([[VAR_0_14_]] : !llvm.ptr), ^bb3
-// CHECK:         ^bb3:  // pred: ^bb2
-// CHECK:           [[VAR_12_4_:%.+]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:           llvm.return [[VAR_12_4_]] : !llvm.ptr
+// CHECK:           llvm.cond_br [[VAR_11_4_]], ^bb1([[VAR_0_14_]] : !llvm.ptr), ^bb1([[VAR_0]] : !llvm.ptr)
 // CHECK:         }
 }
 
@@ -178,6 +170,7 @@ module attributes {"onnx-mlir.accels" = ["Pseudo-0x10001", "NNPA-0x10000"]} {
 // CHECK:      llvm.func @OMInitCompatibleAccelNNPA(i64)
 // CHECK:      llvm.func @OMInitCompatibleAccelPseudo(i64)
 // CHECK:      llvm.func @run_main_graph({{.*}}: !llvm.ptr) -> !llvm.ptr {
+// CHECK-DAG:    [[VAR_0:%.+]] = llvm.mlir.zero : !llvm.ptr
 // CHECK-DAG:    [[FALSE:%.+]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:    [[VERSION_NUMBER_0:%.+]] = llvm.mlir.constant(65537 : i64) : i64
 // CHECK-DAG:    [[VERSION_NUMBER_1:%.+]] = llvm.mlir.constant(65536 : i64) : i64
@@ -185,8 +178,7 @@ module attributes {"onnx-mlir.accels" = ["Pseudo-0x10001", "NNPA-0x10000"]} {
 // CHECK-NEXT:   [[FAILED:%.+]] = llvm.icmp "eq" [[COMPATIBLE]], [[FALSE]] : i64
 // CHECK-NEXT:   llvm.cond_br [[FAILED]], ^bb1, ^bb2
 // CHECK-NEXT: ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK-NEXT:   [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
-// CHECK-NEXT:   llvm.return [[NULL]] : !llvm.ptr
+// CHECK-NEXT:   llvm.return [[VAR_0]] : !llvm.ptr
 // CHECK-NEXT: ^bb2:  // pred: ^bb0
 // CHECK-NEXT:   [[COMPATIBLE:%.+]] = llvm.call @OMInitCompatibleAccelNNPA([[VERSION_NUMBER_1]]) : (i64) -> i64
 // CHECK-NEXT:   [[FAILED:%.+]] = llvm.icmp "eq" [[COMPATIBLE]], [[FALSE]] : i64

--- a/test/mlir/conversion/krnl_to_llvm/input_verification.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/input_verification.mlir
@@ -11,6 +11,7 @@ module {
   "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 1 : i32, signature = "[    { \22type\22 : \22f32\22 , \22dims\22 : [3 , 4 , 5] , \22name\22 : \22input0\22 }\0A ,    { \22type\22 : \22f32\22 , \22dims\22 : [-1 , 4 , 5] , \22name\22 : \22input1\22 }\0A\0A]\00@[   { \22type\22 : \22f32\22 , \22dims\22 : [3 , 4 , 5] , \22name\22 : \22output0\22 }\0A\0A]\00"} : () -> ()
 
 // CHECK:         llvm.func @run_main_graph([[arg0_:.*]]: !llvm.ptr) -> !llvm.ptr {
+// CHECK-DAG:       [[VAR_0:%.+]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK-DAG:       [[VAR_0_2_:%.+]] = llvm.mlir.addressof @"om_Wrong size for the dimension 2 of the input 1: expect 5, but got {{\%}}lld\0A" : !llvm.ptr
 // CHECK-DAG:       [[VAR_1_2_:%.+]] = llvm.mlir.addressof @"om_Wrong size for the dimension 1 of the input 1: expect 4, but got {{\%}}lld\0A" : !llvm.ptr
 // CHECK-DAG:       [[VAR_2_2_:%.+]] = llvm.mlir.addressof @"om_Wrong size for the dimension 0 of the input 1: expect a non-negative value\0A" : !llvm.ptr
@@ -26,6 +27,7 @@ module {
 // CHECK-DAG:       [[VAR_12_1_:%.+]] = llvm.mlir.constant(3 : i64) : i64
 // CHECK-DAG:       [[VAR_13_1_:%.+]] = llvm.mlir.addressof @"om_Wrong data type for the input 0: expect f32\0A" : !llvm.ptr
 // CHECK-DAG:       [[VAR_14_1_:%.+]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-DAG:       [[VAR_14_2_:%.+]] = llvm.mlir.zero : !llvm.ptr
 // CHECK-DAG:       [[VAR_15_1_:%.+]] = llvm.mlir.constant(22 : i32) : i32
 // CHECK-DAG:       [[VAR_16_1_:%.+]] = llvm.mlir.addressof @"om_Wrong number of input tensors: expect 2, but got {{\%}}lld\0A" : !llvm.ptr
 // CHECK-DAG:       [[VAR_17_1_:%.+]] = llvm.mlir.constant(2 : i64) : i64
@@ -36,8 +38,7 @@ module {
 // CHECK:           llvm.call @printf([[VAR_20_]], [[VAR_21_]]) : (!llvm.ptr, i64) -> ()
 // CHECK:           [[VAR_22_:%.+]] = llvm.call @__errno_location() : () -> !llvm.ptr
 // CHECK:           llvm.store [[VAR_15_1_]], [[VAR_22_]] : i32, !llvm.ptr
-// CHECK:           [[VAR_23_:%.+]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:           llvm.return [[VAR_23_]] : !llvm.ptr
+// CHECK:           llvm.return [[VAR_14_2_]] : !llvm.ptr
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_24_:%.+]] = llvm.call @omTensorListGetOmtArray([[arg0_]]) : (!llvm.ptr) -> !llvm.ptr
 // CHECK:           [[LOAD_VAR_24_MEM_:%.+]] = llvm.load [[VAR_24_]] : !llvm.ptr -> !llvm.ptr
@@ -48,8 +49,7 @@ module {
 // CHECK:           llvm.call @printf([[VAR_28_]]) : (!llvm.ptr) -> ()
 // CHECK:           [[VAR_29_:%.+]] = llvm.call @__errno_location() : () -> !llvm.ptr
 // CHECK:           llvm.store [[VAR_15_1_]], [[VAR_29_]] : i32, !llvm.ptr
-// CHECK:           [[VAR_30_:%.+]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:           llvm.return [[VAR_30_]] : !llvm.ptr
+// CHECK:           llvm.return [[VAR_14_2_]] : !llvm.ptr
 // CHECK:         ^bb4:  // pred: ^bb2
 // CHECK:           [[VAR_31_:%.+]] = llvm.call @omTensorGetRank([[LOAD_VAR_24_MEM_]]) : (!llvm.ptr) -> i64
 // CHECK:           [[VAR_32_:%.+]] = llvm.icmp "ne" [[VAR_12_1_]], [[VAR_31_]] : i64
@@ -78,7 +78,7 @@ module {
 // CHECK:         ^bb9:  // pred: ^bb8
 // CHECK:           [[VAR_46_:%.+]] = llvm.call @omTensorGetRank([[LOAD_VAR_42_MEM_]]) : (!llvm.ptr) -> i64
 // CHECK:           [[VAR_47_:%.+]] = llvm.icmp "ne" [[VAR_12_1_]], [[VAR_46_]] : i64
-// CHECK:           llvm.cond_br [[VAR_47_]], ^bb1([[VAR_4_2_]], [[VAR_4_2_]]6 : !llvm.ptr, i64), ^bb10
+// CHECK:           llvm.cond_br [[VAR_47_]], ^bb1([[VAR_4_2_]], [[VAR_46_]] : !llvm.ptr, i64), ^bb10
 // CHECK:         ^bb10:  // pred: ^bb9
 // CHECK:           [[VAR_48_:%.+]] = llvm.call @omTensorGetShape([[LOAD_VAR_42_MEM_]]) : (!llvm.ptr) -> !llvm.ptr
 // CHECK:           [[LOAD_VAR_48_MEM_:%.+]] = llvm.load [[VAR_48_]] : !llvm.ptr -> i64
@@ -100,9 +100,8 @@ module {
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[LOAD_VAR_57_MEM_:%.+]] = llvm.load [[VAR_57_]] : !llvm.ptr -> !llvm.ptr
 // CHECK-DAG:       [[VAR_60_:%.+]] = llvm.alloca [[VAR_14_1_]] x !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)> : (i64) -> !llvm.ptr
-// CHECK-DAG:       [[VAR_61_:%.+]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK:           [[VAR_62_:%.+]] = llvm.call @omTensorGetDataPtr([[LOAD_VAR_57_MEM_]]) : (!llvm.ptr) -> !llvm.ptr
-// CHECK:           [[VAR_63_:%.+]] = llvm.insertvalue [[VAR_62_]], [[VAR_61_]][0] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK:           [[VAR_63_:%.+]] = llvm.insertvalue [[VAR_62_]], [[VAR_0]][0] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK:           [[VAR_64_:%.+]] = llvm.insertvalue [[VAR_62_]], [[VAR_63_]][1] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK-DAG:       [[VAR_65_:%.+]] = llvm.insertvalue [[VAR_3_2_]], [[VAR_64_]][2] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK-DAG:       [[VAR_66_:%.+]] = llvm.call @omTensorGetShape([[LOAD_VAR_57_MEM_]]) : (!llvm.ptr) -> !llvm.ptr
@@ -128,9 +127,8 @@ module {
 // CHECK:           [[VAR_84_:%.+]] = llvm.getelementptr [[VAR_57_]][1] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
 // CHECK-DAG:       [[LOAD_VAR_84_MEM_:%.+]] = llvm.load [[VAR_84_]] : !llvm.ptr -> !llvm.ptr
 // CHECK-DAG:       [[VAR_86_:%.+]] = llvm.alloca [[VAR_14_1_]] x !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)> : (i64) -> !llvm.ptr
-// CHECK-DAG:       [[VAR_87_:%.+]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK:           [[VAR_88_:%.+]] = llvm.call @omTensorGetDataPtr([[LOAD_VAR_84_MEM_]]) : (!llvm.ptr) -> !llvm.ptr
-// CHECK:           [[VAR_89_:%.+]] = llvm.insertvalue [[VAR_88_]], [[VAR_87_]][0] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK:           [[VAR_89_:%.+]] = llvm.insertvalue [[VAR_88_]], [[VAR_0]][0] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK:           [[VAR_90_:%.+]] = llvm.insertvalue [[VAR_88_]], [[VAR_89_]][1] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK-DAG:       [[VAR_91_:%.+]] = llvm.insertvalue [[VAR_3_2_]], [[VAR_90_]][2] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK-DAG:       [[VAR_92_:%.+]] = llvm.call @omTensorGetShape([[LOAD_VAR_84_MEM_]]) : (!llvm.ptr) -> !llvm.ptr

--- a/test/mlir/conversion/krnl_to_llvm/krnl_random_normal_lowering.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/krnl_random_normal_lowering.mlir
@@ -20,7 +20,6 @@ func.func @test_random_normal_lowering() -> memref<3x4x5xf32> {
 
   /// Populate tensor:
   // CHECK: [[ALIGNED_TENSOR_MEMORY:%.+]] = llvm.inttoptr {{.*}} : i64 to !llvm.ptr
-  // CHECK: llvm.mlir.undef : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
   // CHECK: [[OUTPUT_TENSOR:%.+]] = llvm.insertvalue {{.*}}, {{.*}}[4, 2] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
   // CHECK: llvm.call @get_random_normal_value_f32([[ALIGNED_TENSOR_MEMORY]], [[ALL_VALUES]], [[MEAN]], [[SCALE]], [[SEED]]) : (!llvm.ptr, i64, f32, f32, f32) -> ()
   // CHECK: llvm.return [[OUTPUT_TENSOR]] : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
@@ -55,6 +54,7 @@ func.func @test_random_normal_dynamic_lowering(%arg0: memref<3x4x?x?xf32>) -> me
   // CHECK: [[SCALE:%.+]] = llvm.mlir.constant(1.000000e+00 : f32) : f32
   // CHECK: [[MEAN:%.+]] = llvm.mlir.constant(0.000000e+00 : f32) : f32
   // CHECK: [[ALL_VALUES1:%.+]] = llvm.mlir.constant(12 : index) : i64
+  // CHECK: [[C0:%.+]] = llvm.mlir.zero : !llvm.ptr
   // CHECK: [[C4:%.+]] = llvm.mlir.constant(4 : index) : i64
   // CHECK: [[C3:%.+]] = llvm.mlir.constant(3 : index) : i64
 
@@ -63,12 +63,10 @@ func.func @test_random_normal_dynamic_lowering(%arg0: memref<3x4x?x?xf32>) -> me
   // CHECK: %[[MUL3:.+]] = llvm.mul [[MUL2]], [[C3]]  : i64
 
   /// Allocate aligned tensor:
-  // CHECK: [[POINTER:%.+]] = llvm.mlir.zero : !llvm.ptr
-  // CHECK: llvm.getelementptr [[POINTER]][%[[MUL3]]]
+  // CHECK: llvm.getelementptr [[C0]][%[[MUL3]]] : (!llvm.ptr, i64) -> !llvm.ptr, f32
   // CHECK: [[ALIGNED_TENSOR_MEMORY:%.+]] = llvm.inttoptr {{.*}} : i64 to !llvm.ptr
 
   /// Populate tensor:
-  // CHECK: llvm.mlir.undef : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
   // CHECK: [[OUTPUT_TENSOR:%.+]] = llvm.insertvalue {{.*}}, {{.*}}[4, 3] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
   
   // CHECK: [[ALL_VALUES2:%.+]] = llvm.mul %arg5, [[ALL_VALUES1]]  : i64

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/xilinx/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 2f8092a73828 && cd ..
+cd llvm-project && git checkout d90c932faccb54276272383e377d36698196c57a && cd ..

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 765206e050453018e861637a08a4520f29238074 && cd ..
+cd llvm-project && git checkout c012e487b7246239c31bd378ab074fb110631186 && cd ..


### PR DESCRIPTION
Needs https://github.com/Xilinx/llvm-project/pull/335

```
commit 0fb216fb2fbb49c1fe90c1c3267873a100b1c356
Author: Ramkumar Ramachandra <ramkumar.ramachandra@codasip.com>
Date:   Tue Jun 11 23:00:02 2024 +0100

    mlir/MathExtras: consolidate with llvm/MathExtras (#95087)
    
    This patch is part of a project to move the Presburger library into
    LLVM.

```

Original ONNX-MLIR wants commit `c012e487b7`:
```
commit c012e487b7246239c31bd378ab074fb110631186
Author: Johannes de Fine Licht <johannes@musicmedia.dk>
Date:   Wed Jun 12 08:29:02 2024 +0200

    [MLIR][LLVM] Promote noinline/alwaysinline/optnone out of passthrough (#95110)
    
    The `noinline`, `alwaysinline`, and `optnone` function attributes are
    already being used in MLIR code for the LLVM inlining interface and in
    some SPIR-V lowering, despite residing in the passthrough dictionary,
    which is intended as exactly that -- a pass through MLIR -- and not to
    model any actual semantics being handled in MLIR itself.
    
    Promote the `noinline`, `alwaysinline`, and `optnone` attributes out of
    the passthrough dictionary on `llvm.func` into first class unit
    attributes, updating the import and export accordingly.
    
    Add a verifier to `llvm.func` that checks that these attributes are not
    set in an incompatible way according to the LLVM specification.
    
    Update the LLVM dialect inlining interface to use the first class
    attributes to check whether inlining is possible.
```