### PR TITLE
[AutoBump] Merge with fixes of 0e442e4d (Jul 09) (17) (needs LLVM Jul 3)

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -15,7 +15,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout c07be08df5731dac0b36e029a0dd03ccb099deea && cd ..
+cd llvm-project && git checkout 6461b921fd06b1c812f1172685b8b7edc0608af7 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -52,7 +52,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout c07be08df5731dac0b36e029a0dd03ccb099deea && cd ..
+cd llvm-project && git checkout 6461b921fd06b1c812f1172685b8b7edc0608af7 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout c07be08df5731dac0b36e029a0dd03ccb099deea && cd ..
+cd llvm-project && git checkout 6461b921fd06b1c812f1172685b8b7edc0608af7 && cd ..


### PR DESCRIPTION
Upstream wants LLVM commit `6461b921`:

```
commit 6461b921fd06b1c812f1172685b8b7edc0608af7
Author: Krzysztof Parzyszek <Krzysztof.Parzyszek@amd.com>
Date:   Wed Jul 3 07:58:01 2024 -0500

    [clang][OpenMP] Change `ActOnOpenMPRegionStart` to use captured regions (#97445)
    
    Instead of checking specific directives, this function now gets the list
    of captured regions, and processes them individually. This makes this
    function directive-agnostic (except a few cases of leaf constructs).
```

It looks like ONNX-MLIR stills works fine with the current LLVM (let CI confirm this).