### PR TITLE
Ignore tests of the krnl dialect

### DIFF
--- a/test/mlir/lit.cfg.py
+++ b/test/mlir/lit.cfg.py
@@ -28,6 +28,9 @@ llvm_config.use_default_substitutions()
 
 config.excludes = ["onnx_to_mhlo"]
 
+# Xilinx fork: Don't care about krnl dialect. Simplifies LLVM bumps
+config.excludes += ["onnx_to_krnl", "krnl_to_affine", "krnl_to_llvm"]
+
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
 


### PR DESCRIPTION
This make bumping LLVM simpler, because those tests depend on a set of upstream dialects, and their test refs need to be updated for LLVM bumps.
We don't use the krnl dialect downstream.