### PR TITLE
Support building with clang-cl

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -239,11 +239,12 @@ endif()
 
 pybind11_add_module(PyCompile PyOMCompileSession.cpp)
 add_dependencies(PyCompile onnx_proto)
-target_compile_options(PyCompile
-  PRIVATE
-  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-frtti -fexceptions>
-  $<$<CXX_COMPILER_ID:MSVC>:/EHsc /GR>
-  )
+if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+  target_compile_options(PyCompile PRIVATE /EHsc /GR)
+elseif (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")
+  target_compile_options(PyCompile PRIVATE -frtti -fexceptions)
+endif()
+
 target_compile_definitions(PyCompile
   PRIVATE
   $<TARGET_PROPERTY:onnx,COMPILE_DEFINITIONS>

--- a/src/Runtime/python/CMakeLists.txt
+++ b/src/Runtime/python/CMakeLists.txt
@@ -70,11 +70,11 @@ target_include_directories(OMPyExecutionSessionBase
 # target_include_directories.
 pybind11_add_module(PyRuntimeC PyExecutionSession.cpp)
 add_dependencies(PyRuntimeC onnx_proto)
-target_compile_options(PyRuntimeC
-  PRIVATE
-  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-frtti -fexceptions>
-  $<$<CXX_COMPILER_ID:MSVC>:/EHsc /GR>
-  )
+if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+  target_compile_options(PyRuntimeC PRIVATE /EHsc /GR)
+elseif (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")
+  target_compile_options(PyRuntimeC PRIVATE -frtti -fexceptions)
+endif()
 target_compile_definitions(PyRuntimeC
   PRIVATE
   $<TARGET_PROPERTY:onnx,COMPILE_DEFINITIONS>
@@ -95,11 +95,11 @@ install(TARGETS PyRuntimeC
 
 pybind11_add_module(PyCompileAndRuntimeC PyOMCompileExecutionSession.cpp)
 add_dependencies(PyCompileAndRuntimeC onnx_proto)
-target_compile_options(PyCompileAndRuntimeC
-  PRIVATE
-  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-frtti -fexceptions>
-  $<$<CXX_COMPILER_ID:MSVC>:/EHsc /GR>
-  )
+if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+  target_compile_options(PyCompileAndRuntimeC PRIVATE /EHsc /GR)
+elseif (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")
+  target_compile_options(PyCompileAndRuntimeC PRIVATE -frtti -fexceptions)
+endif()
 target_compile_definitions(PyCompileAndRuntimeC
   PRIVATE
   $<TARGET_PROPERTY:onnx,COMPILE_DEFINITIONS>


### PR DESCRIPTION
clang-cl satisfies `CXX_COMPILER_ID:Clang`, but requires options to be in MSVC format.