### PR TITLE
Make ONNX_MLIR_SHA a private define

### DIFF
--- a/src/Version/CMakeLists.txt
+++ b/src/Version/CMakeLists.txt
@@ -102,4 +102,6 @@ if (ONNX_MLIR_VENDOR)
   list(APPEND DEFINITIONS "ONNX_MLIR_VENDOR=\"${ONNX_MLIR_VENDOR}\"")
 endif()
 list(APPEND DEFINITIONS "LLVM_PACKAGE_VERSION=\"${LLVM_PACKAGE_VERSION}\"")
-target_compile_definitions(OMVersion PUBLIC ${DEFINITIONS})
+# AMD change: Make the definition of ONNX_MLIR_SHA private to avoid recompiling
+# all objects when moving to another commit.
+target_compile_definitions(OMVersion PRIVATE ${DEFINITIONS})


### PR DESCRIPTION
We currently have `-DONNX_MLIR_SHA="<current git hash of onnx-mlir>"` on many of our compile command lines.
Only use this when compiling version.cpp to avoid many ccache misses and recompilations.