### PR TITLE
[AutoBump] Merge with fixes of 67ea9b55 (Jul 22) (21) (needs LLVM Jul 12)

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -15,7 +15,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 6461b921fd06b1c812f1172685b8b7edc0608af7 && cd ..
+cd llvm-project && git checkout 0913547d0e3939cc420e88ecd037240f33736820 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -52,7 +52,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 6461b921fd06b1c812f1172685b8b7edc0608af7 && cd ..
+cd llvm-project && git checkout 0913547d0e3939cc420e88ecd037240f33736820 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/docs/Dialects/krnl.md
+++ b/docs/Dialects/krnl.md
@@ -149,9 +149,9 @@ means to block the for loop referred to by %i using a tile size of 4.
 _Call operation_
 
 The call operation provides a generic way to replace an ONNX Op with a call
-to an external function at Krnl level. 
-`funcName` attributes determines which function to call. 
-`parameters` is the inputs to Krnl.Call. It includes the outputs and inputs 
+to an external function at Krnl level.
+`funcName` attributes determines which function to call.
+`parameters` is the inputs to Krnl.Call. It includes the outputs and inputs
 of the ONNX Op. The outputs and inputs are already lowered to MemRefs.
 The external function is assumed NOT to allocate or free any memory.
 'numOfOutput` attribute to tell how manu outputs Memref in parameters.
@@ -175,7 +175,7 @@ The krnl.call op will be lowered to llvm at krnl-to-llvm conversion in which
 OMTensor is used as a container for MemRef arguments. Other representation
 of parameters, such as data pointer only, will be supported in future.
 
-Interfaces: MemoryEffectOpInterface
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -212,7 +212,7 @@ in the tile, the actual tile size can be given using the tileSize
 optional attribute. This attributes has the same rank as the buffer size,
 and each dimension must be smaller or equal to the actual buffer size.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
 
 #### Attributes:
 
@@ -279,7 +279,7 @@ several actions may happen.
 `padToNext` and `overreadToNex`t are of the same rank as source and memory
 memrefs.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
 
 #### Attributes:
 
@@ -306,6 +306,10 @@ _Define_loops operation_
 The "krnl.define_loops" operation is used to define input loops,
 those are the for loops appearing in the input program that we
 intend to optimize.
+
+Interfaces: `NoMemoryEffect (MemoryEffectOpInterface)`
+
+Effects: `MemoryEffects::Effect{}`
 
 #### Results:
 
@@ -346,11 +350,11 @@ given two arrays of int32_t values (G and V), which are used to represent a perf
 hash table for a dictionary, returns the index corresponding to the input value.
 The index returned is valid only if 'input' is in the dictionary described by G and V.
 
-Traits: AlwaysSpeculatableImplTrait, MemRefsNormalizable
+Traits: `AlwaysSpeculatableImplTrait`, `MemRefsNormalizable`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -386,6 +390,10 @@ For example, this operation can be applied to loop references corresponding to
 inter-tile iterations. The return values will be the starting index of the
 current tile being iterated over.
 
+Interfaces: `NoMemoryEffect (MemoryEffectOpInterface)`
+
+Effects: `MemoryEffects::Effect{}`
+
 #### Operands:
 
 | Operand | Description |
@@ -398,6 +406,37 @@ current tile being iterated over.
 | :----: | ----------- |
 | `ind_var_vals` | variadic of any type
 
+### `krnl.get_linear_offset_index` (KrnlGetLinearOffsetIndexOp)
+
+_A Krnl operation to compute a linear offset index from a N-D index._
+
+Given a MemRef and an N-D index (id_1, id_2, ..., id_n), where n is
+the rank of the MemRef, this operation computes a linear offset index.
+
+Traits: `MemRefsNormalizable`
+
+Interfaces: `AffineMapAccessInterface`, `AffineReadOpInterface`
+
+#### Attributes:
+
+<table>
+<tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
+<tr><td><code>map</code></td><td>::mlir::AffineMapAttr</td><td>AffineMap attribute</td></tr>
+</table>
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+| `memref` | memref of any type values
+| `indices` | variadic of index
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+| `result` | index
+
 ### `krnl.global` (KrnlGlobalOp)
 
 _Krnl global operation_
@@ -406,11 +445,11 @@ Operation for holding global data values. A global constant can have a
 meaningful name recorded as its `name` attribute. Its content is stored
 in the `value` dense element attribute.
 
-Traits: AlwaysSpeculatableImplTrait, MemRefsNormalizable
+Traits: `AlwaysSpeculatableImplTrait`, `MemRefsNormalizable`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -510,15 +549,21 @@ for (i0 = 0; i0 < 10; i0++)
     // Some operations.
 ```
 
-Traits: SingleBlock, SingleBlockImplicitTerminator<KrnlTerminatorOp>
+Traits: `RecursiveMemoryEffects`, `SingleBlockImplicitTerminator<KrnlYieldOp>`, `SingleBlock`
 
-Interfaces: LoopLikeOpInterface
+Interfaces: `LoopLikeOpInterface`
 
 #### Operands:
 
 | Operand | Description |
 | :-----: | ----------- |
 &laquo;unnamed&raquo; | variadic of any type
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+| `results` | variadic of any type
 
 ### `krnl.load` (KrnlLoadOp)
 
@@ -537,7 +582,7 @@ of the memref. The arity of indices is the rank of the memref (i.e., if the
 memref loaded from is of rank 3, then 3 indices are required for the load
 following the memref identifier).
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
 
 #### Operands:
 
@@ -730,9 +775,9 @@ operation ::= `krnl.matmul` $A `[` $aGlobalIndexMemStart `]` `,`
     1) The vector length is the second entry of (i, j, k) compute tile size.
        The vector length must be a compile time constant.
 
-Traits: AttrSizedOperandSegments, MemRefsNormalizable
+Traits: `AttrSizedOperandSegments`, `MemRefsNormalizable`
 
-Interfaces: SpecializedKernelOpInterface
+Interfaces: `SpecializedKernelOpInterface`
 
 #### Attributes:
 
@@ -776,7 +821,9 @@ Starting positions for `src` and `dest` are defined by `src_offset` and
 
 It is the users' responsibility to make sure there is no out-of-bound read/write.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Operands:
 
@@ -820,7 +867,9 @@ If `delayed = true`, the extended iteration space is used to set values.
 In the above example, all 8 elements will be set to the given value.
 
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -856,7 +905,7 @@ to assist with maintaining the relative positioning of loop and inner-loop state
 This construct is particularly helpful, for example, for lowering statements that
 are nested imperfectly between an "eager" and a "lazy" loop.
 
-Traits: SingleBlock, SingleBlockImplicitTerminator<KrnlTerminatorOp>
+Traits: `SingleBlockImplicitTerminator<KrnlTerminatorOp>`, `SingleBlock`
 
 ### `krnl.noValue` (KrnlNoneOp)
 
@@ -985,6 +1034,34 @@ affine.for %arg0 = 0 to 1024 step 4 {
 | :-----: | ----------- |
 | `loops` | variadic of any type
 
+### `krnl.prefetch` (KrnlPrefetchOp)
+
+_A Krnl operation to compute a linear offset index from a N-D index._
+
+Given a MemRef and an N-D index (id_1, id_2, ..., id_n), prefetch the memory
+location pointed by this memory reference.
+
+Traits: `MemRefsNormalizable`
+
+Interfaces: `AffineMapAccessInterface`
+
+#### Attributes:
+
+<table>
+<tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
+<tr><td><code>isWrite</code></td><td>::mlir::BoolAttr</td><td>bool attribute</td></tr>
+<tr><td><code>localityHint</code></td><td>::mlir::IntegerAttr</td><td>32-bit signless integer attribute whose minimum value is 0 whose maximum value is 3</td></tr>
+<tr><td><code>isDataCache</code></td><td>::mlir::BoolAttr</td><td>bool attribute</td></tr>
+<tr><td><code>map</code></td><td>::mlir::AffineMapAttr</td><td>AffineMap attribute</td></tr>
+</table>
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+| `memref` | memref of any type values
+| `indices` | variadic of index
+
 ### `krnl.print` (KrnlPrintOp)
 
 _Print a value._
@@ -993,7 +1070,7 @@ This operation can be used to print the input value. The user needs to provide a
 format string (à la printf) to specify how to print the input value.
 If the input value is not specified the operator will print the format string.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
 
 #### Attributes:
 
@@ -1022,7 +1099,7 @@ At the beginning of the msg string, user can add formatting instructions. The fl
 When no formatting is provided, `%s%d` is used (detailed signature and data) by default.
 Print operation ends with a newline, except when only requesting a compact types (`%t`).
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
 
 #### Attributes:
 
@@ -1043,7 +1120,7 @@ _Generate a random normal tensor._
 
 Operation that generates a random normally distributed tensor.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
 
 #### Operands:
 
@@ -1070,7 +1147,7 @@ The `krnl.region` will be removed after affine.for is lowered.
 ToFix: current `krnl.region` does not have input and output. You cannot
 create a new memref inside the region and use it outside of the region.
 
-Traits: AffineScope, NoTerminator, SingleBlock
+Traits: `AffineScope`, `NoTerminator`, `SingleBlock`
 
 ### `krnl.seqalloc` (KrnlSeqAllocOp)
 
@@ -1081,9 +1158,9 @@ The output is tagged with Allocate side effect, and a deallocation is defined fo
 sequence. This deallocation will free all the elements in the sequence as well as
 the sequence itself.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
 
-Interfaces: AllocationOpInterface, MemoryEffectOpInterface
+Interfaces: `AllocationOpInterface`, `MemoryEffectOpInterface`
 
 #### Operands:
 
@@ -1104,7 +1181,7 @@ _Krnl dealloc a sequence_
 This op deallocate the elements in the sequence and the sequence itself
 with memref::dealloc. This Op is a deep dealloc for sequence type.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
 
 #### Operands:
 
@@ -1130,9 +1207,9 @@ The returned element is marked as allocated by this Op with the bufferation
 interface so that deallocation can be generated correctly through the
 Bufferization::Deallocation pass.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
 
-Interfaces: AllocationOpInterface, MemoryEffectOpInterface
+Interfaces: `AllocationOpInterface`, `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -1165,7 +1242,9 @@ There is no return of a new seq, different from KrnlSeqInsertOp.
 This Op is introduced to accumulate a dynamic tensor in a LoopOp with
 statically known iteration count.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Operands:
 
@@ -1188,7 +1267,7 @@ operation ::= `krnl.specialized_kernel` `(` $loops `)` attr-dict `:` type($loops
 
 Krnl operation to convert.
 
-Interfaces: SpecializedKernelOpInterface
+Interfaces: `SpecializedKernelOpInterface`
 
 #### Operands:
 
@@ -1212,7 +1291,7 @@ value stored should have the same type as the elemental type of the memref.
 The number of arguments provided within brackets need to match the rank of
 the memref.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
 
 #### Operands:
 
@@ -1228,11 +1307,11 @@ _Compute the length of a string._
 
 Krnl operation that computes the length of a string.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -1252,11 +1331,11 @@ _Perform string comparison up to N bytes._
 
 Krnl operation that performs a string comparison up to N bytes.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -1301,9 +1380,11 @@ successor of the operation enclosing the region.
 This operation does _not_ have a custom syntax. However, krnl control
 operations omit the terminator in their custom syntax for brevity.
 
-Traits: ReturnLike, Terminator
+Traits: `ReturnLike`, `Terminator`
 
-Interfaces: RegionBranchTerminatorOpInterface
+Interfaces: `NoMemoryEffect (MemoryEffectOpInterface)`, `RegionBranchTerminatorOpInterface`
+
+Effects: `MemoryEffects::Effect{}`
 
 ### `krnl.unroll` (KrnlUnrollOp)
 
@@ -1350,11 +1431,11 @@ corresponding dimension for target memref type.
 %AV = vector_type_cast %A : memref<?x?xf32> to memref<?x?xvector<8xf32>>
 ```
 
-Traits: AlwaysSpeculatableImplTrait, MemRefsNormalizable
+Traits: `AlwaysSpeculatableImplTrait`, `MemRefsNormalizable`
 
-Interfaces: CastOpInterface, ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ViewLikeOpInterface
+Interfaces: `CastOpInterface`, `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ViewLikeOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -1367,4 +1448,37 @@ Effects: MemoryEffects::Effect{}
 | Result | Description |
 | :----: | ----------- |
 | `result` | memref of any type values
+
+### `krnl.yield` (KrnlYieldOp)
+
+_Yield values to parent operation_
+
+
+Syntax:
+
+```
+operation ::= `krnl.yield` attr-dict ($operands^ `:` type($operands))?
+```
+
+The `krnl.yield` yields zero or more SSA values from an krnl.iterate op region and
+terminates the region. The semantics of how the values yielded are used
+is defined by the parent operation.
+If `krnl.yield` has any operands, the operands must match the parent
+operation's results.
+If the parent operation defines no values, then the `krnl.yield` may be
+left out in the custom syntax and the builders will insert one implicitly.
+Otherwise, it has to be present in the syntax to indicate which values are
+yielded.
+
+Traits: `AlwaysSpeculatableImplTrait`, `MemRefsNormalizable`, `ReturnLike`, `Terminator`
+
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `RegionBranchTerminatorOpInterface`
+
+Effects: `MemoryEffects::Effect{}`
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+| `operands` | variadic of any type
 

--- a/docs/Dialects/onnx.md
+++ b/docs/Dialects/onnx.md
@@ -7,11 +7,11 @@ Absolute takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where absolute value, y = abs(x), is applied to
 the tensor elementwise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -31,11 +31,11 @@ _ONNX Acos operation_
 
 Calculates the arccosine (inverse of cosine) of the given input tensor, element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -55,11 +55,11 @@ _ONNX Acosh operation_
 
 Calculates the hyperbolic arccosine of the given input tensor element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -128,11 +128,11 @@ Compute one iteration of ADAGRAD, a stochastic gradient based optimization
     In that reference paper, this operator is a special case of the Figure 1's composite mirror
     descent update.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -223,11 +223,11 @@ Compute one iteration of Adam, a stochastic gradient based optimization
     If there are multiple inputs to be optimized, the pseudo code will be applied
     independently to each of them.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -264,11 +264,11 @@ This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; fo
 
 (Opset 14 change): Extend supported types to include uint8, int8, uint16, and int16.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -292,11 +292,11 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -323,11 +323,11 @@ is selected if the max appears more than once in the input. Otherwise the index 
 first occurrence is selected.
 The type of the output tensor is integer.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -362,11 +362,11 @@ is selected if the min appears more than once in the input. Otherwise the index 
 first occurrence is selected.
 The type of the output tensor is integer.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -396,11 +396,11 @@ _ONNX ArrayFeatureExtractor operation_
 Select elements of the input tensor based on the indices passed.<br>
     The indices are applied to the last axes of the tensor.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -421,11 +421,11 @@ _ONNX Asin operation_
 
 Calculates the arcsine (inverse of sine) of the given input tensor, element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -445,11 +445,11 @@ _ONNX Asinh operation_
 
 Calculates the hyperbolic arcsine of the given input tensor element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -469,11 +469,11 @@ _ONNX Atan operation_
 
 Calculates the arctangent (inverse of tangent) of the given input tensor, element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -493,11 +493,11 @@ _ONNX Atanh operation_
 
 Calculates the hyperbolic arctangent of the given input tensor element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -548,11 +548,11 @@ AveragePool consumes an input tensor X and applies average pooling across
  The output of each pooling window is divided by the number of elements (exclude pad when attribute count_include_pad is zero).
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -600,11 +600,11 @@ by an argument that is present) may also be simply omitted.
 
 This operation is not part of the standard and was added to assist onnx-mlir.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -674,11 +674,11 @@ For previous (depreciated) non-spatial cases, implementors are suggested
 to flatten the input shape to (N x C * D1 * D2 * ... * Dn) before a BatchNormalization Op.
 This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -718,11 +718,11 @@ where an output of 1 is produced with probability p and an output of 0 is produc
 This operator is non-deterministic and may not produce the same values in different
 implementations (even if a seed is specified).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -750,11 +750,11 @@ _ONNX Binarizer operation_
 
 Maps the values of the input tensor to either 0 or 1, element-wise, based on the outcome of a comparison against a threshold value.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -792,11 +792,11 @@ Because this operator supports Numpy-style broadcasting, X's and Y's shapes are
 not necessarily identical.
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -827,11 +827,11 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -852,11 +852,11 @@ _ONNX BitwiseNot operation_
 
 Returns the bitwise not of the input tensor element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -879,11 +879,11 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -907,11 +907,11 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -932,11 +932,11 @@ _ONNX BlackmanWindow operation_
 
 Generates a Blackman window as described in the paper https://ieeexplore.ieee.org/document/1455106.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -966,11 +966,11 @@ The operator casts the elements of a given input tensor (the first input) to
 the same data type as the elements of the second input tensor.
 See documentation of the Cast operator for further details.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1000,11 +1000,11 @@ Converts a map to a tensor.<br>The map key must be an int64 and the values will 
     in ascending order based on this key.<br>The operator supports dense packing or sparse packing.
     If using sparse packing, the key cannot exceed the max_map-1 value.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1096,11 +1096,11 @@ The rules then become:
 | [x] < -FLT_MAX | NaN | NaN | -Inf | NaN |
 | else | RNE | RNE | RNE | RNE |
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ResultTypeInferenceOpInterface, ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ResultTypeInferenceOpInterface`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1135,11 +1135,11 @@ Converts strings to integers and vice versa.<br>
     If the string default value is set, it will convert integers to strings.
     If the int default value is set, it will convert strings to integers.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1171,11 +1171,11 @@ Ceil takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the ceil is, y = ceil(x), is applied to
 the tensor elementwise. If x is integral, +0, -0, NaN,  or infinite, x itself is returned.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -1201,11 +1201,11 @@ using formula:
 max(0,x) + min(0,alpha*(exp(x/alpha)-1))
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1239,11 +1239,11 @@ If the input dimensions are bigger than the crop shape, a centered cropping wind
 If the input dimensions are smaller than the crop shape, the input is padded on each side equally,
 so that the input is centered in the output.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1273,11 +1273,11 @@ Clip operator limits the given input within an interval. The interval is
 specified by the inputs 'min' and 'max'. They default to
 numeric_limits::lowest() and numeric_limits::max(), respectively.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -1301,11 +1301,11 @@ Clip operator limits the given input within an interval. The interval is
 specified by the inputs 'min' and 'max'. They default to
 numeric_limits::lowest() and numeric_limits::max(), respectively.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -1329,11 +1329,11 @@ Clip operator limits the given input within an interval. The interval is
 specified by the inputs 'min' and 'max'. They default to
 numeric_limits::lowest() and numeric_limits::max(), respectively.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -1357,11 +1357,11 @@ Clip operator limits the given input within an interval. The interval is
 specified with arguments 'min' and 'max'. They default to
 numeric_limits::lowest() and numeric_limits::max() respectively.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1398,11 +1398,11 @@ NOTE:
   convolution formulas, it is required as input for more advanced scenarios as explained
   at PyTorch's implementation (https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Col2Im.cpp#L10)
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1436,11 +1436,11 @@ Selects slices from an input tensor along a given axis where condition evaluates
     Compress behaves like numpy.compress: https://docs.scipy.org/doc/numpy/reference/generated/numpy.compress.html
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1471,11 +1471,11 @@ All input tensors must have the same shape, except for the dimension size of the
 By default 'new_axis' is 0, the behavior is similar to numpy.concatenate.
 When 'new_axis' is 1, the behavior is similar to numpy.stack.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1503,11 +1503,11 @@ _ONNX Concat operation_
 
 Concatenate a list of tensors into a single tensor. All input tensors must have the same shape, except for the dimension size of the axis to concatenate on.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1539,11 +1539,11 @@ v3 = onnx.transpose(v1)
 
 This operation is not part of the standard and was added to assist onnx-mlir.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1574,11 +1574,11 @@ _ONNX ConstantOfShape operation_
 
 Generate a tensor with given value and shape.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ResultTypeInferenceOpInterface, ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ResultTypeInferenceOpInterface`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1606,11 +1606,11 @@ _ONNX Constant operation_
 This operator produces a constant tensor. Exactly one of the provided attributes, either value, sparse_value,
 or value_* must be specified.
 
-Traits: AlwaysSpeculatableImplTrait, ConstantLike
+Traits: `AlwaysSpeculatableImplTrait`, `ConstantLike`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ResultTypeInferenceOpInterface, ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ResultTypeInferenceOpInterface`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1639,11 +1639,11 @@ _ONNX ConvInteger operation_
 The integer convolution operator consumes an input tensor, its zero-point, a filter, and its zero-point,
 and computes the output. The production MUST never overflow. The accumulation may overflow if and only if in 32 bits.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1679,11 +1679,11 @@ _ONNX Conv operation_
 The convolution operator consumes an input tensor and a filter, and
 computes the output.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1730,11 +1730,11 @@ output_shape can also be explicitly specified in which case pads values are auto
 
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1770,11 +1770,11 @@ _ONNX Cos operation_
 
 Calculates the cosine of the given input tensor, element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -1794,11 +1794,11 @@ _ONNX Cosh operation_
 
 Calculates the hyperbolic cosine of the given input tensor element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -1837,11 +1837,11 @@ output = [5, 3, 0]
 ```
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1920,11 +1920,11 @@ All of these additional attributes are optional, designed to be less
 intrusive. The .mlir file can remain the same when a new attribute is
 added.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1970,11 +1970,11 @@ The actual shape of the output is specified in the \"output\" section.
 
 Reference: https://docs.scipy.org/doc/scipy/tutorial/fft.html
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -1998,6 +1998,40 @@ Effects: MemoryEffects::Effect{}
 | :----: | ----------- |
 | `output` | tensor of bfloat16 type values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values
 
+### `onnx.DFTV17` (ONNXDFTV17Op)
+
+_ONNX DFT operation_
+
+Computes the discrete Fourier transform of input.
+
+Traits: `AlwaysSpeculatableImplTrait`
+
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
+
+Effects: `MemoryEffects::Effect{}`
+
+#### Attributes:
+
+<table>
+<tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
+<tr><td><code>axis</code></td><td>::mlir::IntegerAttr</td><td>64-bit signed integer attribute</td></tr>
+<tr><td><code>inverse</code></td><td>::mlir::IntegerAttr</td><td>64-bit signed integer attribute</td></tr>
+<tr><td><code>onesided</code></td><td>::mlir::IntegerAttr</td><td>64-bit signed integer attribute</td></tr>
+</table>
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+| `input` | tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of bfloat16 type values
+| `dft_length` | tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or none type
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+| `output` | tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of bfloat16 type values
+
 ### `onnx.DeformConv` (ONNXDeformConvOp)
 
 _ONNX DeformConv operation_
@@ -2005,11 +2039,11 @@ _ONNX DeformConv operation_
 Performs deformable convolution as described in https://arxiv.org/abs/1703.06211 and https://arxiv.org/abs/1811.11168.
 This operator specification supports the general N-D case. Note that most common use cases have 2D or 3D data.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2067,11 +2101,11 @@ tmp = np.transpose(tmp, [0, 1, 4, 2, 5, 3])
 y = np.reshape(tmp, [b, c // (blocksize ** 2), h * blocksize, w * blocksize])
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2105,11 +2139,11 @@ there's no zero point (zero point is supposed to be 0).
 `zero-point` is usually not used in the case of float8e4m3fn, float8e4m3fnuz, float8e5m2, float8e5m2fnuz quantization,
 but the dequantization formula remains the same for consistency and 'x_scale' still determines the output type.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2142,11 +2176,11 @@ and the inner-most 2 dimensions form square matrices.
 The output is a tensor of shape `[*]`, containing the determinants of all input submatrices.
 e.g., When the input is 2-D, the output is a scalar(shape is empty: `[]`).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -2177,11 +2211,11 @@ Uses an index mapping to convert a dictionary to an array.<br>
     then an input of ``{\"a\": 4, \"c\": 8}`` will produce an output of ``[4, 8, 0, 0]``.
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2253,11 +2287,11 @@ The axis identifies the dimension within the shape which is going to be obtained
 
 This operation is not part of the standard and was added to assist onnx-mlir.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2288,11 +2322,11 @@ This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; fo
 
 (Opset 14 change): Extend supported types to include uint8, int8, uint16, and int16.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -2324,11 +2358,11 @@ scale = 1. / (1. - ratio).
 ```
 This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2384,11 +2418,11 @@ y = saturate (round (x / y_scale) + y_zero_point)
 * for saturation, it saturates to [0, 255] if it's uint8, or [-127, 127] if it's int8. Right now only uint8 is supported.
 * rounding to nearest ties to even.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -2434,11 +2468,11 @@ Specifically, every occurrence of ellipsis in the equation must represent the sa
 The right-hand side may contain exactly one ellipsis. In implicit mode, the ellipsis dimensions are set to the
 beginning of the output. The equation string may contain space (U+0020) character.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2468,11 +2502,11 @@ Elu takes one input data (Tensor<T>) and produces one output data
 0`, `f(x) = x for x >= 0`., is applied to the tensor elementwise.
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2517,11 +2551,11 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -2542,11 +2576,11 @@ _ONNX Erf operation_
 
 Computes the error function of the given input tensor element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -2566,11 +2600,11 @@ _ONNX Exp operation_
 
 Calculates the exponential of the given input tensor, element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -2597,11 +2631,11 @@ but the major difference is numpy.broadcast_to() does not allow shape to be smal
 It is possible that the output.shape is not equal to shape, when some dimensions in shape is equal to 1,
 or the shape.ndim < input.shape.ndim.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -2628,11 +2662,11 @@ is populated with ones, but attribute 'k' can be used to populate upper or lower
 The 'dtype' argument must be one of the data types specified in the 'DataType' enum field in the
 TensorProto message and be valid as an output type.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2663,11 +2697,11 @@ Concatenates input tensors into one continuous output.<br>
     Inputs are copied to the output maintaining the order of the input arguments.<br>
     All inputs must be integers or floats, while the output will be all floating point values.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2696,11 +2730,11 @@ Flattens the input tensor into a 2D matrix. If input tensor has shape
 (d_0, d_1, ... d_n) then the output will have shape
 (d_0 X d_1 ... d_(axis-1), d_axis X d_(axis+1) ... X dn).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2729,11 +2763,11 @@ Floor takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the floor is, y = floor(x), is applied to
 the tensor elementwise. If x is integral, +0, -0, NaN,  or infinite, x itself is returned.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -2799,11 +2833,11 @@ Equations (Default: f=Sigmoid, g=Tanh):
 * Ht = (1 - zt) (.) ht + zt (.) Ht-1
 This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -2893,11 +2927,11 @@ output = [
 ]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3008,11 +3042,11 @@ indices = [[1],[0]]                     # indices_shape = [2, 1]
 output  = [[2,3],[4,5]]                 # output_shape  = [2, 2]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3087,11 +3121,11 @@ output = [
 ]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3125,11 +3159,11 @@ $y = 0.5 * x * (1 + Tanh(sqrt(2/\pi) * (x + 0.044715 * x^3)))$ is used and appli
 to the tensor elementwise.
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3167,11 +3201,11 @@ computation if attribute transA is non-zero, same for B and transB.
 This operator supports **unidirectional broadcasting** (tensor C should be unidirectional broadcastable to tensor A * B); for more details please check [the doc](Broadcasting.md).
 This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3205,11 +3239,11 @@ GlobalAveragePool consumes an input tensor X and applies average pooling across
  the values in the same channel. This is equivalent to AveragePool with kernel size
  equal to the spatial dimension of input tensor.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -3231,11 +3265,11 @@ GlobalLpPool consumes an input tensor X and applies lp pool pooling across
  the values in the same channel. This is equivalent to LpPool with kernel size
  equal to the spatial dimension of input tensor.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3264,11 +3298,11 @@ GlobalMaxPool consumes an input tensor X and applies max pooling across
  the values in the same channel. This is equivalent to MaxPool with kernel size
  equal to the spatial dimension of input tensor.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -3410,11 +3444,11 @@ forward pass can be reused if the gradient is computed via reverse-mode
 auto-differentiation.
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3446,11 +3480,11 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -3474,11 +3508,11 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -3511,11 +3545,11 @@ They are used to interpolate output values of `Y[N, C, H_out, W_out]`.
 The GridSample operator is often used in doing grid generator and sampler in the [Spatial Transformer Networks](https://arxiv.org/abs/1506.02025).
 See also in [torch.nn.functional.grid_sample](https://pytorch.org/docs/master/generated/torch.nn.functional.grid_sample.html#torch-nn-functional-grid-sample).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3559,11 +3593,11 @@ When the number of groups is the same as the number of channels, this operator i
 equivalent to InstanceNormalization. When there is only one group, this operator
 is equivalent to LayerNormalization.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3593,11 +3627,11 @@ _ONNX HammingWindow operation_
 
 Generates a Hamming window as described in the paper https://ieeexplore.ieee.org/document/1455106.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3625,11 +3659,11 @@ _ONNX HannWindow operation_
 
 Generates a Hann window as described in the paper https://ieeexplore.ieee.org/document/1455106.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3659,11 +3693,11 @@ HardSigmoid takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the HardSigmoid function, y = max(0, min(1, alpha * x + beta)),
 is applied to the tensor elementwise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3693,11 +3727,11 @@ HardSwish takes one input data (Tensor<T>) and produces one output data (Tensor<
 the HardSwish function, y = x * max(0, min(1, alpha * x + beta)) = x * HardSigmoid<alpha, beta>(x),
 where alpha = 1/6 and beta = 0.5, is applied to the tensor elementwise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -3723,11 +3757,11 @@ The \"axis\" attribute indicates the dimension along which Hardmax
 will be performed. The output tensor has the same shape
 and contains the Hardmax values of the corresponding input.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3754,11 +3788,11 @@ _ONNX Identity operation_
 
 Identity operator
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -3778,11 +3812,11 @@ _ONNX If operation_
 
 If conditional
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, HasOnnxSubgraphOpInterface, NoMemoryEffect (MemoryEffectOpInterface), ResultTypeInferenceOpInterface, ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `HasOnnxSubgraphOpInterface`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ResultTypeInferenceOpInterface`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -3809,11 +3843,11 @@ Replaces inputs that equal one value with another, leaving all other elements al
     which one depends on whether floats or integers are being processed.<br>
     The imputed_value attribute length can be 1 element, or it can have one element per input feature.<br>In other words, if the input tensor has the shape [*,F], then the length of the attribute array may be 1 or F. If it is 1, then it is broadcast along the last dimension and applied to each feature.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3848,11 +3882,11 @@ y = scale * (x - mean) / sqrt(variance + epsilon) + B,
 where mean and variance are computed per instance per channel.
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3881,11 +3915,11 @@ _ONNX IsInf operation_
 
 Map infinity to true and other values to false.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -3913,11 +3947,11 @@ _ONNX IsNaN operation_
 
 Returns which elements of the input are NaN.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -3946,11 +3980,11 @@ where `max(0, c - floor((size - 1) / 2)) <= i <= min(C - 1, c + ceil((size - 1) 
 
 `Y[n, c, d1, ..., dk] = X[n, c, d1, ..., dk] / (bias + alpha / size * square_sum[n, c, d1, ..., dk] ) ^ beta`
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4029,11 +4063,11 @@ Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
 * Ht = ot (.) h(Ct)
 This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4092,11 +4126,11 @@ Maps each element in the input tensor to another value.<br>
     For key look-up, bit-wise comparison is used so even a float NaN can be
     mapped to a value in 'values_*' attribute.<br>
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4169,11 +4203,11 @@ This is layer normalization defined in ONNX as function.
       the shape of `Mean` and `InvStdDev` is `[d[0], ..., d[axis-1], 1, ..., 1]`.
       `Y` and `X` have the same shape.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4218,11 +4252,11 @@ The input and output tensors must have the same shape.
 
 This operation is not part of the standard and was added to assist onnx-mlir.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4251,11 +4285,11 @@ LeakyRelu takes input data (Tensor<T>) and an argument alpha, and produces one
 output data (Tensor<T>) where the function `f(x) = alpha * x for x < 0`,
 `f(x) = x for x >= 0`, is applied to the data tensor elementwise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4285,11 +4319,11 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -4313,11 +4347,11 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -4338,11 +4372,11 @@ _ONNX LinearClassifier operation_
 
 Linear classifier
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4380,11 +4414,11 @@ Generalized linear regression evaluation.<br>
     The coefficients array is of length n, and the coefficients for each target are contiguous.
     Intercepts are optional but if provided must match the number of targets.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4414,11 +4448,11 @@ _ONNX Log operation_
 
 Calculates the natural log of the given input tensor, element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -4444,11 +4478,11 @@ The \"axis\" attribute indicates the dimension along which LogSoftmax
 will be performed. The output tensor has the same shape
 and contains the LogSoftmax values of the corresponding input.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4609,11 +4643,11 @@ point-wise operators (e.g. dropout, residual connections, linear layer).
 
 The input/output of subgraph (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, HasOnnxSubgraphOpInterface, NoMemoryEffect (MemoryEffectOpInterface), ResultTypeInferenceOpInterface, ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `HasOnnxSubgraphOpInterface`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ResultTypeInferenceOpInterface`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -4635,11 +4669,11 @@ _ONNX LpNormalization operation_
 
 Given a matrix, apply Lp-normalization along the provided axis.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4689,11 +4723,11 @@ LpPool consumes an input tensor X and applies Lp pooling across
  pad_shape[i] = (output_spatial_shape[i] - 1) * strides_spatial_shape[i] + {kernelSpatialShape} - input_spatial_shape[i]
  ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4727,11 +4761,11 @@ _ONNX MatMulInteger operation_
 Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html.
 The production MUST never overflow. The accumulation may overflow if and only if in 32 bits.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -4754,11 +4788,11 @@ _ONNX MatMul operation_
 
 Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -4781,11 +4815,11 @@ Element-wise max of each of the input tensors (with Numpy-style broadcasting sup
 All inputs and outputs must have the same data type.
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -4836,11 +4870,11 @@ MaxPool consumes an input tensor X and applies max pooling across
  The output of each pooling window is maximum number of elements exclude pad. 
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4877,11 +4911,11 @@ See ONNXMaxPoolOp for a full description of the MaxPool semantics.
 
 This operation is not part of the standard and was added to assist onnx-mlir.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4916,11 +4950,11 @@ ROI max pool consumes an input tensor X and region of interests (RoIs) to
  apply max pooling across each RoI, to produce output 4-D tensor of shape
  (num_rois, channels, pooled_shape[0], pooled_shape[1]).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -4966,11 +5000,11 @@ In addition to the inputs, MaxUnpool takes three attributes, namely kernel_shape
  which define the exact unpooling op. The attributes typically have the same values as the corresponding
  pooling op that the unpooling op is trying to invert.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5003,11 +5037,11 @@ Element-wise mean of each of the input tensors (with Numpy-style broadcasting su
 All inputs and outputs must have the same data type.
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -5028,11 +5062,11 @@ _ONNX MeanVarianceNormalization operation_
 A MeanVarianceNormalization Function: Perform mean variance normalization
       on the input tensor X using formula: `(X-EX)/sqrt(E(X-EX)^2)`
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5066,11 +5100,11 @@ In the returned matrix, all the triangles (filterbanks) have a peak value of 1.0
 
 The returned MelWeightMatrix can be used to right-multiply a spectrogram S of shape [frames, num_spectrogram_bins] of linear scale spectrum values (e.g. STFT magnitudes) to generate a \"mel spectrogram\" M of shape [frames, num_mel_bins].
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5103,11 +5137,11 @@ Element-wise min of each of the input tensors (with Numpy-style broadcasting sup
 All inputs and outputs must have the same data type.
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -5133,11 +5167,11 @@ Perform the linear unit element-wise on the input tensor X using formula:
 mish(x) = x * tanh(softplus(x)) = x * tanh(ln(1 + e^{x}))
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -5169,11 +5203,11 @@ Performs element-wise binary modulus (with Numpy-style broadcasting support).
 
   This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5260,11 +5294,11 @@ Compute one iteration of stochastic gradient update with momentum.
     concatenation of \"X_1\" and \"X_2\" (of course, their gradient and accumulate gradient should
     be concatenated too) and then our pseudo code becomes applicable.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5300,11 +5334,11 @@ This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; fo
 
 (Opset 14 change): Extend supported types to include uint8, int8, uint16, and int16.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -5326,11 +5360,11 @@ _ONNX Multinomial operation_
 Generate a tensor of samples from a multinomial distribution according to the probabilities
 of each of the possible outcomes.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5361,11 +5395,11 @@ Neg takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where each element flipped sign, y = -x, is applied to
 the tensor elementwise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -5485,11 +5519,11 @@ loss = np.sum(loss) / weight_total
 // -1.57
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5525,11 +5559,11 @@ result in the same boxes being selected by the algorithm.
 The selected_indices output is a set of integers indexing into the input collection of bounding boxes representing the selected boxes.
 The bounding box coordinates corresponding to the selected indices can then be obtained using the Gather or GatherND operation.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5564,11 +5598,11 @@ Returns the indices of the elements that are non-zero
     https://docs.scipy.org/doc/numpy/reference/generated/numpy.nonzero.html,
     but for scalar input, NonZero produces output shape (0, N) instead of (1, N), which is different from Numpy's behavior.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -5597,11 +5631,11 @@ Example:
 
 This operation is not part of the standard and was added to assist onnx-mlir.
 
-Traits: AlwaysSpeculatableImplTrait, ConstantLike
+Traits: `AlwaysSpeculatableImplTrait`, `ConstantLike`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5631,11 +5665,11 @@ Normalize the input.  There are three normalization modes, which have the corres
     For batches, that is, [N,C] tensors, normalization is done along the C axis. In other words, each row
     of the batch is normalized independently.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5662,11 +5696,11 @@ _ONNX Not operation_
 
 Returns the negation of the input tensor element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -5693,11 +5727,11 @@ Replace each input element with an array of ones and zeros, where a single
     If the input is a tensor of float, int32, or double, the data will be cast
     to integers and the cats_int64s category list will be used for the lookups.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5744,11 +5778,11 @@ Produces a one-hot tensor based on inputs.
     output[i, j, k, input[i, j, k]] = 1 for all i, j, k and 0 otherwise.
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5779,11 +5813,11 @@ If the input is a tensor or sequence type, it returns the input.
 If the input is an optional type, it outputs the element in the input.
 It is an error if the input is an empty optional-type (i.e. does not have an element) and the behavior is undefined in this case.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -5805,11 +5839,11 @@ Returns true if (1) the input is an optional-type and contains an element,
 or, (2) the input is a tensor or sequence type.
 If the input is not provided or is an empty optional-type, this op returns false.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -5830,11 +5864,11 @@ _ONNX Optional operation_
 Constructs an optional-type value containing either an empty optional of a certain type specified by the attribute,
 or a non-empty value containing the input element.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -5864,11 +5898,11 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -5892,11 +5926,11 @@ output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
 `f(x) = x for x >= 0`., is applied to the data tensor elementwise.
 This operator supports **unidirectional broadcasting** (tensor slope should be unidirectional broadcastable to input tensor X); for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -6016,11 +6050,11 @@ output = [
 ]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6124,11 +6158,11 @@ Example 3 (`edge` mode):
   ]
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6231,11 +6265,11 @@ Example 3 (`edge` mode):
   ]
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6338,11 +6372,11 @@ output = [
 ]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6387,11 +6421,11 @@ Example:
       ],
   ]
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6423,11 +6457,11 @@ produces one output data (Tensor<T>) where the function `f(x) = x^exponent`,
 is applied to the data tensor elementwise.
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -6476,11 +6510,11 @@ Each input or output and its related zero point must have same type.
 When bias is present it must be quantized using scale = input scale * weight scale and
 zero point as 0.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6530,11 +6564,11 @@ for per column quantization. If the input is N-D tensor with shape [D1, D2, M, K
 have shape [D1, D2, M, 1] for per row quantization and shape [D1, D2, 1, K] for per column quantization.
 Production must never overflow, and accumulation may overflow if and only if in 32 bits.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -6569,11 +6603,11 @@ For (x / y_scale), it's rounding to the nearest even. Refer to https://en.wikipe
 but the quantization formula remains the same for consistency and
 the type of the attribute 'y_zero_point' still determines the quantization type.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6639,11 +6673,11 @@ This is RMS layer normalization defined in ONNX as function.
       the shape of `Mean` and `InvStdDev` is `[d[0], ..., d[axis-1], 1, ..., 1]`.
       `Y` and `X` have the same shape.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6714,11 +6748,11 @@ Equations (Default: f=Tanh):
 * Ht = f(Xt*(Wi^T) + Ht-1*(Ri^T) + Wbi + Rbi)
 This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6763,11 +6797,11 @@ The data type is specified by the 'dtype' argument, or copied from the input ten
 The 'dtype' argument must be one of the data types specified in the 'DataType' enum field in the
 TensorProto message, and be valid as an output type.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6803,11 +6837,11 @@ The data type is specified by the 'dtype' argument. The 'dtype' argument must
 be one of the data types specified in the 'DataType' enum field in the
 TensorProto message.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ResultTypeInferenceOpInterface, ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ResultTypeInferenceOpInterface`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6838,11 +6872,11 @@ The data type is specified by the 'dtype' argument, or copied from the input ten
 The 'dtype' argument must be one of the data types specified in the 'DataType' enum field in the
 TensorProto message and be valid as an output type.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6877,11 +6911,11 @@ The data type is specified by the 'dtype' argument. The 'dtype' argument must
 be one of the data types specified in the 'DataType' enum field in the
 TensorProto message.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -6935,11 +6969,11 @@ Inputs: start = 10, limit = 4, delta = -2
 Output: [10, 8, 6]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -6963,11 +6997,11 @@ Reciprocal takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the reciprocal is, y = 1/x, is applied to
 the tensor elementwise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -6994,11 +7028,11 @@ valid. Reduction over an empty set of values yields 0.
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7034,11 +7068,11 @@ valid. Reduction over an empty set of values yields 0.
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7073,11 +7107,11 @@ valid. Reduction over an empty set of values yields 0.
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7113,11 +7147,11 @@ valid. Reduction over an empty set of values yields 0.
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7152,11 +7186,11 @@ valid. Reduction over an empty set of values yields minus infinity (if supported
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7192,11 +7226,11 @@ valid. Reduction over an empty set of values yields minus infinity (if supported
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7231,11 +7265,11 @@ valid. Reduction over an empty set of values yields minus infinity (if supported
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7271,11 +7305,11 @@ valid. Reduction over an empty set of values yields minus infinity (if supported
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7312,11 +7346,11 @@ If the input data type is Boolean, the comparison should consider `False < True`
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7352,11 +7386,11 @@ valid. Reduction over an empty set of values yields minus infinity (if supported
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7391,11 +7425,11 @@ valid. Reduction over an empty set of values yields minus infinity (if supported
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7431,11 +7465,11 @@ valid. Reduction over an empty set of values yields undefined.
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7471,11 +7505,11 @@ valid. Reduction over an empty set of values yields undefined.
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7512,11 +7546,11 @@ If the input data type is Boolean, the comparison should consider `False < True`
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7552,11 +7586,11 @@ valid. Reduction over an empty set of values yields plus infinity (if supported 
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7591,11 +7625,11 @@ valid. Reduction over an empty set of values yields plus infinity (if supported 
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7631,11 +7665,11 @@ valid. Reduction over an empty set of values yields 1.
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7671,11 +7705,11 @@ valid. Reduction over an empty set of values yields 1.
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7710,11 +7744,11 @@ valid. Reduction over an empty set of values yields 0.
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7750,11 +7784,11 @@ valid. Reduction over an empty set of values yields 0.
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7790,11 +7824,11 @@ valid. Reduction over an empty set of values yields 0.
 The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
 to `False` instead of `True`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7827,11 +7861,11 @@ the resulted tensor have the reduced dimension pruned.
 The above behavior is similar to numpy, with the exception that numpy defaults keepdims to
 False instead of True.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7861,11 +7895,11 @@ Relu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the rectified linear function, y = max(0, x), is applied to
 the tensor elementwise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -7897,11 +7931,11 @@ If the attribute 'allowzero' is set, it is invalid for the specified shape to
 contain both a zero value and -1, as the value of the dimension corresponding
 to -1 cannot be determined uniquely.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7934,11 +7968,11 @@ output_dimension = floor(input_dimension * (roi_end - roi_start) * scale)
 ```
 if input \\"sizes\\" is not specified.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -7978,11 +8012,11 @@ Resize the input tensor.
 Each dimension value of the output tensor is:
   output_dimension = floor(input_dimension * scale).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8012,11 +8046,11 @@ Resize the input tensor. In general, it calculates every value in the output ten
 Each dimension value of the output tensor is:
   output_dimension = floor(input_dimension * (roi_end - roi_start) * scale) if input \\"sizes\\" is not specified.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8053,11 +8087,11 @@ Resize the input tensor. In general, it calculates every value in the output ten
 Each dimension value of the output tensor is:
   output_dimension = floor(input_dimension * (roi_end - roi_start) * scale) if input \\"sizes\\" is not specified.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8095,11 +8129,11 @@ Each dimension value of the output tensor is: <br/>
   `output_dimension = floor(input_dimension * (roi_end - roi_start) * scale)` <br/>
 if input \\"sizes\\" is not specified.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8152,11 +8186,11 @@ This operation terminates a func::FuncOp in the ONNX dialect and is replaced
 by func::ReturnOp in StandardFuncReturnPass before lowering to Krnl or other
 dialects.
 
-Traits: AlwaysSpeculatableImplTrait, HasParent<func::FuncOp>, ReturnLike, Terminator
+Traits: `AlwaysSpeculatableImplTrait`, `HasParent<func::FuncOp>`, `ReturnLike`, `Terminator`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), RegionBranchTerminatorOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `RegionBranchTerminatorOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -8202,11 +8236,11 @@ Example 2:
             [10.0, 9.0,  8.0,  11.0],
             [15.0, 14.0, 13.0, 12.0]]
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8245,11 +8279,11 @@ map and from feature map into RoI feature; in each ROI bin,
 the value of the sampled locations are computed directly
 through bilinear interpolation.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8296,11 +8330,11 @@ round([1.5]) = [2.0]
 round([-4.5]) = [-4.0]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -8320,11 +8354,11 @@ _ONNX STFT operation_
 
 Computes the Short-time Fourier Transform of the signal.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8354,11 +8388,11 @@ _ONNX SVMClassifier operation_
 
 Support Vector Machine classifier
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8396,11 +8430,11 @@ _ONNX SVMRegressor operation_
 
 Support Vector Machine regression prediction and one-class SVM anomaly detection.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8434,11 +8468,11 @@ _ONNX Scaler operation_
 
 Rescale input data, for example to standardize features by removing the mean and scaling to unit variance.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8586,11 +8620,11 @@ values are computed in the outer graph, they need to be passed in as extra state
     }
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, HasOnnxSubgraphOpInterface, NoMemoryEffect (MemoryEffectOpInterface), ResultTypeInferenceOpInterface, ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `HasOnnxSubgraphOpInterface`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ResultTypeInferenceOpInterface`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8682,11 +8716,11 @@ axis = 1
 output = [[1.0, 1.1, 3.0, 2.1, 5.0]]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8790,11 +8824,11 @@ output  = [[[5, 5, 5, 5], [6, 6, 6, 6], [7, 7, 7, 7], [8, 8, 8, 8]],
             [[8, 7, 6, 5], [4, 3, 2, 1], [1, 2, 3, 4], [5, 6, 7, 8]]]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8875,11 +8909,11 @@ Example 2:
   output = [[1.0, 1.1, 3.0, 2.1, 5.0]]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8911,11 +8945,11 @@ Selu takes one input data (Tensor<T>) and produces one output data
 `y = gamma * (alpha * e^x - alpha) for x <= 0`, `y = gamma * x for x > 0`,
 is applied to the tensor elementwise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -8945,11 +8979,11 @@ Outputs a tensor copy from the tensor at 'position' in 'input_sequence'.
 Accepted range for 'position' is in `[-n, n - 1]`, where `n` is the number of tensors in 'input_sequence'.
 Negative value means counting positions from the back.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -8971,11 +9005,11 @@ _ONNX SequenceConstruct operation_
 Construct a tensor sequence containing 'inputs' tensors.
 All tensors in 'inputs' must have the same data type.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -8995,11 +9029,11 @@ _ONNX SequenceEmpty operation_
 
 Construct an empty tensor sequence, with given data type.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9023,11 +9057,11 @@ Accepted range for 'position' is in `[-n, n - 1]`, where `n` is the number of te
 Negative value means counting positions from the back.
 'position' is optional, by default it erases the last tensor from 'input_sequence'.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9052,11 +9086,11 @@ Accepted range for 'position' is in `[-n, n]`, where `n` is the number of tensor
 Negative value means counting positions from the back.
 'position' is optional, by default it inserts 'tensor' to the back of 'input_sequence'.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9078,11 +9112,11 @@ _ONNX SequenceLength operation_
 
 Produces a scalar(tensor of empty shape) containing the number of tensors in 'input_sequence'.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9115,11 +9149,11 @@ the input.
 This operator assumes that processing each sample is independent and could executed in parallel
 or in any order. Users cannot expect any specific ordering in which each subgraph is computed.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, HasOnnxSubgraphOpInterface, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `HasOnnxSubgraphOpInterface`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9177,11 +9211,11 @@ end: 2
 Output: [3]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9238,11 +9272,11 @@ At this moment, this operation only supports static dimensions.
 
 This operation is not part of the standard and was added to assist onnx-mlir.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9272,11 +9306,11 @@ having same datatype and shape with input. It has two attributes, lambd and
 bias. The formula of this operator is: If x < -lambd, y = x + bias;
 If x > lambd, y = x - bias; Otherwise, y = 0.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9306,11 +9340,11 @@ Sigmoid takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the sigmoid function, y = 1 / (1 + exp(-x)), is applied to the
 tensor elementwise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9331,11 +9365,11 @@ _ONNX Sign operation_
 Calculate the sign of the given input tensor element-wise.
 If input > 0, output 1. if input < 0, output -1. if input == 0, output 0.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9355,11 +9389,11 @@ _ONNX Sin operation_
 
 Calculates the sine of the given input tensor, element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9379,11 +9413,11 @@ _ONNX Sinh operation_
 
 Calculates the hyperbolic sine of the given input tensor element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9403,11 +9437,11 @@ _ONNX Size operation_
 
 Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9488,11 +9522,11 @@ result = [
 ]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9555,11 +9589,11 @@ Finally, L is optionally reduced:
 * If reduction = 'mean', the output is scalar: ReduceMean(L), or if weight is provided: `ReduceSum(L) / ReduceSum(W)`,
   where tensor W is of shape `(N, D1, D2, ..., Dk)` and `W[n][d1][d2]...[dk] = weights[labels[i][d1][d2]...[dk]]`.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9596,11 +9630,11 @@ The \"axis\" attribute indicates the dimension along which Softmax
 will be performed. The output tensor has the same shape
 and contains the Softmax values of the corresponding input.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9640,11 +9674,11 @@ Each of these dimensions must be matched correctly, or else the operator
 will throw errors. The output tensor has the same shape
 and contains the softmax values of the corresponding input.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9673,11 +9707,11 @@ Softplus takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the softplus function, y = ln(exp(x) + 1), is applied to
 the tensor elementwise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9697,11 +9731,11 @@ _ONNX Softsign operation_
 
 Calculates the softsign (x/(1+|x|)) of the given input tensor element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9723,11 +9757,11 @@ SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
 this op outputs a copy of the input tensor where values from the height and width dimensions
 are moved to the depth dimension.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9758,11 +9792,11 @@ If the attribute 'num_outputs' is specified, then the tensor is split into equal
 If the tensor is not evenly splittable into `num_outputs`, the last chunk will be smaller.
 If the input 'split' is specified, it indicates the sizes of each output in the split.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9802,11 +9836,11 @@ If 'split' is a 1-dimensional tensor, the input tensor is split into 'size(split
 with lengths of the parts on 'axis' specified in 'split'. In this scenario, the sum of entries
 in 'split' must be equal to the dimension size of input tensor on 'axis'.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9837,11 +9871,11 @@ Split a tensor into a list of tensors, along the specified
 'axis'. Lengths of the parts can be specified using argument 'split'.
 Otherwise, the tensor is split to equal sized parts.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9871,11 +9905,11 @@ Split a tensor into a list of tensors, along the specified
 'axis'. Lengths of the parts can be specified using input 'split'.
 Otherwise, the tensor is split to equal sized parts.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9905,11 +9939,11 @@ Square root takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the square root is, y = x^0.5, is applied to
 the tensor elementwise. If x is negative, then it will return NaN.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9932,11 +9966,11 @@ Takes an input `axes` with a list of axes to squeeze.
 If `axes` is not provided, all the single dimensions will be removed from
 the shape. If an axis is selected with shape entry not equal to one, an error is raised.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -9960,11 +9994,11 @@ Takes a  parameter `axes` with a list of axes to squeeze.
 If `axes` is not provided, all the single dimensions will be removed from
 the shape. If an axis is selected with shape entry not equal to one, an error is raised.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -9999,11 +10033,11 @@ This operator only accepts [C]- and [1, C]-tensor.
 If all elements in X are dropped, the output will be the empty value of string tensor with shape [1]
 if input shape is [C] and shape [1, 1] if input shape is [1, C].
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10037,11 +10071,11 @@ This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; fo
 
 (Opset 14 change): Extend supported types to include uint8, int8, uint16, and int16.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -10064,11 +10098,11 @@ Element-wise sum of each of the input tensors (with Numpy-style broadcasting sup
 All inputs and outputs must have the same data type.
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -10088,11 +10122,11 @@ _ONNX Tan operation_
 
 Calculates the tangent of the given input tensor, element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -10112,11 +10146,11 @@ _ONNX Tanh operation_
 
 Calculates the hyperbolic tangent of the given input tensor element-wise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -10162,11 +10196,11 @@ this operator first computes the counts of all n-grams and then scale them by th
 Only one of pool_strings and pool_int64s can be set. If pool_int64s is set, the input should be an integer tensor.
 If pool_strings is set, the input must be a string tensor.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10203,11 +10237,11 @@ ThresholdedRelu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the rectified linear function, y = x for x > alpha, y = 0 otherwise,
 is applied to the tensor elementwise.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10236,11 +10270,11 @@ Constructs a tensor by tiling a given tensor.
 This is the same as function `tile` in Numpy, but no broadcast.
 For example A = [[1, 2], [3, 4]], B = [1, 2], tile(A, B) = [[1, 2, 1, 2], [3, 4, 3, 4]]
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -10275,11 +10309,11 @@ shape [a_1, a_2, ..., a_n, r] and integer argument k, return two outputs:
 Given two equivalent values, this operator uses the indices along the axis as
 a tiebreaker. That is, the element with the lower index will appear first.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10312,11 +10346,11 @@ Transpose the input tensor similar to numpy.transpose. For example, when
 perm=(1, 0, 2), given an input tensor of shape (1, 2, 3), the output shape
 will be (2, 1, 3).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10351,11 +10385,11 @@ Tree Ensemble classifier.  Returns the top class for each of N inputs.<br>
     One and only one of classlabels_strings or classlabels_int64s
     will be defined. The class_ids are indices into this list.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10408,11 +10442,11 @@ Tree Ensemble regressor.  Returns the regressed values for each input in N.<br>
     All trees must have their node ids start at 0 and increment by 1.<br>
     Mode enum is BRANCH_LEQ, BRANCH_LT, BRANCH_GTE, BRANCH_GT, BRANCH_EQ, BRANCH_NEQ, LEAF
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10466,11 +10500,11 @@ A negative k value retains the main diagonal and |k| diagonals below it.
 If upper is set to false, a positive k retains the lower triangular matrix including the main diagonal and k diagonals above it.
 A negative k value excludes the main diagonal and (|k|-1) diagonals below it.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10594,11 +10628,11 @@ output_counts:
 [2, 1, 1]
 ```
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10638,11 +10672,11 @@ The rank of the output tensor (`output_rank`) is the rank of the input tensor (`
 Each value in `axes` should be within the (inclusive) range [-output_rank , output_rank - 1].
 The order of values in `axes` does not matter and can come in any order.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -10674,11 +10708,11 @@ Each value in `axes` should be within the (inclusive) range [-output_rank , outp
 The order of values in `axes` does not matter and can come in any order.
 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10707,11 +10741,11 @@ Upsample the input tensor.
 Each dimension value of the output tensor is:
   output_dimension = floor(input_dimension * scale).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10741,11 +10775,11 @@ Upsample the input tensor.
 Each dimension value of the output tensor is:
   output_dimension = floor(input_dimension * scale).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -10778,11 +10812,11 @@ with three parameters.
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -10807,11 +10841,11 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
 
 This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -10843,11 +10877,11 @@ The operation takes variable number of operands and produces no results.
 This operation is not part of the standard and was added to assist onnx-mlir.
 It terminates a ONNXLoop/Scan/IfOp region.
 
-Traits: AlwaysSpeculatableImplTrait, ReturnLike, Terminator
+Traits: `AlwaysSpeculatableImplTrait`, `ReturnLike`, `Terminator`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), RegionBranchTerminatorOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `RegionBranchTerminatorOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -10864,11 +10898,11 @@ Creates a map from the input and the attributes.<br>
     Must provide keys in either classlabels_strings or classlabels_int64s (but not both).<br>
     The columns of the tensor correspond one-by-one to the keys specified by the attributes. There must be as many columns as keys.<br>
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 

--- a/docs/Dialects/zhigh.md
+++ b/docs/Dialects/zhigh.md
@@ -6,11 +6,11 @@ _ZHigh Add operation_
 ZHigh operation to perform an Add.
 This operation does not support broadcasting.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -31,11 +31,11 @@ _ZHigh 2D average pooling operation_
 
 ZHigh operation to perform 2D average pooling.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -64,11 +64,11 @@ _ZHigh batchnorm operation_
 
 ZHigh operation to perform batchnorm.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -88,21 +88,21 @@ Effects: MemoryEffects::Effect{}
 
 _ZHigh 2D convolution operation_
 
-ZHigh operation to perform 2D convolution. 
+ZHigh operation to perform 2D convolution.
 * input: `[num_batches, height_in, width_in, channels_in]`
-* input_kernel: `[kernel_height, kernel_width, channels_in, channels_out]` 
+* input_kernel: `[kernel_height, kernel_width, channels_in, channels_out]`
 * input_bias: `[channels_out] `
-* kernel_shape: 1D array of kernel height and width 
-* strides: 1D array of stride height and width 
-* padding_type: SAME_PADDING or VALID_PADDING 
-* act_func: ACT_NONE or ACT_RELU 
+* kernel_shape: 1D array of kernel height and width
+* strides: 1D array of stride height and width
+* padding_type: SAME_PADDING or VALID_PADDING
+* act_func: ACT_NONE or ACT_RELU
 * output: `[num_batches, height_out, width_out, channels_out]`
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -134,11 +134,11 @@ _ZHigh DLF16ToF32 operation_
 
 ZHigh operation to convert a tensor of dlfloat16 to a tensor of f32.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -159,11 +159,11 @@ _ZHigh Div operation_
 ZHigh operation to perform a Div.
 This operation does not support broadcasting.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -184,11 +184,11 @@ _ZHigh Exp operation_
 
 ZHigh operation to perform a Exp.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -208,11 +208,22 @@ _ZHigh F32ToDLF16 operation_
 
 ZHigh operation to convert a tensor of f32 to a tensor of dlfloat16.
 
-Traits: AlwaysSpeculatableImplTrait
+Optional `saturation` indicates whether the CPU tensor is saturated before stickification
+or not. If it is saturated, the dlfloat16 range would be used.
+Saturation if off if `saturation == 0` or it is not given. Otherwise, it is on.
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Traits: `AlwaysSpeculatableImplTrait`
 
-Effects: MemoryEffects::Effect{}
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
+
+Effects: `MemoryEffects::Effect{}`
+
+#### Attributes:
+
+<table>
+<tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
+<tr><td><code>saturation</code></td><td>::mlir::IntegerAttr</td><td>64-bit signed integer attribute</td></tr>
+</table>
 
 #### Operands:
 
@@ -232,11 +243,11 @@ _Fix Y result of GRU for sequence_lens_
 
 Fix Y result of GRU by padding value after sequence_lens.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -258,11 +269,11 @@ _Fix Yh result of GRU for sequence_lens_
 
 Fix Yh result of GRU by picking the value in Y according to sequence_lens.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -286,19 +297,19 @@ _ZHigh GRU operation_
 * Shape for input_weights is `[D, I, 3*H]`.
 * Shape for hidden_weights is `[D, H, 3*H]`.
 * Shape for input_bias and hidden_bias is `[D, 3*H]`.
-* Shape for hn_output is `[S, D, B, H]` if return all timesteps 
+* Shape for hn_output is `[S, D, B, H]` if return all timesteps
   and `[1, D, B, H]` if return the final step only.
-* S is timesteps, D is the number of directions (1 for unidirectional and 
-* 2 for bidirectional), B is batch size, I is input size, and 
+* S is timesteps, D is the number of directions (1 for unidirectional and
+* 2 for bidirectional), B is batch size, I is input size, and
 * H is hidden size.
 * direction accepts "forward", "reverse", or "bidirectional
 * return_all_steps: -1 returns all timesteps, 0: returns only the last timestep."
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -335,20 +346,20 @@ zHigh operation to perform a LSTM.
 * Shape for input_weights is  `[D, I, 4*H]`.
 * Shape for hidden_weights is  `[D, H, 4*H]`.
 * Shape for input_bias and hidden_bias is `[D, 4*H]`.
-* Shape for hn_output is `[S, D, B, H]` if return all timesteps 
+* Shape for hn_output is `[S, D, B, H]` if return all timesteps
   and `[1, D, B, H]` if return the final step only.
 * Shape for cf_output is `[1, D, B, H]`.
-* S is timesteps, D is the number of directions (1 for unidirectional and 
-* 2 for bidirectional), B is batch size, I is input size, and 
+* S is timesteps, D is the number of directions (1 for unidirectional and
+* 2 for bidirectional), B is batch size, I is input size, and
 * H is hidden size.
 * direction accepts "forward", "reverse", or "bidirectional
 * return_all_steps: -1 returns all timesteps, 0: returns only the last timestep.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -384,11 +395,11 @@ _ZHigh Log operation_
 
 ZHigh operation to perform a Log.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -408,11 +419,11 @@ _ZHigh MatMul operation_
 
 ZHigh operation to perform a MatMul.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -435,11 +446,11 @@ _ZHigh Max operation_
 ZHigh operation to perform a Max.
 This operation does not support broadcasting.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -460,11 +471,11 @@ _ZHigh 2D max pooling operation_
 
 ZHigh operation to perform 2D max pooling.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -491,16 +502,16 @@ Effects: MemoryEffects::Effect{}
 
 _ZHigh 2D mean reduce operation_
 
-ZHigh operation to perform 2D mean reduce. Given an input 4D tensor, 
-returns a downsampled tensor reducing the middle 2nd and 3rd dimensions 
+ZHigh operation to perform 2D mean reduce. Given an input 4D tensor,
+returns a downsampled tensor reducing the middle 2nd and 3rd dimensions
 to a size of 1 based on the mean of the original values.
  Input and Output tensors should be in the 3D layout.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -521,11 +532,11 @@ _ZHigh Min operation_
 ZHigh operation to perform a Min.
 This operation does not support broadcasting.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -547,11 +558,11 @@ _ZHigh Mul operation_
 ZHigh operation to perform a Mul.
 This operation does not support broadcasting.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -572,11 +583,11 @@ _ZHigh Relu operation_
 
 "ZHigh operation to perform a Relu."
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -596,11 +607,11 @@ _ZHigh Sigmoid operation_
 
 ZHigh operation to perform a Sigmoid.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -621,11 +632,11 @@ _ZHigh Softmax operation_
 ZHigh operation to perform a Softmax.
 act_func: ACT_NONE or ACT_LOG.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -651,15 +662,15 @@ Effects: MemoryEffects::Effect{}
 _ZHigh stick operation for GRU_
 
 ZHigh operation to perform a stick for GRU.
-Variadic: list of pointers for input data to be transformed: 
+Variadic: list of pointers for input data to be transformed:
   - GRU concatenated: 3 data pointers, one for each input gate in
 (Z)update, Reset, Hidden, (ZRH) gate order
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -680,15 +691,15 @@ Effects: MemoryEffects::Effect{}
 _ZHigh stick operation for LSTM_
 
 ZHigh operation to perform a stick for LSTM.
-Variadic: list of pointers for input data to be transformed: 
-  - LSTM concatenated: 4 data pointers, one for each input gate in 
-Forget, Input, Cell, Output (FICO) order, 
+Variadic: list of pointers for input data to be transformed:
+  - LSTM concatenated: 4 data pointers, one for each input gate in
+Forget, Input, Cell, Output (FICO) order,
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -710,19 +721,25 @@ Effects: MemoryEffects::Effect{}
 _ZHigh Stick operation_
 
 ZHigh operation to perform a Stick."
+
 If `layout`=`NHWC`, input must be in `NCHW` and output will be in `NHWC`.
 
-Traits: AlwaysSpeculatableImplTrait
+Optional `saturation` indicates whether the CPU tensor is saturated before stickification
+or not. If it is saturated, the dlfloat16 range would be used.
+Saturation if off if `saturation == 0` or it is not given. Otherwise, it is on.
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Traits: `AlwaysSpeculatableImplTrait`
 
-Effects: MemoryEffects::Effect{}
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
+
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
 <table>
 <tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
 <tr><td><code>layout</code></td><td>::mlir::StringAttr</td><td>string attribute</td></tr>
+<tr><td><code>saturation</code></td><td>::mlir::IntegerAttr</td><td>64-bit signed integer attribute</td></tr>
 </table>
 
 #### Operands:
@@ -742,14 +759,14 @@ Effects: MemoryEffects::Effect{}
 _ZHigh Stickified Constant operation for a dynamic shape_
 
 This operator produces a constant tensor to store stickified data.
-The stickified data is defined by a f32 scalar value, a dynamic shape 
+The stickified data is defined by a f32 scalar value, a dynamic shape
 and a layout. Stickified data is 4K-aligned.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -780,11 +797,11 @@ Stickified data is opaque and must be 4K-aligned. One who produces
 the stickified data must make sure its size in bytes consistent with
 the output tensor's size.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Attributes:
 
@@ -807,11 +824,11 @@ _ZHigh Sub operation_
 ZHigh operation to perform a Sub.
 This operation does not support broadcasting.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -832,11 +849,11 @@ _ZHigh Tanh operation_
 
 ZHigh operation to perform a Tanh.
 
-Traits: AlwaysSpeculatableImplTrait, SameOperandsAndResultLayout
+Traits: `AlwaysSpeculatableImplTrait`, `SameOperandsAndResultLayout`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -856,11 +873,11 @@ _ZHigh Unstick operation_
 
 ZHigh operation to perform a Unstick.
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface), ShapeHelperOpInterface, ShapeInferenceOpInterface
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 

--- a/docs/Dialects/zlow.md
+++ b/docs/Dialects/zlow.md
@@ -5,7 +5,9 @@ _ZLow add operation_
 
 ZLow operation to perform an add.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -39,7 +41,9 @@ ZLow operation to perform 2D average pooling.
 * strides: 1D array of stride height and width
 * padding_type: SAME_PADDING or VALID_PADDING.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -69,7 +73,9 @@ ZLow operation to perform batchnorm.
   * 3rd item: width
   * 4th item: channel
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Operands:
 
@@ -99,7 +105,9 @@ ZLow operation to perform 2D convolution.
 * padding_type: SAME_PADDING or VALID_PADDING.
 * act_func: ACT_NONE or ACT_RELU.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -127,11 +135,11 @@ _Convert a dlfloat16 value to a float32 value_
 
 This operation converts a dlfloat16 value to a float32 value. 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -151,11 +159,11 @@ _Convert dlfloat16 values to float32 values_
 
 This operation converts dlfloat16 values to float32 values. 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -176,11 +184,11 @@ _Convert a float32 value to a dlfloat16 value_
 
 This operation converts a float32 value to a dlfloat16 value. 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -200,11 +208,11 @@ _Convert float32 values to dlfloat16 values_
 
 This operation converts float32 values to dlfloat16 values. 
 
-Traits: AlwaysSpeculatableImplTrait
+Traits: `AlwaysSpeculatableImplTrait`
 
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`
 
-Effects: MemoryEffects::Effect{}
+Effects: `MemoryEffects::Effect{}`
 
 #### Operands:
 
@@ -225,7 +233,9 @@ _ZLow div operation_
 
 ZLow operation to perform a div.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -250,7 +260,7 @@ _ZLow dummy operation that behaves like identity_
 ZLow operation to forward the input value to the output value.
 It will be removed if canonicalization is called.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
 
 #### Operands:
 
@@ -270,7 +280,9 @@ _ZLow exp operation_
 
 ZLow operation to perform a exp.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -303,7 +315,9 @@ ZLow operation to perform a gru.
 * return_all_steps: -1 returns all timesteps, 0: returns only the last timestep.
 * prev_layer for where input comes is "none", "uni", or "bidir"
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -344,7 +358,9 @@ work_area: a 4K-aligned buffer.
 * return_all_steps: -1 returns all timesteps, 0: returns only the last timestep
 * prev_layer for where input comes is "none", "uni", or "bidir"
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -377,7 +393,9 @@ _ZLow log operation_
 
 ZLow operation to perform a log.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -414,7 +432,9 @@ shape is a 1D MemRef (memref<4xi64>) whose items are:
 * is_bcast: -1 broadcasting, 0: no broadcasting.
 * is_stacked: -1 stacked, 0: unstacked.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -440,7 +460,9 @@ _ZLow max operation_
 
 ZLow operation to perform a max.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -474,7 +496,9 @@ ZLow operation to perform 2D max pooling.
 * strides: 1D array of stride height and width
 * padding_type: SAME_PADDING or VALID_PADDING.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -504,7 +528,9 @@ ZLow operation to perform 2D mean reduce.
   * 3th item: width": 3rd dim of input
   * 4nd item: channel": 4th dim of input
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Operands:
 
@@ -520,7 +546,9 @@ _ZLow min operation_
 
 ZLow operation to perform a min.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -544,7 +572,9 @@ _ZLow mul operation_
 
 ZLow operation to perform a mul.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -568,7 +598,9 @@ _ZLow relu operation_
 
 ZLow operation to perform a relu.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -591,7 +623,9 @@ _ZLow sigmoid operation_
 
 ZLow operation to perform a sigmoid.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -616,7 +650,9 @@ ZLow operation to perform a softmax.
 work_area: a 4K-aligned buffer.
 act_func: ACT_NONE or ACT_LOG.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -642,7 +678,9 @@ ZLow operation to perform a stick for GRU.
 Variadic: list of pointers for input data to be transformed: 
   - GRU concatenated: 3 data pointers, one for each input gate in (Z)update, Reset, Hidden, (ZRH) gate order.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -668,7 +706,9 @@ ZLow operation to perform a stick for LSTM.
 Variadic: list of pointers for input data to be transformed: 
   - LSTM concatenated: 4 data pointers, one for each input gate in Forget, Input, Cell, Output (FICO) order.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -693,13 +733,16 @@ _ZLow stick operation_
 
 "ZLow operation to perform a stick."
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
 <table>
 <tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
 <tr><td><code>layout</code></td><td>::mlir::StringAttr</td><td>string attribute</td></tr>
+<tr><td><code>saturation</code></td><td>::mlir::IntegerAttr</td><td>64-bit signed integer attribute</td></tr>
 </table>
 
 #### Operands:
@@ -715,7 +758,9 @@ _ZLow sub operation_
 
 ZLow operation to perform a sub.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -739,7 +784,9 @@ _ZLow tanh operation_
 
 ZLow operation to perform a tanh.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 
@@ -762,7 +809,9 @@ _ZLow unstick operation_
 
 ZLow operation to perform a unstick.
 
-Traits: MemRefsNormalizable
+Traits: `MemRefsNormalizable`
+
+Interfaces: `MemoryEffectOpInterface`
 
 #### Attributes:
 

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.cpp
@@ -91,4 +91,9 @@ llvm::cl::opt<NNPAPlacementHeuristic> nnpaPlacementHeuristic{
             "Much/Significantly FasterOps with stick/unstick cost")),
     llvm::cl::init(QualifyingOps), llvm::cl::cat(OnnxMlirOptions)};
 
+llvm::cl::opt<bool> nnpaEnableSaturation("nnpa-saturation",
+    llvm::cl::desc("Enable saturating f32 values before stickify them."
+                   "Default is false."),
+    llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
+
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.hpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.hpp
@@ -66,5 +66,6 @@ extern llvm::cl::opt<NNPAPlacementHeuristic> nnpaPlacementHeuristic;
 extern llvm::cl::opt<bool> profileZHighIR;
 extern llvm::cl::opt<std::string> nnpaLoadDevicePlacementFile;
 extern llvm::cl::opt<std::string> nnpaSaveDevicePlacementFile;
+extern llvm::cl::opt<bool> nnpaEnableSaturation;
 
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.cpp
@@ -16,6 +16,7 @@
 #include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.hpp"
 #include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.hpp"
 #include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps.hpp"
+#include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.hpp"
 #include "src/Accelerators/NNPA/Pass/NNPAPasses.hpp"
 #include "src/Conversion/ONNXToKrnl/RNN/RNNBase.hpp"
 #include "src/Dialect/ONNX/DialectBuilder.hpp"

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
@@ -17,6 +17,7 @@
 #ifndef OP_BASE
 include "src/Dialect/ONNX/ONNX.td"
 include "src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td"
+include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td"
 include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.td"
 #endif // OP_BASE
 
@@ -30,8 +31,6 @@ include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.td"
 /// >;
 
 def IsEnableScalarBcastBinary: Constraint<CPred<"isEnableScalarBcastBinary()">>;
-
-def IsNoneType : Constraint<CPred<"mlir::isa<NoneType>(($_self).getType())">>;
 
 def IsNotNoneType : Constraint<CPred<"!mlir::isa<NoneType>(($_self).getType())">>;
 
@@ -115,7 +114,7 @@ def GetScalarF32AttrFromConstant :
 //===----------------------------------------------------------------------===//
 def replaceONNXReluPattern : Pat<
   (ONNXReluOp $x),
-  (ZHighUnstickOp (ZHighReluOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr)),
+  (ZHighUnstickOp (ZHighReluOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr), (GetDefaultSaturation)),
                                (returnType $s_x)))
 >;
 
@@ -124,7 +123,7 @@ def replaceONNXReluPattern : Pat<
 //===----------------------------------------------------------------------===//
 def replaceONNXTanhPattern : Pat<
   (ONNXTanhOp $x),
-  (ZHighUnstickOp (ZHighTanhOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr)),
+  (ZHighUnstickOp (ZHighTanhOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr), (GetDefaultSaturation)),
                                (returnType $s_x)))
 >;
 
@@ -133,7 +132,7 @@ def replaceONNXTanhPattern : Pat<
 //===----------------------------------------------------------------------===//
 def replaceONNXSigmoidPattern : Pat<
   (ONNXSigmoidOp $x),
-  (ZHighUnstickOp (ZHighSigmoidOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr)),
+  (ZHighUnstickOp (ZHighSigmoidOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr), (GetDefaultSaturation)),
                                   (returnType $s_x)))
 >;
 
@@ -143,8 +142,8 @@ def replaceONNXSigmoidPattern : Pat<
 //===----------------------------------------------------------------------===//
 def replaceONNXAddPattern : Pat<
   (ONNXAddOp $x, $y),
-  (ZHighUnstickOp (ZHighAddOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr)),
-                              (ZHighStickOp $y, (NoneLayoutAttr)),
+  (ZHighUnstickOp (ZHighAddOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr), (GetDefaultSaturation)),
+                              (ZHighStickOp $y, (NoneLayoutAttr), (GetDefaultSaturation)),
                               (returnType $s_x))
 )
 >;
@@ -167,8 +166,8 @@ def replaceONNXSumOpPatternRecursion : Pat<
   (ONNXSumOp $x),
   (ZHighUnstickOp
      (ZHighAddOp
-        (ZHighStickOp:$s_x (GetNthVariadicOperand<0> $x), (NoneLayoutAttr)),
-        (ZHighStickOp (GetONNXSumOpWithoutFirst $x), (NoneLayoutAttr)),
+        (ZHighStickOp:$s_x (GetNthVariadicOperand<0> $x), (NoneLayoutAttr), (GetDefaultSaturation)),
+        (ZHighStickOp (GetONNXSumOpWithoutFirst $x), (NoneLayoutAttr), (GetDefaultSaturation)),
         (returnType $s_x))),
   [(VariadicSizeIsGT<2> $x)], [], (addBenefit 1)
 >;
@@ -178,8 +177,8 @@ def replaceONNXSumOpPatternSingleton : Pat<
   (ONNXSumOp $x),
   (ZHighUnstickOp
      (ZHighAddOp
-        (ZHighStickOp:$s_x (GetNthVariadicOperand<0> $x), (NoneLayoutAttr)),
-        (ZHighStickOp (GetNthVariadicOperand<1> $x), (NoneLayoutAttr)),
+        (ZHighStickOp:$s_x (GetNthVariadicOperand<0> $x), (NoneLayoutAttr), (GetDefaultSaturation)),
+        (ZHighStickOp (GetNthVariadicOperand<1> $x), (NoneLayoutAttr), (GetDefaultSaturation)),
         (returnType $s_x))),
   [(VariadicSizeIs<2> $x)], [], (addBenefit 0)
 >;
@@ -190,8 +189,8 @@ def replaceONNXSumOpPatternSingleton : Pat<
 //===----------------------------------------------------------------------===//
 def replaceONNXSubPattern : Pat<
   (ONNXSubOp $x, $y),
-  (ZHighUnstickOp (ZHighSubOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr)),
-                              (ZHighStickOp $y, (NoneLayoutAttr)),
+  (ZHighUnstickOp (ZHighSubOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr), (GetDefaultSaturation)),
+                              (ZHighStickOp $y, (NoneLayoutAttr), (GetDefaultSaturation)),
                               (returnType $s_x)))
 >;
 
@@ -201,8 +200,8 @@ def replaceONNXSubPattern : Pat<
 //===----------------------------------------------------------------------===//
 def replaceONNXMulPattern : Pat<
   (ONNXMulOp $x, $y),
-  (ZHighUnstickOp (ZHighMulOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr)),
-                              (ZHighStickOp $y, (NoneLayoutAttr)),
+  (ZHighUnstickOp (ZHighMulOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr), (GetDefaultSaturation)),
+                              (ZHighStickOp $y, (NoneLayoutAttr), (GetDefaultSaturation)),
                               (returnType $s_x)))
 >;
 
@@ -212,8 +211,8 @@ def replaceONNXMulPattern : Pat<
 //===----------------------------------------------------------------------===//
 def replaceONNXDivPattern : Pat<
   (ONNXDivOp $x, $y),
-  (ZHighUnstickOp (ZHighDivOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr)),
-                              (ZHighStickOp $y, (NoneLayoutAttr)),
+  (ZHighUnstickOp (ZHighDivOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr), (GetDefaultSaturation)),
+                              (ZHighStickOp $y, (NoneLayoutAttr), (GetDefaultSaturation)),
                               (returnType $s_x))),
   [], [],
   (addBenefit 0)
@@ -223,7 +222,7 @@ def replaceONNXDivBroadcastPattern1 : Pat<
   (ONNXDivOp $x, $y),
   (ZHighUnstickOp
     (ZHighDivOp
-      (ZHighStickOp:$s_x $x, (NoneLayoutAttr)),
+      (ZHighStickOp:$s_x $x, (NoneLayoutAttr), (GetDefaultSaturation)),
       (ZHighStickifiedConstantOfShapeOp
         (GetDynShape $x),
         (GetScalarF32AttrFromConstant $y),
@@ -241,7 +240,7 @@ def replaceONNXDivBroadcastPattern2 : Pat<
         (GetDynShape $y),
         (GetScalarF32AttrFromConstant $x),
         (NoneLayoutAttr)),
-      (ZHighStickOp:$s_y $y, (NoneLayoutAttr)),
+      (ZHighStickOp:$s_y $y, (NoneLayoutAttr), (GetDefaultSaturation)),
       (returnType $s_y))),
   [(IsEnableScalarBcastBinary), (IsF32ScalarConstantTensor $x)], [],
   (addBenefit 1)
@@ -252,7 +251,7 @@ def replaceONNXDivBroadcastPattern2 : Pat<
 //===----------------------------------------------------------------------===//
 def replaceONNXLogPattern : Pat<
   (ONNXLogOp $x),
-  (ZHighUnstickOp (ZHighLogOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr)),
+  (ZHighUnstickOp (ZHighLogOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr), (GetDefaultSaturation)),
                               (returnType $s_x)))
 >;
 
@@ -261,7 +260,7 @@ def replaceONNXLogPattern : Pat<
 //===----------------------------------------------------------------------===//
 def replaceONNXExpPattern : Pat<
   (ONNXExpOp $x),
-  (ZHighUnstickOp (ZHighExpOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr)),
+  (ZHighUnstickOp (ZHighExpOp (ZHighStickOp:$s_x $x, (NoneLayoutAttr), (GetDefaultSaturation)),
                               (returnType $s_x)))
 >;
 
@@ -272,9 +271,11 @@ def replaceONNXExpPattern : Pat<
 def replaceONNXMinPattern : Pat<
   (ONNXMinOp $x),
   (ZHighUnstickOp (ZHighMinOp (ZHighStickOp:$s_x (getNth<0, "x">),
-                                                 (NoneLayoutAttr)),
+                                                 (NoneLayoutAttr),
+                                                 (GetDefaultSaturation)),
                               (ZHighStickOp (getNth<1, "x">),
-                                            (NoneLayoutAttr)),
+                                            (NoneLayoutAttr),
+                                            (GetDefaultSaturation)),
                               (returnType $s_x)))
 >;
 
@@ -285,9 +286,11 @@ def replaceONNXMinPattern : Pat<
 def replaceONNXMaxPattern : Pat<
   (ONNXMaxOp $x),
   (ZHighUnstickOp (ZHighMaxOp (ZHighStickOp:$s_x (getNth<0, "x">),
-                                                 (NoneLayoutAttr)),
+                                                 (NoneLayoutAttr),
+                                                 (GetDefaultSaturation)),
                               (ZHighStickOp (getNth<1, "x">),
-                                            (NoneLayoutAttr)),
+                                            (NoneLayoutAttr),
+                                            (GetDefaultSaturation)),
                               (returnType $s_x)))
 >;
 
@@ -295,7 +298,7 @@ def replaceONNXMaxPattern : Pat<
 // ONNXSoftmaxOp %X = ONNXSqueezeOp
 //                        (ZHighUnstickOp
 //                            (ZHighSoftmaxOp
-//                                (ZHighStickOp (ONNXUnsqueezeOp %X, 0)),
+//                                (ZHighStickOp (ONNXUnsqueezeOp %X, 0), (GetDefaultSaturation)),
 //                                0))
 //===----------------------------------------------------------------------===//
 
@@ -310,7 +313,8 @@ def replaceONNXSoftmax2DPattern : Pattern<
                    (GetUnrankedTensorTypeOf $x),
                    $x,
                    (GetI64ArrayAttr<0>)),
-               (_3DSLayoutAttr)),
+               (_3DSLayoutAttr),
+               (GetDefaultSaturation)),
            (GetStringAttr<"ACT_NONE">),
            (returnType $s_x))),
 
@@ -327,7 +331,7 @@ def replaceONNXSoftmax3DPattern : Pat<
   // Get unstick result
   (ZHighUnstickOp:$unstick
      (ZHighSoftmaxOp
-        (ZHighStickOp:$s_x $x, (_3DSLayoutAttr)),
+        (ZHighStickOp:$s_x $x, (_3DSLayoutAttr), (GetDefaultSaturation)),
         (GetStringAttr<"ACT_NONE">),
         (returnType $s_x))),
   [(HasRankOf<3> $x)]
@@ -338,7 +342,7 @@ def replaceONNXSoftmax3DPattern : Pat<
 //   ONNXSqueezeOp
 //     (ZHighUnstickOp
 //         (ZHighSoftmaxOp
-//            (ZHighStickOp (ONNXUnsqueezeOp %X, 0)),
+//            (ZHighStickOp (ONNXUnsqueezeOp %X, 0), (GetDefaultSaturation)),
 //            "ACT_LOG"),
 //     0)
 //===----------------------------------------------------------------------===//
@@ -358,7 +362,8 @@ def replaceONNXLogSoftmaxPattern : Pattern<
                    (GetUnrankedTensorTypeOf $x),
                    $x,
                    (GetI64ArrayAttr<0>)),
-               (_3DSLayoutAttr)),
+               (_3DSLayoutAttr),
+               (GetDefaultSaturation)),
            (GetStringAttr<"ACT_LOG">),
            (returnType $s_x))),
 
@@ -377,7 +382,7 @@ def replaceONNXLogSoftmaxPattern : Pattern<
 //===----------------------------------------------------------------------===//
 def replaceONNXReduceMeanV13Pattern : Pat<
   (ONNXReduceMeanV13Op:$res $x, $_, $_),
-  (ZHighUnstickOp (ZHighMeanReduce2DOp (ZHighStickOp $x, (NHWCLayoutAttr))))
+  (ZHighUnstickOp (ZHighMeanReduce2DOp (ZHighStickOp $x, (NHWCLayoutAttr), (GetDefaultSaturation))))
 >;
 
 //===----------------------------------------------------------------------===//
@@ -415,7 +420,7 @@ def replaceONNXMaxPoolSingleOutPattern : Pattern<
 
     (ZHighUnstickOp
        (ZHighMaxPool2DOp
-          (ZHighStickOp $x, (NHWCLayoutAttr)),
+          (ZHighStickOp $x, (NHWCLayoutAttr), (GetDefaultSaturation)),
           $kernel_shape,
           $strides,
           $padtype))
@@ -457,7 +462,7 @@ def replaceONNXAveragePoolPattern : Pattern<
 
     (ZHighUnstickOp
        (ZHighAvgPool2DOp
-          (ZHighStickOp $x, (NHWCLayoutAttr)),
+          (ZHighStickOp $x, (NHWCLayoutAttr), (GetDefaultSaturation)),
           $kernel_shape,
           $strides,
           $padtype))
@@ -488,8 +493,8 @@ def replaceONNXMatMulPattern : Pat<
   (ONNXMatMulOp:$res $x, $y),
   (ZHighUnstickOp
      (ZHighMatMulOp
-        (ZHighStickOp $x, (GetMatMulLayoutStringAttr (GetRank $x))),
-        (ZHighStickOp $y, (GetMatMulLayoutStringAttr (GetRank $y))),
+        (ZHighStickOp $x, (GetMatMulLayoutStringAttr (GetRank $x)), (GetDefaultSaturation)),
+        (ZHighStickOp $y, (GetMatMulLayoutStringAttr (GetRank $y)), (GetDefaultSaturation)),
         (CreateNoneValue)))
 >;
 
@@ -525,10 +530,10 @@ def replaceONNXMatMulAddPattern1 : Pat<
   // To ZHighMatMulOp
   (ZHighUnstickOp
      (ZHighMatMulOp
-        (ZHighStickOp $x, (GetMatMulLayoutStringAttr (GetRank $x))),
-        (ZHighStickOp $y, (GetMatMulLayoutStringAttr (GetRank $y))),
+        (ZHighStickOp $x, (GetMatMulLayoutStringAttr (GetRank $x)), (GetDefaultSaturation)),
+        (ZHighStickOp $y, (GetMatMulLayoutStringAttr (GetRank $y)), (GetDefaultSaturation)),
         (ZHighStickOp $b, (GetMatMulBiasLayoutStringAttr (GetRank $x),
-                                                         (GetRank $y))))),
+                                                         (GetRank $y)), (GetDefaultSaturation)))),
   [(IsMatMulLegalForZDNN $m), (HasRankOf<2> $y), (HasRankOf<1> $b),
    (HaveSameLastDimR2R1 $y, $b)], [],
   (addBenefit 0)
@@ -540,10 +545,10 @@ def replaceONNXMatMulAddPattern2 : Pat<
   // To ZHighMatMulOp
   (ZHighUnstickOp
      (ZHighMatMulOp
-        (ZHighStickOp $x, (GetMatMulLayoutStringAttr (GetRank $x))),
-        (ZHighStickOp $y, (GetMatMulLayoutStringAttr (GetRank $y))),
+        (ZHighStickOp $x, (GetMatMulLayoutStringAttr (GetRank $x)), (GetDefaultSaturation)),
+        (ZHighStickOp $y, (GetMatMulLayoutStringAttr (GetRank $y)), (GetDefaultSaturation)),
         (ZHighStickOp $b, (GetMatMulBiasLayoutStringAttr (GetRank $x),
-                                                         (GetRank $y))))),
+                                                         (GetRank $y)), (GetDefaultSaturation)))),
   [(IsMatMulLegalForZDNN $m), (HasRankOf<2> $y), (HasRankOf<1> $b),
    (HaveSameLastDimR2R1 $y, $b)], [],
   (addBenefit 0)
@@ -597,9 +602,9 @@ def replaceONNXGemmBiasNoneOr1DPattern : Pat<
   (ONNXGemmOp $a, $b, $c, $_, $_, $_, $_),
   (ZHighUnstickOp
      (ZHighMatMulOp
-        (ZHighStickOp $a, (_2DLayoutAttr)),
-        (ZHighStickOp $b, (_2DLayoutAttr)),
-        (ZHighStickOp $c, (_1DLayoutAttr)))),
+        (ZHighStickOp $a, (_2DLayoutAttr), (GetDefaultSaturation)),
+        (ZHighStickOp $b, (_2DLayoutAttr), (GetDefaultSaturation)),
+        (ZHighStickOp $c, (_1DLayoutAttr), (GetDefaultSaturation)))),
   [(IsBiasNoneOr1D:$c)], [],
   (addBenefit 0)
 >;
@@ -609,8 +614,8 @@ def replaceONNXGemmBias2DPattern : Pat<
   (ONNXAddOp
     (ZHighUnstickOp
        (ZHighMatMulOp
-          (ZHighStickOp $a, (_2DLayoutAttr)),
-          (ZHighStickOp $b, (_2DLayoutAttr)),
+          (ZHighStickOp $a, (_2DLayoutAttr), (GetDefaultSaturation)),
+          (ZHighStickOp $b, (_2DLayoutAttr), (GetDefaultSaturation)),
           (CreateNoneValue)),
        (returnType $res)),
     $c),
@@ -681,16 +686,16 @@ def replaceONNXLSTMPattern1 : Pattern<
    // Main-process to lower ONNXLSTMOp into ZHighLSTMOp.
    //
    (ZHighLSTMOp:$zhighLSTM
-      (ZHighStickOp $x, (_3DSLayoutAttr)),               // input
-      (ZHighStickOp $initial_h, (_3DSLayoutAttr)),       // h0
-      (ZHighStickOp $initial_c, (_3DSLayoutAttr)),       // c0
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $w),   // input weights
-      $input_bias,                                       // input bias
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $r),   // hidden weights
-      $hidden_bias,                                      // hidden bias
-      $hidden_size,                                      // hidden_size
-      $direction,                                        // direction
-      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),  // return_all_steps
+      (ZHighStickOp $x, (_3DSLayoutAttr), (GetDefaultSaturation)),               // input
+      (ZHighStickOp $initial_h, (_3DSLayoutAttr), (GetDefaultSaturation)),       // h0
+      (ZHighStickOp $initial_c, (_3DSLayoutAttr), (GetDefaultSaturation)),       // c0
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $w),                           // input weights
+      $input_bias,                                                               // input bias
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $r),                           // hidden weights
+      $hidden_bias,                                                              // hidden bias
+      $hidden_size,                                                              // hidden_size
+      $direction,                                                                // direction
+      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),                          // return_all_steps
 
    //
    // Post-process to generate three return values of ONNXLSTMOp
@@ -715,16 +720,16 @@ def replaceONNXLSTMPattern2 : Pattern<
    // Main-process to lower ONNXLSTMOp into ZHighLSTMOp.
    //
    (ZHighLSTMOp:$zhighLSTM
-      (ZHighStickOp $x, (_3DSLayoutAttr)),               // input
-      (ZHighStickOp $initial_h, (_3DSLayoutAttr)),       // h0
-      (ZHighStickOp $initial_c, (_3DSLayoutAttr)),       // c0
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $w),   // input weights
-      $b,                                                // input bias
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $r),   // hidden weights
-      $b,                                                // nontype hidden bias
-      $hidden_size,                                      // hidden_size
-      $direction,                                        // direction
-      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),  // return_all_steps
+      (ZHighStickOp $x, (_3DSLayoutAttr), (GetDefaultSaturation)),               // input
+      (ZHighStickOp $initial_h, (_3DSLayoutAttr), (GetDefaultSaturation)),       // h0
+      (ZHighStickOp $initial_c, (_3DSLayoutAttr), (GetDefaultSaturation)),       // c0
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $w),                           // input weights
+      $b,                                                                        // input bias
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $r),                           // hidden weights
+      $b,                                                                        // nontype hidden bias
+      $hidden_size,                                                              // hidden_size
+      $direction,                                                                // direction
+      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),                          // return_all_steps
 
    //
    // Post-process to generate three return values of ONNXLSTMOp
@@ -756,16 +761,16 @@ def replaceONNXLSTMPattern3 : Pattern<
    // Main-process to lower ONNXLSTMOp into ZHighLSTMOp.
    //
    (ZHighLSTMOp:$zhighLSTM
-      (ZHighStickOp $x, (_3DSLayoutAttr)),               // input
-      (ZHighStickOp $initial_h, (_3DSLayoutAttr)),       // h0
-      (ZHighStickOp $initial_c, (_3DSLayoutAttr)),       // c0
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $w),   // input weights
-      $input_bias,                                       // input bias
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $r),   // hidden weights
-      $hidden_bias,                                      // hidden bias
-      $hidden_size,                                      // hidden_size
-      $direction,                                        // direction
-      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),  // return_all_steps
+      (ZHighStickOp $x, (_3DSLayoutAttr), (GetDefaultSaturation)),               // input
+      (ZHighStickOp $initial_h, (_3DSLayoutAttr), (GetDefaultSaturation)),       // h0
+      (ZHighStickOp $initial_c, (_3DSLayoutAttr), (GetDefaultSaturation)),       // c0
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $w),                           // input weights
+      $input_bias,                                                               // input bias
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $r),                           // hidden weights
+      $hidden_bias,                                                              // hidden bias
+      $hidden_size,                                                              // hidden_size
+      $direction,                                                                // direction
+      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),                          // return_all_steps
 
    //
    // Post-process to generate three return values of ONNXLSTMOp
@@ -790,16 +795,16 @@ def replaceONNXLSTMPattern4 : Pattern<
    // Main-process to lower ONNXLSTMOp into ZHighLSTMOp.
    //
    (ZHighLSTMOp:$zhighLSTM
-      (ZHighStickOp $x, (_3DSLayoutAttr)),               // input
-      (ZHighStickOp $initial_h, (_3DSLayoutAttr)),       // h0
-      (ZHighStickOp $initial_c, (_3DSLayoutAttr)),       // c0
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $w),   // input weights
-      $b,                                                // input bias
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $r),   // hidden weights
-      $b,                                                // nontype hidden bias
-      $hidden_size,                                      // hidden_size
-      $direction,                                        // direction
-      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),  // return_all_steps
+      (ZHighStickOp $x, (_3DSLayoutAttr), (GetDefaultSaturation)),               // input
+      (ZHighStickOp $initial_h, (_3DSLayoutAttr), (GetDefaultSaturation)),       // h0
+      (ZHighStickOp $initial_c, (_3DSLayoutAttr), (GetDefaultSaturation)),       // c0
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $w),                           // input weights
+      $b,                                                                        // input bias
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"LSTM"> $r),                           // hidden weights
+      $b,                                                                        // nontype hidden bias
+      $hidden_size,                                                              // hidden_size
+      $direction,                                                                // direction
+      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),                          // return_all_steps
 
    //
    // Post-process to generate three return values of ONNXLSTMOp
@@ -838,15 +843,15 @@ def replaceONNXGRUPattern1 : Pattern<
    // Main-process to lower ONNXGRUOp into ZHighGRUOp.
    //
    (ZHighGRUOp:$zhighGRU
-      (ZHighStickOp $x, (_3DSLayoutAttr)),               // input
-      (ZHighStickOp $initial_h, (_3DSLayoutAttr)),       // h0
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $w),    // input weights
-      $input_bias,                                       // input bias
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $r),    // hidden weights
-      $hidden_bias,                                      // hiden bias
-      $hidden_size,                                      // hidden_size
-      $direction,                                        // direction
-      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),  // return_all_steps
+      (ZHighStickOp $x, (_3DSLayoutAttr), (GetDefaultSaturation)),               // input
+      (ZHighStickOp $initial_h, (_3DSLayoutAttr), (GetDefaultSaturation)),       // h0
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $w),                            // input weights
+      $input_bias,                                                               // input bias
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $r),                            // hidden weights
+      $hidden_bias,                                                              // hiden bias
+      $hidden_size,                                                              // hidden_size
+      $direction,                                                                // direction
+      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),                          // return_all_steps
 
    //
    // Post-process to generate two return values of ONNXGRUOp
@@ -869,15 +874,15 @@ def replaceONNXGRUPattern2 : Pattern<
    // Main-process to lower ONNXGRUOp into ZHighGRUOp.
    //
    (ZHighGRUOp:$zhighGRU
-      (ZHighStickOp $x, (_3DSLayoutAttr)),                // input
-      (ZHighStickOp $initial_h, (_3DSLayoutAttr)),        // h0
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $w),     // input weights
-      $b,                                                 // nontype input bias
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $r),     // hidden weights
-      $b,                                                 // nontype hidden bias
-      $hidden_size,                                       // hidden_size
-      $direction,                                         // direction
-      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),   // return_all_steps
+      (ZHighStickOp $x, (_3DSLayoutAttr), (GetDefaultSaturation)),                // input
+      (ZHighStickOp $initial_h, (_3DSLayoutAttr), (GetDefaultSaturation)),        // h0
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $w),                             // input weights
+      $b,                                                                         // nontype input bias
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $r),                             // hidden weights
+      $b,                                                                         // nontype hidden bias
+      $hidden_size,                                                               // hidden_size
+      $direction,                                                                 // direction
+      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),                           // return_all_steps
 
    //
    // Post-process to generate two return values of ONNXGRUOp
@@ -908,15 +913,15 @@ def replaceONNXGRUPattern3 : Pattern<
    // Main-process to lower ONNXGRUOp into ZHighGRUOp.
    //
    (ZHighGRUOp:$zhighGRU
-      (ZHighStickOp $x, (_3DSLayoutAttr)),               // input
-      (ZHighStickOp $initial_h, (_3DSLayoutAttr)),       // h0
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $w),    // input weights
-      $input_bias,                                       // input bias
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $r),    // hidden weights
-      $hidden_bias,                                      // hiden bias
-      $hidden_size,                                      // hidden_size
-      $direction,                                        // direction
-      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),  // return_all_steps
+      (ZHighStickOp $x, (_3DSLayoutAttr), (GetDefaultSaturation)),               // input
+      (ZHighStickOp $initial_h, (_3DSLayoutAttr), (GetDefaultSaturation)),       // h0
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $w),                            // input weights
+      $input_bias,                                                               // input bias
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $r),                            // hidden weights
+      $hidden_bias,                                                              // hiden bias
+      $hidden_size,                                                              // hidden_size
+      $direction,                                                                // direction
+      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),                          // return_all_steps
 
    //
    // Post-process to generate two return values of ONNXGRUOp
@@ -939,15 +944,15 @@ def replaceONNXGRUPattern4 : Pattern<
    // Main-process to lower ONNXGRUOp into ZHighGRUOp.
    //
    (ZHighGRUOp:$zhighGRU
-      (ZHighStickOp $x, (_3DSLayoutAttr)),                // input
-      (ZHighStickOp $initial_h, (_3DSLayoutAttr)),        // h0
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $w),     // input weights
-      $b,                                                 // nontype input bias
-      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $r),     // hidden weights
-      $b,                                                 // nontype hidden bias
-      $hidden_size,                                       // hidden_size
-      $direction,                                         // direction
-      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),   // return_all_steps
+      (ZHighStickOp $x, (_3DSLayoutAttr), (GetDefaultSaturation)),                // input
+      (ZHighStickOp $initial_h, (_3DSLayoutAttr), (GetDefaultSaturation)),        // h0
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $w),                             // input weights
+      $b,                                                                         // nontype input bias
+      (GetLSTMGRUZDNNWeightFromONNXWeight<"GRU"> $r),                             // hidden weights
+      $b,                                                                         // nontype hidden bias
+      $hidden_size,                                                               // hidden_size
+      $direction,                                                                 // direction
+      (GetLSTMGRUReturnAllStepsAttr $res__0, $res__1)),                           // return_all_steps
 
    //
    // Post-process to generate three return values of ONNXGRUOp
@@ -1001,9 +1006,9 @@ def replaceONNXConv2DPattern : Pattern<
 
    (ZHighUnstickOp
     (ZHighConv2DOp
-       (ZHighStickOp $x, (NHWCLayoutAttr)),
-       (ZHighStickOp (NCHWtoHWCK $w), (HWCKLayoutAttr)),
-       (ZHighStickOp $b, (_1DLayoutAttr)),
+       (ZHighStickOp $x, (NHWCLayoutAttr), (GetDefaultSaturation)),
+       (ZHighStickOp (NCHWtoHWCK $w), (HWCKLayoutAttr), (GetDefaultSaturation)),
+       (ZHighStickOp $b, (_1DLayoutAttr), (GetDefaultSaturation)),
        $kernel_shape,
        $strides,
        $padtype,
@@ -1046,9 +1051,9 @@ def replaceONNXReluConvPattern : Pattern<
 
    (ZHighUnstickOp
     (ZHighConv2DOp
-       (ZHighStickOp $x, (NHWCLayoutAttr)),
-       (ZHighStickOp (NCHWtoHWCK $w), (HWCKLayoutAttr)),
-       (ZHighStickOp $b, (_1DLayoutAttr)),
+       (ZHighStickOp $x, (NHWCLayoutAttr), (GetDefaultSaturation)),
+       (ZHighStickOp (NCHWtoHWCK $w), (HWCKLayoutAttr), (GetDefaultSaturation)),
+       (ZHighStickOp $b, (_1DLayoutAttr), (GetDefaultSaturation)),
        $kernel_shape,
        $strides,
        $padtype,

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
@@ -27,6 +27,7 @@
 #include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.hpp"
 #include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.hpp"
 #include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps.hpp"
+#include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.hpp"
 #include "src/Accelerators/NNPA/Pass/NNPAPasses.hpp"
 #include "src/Accelerators/NNPA/Support/NNPALimit.hpp"
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
@@ -17,6 +17,7 @@
 #ifndef OP_BASE
 include "src/Dialect/ONNX/ONNX.td"
 include "src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td"
+include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td"
 include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.td"
 #endif // OP_BASE
 
@@ -67,9 +68,9 @@ def replaceONNXBatchNormalizationInferenceModePattern : Pattern<
     // Calculate BatchNorm Op using $A and $B
     (ZHighUnstickOp
         (ZHighBatchNormOp
-            (ZHighStickOp $x, (NHWCLayoutAttr)),
-            (ZHighStickOp $A, (_1DLayoutAttr)),
-            (ZHighStickOp $B, (_1DLayoutAttr))))
+            (ZHighStickOp $x, (NHWCLayoutAttr), (GetDefaultSaturation)),
+            (ZHighStickOp $A, (_1DLayoutAttr), (GetDefaultSaturation)),
+            (ZHighStickOp $B, (_1DLayoutAttr), (GetDefaultSaturation))))
   ]
 >;
 

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ZHighToONNX.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ZHighToONNX.td
@@ -38,13 +38,13 @@ def CreateONNXMaxOp : NativeCodeCall<"$_builder.create<ONNXMaxOp>($_loc, $0.getT
 // (ZHighStickOp %Y))
 //===----------------------------------------------------------------------===//
 def replaceZHighAddPattern1 : Pat<
-  (ZHighUnstickOp (ZHighAddOp (ZHighStickOp:$s_x $x, $_), $y)),
+  (ZHighUnstickOp (ZHighAddOp (ZHighStickOp:$s_x $x, $_, $_), $y)),
   (ONNXAddOp $x, (ZHighUnstickOp $y)),
   [(NotBlockArgument:$x), (HasOneUse:$s_x)]
 >;
 
 def replaceZHighAddPattern2 : Pat<
-  (ZHighUnstickOp (ZHighAddOp $x, (ZHighStickOp:$s_y $y, $_))),
+  (ZHighUnstickOp (ZHighAddOp $x, (ZHighStickOp:$s_y $y, $_, $_))),
   (ONNXAddOp (ZHighUnstickOp $x), $y),
   [(NotBlockArgument:$y), (HasOneUse:$s_y)]
 >;
@@ -54,14 +54,14 @@ def replaceZHighAddPattern2 : Pat<
 // (ZHighStickOp %Y))
 //===----------------------------------------------------------------------===//
 def replaceZHighMulPattern1 : Pat<
-  (ZHighUnstickOp (ZHighMulOp (ZHighStickOp:$s_x $x, $_), $y)),
+  (ZHighUnstickOp (ZHighMulOp (ZHighStickOp:$s_x $x, $_, $_), $y)),
   (ONNXMulOp $x, (ZHighUnstickOp $y)),
   [(NotBlockArgument:$x), (HasOneUse:$s_x)], [ ],
   (addBenefit 1)
 >;
 
 def replaceZHighMulPattern2 : Pat<
-  (ZHighUnstickOp (ZHighMulOp $x, (ZHighStickOp:$s_y $y, $_))),
+  (ZHighUnstickOp (ZHighMulOp $x, (ZHighStickOp:$s_y $y, $_, $_))),
   (ONNXMulOp (ZHighUnstickOp $x), $y),
   [(NotBlockArgument:$y), (HasOneUse:$s_y)], [],
   (addBenefit 0)
@@ -72,14 +72,14 @@ def replaceZHighMulPattern2 : Pat<
 // (ZHighStickOp %Y))
 //===----------------------------------------------------------------------===//
 def replaceZHighSubPattern1 : Pat<
-  (ZHighUnstickOp (ZHighSubOp (ZHighStickOp:$s_x $x, $_), $y)),
+  (ZHighUnstickOp (ZHighSubOp (ZHighStickOp:$s_x $x, $_, $_), $y)),
   (ONNXSubOp $x, (ZHighUnstickOp $y)),
   [(NotBlockArgument:$x), (HasOneUse:$s_x)], [ ],
   (addBenefit 1)
 >;
 
 def replaceZHighSubPattern2 : Pat<
-  (ZHighUnstickOp (ZHighSubOp $x, (ZHighStickOp:$s_y $y, $_))),
+  (ZHighUnstickOp (ZHighSubOp $x, (ZHighStickOp:$s_y $y, $_, $_))),
   (ONNXSubOp (ZHighUnstickOp $x), $y),
   [(NotBlockArgument:$y), (HasOneUse:$s_y)], [ ],
   (addBenefit 0)
@@ -109,14 +109,14 @@ def replaceZHighSubPattern2 : Pat<
 // (ZHighStickOp %Y))
 //===----------------------------------------------------------------------===//
 def replaceZHighMinPattern1 : Pat<
-  (ZHighUnstickOp:$u (ZHighMinOp (ZHighStickOp:$s_x $x, $_), $y)),
+  (ZHighUnstickOp:$u (ZHighMinOp (ZHighStickOp:$s_x $x, $_, $_), $y)),
   (CreateONNXMinOp $u, $x, (ZHighUnstickOp $y)),
   [(NotBlockArgument:$x), (HasOneUse:$s_x)], [ ],
   (addBenefit 1)
 >;
 
 def replaceZHighMinPattern2 : Pat<
-  (ZHighUnstickOp:$u (ZHighMinOp $x, (ZHighStickOp:$s_y $y, $_))),
+  (ZHighUnstickOp:$u (ZHighMinOp $x, (ZHighStickOp:$s_y $y, $_, $_))),
   (CreateONNXMinOp $u, (ZHighUnstickOp $x), $y),
   [(NotBlockArgument:$y), (HasOneUse:$s_y)], [ ],
   (addBenefit 0)
@@ -127,14 +127,14 @@ def replaceZHighMinPattern2 : Pat<
 // (ZHighStickOp %Y))
 //===----------------------------------------------------------------------===//
 def replaceZHighMaxPattern1 : Pat<
-  (ZHighUnstickOp:$u (ZHighMaxOp (ZHighStickOp:$s_x $x, $_), $y)),
+  (ZHighUnstickOp:$u (ZHighMaxOp (ZHighStickOp:$s_x $x, $_, $_), $y)),
   (CreateONNXMaxOp $u, $x, (ZHighUnstickOp $y)),
   [(NotBlockArgument:$x), (HasOneUse:$s_x)], [ ],
   (addBenefit 1)
 >;
 
 def replaceZHighMaxPattern2 : Pat<
-  (ZHighUnstickOp:$u (ZHighMaxOp $x, (ZHighStickOp:$s_y $y, $_))),
+  (ZHighUnstickOp:$u (ZHighMaxOp $x, (ZHighStickOp:$s_y $y, $_, $_))),
   (CreateONNXMaxOp $u, (ZHighUnstickOp $x), $y),
   [(NotBlockArgument:$y), (HasOneUse:$s_y)], [ ],
   (addBenefit 0)
@@ -144,7 +144,7 @@ def replaceZHighMaxPattern2 : Pat<
 // ONNXReluOp %X = ZHighUnstickOp (ZHighReluOp (ZHighStickOp %X))
 //===----------------------------------------------------------------------===//
 def replaceZHighReluPattern : Pat<
-  (ZHighUnstickOp (ZHighReluOp (ZHighStickOp:$s_x $x, $_))),
+  (ZHighUnstickOp (ZHighReluOp (ZHighStickOp:$s_x $x, $_, $_))),
   (ONNXReluOp $x),
   [(NotBlockArgument:$x), (HasOneUse:$s_x)]
 >;

--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
@@ -500,10 +500,12 @@ struct ZHighToZLowStickOpLowering : public ConversionPattern {
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
     Location loc = op->getLoc();
+    ZHighStickOp stickOp = cast<ZHighStickOp>(op);
 
     ZHighStickOpAdaptor operandAdaptor(operands);
     Value input = operandAdaptor.getIn();
-    StringAttr layout = cast<ZHighStickOp>(op).getLayoutAttr();
+    StringAttr layout = stickOp.getLayoutAttr();
+    IntegerAttr saturation = stickOp.getSaturationAttr();
 
     IndexExprBuilderForKrnl createKrnlIE(rewriter, loc);
     ZHighStickOpShapeHelper shapeHelper(op, operands, &createKrnlIE);
@@ -521,7 +523,7 @@ struct ZHighToZLowStickOpLowering : public ConversionPattern {
       layout = getNCHWLayoutAttr(rewriter);
 
     // Else, emit a ZLow operation.
-    rewriter.create<ZLowStickOp>(loc, input, alloc, layout);
+    rewriter.create<ZLowStickOp>(loc, input, alloc, layout, saturation);
     rewriter.replaceOp(op, alloc);
     return success();
   }

--- a/src/Accelerators/NNPA/Dialect/ZHigh/CMakeLists.txt
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/CMakeLists.txt
@@ -47,6 +47,7 @@ add_onnx_mlir_library(OMZHighOps
   OMONNXOps # Use ONNXShapeHelper 
   OMLayoutHelper
   OMShapeHelperOpInterface
+  OMNNPACompilerOptions
   MLIRIR
 
   ACCEL_INCLUDE_DIRS PRIVATE

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
@@ -142,16 +142,26 @@ def ZHighStickOp:ZHigh_Op<"Stick", [Pure,
   let summary = "ZHigh Stick operation";
   let description = [{
     ZHigh operation to perform a Stick."
+
     If `layout`=`NHWC`, input must be in `NCHW` and output will be in `NHWC`.
+
+    Optional `saturation` indicates whether the CPU tensor is saturated before stickification
+    or not. If it is saturated, the dlfloat16 range would be used.
+    Saturation if off if `saturation == 0` or it is not given. Otherwise, it is on.
   }];
   let arguments = (ins AnyTypeOf<[TensorOf<[F32]>, NoneType]>:$In,
-                       OptionalAttr<StrAttr>:$layout);
+                       OptionalAttr<StrAttr>:$layout,
+                       OptionalAttr<SI64Attr>:$saturation);
   let results = (outs AnyTypeOf<[ZTensor_1D, ZTensor_2D, ZTensor_3D, ZTensor_4D,
                                  ZTensor_2DS, ZTensor_3DS, ZTensor_4DS,
                                  ZTensor_NHWC,  ZTensor_NCHW, ZTensor_HWCK,
                                  NoneType]>:$Out);
   let builders = [
-    OpBuilder<(ins "::mlir::Value":$In, "::mlir::StringAttr":$layout)>
+    OpBuilder<(ins "::mlir::Value":$In, "::mlir::StringAttr":$layout), [{
+      build($_builder, $_state, In, layout, IntegerAttr());
+    }]>,
+    OpBuilder<(ins "::mlir::Value":$In, "::mlir::StringAttr":$layout,
+               "::mlir::IntegerAttr":$saturation)>
   ];
   let hasCanonicalizer = 1;
   let extraClassDefinition = [{
@@ -195,11 +205,19 @@ def ZHighF32ToDLF16Op:ZHigh_Op<"F32ToDLF16", [Pure,
   let summary = "ZHigh F32ToDLF16 operation";
   let description = [{
     ZHigh operation to convert a tensor of f32 to a tensor of dlfloat16.
+
+    Optional `saturation` indicates whether the CPU tensor is saturated before stickification
+    or not. If it is saturated, the dlfloat16 range would be used.
+    Saturation if off if `saturation == 0` or it is not given. Otherwise, it is on.
   }];
-  let arguments = (ins TensorOf<[F32]>: $In);
+  let arguments = (ins TensorOf<[F32]>: $In,
+                       OptionalAttr<SI64Attr>:$saturation);
   let results = (outs TensorOf<[F16]>:$Out);
   let builders = [
-    OpBuilder<(ins "::mlir::Value":$In)>,
+    OpBuilder<(ins "::mlir::Value":$In), [{
+      build($_builder, $_state, In, IntegerAttr());
+    }]>,
+    OpBuilder<(ins "::mlir::Value":$In, "::mlir::IntegerAttr":$saturation)>
   ];
   let hasCanonicalizer = 1;
   let extraClassDefinition = [{

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/DLF16ToF32/ZHighDLF16ToF32.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/DLF16ToF32/ZHighDLF16ToF32.td
@@ -40,7 +40,7 @@ def GetTypeInDLF16: NativeCodeCall<
 
 // zhigh.DLF16ToF32 (zhigh.F32ToDLF16(%X)) = %X
 def ConversionRemovalPattern : Pat<
-  (ZHighDLF16ToF32Op (ZHighF32ToDLF16Op $arg)),
+  (ZHighDLF16ToF32Op (ZHighF32ToDLF16Op $arg, $saturation)),
   (replaceWithValue $arg)
 >;
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/F32ToDLF16/F32ToDLF16.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/F32ToDLF16/F32ToDLF16.cpp
@@ -28,15 +28,15 @@ namespace zhigh {
 // Custom builders
 //===----------------------------------------------------------------------===//
 
-void ZHighF32ToDLF16Op::build(
-    OpBuilder &builder, OperationState &state, Value input) {
+void ZHighF32ToDLF16Op::build(OpBuilder &builder, OperationState &state,
+    Value input, IntegerAttr saturation) {
   Type elementType = builder.getF16Type();
   Type resType = UnrankedTensorType::get(elementType);
 
   if (auto inType = dyn_cast<RankedTensorType>(input.getType()))
     resType = RankedTensorType::get(inType.getShape(), elementType);
 
-  build(builder, state, resType, input);
+  build(builder, state, resType, input, saturation);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/F32ToDLF16/ZHighF32ToDLF16.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/F32ToDLF16/ZHighF32ToDLF16.td
@@ -36,7 +36,7 @@ include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td"
 
 // zhigh.F32ToDLF16 (zhigh.DLF16ToF32(%X)) = %X
 def ConversionRemovalPattern : Pat<
-  (ZHighF32ToDLF16Op (ZHighDLF16ToF32Op $arg)),
+  (ZHighF32ToDLF16Op (ZHighDLF16ToF32Op $arg), $saturation),
   (replaceWithValue $arg)
 >;
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.hpp"
+#include "src/Accelerators/NNPA/Compiler/NNPACompilerOptions.hpp"
 #include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps.hpp"
 #include "src/Accelerators/NNPA/Support/LayoutHelper.hpp"
 
@@ -470,6 +471,15 @@ bool hasNNPAUse(Value v) {
             !isa<ZHighStickOp, ZHighUnstickOp, ZHighStickForLSTMOp,
                 ZHighStickForGRUOp>(op));
   });
+}
+
+/// Get default saturation setting.
+IntegerAttr getDefaultSaturation(PatternRewriter &rewriter) {
+  Type si64Ty = rewriter.getIntegerType(64, true);
+  if (nnpaEnableSaturation)
+    return rewriter.getIntegerAttr(si64Ty, -1);
+  else
+    return IntegerAttr();
 }
 
 } // namespace zhigh

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.hpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.hpp
@@ -84,5 +84,8 @@ mlir::IntegerAttr getAxisNHWC(mlir::IntegerAttr axisNCHWAttr);
 /// Check if the value has NNPA users (or is consumed by an NNPA op).
 bool hasNNPAUse(mlir::Value v);
 
+/// Get saturation settings.
+mlir::IntegerAttr getDefaultSaturation(mlir::PatternRewriter &rewriter);
+
 } // namespace zhigh
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td
@@ -195,4 +195,10 @@ def GetAxisNHWC : NativeCodeCall<
   "::onnx_mlir::zhigh::getAxisNHWC($0)"
 >;
 
+def NoneIntegerAttr: NativeCodeCall<"IntegerAttr()">;
+
+def GetDefaultSaturation : NativeCodeCall<
+  "::onnx_mlir::zhigh::getDefaultSaturation($_builder)"
+>;
+
 #endif // OP_HELPER

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Stick/Stick.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Stick/Stick.cpp
@@ -28,8 +28,8 @@ namespace zhigh {
 // Custom builders
 //===----------------------------------------------------------------------===//
 
-void ZHighStickOp::build(
-    OpBuilder &builder, OperationState &state, Value input, StringAttr layout) {
+void ZHighStickOp::build(OpBuilder &builder, OperationState &state, Value input,
+    StringAttr layout, IntegerAttr saturation) {
   Type resType = builder.getNoneType();
   Type resElementType = builder.getF16Type();
   if (!mlir::isa<NoneType>(input.getType())) {
@@ -63,7 +63,7 @@ void ZHighStickOp::build(
       resType = UnrankedTensorType::get(resElementType);
     }
   }
-  build(builder, state, resType, input, layout);
+  build(builder, state, resType, input, layout, saturation);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Stick/ZHighStick.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Stick/ZHighStick.td
@@ -35,14 +35,14 @@ include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td"
 //===----------------------------------------------------------------------===//
 
 def NoneTypeStickRemovalPattern : Pat<
-  (ZHighStickOp:$stick $arg, $layout1),
+  (ZHighStickOp:$stick $arg, $layout1, $_),
   (replaceWithValue $arg),
   [(IsNoneType:$arg)]
 >;
 
 // zhigh.Stick (zhigh.Unstick (%X)) = %X
 def StickUnstickSameLayoutRemovalPattern : Pat<
-  (ZHighStickOp:$stick (ZHighUnstickOp:$unstick $arg), $_),
+  (ZHighStickOp:$stick (ZHighUnstickOp:$unstick $arg), $_, $_),
   (replaceWithValue $arg),
   [(SameLayout $arg, $stick)]
 >;
@@ -52,7 +52,7 @@ def StickUnstickSameLayoutRemovalPattern : Pat<
 // the input and output must have the same shape, but NHWC stickify/unstickify
 // transposes the shape.
 def StickUnstickDiffLayoutRemovalPattern : Pat<
-  (ZHighStickOp:$stick (ZHighUnstickOp:$unstick $arg), $_),
+  (ZHighStickOp:$stick (ZHighUnstickOp:$unstick $arg), $_, $_),
   (ONNXLayoutTransformOp $arg, (GetEncodingAttr $stick)),
   [(NotSameLayout $arg, $stick), (NoOneIsOfNHWCLayout $arg, $stick),
    // Do not support 1D and 2DS because of this issue: https://github.com/onnx/onnx-mlir/issues/1940
@@ -70,13 +70,15 @@ def StickUnstickDiffLayoutRemovalPattern : Pat<
 //
 def ReplaceONNXLeakyReluPattern: Pat<
   (ZHighStickOp:$stickout (ONNXLeakyReluOp:$out (ZHighUnstickOp $X), $alpha),
-                $layout),
+                $layout, $_),
   (ZHighSubOp
      (ZHighReluOp $X, (returnType $X)),
      (ZHighReluOp (ZHighMulOp $X,
                               (ZHighStickOp (GetMinusBcastConst $alpha,
                                              $out),
-                                            $layout),
+                                            $layout,
+                                            // Donot saturate since input orignally from NNPA
+                                            (NoneIntegerAttr)), 
                               (returnType $X)),
                   (returnType $X))),
   [(IsStaticShapeTensor $X), (IsPlusConstantFloat $alpha),
@@ -100,11 +102,12 @@ def ReplaceONNXLeakyReluPattern: Pat<
 //   - %X should have static shape
 //
 def ReplaceONNXSoftplusPattern: Pattern<
-  (ZHighStickOp:$stickout (ONNXSoftplusOp:$out (ZHighUnstickOp $X)), $layout),
+  (ZHighStickOp:$stickout (ONNXSoftplusOp:$out (ZHighUnstickOp $X)), $layout, $_),
   [
-   // Get stickified constant of minus one with input shape
-   (ZHighStickOp:$minusOne (GetConstantOfType<"-1.0"> $out), $layout),
-   // Get minus X with input shape
+   // Get stickified constant of minus one with input shape.
+   // Donot saturate since input orignally from NNPA.
+   (ZHighStickOp:$minusOne (GetConstantOfType<"-1.0"> $out), $layout, (NoneIntegerAttr)),
+   // Get minus X with input shape.
    (ZHighMulOp:$minusX $X, $minusOne, (returnType $X)),
 
    // Get Softplus
@@ -139,9 +142,9 @@ def ReplaceONNXSoftplusPattern: Pattern<
 //   - %X should have static shape, and %alpha should be constant.
 //
 def ReplaceONNXReciprocalSqrtPattern: Pat<
-  (ZHighStickOp:$stick (ONNXReciprocalOp (ONNXSqrtOp (ZHighUnstickOp:$unstick $X))), $layout),
+  (ZHighStickOp:$stick (ONNXReciprocalOp (ONNXSqrtOp (ZHighUnstickOp:$unstick $X))), $layout, $saturation),
   (ZHighExpOp (ZHighMulOp (ZHighLogOp $X, (returnType $X)),
-                          (ZHighStickOp (GetConstantOfType<"-0.5"> $unstick), $layout),
+                          (ZHighStickOp (GetConstantOfType<"-0.5"> $unstick), $layout, $saturation),
                           (returnType $X))),
   [(IsStaticShapeTensor $X), (SameLayout $X, $stick)]
 >;
@@ -173,7 +176,7 @@ def ReshapeTransposeReshape2DTo3DSPattern : Pat<
           $shape1, $_),
         $perm),
       $shape2, $_),
-    $layout3DS),
+    $layout3DS, $saturation),
   (ZHighStickOp
     (ONNXShapeTransformOp // reshape
       (ONNXShapeTransformOp // transpose
@@ -185,7 +188,7 @@ def ReshapeTransposeReshape2DTo3DSPattern : Pat<
         (returnType (GetResultType $transpose))),
       (GetCollapsing4DTo3DMap $reshape2),
       (returnType (GetResultType $reshape2))),
-    $layout3DS),
+    $layout3DS, $saturation),
   [(TensorHas2DLayout $X), (Is3DSLayout $layout3DS),
    (IsStaticShapeTensor $X), (IsStaticShapeTensor $unstick),
    (IsStaticShapeTensor $reshape1), (IsStaticShapeTensor $transpose),
@@ -205,7 +208,7 @@ def ReshapeTransposeReshape3DSTo2DPattern : Pat<
           $shape1, $_),
         $perm),
       $shape2, $_),
-    $layout2D),
+    $layout2D, $saturation),
   (ZHighStickOp
     (ONNXShapeTransformOp // reshape
       (ONNXShapeTransformOp // transpose
@@ -217,7 +220,7 @@ def ReshapeTransposeReshape3DSTo2DPattern : Pat<
         (returnType (GetResultType $transpose))),
       (GetCollapsing4DTo2DMap $reshape2),
       (returnType (GetResultType $reshape2))),
-    $layout2D),
+    $layout2D, $saturation),
   [(TensorHas3DSLayout $X), (Is2DLayout $layout2D),
    (IsStaticShapeTensor $X), (IsStaticShapeTensor $unstick),
    (IsStaticShapeTensor $reshape1), (IsStaticShapeTensor $transpose),

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Unstick/ZHighUnstick.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Unstick/ZHighUnstick.td
@@ -36,7 +36,7 @@ include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td"
 
 // zhigh.Unstick (zhigh.Stick (%X)) = %X
 def UnstickStickRemovalPattern : Pat<
-  (ZHighUnstickOp (ZHighStickOp $arg, $_)),
+  (ZHighUnstickOp (ZHighStickOp $arg, $_, $_)),
   (replaceWithValue $arg)
 >;
 

--- a/src/Accelerators/NNPA/Dialect/ZLow/ZLow.td
+++ b/src/Accelerators/NNPA/Dialect/ZLow/ZLow.td
@@ -297,10 +297,14 @@ def ZLowStickOp:ZLow_Op<"stick", [MemRefsNormalizable,
   }];
   let arguments = (ins MemRefOf<[F16, F32]>:$X,
                        ZMemRef:$Out,
-                       OptionalAttr<StrAttr>:$layout);
+                       OptionalAttr<StrAttr>:$layout,
+                       OptionalAttr<SI64Attr>:$saturation);
   let builders = [
     OpBuilder<(ins "::mlir::Value":$X, "::mlir::Value":$Out), [{
-      build($_builder, $_state, X, Out, StringAttr());
+      build($_builder, $_state, X, Out, StringAttr(), IntegerAttr());
+    }]>,
+    OpBuilder<(ins "::mlir::Value":$X, "::mlir::Value":$Out, "::mlir::StringAttr":$layout), [{
+      build($_builder, $_state, X, Out, layout, IntegerAttr());
     }]>
   ];
 }

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighClipToDLFloat.cpp
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighClipToDLFloat.cpp
@@ -119,8 +119,9 @@ public:
         RankedTensorType::get({1}, inputElementType), DLF16_MIN);
     Value minVal = create.onnx.constant(minAttr);
     Value clippedVal = create.onnx.max({input, minVal});
-    Value replacedVal = rewriter.create<ZHighStickOp>(
-        loc, stickOp.getOut().getType(), clippedVal, stickOp.getLayoutAttr());
+    Value replacedVal =
+        rewriter.create<ZHighStickOp>(loc, stickOp.getOut().getType(),
+            clippedVal, stickOp.getLayoutAttr(), IntegerAttr());
 
     rewriter.replaceOp(genericOp, replacedVal);
     return success();

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighConstPropagation.td
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighConstPropagation.td
@@ -53,10 +53,11 @@ def CreateConstantForStickForGRU : NativeCodeCall<
 >;
 
 // zhigh.Stick (c) = krnl.global(c1), where c1 is stickified data.
+// Always saturate constants.
 def ConstantStickPattern : Pat<
   (ZHighStickOp:$stickOp
      (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_),
-     $layout),
+     $layout, $_),
   (CreateConstantForStick $stickOp, $c, $layout),
   [(IsFromDenseONNXConstantOp:$c)]
 >;

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighDecomposeStickUnstick.td
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighDecomposeStickUnstick.td
@@ -40,8 +40,8 @@ def NoneLayoutAttr: NativeCodeCall<"StringAttr()">;
 // Not support NHWC layout since the stick does transpose internally. We can
 // introduce transpose explicitly, but need to evaluate its overhead.
 def DecomposeStickPattern: Pat<
-  (ZHighStickOp $input, $layout),
-  (ONNXLayoutTransformOp (ZHighF32ToDLF16Op $input), $layout),
+  (ZHighStickOp $input, $layout, $saturation),
+  (ONNXLayoutTransformOp (ZHighF32ToDLF16Op $input, $saturation), $layout),
   [(IsNotNHWCLayout $layout)]
 >;
 

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighLayoutPropagation.cpp
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighLayoutPropagation.cpp
@@ -80,7 +80,8 @@ SmallVector<Value, 4> getZTensors(
 Type getZTensorType(
     PatternRewriter &rewriter, Location loc, Value tensor, StringAttr layout) {
   // Borrow ZHighStickOp to infer a zTensor type.
-  ZHighStickOp stickOp = rewriter.create<ZHighStickOp>(loc, tensor, layout);
+  ZHighStickOp stickOp =
+      rewriter.create<ZHighStickOp>(loc, tensor, layout, IntegerAttr());
   (void)stickOp.inferShapes([](Region &region) {});
 
   Type returnType = stickOp.getOut().getType();

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighLayoutPropagation.td
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighLayoutPropagation.td
@@ -63,36 +63,36 @@ def LayoutIsNot: Constraint<
 
 // Exp
 def ExpLayoutPropagatePattern : Pat<
-  (ZHighExpOp (ZHighStickOp (ZHighUnstickOp $x), $prevLayout)),
-  (ZHighStickOp (ZHighUnstickOp (ZHighExpOp $x, (returnType $x))), $prevLayout),
+  (ZHighExpOp (ZHighStickOp (ZHighUnstickOp $x), $prevLayout, $saturation)),
+  (ZHighStickOp (ZHighUnstickOp (ZHighExpOp $x, (returnType $x))), $prevLayout, $saturation),
   [(LayoutIsNot:$x $prevLayout)]
 >;
 
 // Log
 def LogLayoutPropagatePattern : Pat<
-  (ZHighLogOp (ZHighStickOp (ZHighUnstickOp $x), $prevLayout)),
-  (ZHighStickOp (ZHighUnstickOp (ZHighLogOp $x, (returnType $x))), $prevLayout),
+  (ZHighLogOp (ZHighStickOp (ZHighUnstickOp $x), $prevLayout, $saturation)),
+  (ZHighStickOp (ZHighUnstickOp (ZHighLogOp $x, (returnType $x))), $prevLayout, $saturation),
   [(LayoutIsNot:$x $prevLayout)]
 >;
 
 // Relu
 def ReluLayoutPropagatePattern : Pat<
-  (ZHighReluOp (ZHighStickOp (ZHighUnstickOp $x), $prevLayout)),
-  (ZHighStickOp (ZHighUnstickOp (ZHighReluOp $x, (returnType $x))), $prevLayout),
+  (ZHighReluOp (ZHighStickOp (ZHighUnstickOp $x), $prevLayout, $saturation)),
+  (ZHighStickOp (ZHighUnstickOp (ZHighReluOp $x, (returnType $x))), $prevLayout, $saturation),
   [(LayoutIsNot:$x $prevLayout)]
 >;
 
 // Sigmoid
 def SigmoidLayoutPropagatePattern : Pat<
-  (ZHighSigmoidOp (ZHighStickOp (ZHighUnstickOp $x), $prevLayout)),
-  (ZHighStickOp (ZHighUnstickOp (ZHighSigmoidOp $x, (returnType $x))), $prevLayout),
+  (ZHighSigmoidOp (ZHighStickOp (ZHighUnstickOp $x), $prevLayout, $saturation)),
+  (ZHighStickOp (ZHighUnstickOp (ZHighSigmoidOp $x, (returnType $x))), $prevLayout, $saturation),
   [(LayoutIsNot:$x $prevLayout)]
 >;
 
 // Tanh
 def TanhLayoutPropagatePattern : Pat<
-  (ZHighTanhOp (ZHighStickOp (ZHighUnstickOp $x), $prevLayout)),
-  (ZHighStickOp (ZHighUnstickOp (ZHighTanhOp $x, (returnType $x))), $prevLayout),
+  (ZHighTanhOp (ZHighStickOp (ZHighUnstickOp $x), $prevLayout, $saturation)),
+  (ZHighStickOp (ZHighUnstickOp (ZHighTanhOp $x, (returnType $x))), $prevLayout, $saturation),
   [(LayoutIsNot:$x $prevLayout)]
 >;
 
@@ -120,15 +120,15 @@ def TanhLayoutPropagatePattern : Pat<
 // Add
 def AddLayoutPropagatePattern1 : Pat<
   (ZHighAddOp
-     (ZHighStickOp (ZHighUnstickOp $x), $prevLayout),
+     (ZHighStickOp (ZHighUnstickOp $x), $prevLayout, $saturation),
      $y),
   (ZHighStickOp
      (ZHighUnstickOp
        (ZHighAddOp
          $x,
-         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x)),
+         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x), $saturation),
          (returnType $x))),
-     $prevLayout),
+     $prevLayout, $saturation),
   [(LayoutIs:$y $prevLayout),   // Two inputs must have the same layout.
    (LayoutIsNot:$x $prevLayout) // The previous layout is different.
   ]
@@ -137,14 +137,14 @@ def AddLayoutPropagatePattern1 : Pat<
 def AddLayoutPropagatePattern2 : Pat<
   (ZHighAddOp
      $x,
-     (ZHighStickOp (ZHighUnstickOp $y), $prevLayout)),
+     (ZHighStickOp (ZHighUnstickOp $y), $prevLayout, $saturation)),
   (ZHighStickOp
      (ZHighUnstickOp
        (ZHighAddOp
          $y,
-         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y)),
+         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y), $saturation),
          (returnType $y))),
-     $prevLayout),
+     $prevLayout, $saturation),
   [(LayoutIs:$y $prevLayout),   // Two inputs must have the same layout.
    (LayoutIsNot:$x $prevLayout) // The previous layout is different.
   ]
@@ -153,15 +153,15 @@ def AddLayoutPropagatePattern2 : Pat<
 // Sub
 def SubLayoutPropagatePattern1 : Pat<
   (ZHighSubOp
-     (ZHighStickOp (ZHighUnstickOp $x), $prevLayout),
+     (ZHighStickOp (ZHighUnstickOp $x), $prevLayout, $saturation),
      $y),
   (ZHighStickOp
      (ZHighUnstickOp
        (ZHighSubOp
          $x,
-         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x)),
+         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x), $saturation),
          (returnType $x))),
-     $prevLayout),
+     $prevLayout, $saturation),
   [(LayoutIs:$y $prevLayout),   // Two inputs must have the same layout.
    (LayoutIsNot:$x $prevLayout) // The previous layout is different.
   ]
@@ -170,14 +170,14 @@ def SubLayoutPropagatePattern1 : Pat<
 def SubLayoutPropagatePattern2 : Pat<
   (ZHighSubOp
      $x,
-     (ZHighStickOp (ZHighUnstickOp $y), $prevLayout)),
+     (ZHighStickOp (ZHighUnstickOp $y), $prevLayout, $saturation)),
   (ZHighStickOp
      (ZHighUnstickOp
        (ZHighSubOp
          $y,
-         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y)),
+         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y), $saturation),
          (returnType $y))),
-     $prevLayout),
+     $prevLayout, $saturation),
   [(LayoutIs:$y $prevLayout),   // Two inputs must have the same layout.
    (LayoutIsNot:$x $prevLayout) // The previous layout is different.
   ]
@@ -186,15 +186,15 @@ def SubLayoutPropagatePattern2 : Pat<
 // Mul
 def MulLayoutPropagatePattern1 : Pat<
   (ZHighMulOp
-     (ZHighStickOp (ZHighUnstickOp $x), $prevLayout),
+     (ZHighStickOp (ZHighUnstickOp $x), $prevLayout, $saturation),
      $y),
   (ZHighStickOp
      (ZHighUnstickOp
        (ZHighMulOp
          $x,
-         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x)),
+         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x), $saturation),
          (returnType $x))),
-     $prevLayout),
+     $prevLayout, $saturation),
   [(LayoutIs:$y $prevLayout),   // Two inputs must have the same layout.
    (LayoutIsNot:$x $prevLayout) // The previous layout is different.
   ]
@@ -203,14 +203,14 @@ def MulLayoutPropagatePattern1 : Pat<
 def MulLayoutPropagatePattern2 : Pat<
   (ZHighMulOp
      $x,
-     (ZHighStickOp (ZHighUnstickOp $y), $prevLayout)),
+     (ZHighStickOp (ZHighUnstickOp $y), $prevLayout, $saturation)),
   (ZHighStickOp
      (ZHighUnstickOp
        (ZHighMulOp
          $y,
-         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y)),
+         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y), $saturation),
          (returnType $y))),
-     $prevLayout),
+     $prevLayout, $saturation),
   [(LayoutIs:$y $prevLayout),   // Two inputs must have the same layout.
    (LayoutIsNot:$x $prevLayout) // The previous layout is different.
   ]
@@ -219,15 +219,15 @@ def MulLayoutPropagatePattern2 : Pat<
 // Div
 def DivLayoutPropagatePattern1 : Pat<
   (ZHighDivOp
-     (ZHighStickOp (ZHighUnstickOp $x), $prevLayout),
+     (ZHighStickOp (ZHighUnstickOp $x), $prevLayout, $saturation),
      $y),
   (ZHighStickOp
      (ZHighUnstickOp
        (ZHighDivOp
          $x,
-         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x)),
+         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x), $saturation),
          (returnType $x))),
-     $prevLayout),
+     $prevLayout, $saturation),
   [(LayoutIs:$y $prevLayout),   // Two inputs must have the same layout.
    (LayoutIsNot:$x $prevLayout) // The previous layout is different.
   ]
@@ -236,14 +236,14 @@ def DivLayoutPropagatePattern1 : Pat<
 def DivLayoutPropagatePattern2 : Pat<
   (ZHighDivOp
      $x,
-     (ZHighStickOp (ZHighUnstickOp $y), $prevLayout)),
+     (ZHighStickOp (ZHighUnstickOp $y), $prevLayout, $saturation)),
   (ZHighStickOp
      (ZHighUnstickOp
        (ZHighDivOp
          $y,
-         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y)),
+         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y), $saturation),
          (returnType $y))),
-     $prevLayout),
+     $prevLayout, $saturation),
   [(LayoutIs:$y $prevLayout),   // Two inputs must have the same layout.
    (LayoutIsNot:$x $prevLayout) // The previous layout is different.
   ]

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighRecomposeToStickUnstick.td
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighRecomposeToStickUnstick.td
@@ -40,8 +40,8 @@ def NoneLayoutAttr: NativeCodeCall<"StringAttr()">;
 // Not support NHWC layout since the stick does transpose internally. We can
 // introduce transpose explicitly, but need to evaluate its overhead.
 def RecomposeToStickPattern: Pat<
-  (ONNXLayoutTransformOp (ZHighF32ToDLF16Op $input), $layout),
-  (ZHighStickOp $input, $layout),
+  (ONNXLayoutTransformOp (ZHighF32ToDLF16Op $input, $saturation), $layout),
+  (ZHighStickOp $input, $layout, $saturation),
   []
 >;
 

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -44,9 +44,6 @@
 #define PREFETCH_CSU_DIST 0
 #define PREFETCH_CSU 1
 
-// TODO, integrate.
-#define SATURATION_ON 0
-
 using namespace mlir;
 
 namespace onnx_mlir {
@@ -330,12 +327,8 @@ public:
     // Compute output dims and rank.
     Value input = stickOp.getX();
     Value alloc = stickOp.getOut();
-
-    bool saturation = false;
-#if SATURATION_ON
-    // TODO: hook to operation's attribute.
-    saturation = true;
-#endif
+    std::optional<int64_t> saturationOpt = stickOp.getSaturation();
+    bool saturation = saturationOpt.has_value() && saturationOpt.value() != 0;
 
     DimsExpr outputDims;
     create.krnlIE.getShapeAsSymbols(alloc, outputDims);

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -52,6 +52,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Endian.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 
 #include "onnx/onnx_pb.h"
@@ -515,12 +516,13 @@ bool extractConstantsToFile(ModuleOp &module, std::string filepath,
     return (leftAlign < rightAlign);
   });
 
-  // Pack all constants into a single buffer in order to save to file.
+  // Store each constant into single file.
   // Constants with the highest alignment will be packed first in the file.
   // The file will be mmaped later at runtime and aligned at the page boundary,
-  // So every constants must be correctly aligned in the packed constant. Pads
-  // are added if necessary.
-  std::vector<char> packedConst;
+  // So every constants must be correctly aligned. Pads are added if necessary.
+  llvm::sys::fs::remove(filepath);
+  std::ofstream outfile(filepath, std::ios::app | std::ios::binary);
+  uint64_t totalConstSize = 0;
   for (int64_t i = globalOfInterest.size() - 1; i >= 0; --i) {
     KrnlGlobalOp op = globalOfInterest[i];
     ArrayRef<char> rawData = getRawData(op);
@@ -531,26 +533,24 @@ bool extractConstantsToFile(ModuleOp &module, std::string filepath,
       alignment = op.getAlignment().value();
 
     // Padding if necessary.
-    if ((alignment > 0) && (packedConst.size() % alignment != 0)) {
+    if ((alignment > 0) && (totalConstSize % alignment != 0)) {
       uint64_t padSize =
-          ((uint64_t)(packedConst.size() / alignment) + 1) * alignment -
-          packedConst.size();
+          ((uint64_t)(totalConstSize / alignment) + 1) * alignment -
+          totalConstSize;
       SmallVector<char> pads(padSize, (char)0);
-      packedConst.insert(packedConst.end(), pads.begin(), pads.end());
+      outfile.write(pads.data(), pads.size());
+      totalConstSize += pads.size();
     }
 
-    op.setOffsetAttr(b.getI64IntegerAttr(packedConst.size()));
+    op.setOffsetAttr(b.getI64IntegerAttr(totalConstSize));
     op.removeValueAttr();
-    packedConst.insert(packedConst.end(), rawData.begin(), rawData.end());
+    outfile.write(rawData.data(), rawData.size());
+    totalConstSize += rawData.size();
   }
 
   // No constant statisfying thresholds, do not store constants to file.
-  if (packedConst.empty())
+  if (totalConstSize == 0)
     return false;
-
-  // Save to file.
-  std::ofstream outfile(filepath, std::ofstream::binary);
-  outfile.write(packedConst.data(), packedConst.size());
 
   // Create a global op to store the filename in the IR.
   OpBuilder::InsertionGuard guard(b);
@@ -564,7 +564,8 @@ bool extractConstantsToFile(ModuleOp &module, std::string filepath,
   create.llvm.globalOp(llvmI64Ty,
       /*isConstant=*/true, LLVM::Linkage::Internal,
       EXTERNAL_CONSTANT_PREFIX + "filesize",
-      b.getI64IntegerAttr(packedConst.size()));
+      b.getI64IntegerAttr(totalConstSize));
+
   // Create a global to store isLE.
   bool isLE = llvm::endianness::native == llvm::endianness::little;
   create.llvm.globalOp(llvmI8Ty,

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -587,9 +587,8 @@ struct ScalarOp<ONNXHardSigmoidOp> {
 template <>
 double analyzeSimdFor<ONNXHardSigmoidOp>(
     Type t, Operation *op, int64_t &von, int64_t &son) {
-  return simdAnalysis({GenericOps::ArithmeticGop, GenericOps::MulGop,
-                          GenericOps::CompareGop, GenericOps::SelectGop},
-      {1, 1, 2, 2}, t, von, son);
+  return simdAnalysis(
+      {GenericOps::ArithmeticGop, GenericOps::MulGop}, {2, 1}, t, von, son);
 }
 
 template <>
@@ -615,10 +614,9 @@ Value emitScalarOpFor<ONNXHardSigmoidOp>(ConversionPatternRewriter &rewriter,
   Value beta = create.math.constant(elementType, betaLit);
   // Perform computations.
   Value add = create.math.add(create.math.mul(alpha, operand), beta);
-  Value maxPredicate = create.math.sgt(add, zero);
-  Value max = create.math.select(maxPredicate, add, zero);
-  Value minPredicate = create.math.slt(max, one);
-  return create.math.select(minPredicate, max, one);
+  Value clipLowest = create.math.max(add, zero);
+  Value clipHighest = create.math.min(clipLowest, one);
+  return clipHighest;
 }
 
 //===----------------------------------------------------------------------===//
@@ -671,8 +669,7 @@ struct ScalarOp<ONNXReluOp> {
 template <>
 double analyzeSimdFor<ONNXReluOp>(
     Type t, Operation *op, int64_t &von, int64_t &son) {
-  return simdAnalysis(
-      {GenericOps::CompareGop, GenericOps::SelectGop}, {1, 1}, t, von, son);
+  return simdAnalysis({GenericOps::ArithmeticGop}, {1}, t, von, son);
 }
 
 template <>
@@ -683,8 +680,7 @@ Value emitScalarOpFor<ONNXReluOp>(ConversionPatternRewriter &rewriter,
   Value operand = scalarOperands[0];
   MultiDialectBuilder<MathBuilder> create(rewriter, loc);
   Value zero = create.math.constant(elementType, 0);
-  Value geZero = create.math.sge(operand, zero);
-  return create.math.select(geZero, operand, zero);
+  return create.math.max(zero, operand);
 }
 
 //===----------------------------------------------------------------------===//
@@ -956,8 +952,7 @@ struct ScalarOp<ONNXMaxOp> {
 template <>
 double analyzeSimdFor<ONNXMaxOp>(
     Type t, Operation *op, int64_t &von, int64_t &son) {
-  return simdAnalysis(
-      {GenericOps::CompareGop, GenericOps::SelectGop}, {1, 1}, t, von, son);
+  return simdAnalysis({GenericOps::ArithmeticGop}, {1}, t, von, son);
 }
 
 template <>
@@ -971,9 +966,7 @@ Value emitScalarOpFor<ONNXMaxOp>(ConversionPatternRewriter &rewriter,
   Value lhs = scalarOperands[0];
   Value rhs = scalarOperands[1];
   MultiDialectBuilder<MathBuilder> create(rewriter, loc);
-  // could return create.math.max(lhs, rhs);
-  Value cond = create.math.gt(lhs, rhs);
-  return create.math.select(cond, lhs, rhs);
+  return create.math.max(lhs, rhs);
 }
 
 //===----------------------------------------------------------------------===//
@@ -988,8 +981,7 @@ struct ScalarOp<ONNXMinOp> {
 template <>
 double analyzeSimdFor<ONNXMinOp>(
     Type t, Operation *op, int64_t &von, int64_t &son) {
-  return simdAnalysis(
-      {GenericOps::CompareGop, GenericOps::SelectGop}, {1, 1}, t, von, son);
+  return simdAnalysis({GenericOps::ArithmeticGop}, {1}, t, von, son);
 }
 
 template <>
@@ -1004,8 +996,7 @@ Value emitScalarOpFor<ONNXMinOp>(ConversionPatternRewriter &rewriter,
   Value rhs = scalarOperands[1];
   MultiDialectBuilder<MathBuilder> create(rewriter, loc);
   // could return create.math.min(lhs, rhs);
-  Value cond = create.math.lt(lhs, rhs);
-  return create.math.select(cond, lhs, rhs);
+  return create.math.min(lhs, rhs);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1366,8 +1357,7 @@ struct ScalarOp<ONNXClipOp> {
 template <>
 double analyzeSimdFor<ONNXClipOp>(
     Type t, Operation *op, int64_t &von, int64_t &son) {
-  return simdAnalysis(
-      {GenericOps::CompareGop, GenericOps::SelectGop}, {2, 2}, t, von, son);
+  return simdAnalysis({GenericOps::ArithmeticGop}, {2}, t, von, son);
 }
 
 template <>
@@ -1376,16 +1366,12 @@ Value emitScalarOpFor<ONNXClipOp>(ConversionPatternRewriter &rewriter,
     ArrayRef<Value> scalarOperands) {
   MultiDialectBuilder<KrnlBuilder, MathBuilder> create(rewriter, loc);
   Value res = scalarOperands[0];
-  Value min = scalarOperands[1];
-  Value max = scalarOperands[2];
-  if (!isNoneValue(min)) {
-    Value lessThanMin = create.math.slt(res, min); // (input[i,j,k]<min)
-    res = create.math.select(lessThanMin, min, res);
-  }
-  if (!isNoneValue(max)) {
-    Value lessThanMax = create.math.slt(res, max); // (input[i,j,k]>max)
-    res = create.math.select(lessThanMax, res, max);
-  }
+  Value minVal = scalarOperands[1];
+  Value maxVal = scalarOperands[2];
+  if (!isNoneValue(minVal))
+    res = create.math.max(minVal, res);
+  if (!isNoneValue(maxVal))
+    res = create.math.min(maxVal, res);
   return res;
 }
 

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -283,8 +283,7 @@ Value emitScalarOpFor<ONNXReduceMaxV13Op>(ConversionPatternRewriter &rewriter,
   MathBuilder createMath(rewriter, loc);
   Value lhs = scalarOperands[0];
   Value rhs = scalarOperands[1];
-  Value max = createMath.sgt(lhs, rhs);
-  return createMath.select(max, lhs, rhs);
+  return createMath.max(lhs, rhs);
 }
 
 template <>
@@ -294,8 +293,7 @@ Value emitScalarOpFor<ONNXReduceMaxOp>(ConversionPatternRewriter &rewriter,
   MathBuilder createMath(rewriter, loc);
   Value lhs = scalarOperands[0];
   Value rhs = scalarOperands[1];
-  Value max = createMath.sgt(lhs, rhs);
-  return createMath.select(max, lhs, rhs);
+  return createMath.max(lhs, rhs);
 }
 
 //===----------------------------------------------------------------------===//
@@ -308,8 +306,7 @@ Value emitScalarOpFor<ONNXReduceMinV13Op>(ConversionPatternRewriter &rewriter,
   MathBuilder createMath(rewriter, loc);
   Value lhs = scalarOperands[0];
   Value rhs = scalarOperands[1];
-  Value min = createMath.slt(lhs, rhs);
-  return createMath.select(min, lhs, rhs);
+  return createMath.min(lhs, rhs);
 }
 
 template <>
@@ -319,8 +316,7 @@ Value emitScalarOpFor<ONNXReduceMinOp>(ConversionPatternRewriter &rewriter,
   MathBuilder createMath(rewriter, loc);
   Value lhs = scalarOperands[0];
   Value rhs = scalarOperands[1];
-  Value min = createMath.slt(lhs, rhs);
-  return createMath.select(min, lhs, rhs);
+  return createMath.min(lhs, rhs);
 }
 
 // This duplicated code can be eliminated with if constexpr in c++ 17

--- a/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
@@ -21,6 +21,8 @@
 using namespace mlir;
 namespace onnx_mlir {
 
+// TODO: may consider exploiting SIMD.
+
 static void emitInnerLoops(KrnlBuilder &createKrnl, int64_t numberOfLoops,
     SmallVectorImpl<IndexExpr> &Lbs, SmallVectorImpl<IndexExpr> &Ubs,
     ValueRange outerIndices, Value input, Value alloc, Value zero,
@@ -55,9 +57,7 @@ static void emitInnerLoops(KrnlBuilder &createKrnl, int64_t numberOfLoops,
 
         Value max = iterArg;
         Value nextMax = create.krnl.load(input, maxLoopIVs);
-        auto maxCond = create.math.sgt(max, nextMax);
-        max = create.math.select(maxCond, max, nextMax);
-
+        max = create.math.max(max, nextMax);
         create.krnl.yield(max);
       });
   // Get the maximum value.

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -48,8 +48,7 @@ Value emitScalarOpFor<ONNXMaxPoolSingleOutOp>(
   Value lhs = scalarOperands[0];
   Value rhs = scalarOperands[1];
   MultiDialectBuilder<MathBuilder> create(rewriter, loc);
-  Value max = create.math.sgt(lhs, rhs);
-  return create.math.select(max, lhs, rhs);
+  return create.math.max(lhs, rhs);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Conversion/ONNXToKrnl/Quantization/DynamicQuantizeLinear.cpp
+++ b/src/Conversion/ONNXToKrnl/Quantization/DynamicQuantizeLinear.cpp
@@ -21,6 +21,7 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
+// TODO may consider SIMD and parallel.
 struct ONNXDynamicQuantizeLinearOpLowering
     : public OpConversionPattern<ONNXDynamicQuantizeLinearOp> {
   ONNXDynamicQuantizeLinearOpLowering(
@@ -65,6 +66,8 @@ struct ONNXDynamicQuantizeLinearOpLowering
         create.mem.alignedAlloc(yScaleMemRefType, shapeHelper.getOutputDims(1));
     Value YZeroPoint = create.mem.alignedAlloc(
         yZeroPointMemRefType, shapeHelper.getOutputDims(2));
+
+    // TODO: consider SIMD version of this.
 
     // Equations:
     // y_scale = (max(x) - min(x))/(qmax - qmin)

--- a/src/Runtime/OMSort.inc
+++ b/src/Runtime/OMSort.inc
@@ -1,3 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===-- OMSort.inc - OMSort C/C++ Implementation --===//
+//
+// Copyright 2023-2024 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains C/C++ implementation of OMSort.
+//
+//===----------------------------------------------------------------------===//
+
 #ifdef __cplusplus
 #include <cassert>
 #else
@@ -190,8 +204,8 @@ typedef struct indexStack {
 static int64_t log2u(uint64_t n) {
   assert(n > 0);
   int64_t b = 0;
-  for (; n > 0; b++)
-    n = n >> 2;
+  for (; n > 1; b++)
+    n = n >> 1;
   return b;
 }
 

--- a/test/mlir/accelerators/nnpa/driver/saturation.mlir
+++ b/test/mlir/accelerators/nnpa/driver/saturation.mlir
@@ -1,0 +1,44 @@
+// RUN: onnx-mlir -mcpu=z16 -maccel=NNPA --EmitZHighIR --nnpa-saturation=false --printIR %s | FileCheck --check-prefix=ZHIGH_OFF %s
+// RUN: onnx-mlir -mcpu=z16 -maccel=NNPA --EmitZHighIR --nnpa-saturation=true --printIR %s | FileCheck --check-prefix=ZHIGH_ON %s
+// RUN: onnx-mlir -mcpu=z16 -maccel=NNPA --EmitZLowIR --nnpa-saturation=false --printIR %s | FileCheck --check-prefix=ZLOW_OFF %s
+// RUN: onnx-mlir -mcpu=z16 -maccel=NNPA --EmitZLowIR --nnpa-saturation=true --printIR %s | FileCheck --check-prefix=ZLOW_ON %s
+// RUN: onnx-mlir-opt -mcpu=z16 -maccel=NNPA --nnpa-saturation=false --shape-inference --convert-onnx-to-zhigh --zhigh-decompose-stick-unstick %s | FileCheck --check-prefix=DECOMPOSE_OFF %s
+// RUN: onnx-mlir-opt -mcpu=z16 -maccel=NNPA --nnpa-saturation=true --shape-inference --convert-onnx-to-zhigh --zhigh-decompose-stick-unstick %s | FileCheck --check-prefix=DECOMPOSE_ON %s
+// RUN: onnx-mlir -mcpu=z16 -maccel=NNPA --EmitMLIR --nnpa-saturation=false --enable-compiler-stick-unstick --printIR %s | FileCheck --check-prefix=COMPILER_STICK_OFF %s
+// RUN: onnx-mlir -mcpu=z16 -maccel=NNPA --EmitMLIR --nnpa-saturation=true --enable-compiler-stick-unstick --printIR %s | FileCheck --check-prefix=COMPILER_STICK_ON %s
+
+// COM: for each case, check saturation ON and OFF.
+
+func.func @saturation(%arg0 : tensor<10x10xf32>) -> tensor<*xf32> {
+  %0 = "onnx.Relu"(%arg0) : (tensor<10x10xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+// ZHIGH_OFF-LABEL:  func @saturation
+// ZHIGH_OFF: "zhigh.Stick"({{.*}}) {layout = "2D"} : {{.*}} 
+
+// ZHIGH_ON-LABEL:  func @saturation
+// ZHIGH_ON: "zhigh.Stick"({{.*}}) {layout = "2D", saturation = -1 : si64} : {{.*}} 
+
+
+// ZLOW_OFF-LABEL:  func @saturation
+// ZLOW_OFF:   "zlow.stick"({{.*}}, {{.*}}) {layout = "2D"} : {{.*}} 
+
+// ZLOW_ON-LABEL:  func @saturation
+// ZLOW_ON:   "zlow.stick"({{.*}}, {{.*}}) {layout = "2D", saturation = -1 : si64} : {{.*}} 
+
+// DECOMPOSE_OFF-LABEL:  func @saturation
+// DECOMPOSE_OFF: "zhigh.F32ToDLF16"(%arg0) :  {{.*}}
+
+// DECOMPOSE_ON-LABEL:  func @saturation
+// DECOMPOSE_ON: "zhigh.F32ToDLF16"(%arg0) {saturation = -1 : si64} :  {{.*}}
+
+// COMPILER_STICK_OFF-LABEL:  func @saturation
+// COMPILER_STICK_OFF-NOT: arith.minnumf 
+// COMPILER_STICK_OFF-NOT: arith.maxnumf 
+// COMPILER_STICK_OFF: zlow.relu 
+
+// COMPILER_STICK_ON-LABEL:  func @saturation
+// COMPILER_STICK_ON: arith.minnumf 
+// COMPILER_STICK_ON: arith.maxnumf 
+// COMPILER_STICK_ON: zlow.relu 
+}
+

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
@@ -36,6 +36,7 @@ func.func @test_binary_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x5x
 // -----
 
 // COM: Check the template for lowering variadic operations and binary operations whose output type is the same as its input type: Min, Max, Add, Sub, etc.
+
 func.func @test_variadic_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x1xf32>, %arg1: tensor<?x?x5xf32>, %arg2: tensor<?x1x5xf32>) -> tensor<?x4x5xf32> {
   %0 = "onnx.Max"(%arg0, %arg1, %arg2) : (tensor<?x4x1xf32>, tensor<?x?x5xf32>, tensor<?x1x5xf32>) -> tensor<?x4x5xf32>
   return %0 : tensor<?x4x5xf32>
@@ -68,14 +69,12 @@ func.func @test_variadic_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x
 // CHECK-DAG:         [[VAR_10_:%.+]] = arith.cmpi sgt, [[VAR_dim_1_]], [[CST_1_]] : index
 // CHECK:             [[VAR_11_:%.+]] = arith.select [[VAR_10_]], [[VAR_4_]]#1, [[CST_0_]] : index
 // CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[VAR_9_]], [[VAR_11_]], [[VAR_4_]]#2] : memref<?x?x5xf32>
-// CHECK:             [[VAR_13_:%.+]] = arith.cmpf ogt, [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
-// CHECK-DAG:         [[VAR_14_:%.+]] = arith.select [[VAR_13_]], [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
-// CHECK-DAG:         [[VAR_15_:%.+]] = arith.cmpi sgt, [[VAR_dim_2_]], [[CST_1_]] : index
-// CHECK:             [[VAR_16_:%.+]] = arith.select [[VAR_15_]], [[VAR_4_]]#0, [[CST_0_]] : index
-// CHECK:             [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]]{{.}}[[VAR_16_]], [[CST_0_]], [[VAR_4_]]#2] : memref<?x1x5xf32>
-// CHECK:             [[VAR_18_:%.+]] = arith.cmpf ogt, [[VAR_14_]], [[LOAD_PARAM_2_MEM_]] : f32
-// CHECK:             [[VAR_19_:%.+]] = arith.select [[VAR_18_]], [[VAR_14_]], [[LOAD_PARAM_2_MEM_]] : f32
-// CHECK:             krnl.store [[VAR_19_]], [[RES_]]{{.}}[[VAR_4_]]#0, [[VAR_4_]]#1, [[VAR_4_]]#2] : memref<?x4x5xf32>
+// CHECK-DAG:         [[VAR_13_:%.+]] = arith.maxnumf [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK-DAG:         [[VAR_14_:%.+]] = arith.cmpi sgt, [[VAR_dim_2_]], [[CST_1_]] : index
+// CHECK:             [[VAR_15_:%.+]] = arith.select [[VAR_14_]], [[VAR_4_]]#0, [[CST_0_]] : index
+// CHECK:             [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]]{{.}}[[VAR_15_]], [[CST_0_]], [[VAR_4_]]#2] : memref<?x1x5xf32>
+// CHECK:             [[VAR_17_:%.+]] = arith.maxnumf [[VAR_13_]], [[LOAD_PARAM_2_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_17_]], [[RES_]]{{.}}[[VAR_4_]]#0, [[VAR_4_]]#1, [[VAR_4_]]#2] : memref<?x4x5xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x4x5xf32>
 // CHECK:         }
@@ -1101,6 +1100,7 @@ func.func private @test_sigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
 // -----
 
+
 func.func private @test_relu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Relu"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
@@ -1118,9 +1118,8 @@ func.func private @test_relu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[MAP_0_]]([[VAR_dim_0_]]), [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 10){
 // CHECK:             [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<?x10xf32>
-// CHECK:             [[VAR_3_:%.+]] = arith.cmpf oge, [[LOAD_PARAM_0_MEM_]], [[CST_0_dot_000000_]] : f32
-// CHECK:             [[VAR_4_:%.+]] = arith.select [[VAR_3_]], [[LOAD_PARAM_0_MEM_]], [[CST_0_dot_000000_]] : f32
-// CHECK:             krnl.store [[VAR_4_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<?x10xf32>
+// CHECK:             [[VAR_3_:%.+]] = arith.maxnumf [[LOAD_PARAM_0_MEM_]], [[CST_0_dot_000000_]] : f32
+// CHECK:             krnl.store [[VAR_3_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<?x10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x10xf32>
 // CHECK:         }
@@ -1216,6 +1215,7 @@ func.func private @test_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
 // -----
 
+
 func.func private @test_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.HardSigmoid"(%arg0) {alpha=1.0:f32, beta=2.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
@@ -1236,11 +1236,9 @@ func.func private @test_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 // CHECK:             [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<?x10xf32>
 // CHECK:             [[VAR_3_:%.+]] = arith.addf [[LOAD_PARAM_0_MEM_]], [[CST_2_dot_000000_]] : f32
-// CHECK:             [[VAR_4_:%.+]] = arith.cmpf ogt, [[VAR_3_]], [[CST_0_dot_000000_]] : f32
-// CHECK:             [[VAR_5_:%.+]] = arith.select [[VAR_4_]], [[VAR_3_]], [[CST_0_dot_000000_]] : f32
-// CHECK:             [[VAR_6_:%.+]] = arith.cmpf olt, [[VAR_5_]], [[CST_1_dot_000000_]] : f32
-// CHECK:             [[VAR_7_:%.+]] = arith.select [[VAR_6_]], [[VAR_5_]], [[CST_1_dot_000000_]] : f32
-// CHECK:             krnl.store [[VAR_7_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<?x10xf32>
+// CHECK:             [[VAR_4_:%.+]] = arith.maxnumf [[VAR_3_]], [[CST_0_dot_000000_]] : f32
+// CHECK:             [[VAR_5_:%.+]] = arith.minnumf [[VAR_4_]], [[CST_1_dot_000000_]] : f32
+// CHECK:             krnl.store [[VAR_5_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<?x10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x10xf32>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
@@ -419,7 +419,7 @@ func.func @roberta_partial_simd_1dim_tensor3(%arg0: tensor<?x?x768xf32>, %arg1: 
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_tensor3
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1x1x1xf32>) -> memref<?x?x768xf32> 
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1x1x1xf32>) -> memref<?x?x768xf32>
 // CHECK-DAG:       [[CST_768_:%.+]] = arith.constant 768 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
@@ -959,6 +959,7 @@ func.func private @test_sum(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>
 
 // -----
 
+
 func.func private @test_max(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Max"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
@@ -986,15 +987,15 @@ func.func private @test_max(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>
 // CHECK:             [[VAR_1_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
 // CHECK-DAG:         [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_1_]]{{.}} : memref<100xf32>, vector<32xf32>
 // CHECK-DAG:         [[LOAD_VAR_reshape_2_MEM_:%.+]] = vector.load [[VAR_reshape_2_]]{{.}}[[VAR_1_]]{{.}} : memref<100xf32>, vector<32xf32>
-// CHECK:             [[VAR_4_:%.+]] = arith.cmpf ogt, [[LOAD_VAR_reshape_MEM_]], [[LOAD_VAR_reshape_2_MEM_]] : vector<32xf32>
-// CHECK:             [[VAR_5_:%.+]] = arith.select [[VAR_4_]], [[LOAD_VAR_reshape_MEM_]], [[LOAD_VAR_reshape_2_MEM_]] : vector<32xi1>, vector<32xf32>
-// CHECK:             vector.store [[VAR_5_]], [[VAR_reshape_4_]]{{.}}[[VAR_1_]]{{.}} : memref<100xf32>, vector<32xf32>
+// CHECK:             [[VAR_4_:%.+]] = arith.maxnumf [[LOAD_VAR_reshape_MEM_]], [[LOAD_VAR_reshape_2_MEM_]] : vector<32xf32>
+// CHECK:             vector.store [[VAR_4_]], [[VAR_reshape_4_]]{{.}}[[VAR_1_]]{{.}} : memref<100xf32>, vector<32xf32>
 // CHECK:           }
 // CHECK:           return [[VAR_view_]] : memref<10x10xf32>
 // CHECK:         }
 }
 
 // -----
+
 
 func.func private @test_min(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Min"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
@@ -1023,9 +1024,8 @@ func.func private @test_min(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>
 // CHECK:             [[VAR_1_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
 // CHECK-DAG:         [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_1_]]{{.}} : memref<100xf32>, vector<32xf32>
 // CHECK-DAG:         [[LOAD_VAR_reshape_2_MEM_:%.+]] = vector.load [[VAR_reshape_2_]]{{.}}[[VAR_1_]]{{.}} : memref<100xf32>, vector<32xf32>
-// CHECK:             [[VAR_4_:%.+]] = arith.cmpf olt, [[LOAD_VAR_reshape_MEM_]], [[LOAD_VAR_reshape_2_MEM_]] : vector<32xf32>
-// CHECK:             [[VAR_5_:%.+]] = arith.select [[VAR_4_]], [[LOAD_VAR_reshape_MEM_]], [[LOAD_VAR_reshape_2_MEM_]] : vector<32xi1>, vector<32xf32>
-// CHECK:             vector.store [[VAR_5_]], [[VAR_reshape_4_]]{{.}}[[VAR_1_]]{{.}} : memref<100xf32>, vector<32xf32>
+// CHECK:             [[VAR_4_:%.+]] = arith.minnumf [[LOAD_VAR_reshape_MEM_]], [[LOAD_VAR_reshape_2_MEM_]] : vector<32xf32>
+// CHECK:             vector.store [[VAR_4_]], [[VAR_reshape_4_]]{{.}}[[VAR_1_]]{{.}} : memref<100xf32>, vector<32xf32>
 // CHECK:           }
 // CHECK:           return [[VAR_view_]] : memref<10x10xf32>
 // CHECK:         }
@@ -1515,6 +1515,7 @@ func.func private @test_sigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
 // -----
 
+
 func.func private @test_relu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Relu"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
@@ -1546,9 +1547,8 @@ func.func private @test_relu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 // CHECK:           krnl.iterate([[BLOCK_TILE__0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to [[MAP_2_]](){{.}}[[VAR_dim_]], [[VAR_dim_]]_0]){
 // CHECK:             [[VAR_4_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
 // CHECK:             [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_4_]]{{.}} : memref<?xf32>, vector<32xf32>
-// CHECK:             [[VAR_6_:%.+]] = arith.cmpf oge, [[LOAD_VAR_reshape_MEM_]], [[VAR_cst_]] : vector<32xf32>
-// CHECK:             [[VAR_7_:%.+]] = arith.select [[VAR_6_]], [[LOAD_VAR_reshape_MEM_]], [[VAR_cst_]] : vector<32xi1>, vector<32xf32>
-// CHECK:             vector.store [[VAR_7_]], [[VAR_reshape_3_]]{{.}}[[VAR_4_]]{{.}} : memref<?xf32>, vector<32xf32>
+// CHECK:             [[VAR_6_:%.+]] = arith.maxnumf [[LOAD_VAR_reshape_MEM_]], [[VAR_cst_]] : vector<32xf32>
+// CHECK:             vector.store [[VAR_6_]], [[VAR_reshape_3_]]{{.}}[[VAR_4_]]{{.}} : memref<?xf32>, vector<32xf32>
 // CHECK:           }
 // CHECK:           return [[VAR_view_]] : memref<?x10xf32>
 // CHECK:         }
@@ -1686,6 +1686,7 @@ func.func private @test_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
 // -----
 
+
 func.func private @test_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.HardSigmoid"(%arg0) {alpha=1.0:f32, beta=2.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
@@ -1720,11 +1721,9 @@ func.func private @test_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 // CHECK:             [[VAR_4_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
 // CHECK:             [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_4_]]{{.}} : memref<?xf32>, vector<32xf32>
 // CHECK:             [[VAR_6_:%.+]] = arith.addf [[LOAD_VAR_reshape_MEM_]], [[VAR_cst_]] : vector<32xf32>
-// CHECK:             [[VAR_7_:%.+]] = arith.cmpf ogt, [[VAR_6_]], [[VAR_cst_1_]] : vector<32xf32>
-// CHECK:             [[VAR_8_:%.+]] = arith.select [[VAR_7_]], [[VAR_6_]], [[VAR_cst_1_]] : vector<32xi1>, vector<32xf32>
-// CHECK:             [[VAR_9_:%.+]] = arith.cmpf olt, [[VAR_8_]], [[VAR_cst_0_]] : vector<32xf32>
-// CHECK:             [[VAR_10_:%.+]] = arith.select [[VAR_9_]], [[VAR_8_]], [[VAR_cst_0_]] : vector<32xi1>, vector<32xf32>
-// CHECK:             vector.store [[VAR_10_]], [[VAR_reshape_5_]]{{.}}[[VAR_4_]]{{.}} : memref<?xf32>, vector<32xf32>
+// CHECK:             [[VAR_7_:%.+]] = arith.maxnumf [[VAR_6_]], [[VAR_cst_1_]] : vector<32xf32>
+// CHECK:             [[VAR_8_:%.+]] = arith.minnumf [[VAR_7_]], [[VAR_cst_0_]] : vector<32xf32>
+// CHECK:             vector.store [[VAR_8_]], [[VAR_reshape_5_]]{{.}}[[VAR_4_]]{{.}} : memref<?xf32>, vector<32xf32>
 // CHECK:           }
 // CHECK:           return [[VAR_view_]] : memref<?x10xf32>
 // CHECK:         }
@@ -2141,6 +2140,7 @@ func.func private @test_ceil(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
 // -----
 
+
 func.func private @test_clip(%arg0: tensor<128xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<128xf32> {
   %0 = "onnx.Clip"(%arg0, %arg1, %arg2) : (tensor<128xf32>, tensor<f32>, tensor<f32>) -> tensor<128xf32>
   return %0 : tensor<128xf32>
@@ -2160,17 +2160,16 @@ func.func private @test_clip(%arg0: tensor<128xf32>, %arg1: tensor<f32>, %arg2: 
 // CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]][] : memref<f32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_6_:%.+]] = vector.splat [[LOAD_PARAM_2_MEM_]] : vector<32xf32>
-// CHECK-DAG:         [[VAR_7_:%.+]] = arith.cmpf olt, [[LOAD_PARAM_0_MEM_]], [[VAR_4_]] : vector<32xf32>
-// CHECK:             [[VAR_8_:%.+]] = arith.select [[VAR_7_]], [[VAR_4_]], [[LOAD_PARAM_0_MEM_]] : vector<32xi1>, vector<32xf32>
-// CHECK:             [[VAR_9_:%.+]] = arith.cmpf olt, [[VAR_8_]], [[VAR_6_]] : vector<32xf32>
-// CHECK:             [[VAR_10_:%.+]] = arith.select [[VAR_9_]], [[VAR_8_]], [[VAR_6_]] : vector<32xi1>, vector<32xf32>
-// CHECK:             vector.store [[VAR_10_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<128xf32>, vector<32xf32>
+// CHECK-DAG:         [[VAR_7_:%.+]] = arith.maxnumf [[VAR_4_]], [[LOAD_PARAM_0_MEM_]] : vector<32xf32>
+// CHECK:             [[VAR_8_:%.+]] = arith.minnumf [[VAR_6_]], [[VAR_7_]] : vector<32xf32>
+// CHECK:             vector.store [[VAR_8_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<128xf32>, vector<32xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<128xf32>
 // CHECK:         }
 }
 
 // -----
+
 
 func.func private @test_clip_default_min(%arg0: tensor<128xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<128xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
@@ -2188,15 +2187,15 @@ func.func private @test_clip_default_min(%arg0: tensor<128xf32>, %arg1: tensor<f
 // CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_1_]]{{.}} : memref<128xf32>, vector<32xf32>
 // CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]][] : memref<f32>
 // CHECK:             [[VAR_4_:%.+]] = vector.splat [[LOAD_PARAM_2_MEM_]] : vector<32xf32>
-// CHECK:             [[VAR_5_:%.+]] = arith.cmpf olt, [[LOAD_PARAM_0_MEM_]], [[VAR_4_]] : vector<32xf32>
-// CHECK:             [[VAR_6_:%.+]] = arith.select [[VAR_5_]], [[LOAD_PARAM_0_MEM_]], [[VAR_4_]] : vector<32xi1>, vector<32xf32>
-// CHECK:             vector.store [[VAR_6_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<128xf32>, vector<32xf32>
+// CHECK:             [[VAR_5_:%.+]] = arith.minnumf [[VAR_4_]], [[LOAD_PARAM_0_MEM_]] : vector<32xf32>
+// CHECK:             vector.store [[VAR_5_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<128xf32>, vector<32xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<128xf32>
 // CHECK:         }
 }
 
 // -----
+
 
 func.func private @test_clip_default_min_int(%arg0: tensor<128xi32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<128xi32> {
   %cst = "onnx.NoValue"() {value} : () -> none
@@ -2214,10 +2213,10 @@ func.func private @test_clip_default_min_int(%arg0: tensor<128xi32>, %arg1: tens
 // CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_1_]]{{.}} : memref<128xi32>, vector<32xi32>
 // CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]][] : memref<i32>
 // CHECK:             [[VAR_4_:%.+]] = vector.splat [[LOAD_PARAM_2_MEM_]] : vector<32xi32>
-// CHECK:             [[VAR_5_:%.+]] = arith.cmpi slt, [[LOAD_PARAM_0_MEM_]], [[VAR_4_]] : vector<32xi32>
-// CHECK:             [[VAR_6_:%.+]] = arith.select [[VAR_5_]], [[LOAD_PARAM_0_MEM_]], [[VAR_4_]] : vector<32xi1>, vector<32xi32>
-// CHECK:             vector.store [[VAR_6_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<128xi32>, vector<32xi32>
+// CHECK:             [[VAR_5_:%.+]] = arith.minsi [[VAR_4_]], [[LOAD_PARAM_0_MEM_]] : vector<32xi32>
+// CHECK:             vector.store [[VAR_5_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<128xi32>, vector<32xi32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<128xi32>
 // CHECK:         }
 }
+

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_parallel_canonicalize_O3.mlir
@@ -2,47 +2,47 @@
 
 // -----
 
-// With enable-parallel, a krnl.parallel should be created, which takes a loop (to be parallelized) 
+// With enable-parallel, a krnl.parallel should be created, which takes a loop (to be parallelized)
 // as input. The krnl.parallel should be the last operator before krnl.iterate, since the lowering
 // needs to interpret krnl.block, krnl.permute, krnl.unroll first.
-
 // Test parallelization of Relu
+
 func.func @test_relu_parallel(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Relu"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
 
-  // mlir2FileCheck.py
-  // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0] -> (s0 * 40 + 128)>
-  // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<()[s0] -> (s0 * 10)>
-  // CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<()[s0, s1] -> (s0 * 10)>
-  // CHECK-LABEL:  func.func @test_relu_parallel
-  // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x10xf32>) -> memref<?x10xf32> {
-  // CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<0.000000e+00> : vector<32xf32>
-  // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
-  // CHECK:           [[VAR_dim_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x10xf32>
-  // CHECK:           [[VAR_0_:%.+]] = affine.apply [[MAP_0_]](){{.}}[[VAR_dim_]]{{.}}
-  // CHECK:           [[RES_:%.+]] = memref.alloc([[VAR_0_]]) {{.*}}: memref<?xi8>
-  // CHECK-DAG:       [[VAR_view_:%.+]] = memref.view [[RES_]]{{.}}[[CST_0_]]{{.}}{{.}}[[VAR_dim_]]{{.}} : memref<?xi8> to memref<?x10xf32>
-  // CHECK-DAG:       [[VAR_dim_0_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x10xf32>
-  // CHECK-NOT: separator of consecutive DAGs
-  // CHECK-DAG:       [[VAR_1_:%.+]] = affine.apply [[MAP_1_]](){{.}}[[VAR_dim_0_]]{{.}}
-  // CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1xindex>
-  // CHECK:           affine.store [[VAR_1_]], [[RES_1_]][0] : memref<1xindex>
-  // CHECK-DAG:       [[VAR_reshape_:%.+]] = memref.reshape [[PARAM_0_]]([[RES_1_]]) : (memref<?x10xf32>, memref<1xindex>) -> memref<?xf32>
-  // CHECK-DAG:       [[VAR_2_:%.+]] = affine.apply [[MAP_1_]](){{.}}[[VAR_dim_]]{{.}}
-  // CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<1xindex>
-  // CHECK:           affine.store [[VAR_2_]], [[RES_2_]][0] : memref<1xindex>
-  // CHECK-DAG:       [[VAR_reshape_3_:%.+]] = memref.reshape [[VAR_view_]]([[RES_2_]]) : (memref<?x10xf32>, memref<1xindex>) -> memref<?xf32>
-  // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
-  // CHECK:           [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]] 32 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
-  // CHECK:           krnl.parallel([[BLOCK_TILE__0_]]) : !krnl.loop
-  // CHECK:           krnl.iterate([[BLOCK_TILE__0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to [[MAP_2_]](){{.}}[[VAR_dim_]], [[VAR_dim_]]_0]){
-  // CHECK:             [[VAR_4_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
-  // CHECK:             [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_4_]]{{.}} : memref<?xf32>, vector<32xf32>
-  // CHECK:             [[VAR_6_:%.+]] = arith.cmpf oge, [[LOAD_VAR_reshape_MEM_]], [[VAR_cst_]] : vector<32xf32>
-  // CHECK:             [[VAR_7_:%.+]] = arith.select [[VAR_6_]], [[LOAD_VAR_reshape_MEM_]], [[VAR_cst_]] : vector<32xi1>, vector<32xf32>
-  // CHECK:             vector.store [[VAR_7_]], [[VAR_reshape_3_]]{{.}}[[VAR_4_]]{{.}} : memref<?xf32>, vector<32xf32>
-  // CHECK:           }
-  // CHECK:           return [[VAR_view_]] : memref<?x10xf32>
-  // CHECK:         }
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0] -> (s0 * 40 + 128)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<()[s0] -> (s0 * 10)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<()[s0, s1] -> (s0 * 10)>
+// CHECK-LABEL:  func.func @test_relu_parallel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x10xf32>) -> memref<?x10xf32> {
+// CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<0.000000e+00> : vector<32xf32>
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK:           [[VAR_dim_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x10xf32>
+// CHECK:           [[VAR_0_:%.+]] = affine.apply [[MAP_0_]](){{.}}[[VAR_dim_]]{{.}}
+// CHECK:           [[RES_:%.+]] = memref.alloc([[VAR_0_]]) {{.*}}: memref<?xi8>
+// CHECK-DAG:       [[VAR_view_:%.+]] = memref.view [[RES_]]{{.}}[[CST_0_]]{{.}}{{.}}[[VAR_dim_]]{{.}} : memref<?xi8> to memref<?x10xf32>
+// CHECK-DAG:       [[VAR_dim_0_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x10xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = affine.apply [[MAP_1_]](){{.}}[[VAR_dim_0_]]{{.}}
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1xindex>
+// CHECK:           affine.store [[VAR_1_]], [[RES_1_]][0] : memref<1xindex>
+// CHECK-DAG:       [[VAR_reshape_:%.+]] = memref.reshape [[PARAM_0_]]([[RES_1_]]) : (memref<?x10xf32>, memref<1xindex>) -> memref<?xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = affine.apply [[MAP_1_]](){{.}}[[VAR_dim_]]{{.}}
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<1xindex>
+// CHECK:           affine.store [[VAR_2_]], [[RES_2_]][0] : memref<1xindex>
+// CHECK-DAG:       [[VAR_reshape_3_:%.+]] = memref.reshape [[VAR_view_]]([[RES_2_]]) : (memref<?x10xf32>, memref<1xindex>) -> memref<?xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
+// CHECK:           [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]] 32 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+// CHECK:           krnl.parallel([[BLOCK_TILE__0_]]) : !krnl.loop
+// CHECK:           krnl.iterate([[BLOCK_TILE__0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to [[MAP_2_]](){{.}}[[VAR_dim_]], [[VAR_dim_]]_0]){
+// CHECK:             [[VAR_4_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
+// CHECK:             [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_4_]]{{.}} : memref<?xf32>, vector<32xf32>
+// CHECK:             [[VAR_6_:%.+]] = arith.maxnumf [[LOAD_VAR_reshape_MEM_]], [[VAR_cst_]] : vector<32xf32>
+// CHECK:             vector.store [[VAR_6_]], [[VAR_reshape_3_]]{{.}}[[VAR_4_]]{{.}} : memref<?xf32>, vector<32xf32>
+// CHECK:           }
+// CHECK:           return [[VAR_view_]] : memref<?x10xf32>
+// CHECK:         }
 }
+

--- a/test/mlir/conversion/onnx_to_krnl/Math/Reduction_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Reduction_with_canonicalize.mlir
@@ -166,9 +166,8 @@ func.func private @test_reducemax_v13(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32
 // CHECK:             [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
 // CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2] : memref<3x2x2xf32>
 // CHECK-DAG:         [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
-// CHECK:             [[VAR_4_:%.+]] = arith.cmpf ogt, [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:             [[VAR_5_:%.+]] = arith.select [[VAR_4_]], [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:             krnl.store [[VAR_5_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
+// CHECK:             [[VAR_4_:%.+]] = arith.maxnumf [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_4_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<3x2xf32>
 // CHECK:         }
@@ -192,9 +191,8 @@ func.func private @test_reducemin_v13(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32
 // CHECK:             [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
 // CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2] : memref<3x2x2xf32>
 // CHECK-DAG:         [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
-// CHECK:             [[VAR_4_:%.+]] = arith.cmpf olt, [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:             [[VAR_5_:%.+]] = arith.select [[VAR_4_]], [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:             krnl.store [[VAR_5_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
+// CHECK:             [[VAR_4_:%.+]] = arith.minnumf [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_4_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<3x2xf32>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_krnl/Math/Reduction_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Reduction_with_canonicalize_O3.mlir
@@ -24,9 +24,8 @@ func.func private @test_reducemax_v13(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32
 // CHECK:             [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
 // CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2] : memref<3x2x2xf32>
 // CHECK-DAG:         [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
-// CHECK:             [[VAR_4_:%.+]] = arith.cmpf ogt, [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:             [[VAR_5_:%.+]] = arith.select [[VAR_4_]], [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:             krnl.store [[VAR_5_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
+// CHECK:             [[VAR_4_:%.+]] = arith.maxnumf [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_4_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<3x2xf32>
 // CHECK:         }
@@ -50,9 +49,8 @@ func.func private @test_reducemin_v13(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32
 // CHECK:             [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
 // CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2] : memref<3x2x2xf32>
 // CHECK-DAG:         [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
-// CHECK:             [[VAR_4_:%.+]] = arith.cmpf olt, [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:             [[VAR_5_:%.+]] = arith.select [[VAR_4_]], [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:             krnl.store [[VAR_5_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
+// CHECK:             [[VAR_4_:%.+]] = arith.minnumf [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_4_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#2] : memref<3x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<3x2xf32>
 // CHECK:         }
@@ -813,30 +811,26 @@ func.func private @test_reducemax_v13_bis(%arg0 : tensor<1028x256xf32>) -> tenso
 // CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:             [[BLOCK_TILE__1_:%.+]], [[BLOCK_IN__1_:%.+]] = krnl.block [[LOOP_1_]] 4 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
 // CHECK:             krnl.iterate([[BLOCK_TILE__1_]]) with ([[LOOP_1_]] -> [[I_1_:%.+]] = [[CST_0_]] to [[CST_256_]]){
-// CHECK:               [[VAR_19_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__1_]]) : (!krnl.loop) -> index
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_1_]], [[VAR_1_]]9] : memref<1028x256xf32>, vector<4xf32>
+// CHECK:               [[VAR_16_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__1_]]) : (!krnl.loop) -> index
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_1_]], [[VAR_1_]]6] : memref<1028x256xf32>, vector<4xf32>
 // CHECK-DAG:           [[LOAD_RES_1_MEM_:%.+]] = vector.load [[RES_1_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
-// CHECK:               [[VAR_22_:%.+]] = arith.cmpf ogt, [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : vector<4xf32>
-// CHECK:               [[VAR_23_:%.+]] = arith.select [[VAR_22_]], [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : vector<4xi1>, vector<4xf32>
-// CHECK:               vector.store [[VAR_23_]], [[RES_1_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
-// CHECK:               [[VAR_24_:%.+]] = affine.apply [[MAP_0_]]([[VAR_1_]])
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_24_]], [[VAR_19_]]{{.}} : memref<1028x256xf32>, vector<4xf32>
+// CHECK:               [[VAR_19_:%.+]] = arith.maxnumf [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : vector<4xf32>
+// CHECK:               vector.store [[VAR_19_]], [[RES_1_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
+// CHECK:               [[VAR_20_:%.+]] = affine.apply [[MAP_0_]]([[VAR_1_]])
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_20_]], [[VAR_16_]]{{.}} : memref<1028x256xf32>, vector<4xf32>
 // CHECK-DAG:           [[LOAD_RES_1_MEM_1_:%.+]] = vector.load [[RES_1_]]{{.}}[[CST_1_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
-// CHECK:               [[VAR_27_:%.+]] = arith.cmpf ogt, [[LOAD_RES_1_MEM_1_]], [[LOAD_PARAM_0_MEM_1_]] : vector<4xf32>
-// CHECK:               [[VAR_28_:%.+]] = arith.select [[VAR_27_]], [[LOAD_RES_1_MEM_1_]], [[LOAD_PARAM_0_MEM_1_]] : vector<4xi1>, vector<4xf32>
-// CHECK:               vector.store [[VAR_28_]], [[RES_1_]]{{.}}[[CST_1_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
-// CHECK:               [[VAR_29_:%.+]] = affine.apply [[MAP_1_]]([[VAR_1_]])
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_2_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_29_]], [[VAR_19_]]{{.}} : memref<1028x256xf32>, vector<4xf32>
+// CHECK:               [[VAR_23_:%.+]] = arith.maxnumf [[LOAD_RES_1_MEM_1_]], [[LOAD_PARAM_0_MEM_1_]] : vector<4xf32>
+// CHECK:               vector.store [[VAR_23_]], [[RES_1_]]{{.}}[[CST_1_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
+// CHECK:               [[VAR_24_:%.+]] = affine.apply [[MAP_1_]]([[VAR_1_]])
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_2_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_24_]], [[VAR_16_]]{{.}} : memref<1028x256xf32>, vector<4xf32>
 // CHECK-DAG:           [[LOAD_RES_1_MEM_2_:%.+]] = vector.load [[RES_1_]]{{.}}[[CST_2_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
-// CHECK:               [[VAR_32_:%.+]] = arith.cmpf ogt, [[LOAD_RES_1_MEM_2_]], [[LOAD_PARAM_0_MEM_2_]] : vector<4xf32>
-// CHECK:               [[VAR_33_:%.+]] = arith.select [[VAR_32_]], [[LOAD_RES_1_MEM_2_]], [[LOAD_PARAM_0_MEM_2_]] : vector<4xi1>, vector<4xf32>
-// CHECK:               vector.store [[VAR_33_]], [[RES_1_]]{{.}}[[CST_2_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
-// CHECK:               [[VAR_34_:%.+]] = affine.apply [[MAP_2_]]([[VAR_1_]])
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_3_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_34_]], [[VAR_19_]]{{.}} : memref<1028x256xf32>, vector<4xf32>
+// CHECK:               [[VAR_27_:%.+]] = arith.maxnumf [[LOAD_RES_1_MEM_2_]], [[LOAD_PARAM_0_MEM_2_]] : vector<4xf32>
+// CHECK:               vector.store [[VAR_27_]], [[RES_1_]]{{.}}[[CST_2_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
+// CHECK:               [[VAR_28_:%.+]] = affine.apply [[MAP_2_]]([[VAR_1_]])
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_3_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_28_]], [[VAR_16_]]{{.}} : memref<1028x256xf32>, vector<4xf32>
 // CHECK-DAG:           [[LOAD_RES_1_MEM_3_:%.+]] = vector.load [[RES_1_]]{{.}}[[CST_3_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
-// CHECK:               [[VAR_37_:%.+]] = arith.cmpf ogt, [[LOAD_RES_1_MEM_3_]], [[LOAD_PARAM_0_MEM_3_]] : vector<4xf32>
-// CHECK:               [[VAR_38_:%.+]] = arith.select [[VAR_37_]], [[LOAD_RES_1_MEM_3_]], [[LOAD_PARAM_0_MEM_3_]] : vector<4xi1>, vector<4xf32>
-// CHECK:               vector.store [[VAR_38_]], [[RES_1_]]{{.}}[[CST_3_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
+// CHECK:               [[VAR_31_:%.+]] = arith.maxnumf [[LOAD_RES_1_MEM_3_]], [[LOAD_PARAM_0_MEM_3_]] : vector<4xf32>
+// CHECK:               vector.store [[VAR_31_]], [[RES_1_]]{{.}}[[CST_3_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
 // CHECK:             }
 // CHECK-DAG:         [[LOAD_RES_1_MEM_4_:%.+]] = vector.load [[RES_1_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
 // CHECK-DAG:         [[LOAD_RES_1_MEM_5_:%.+]] = vector.load [[RES_1_]]{{.}}[[CST_1_]], [[CST_0_]]{{.}} : memref<4x4xf32>, vector<4xf32>
@@ -845,17 +839,15 @@ func.func private @test_reducemax_v13_bis(%arg0 : tensor<1028x256xf32>) -> tenso
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_7_:%.+]] = vector.shuffle [[LOAD_RES_1_MEM_4_]], [[LOAD_RES_1_MEM_5_]] [0, 4, 1, 5] : vector<4xf32>, vector<4xf32>
 // CHECK-DAG:         [[VAR_8_:%.+]] = vector.shuffle [[LOAD_RES_1_MEM_4_]], [[LOAD_RES_1_MEM_5_]] [2, 6, 3, 7] : vector<4xf32>, vector<4xf32>
-// CHECK:             [[VAR_9_:%.+]] = arith.cmpf ogt, [[VAR_7_]], [[VAR_8_]] : vector<4xf32>
-// CHECK-DAG:         [[VAR_10_:%.+]] = arith.select [[VAR_9_]], [[VAR_7_]], [[VAR_8_]] : vector<4xi1>, vector<4xf32>
-// CHECK-DAG:         [[VAR_11_:%.+]] = vector.shuffle [[LOAD_RES_1_MEM_6_]], [[LOAD_RES_1_MEM_7_]] [0, 4, 1, 5] : vector<4xf32>, vector<4xf32>
-// CHECK-DAG:         [[VAR_12_:%.+]] = vector.shuffle [[LOAD_RES_1_MEM_6_]], [[LOAD_RES_1_MEM_7_]] [2, 6, 3, 7] : vector<4xf32>, vector<4xf32>
-// CHECK:             [[VAR_13_:%.+]] = arith.cmpf ogt, [[VAR_11_]], [[VAR_12_]] : vector<4xf32>
-// CHECK:             [[VAR_14_:%.+]] = arith.select [[VAR_13_]], [[VAR_11_]], [[VAR_12_]] : vector<4xi1>, vector<4xf32>
-// CHECK-DAG:         [[VAR_15_:%.+]] = vector.shuffle [[VAR_10_]], [[VAR_14_]] [0, 1, 4, 5] : vector<4xf32>, vector<4xf32>
-// CHECK-DAG:         [[VAR_16_:%.+]] = vector.shuffle [[VAR_10_]], [[VAR_14_]] [2, 3, 6, 7] : vector<4xf32>, vector<4xf32>
-// CHECK:             [[VAR_17_:%.+]] = arith.cmpf ogt, [[VAR_15_]], [[VAR_16_]] : vector<4xf32>
-// CHECK:             [[VAR_18_:%.+]] = arith.select [[VAR_17_]], [[VAR_15_]], [[VAR_16_]] : vector<4xi1>, vector<4xf32>
-// CHECK:             vector.store [[VAR_18_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<1028xf32>, vector<4xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_9_:%.+]] = arith.maxnumf [[VAR_7_]], [[VAR_8_]] : vector<4xf32>
+// CHECK-DAG:         [[VAR_10_:%.+]] = vector.shuffle [[LOAD_RES_1_MEM_6_]], [[LOAD_RES_1_MEM_7_]] [0, 4, 1, 5] : vector<4xf32>, vector<4xf32>
+// CHECK-DAG:         [[VAR_11_:%.+]] = vector.shuffle [[LOAD_RES_1_MEM_6_]], [[LOAD_RES_1_MEM_7_]] [2, 6, 3, 7] : vector<4xf32>, vector<4xf32>
+// CHECK:             [[VAR_12_:%.+]] = arith.maxnumf [[VAR_10_]], [[VAR_11_]] : vector<4xf32>
+// CHECK-DAG:         [[VAR_13_:%.+]] = vector.shuffle [[VAR_9_]], [[VAR_12_]] [0, 1, 4, 5] : vector<4xf32>, vector<4xf32>
+// CHECK-DAG:         [[VAR_14_:%.+]] = vector.shuffle [[VAR_9_]], [[VAR_12_]] [2, 3, 6, 7] : vector<4xf32>, vector<4xf32>
+// CHECK:             [[VAR_15_:%.+]] = arith.maxnumf [[VAR_13_]], [[VAR_14_]] : vector<4xf32>
+// CHECK:             vector.store [[VAR_15_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<1028xf32>, vector<4xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<1028xf32>
 // CHECK:         }
@@ -886,9 +878,8 @@ func.func private @test_reducemax_int_v13(%arg0 : tensor<128x256x768xi32>) -> te
 // CHECK:               [[VAR_5_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_5_]]{{.}} : memref<128x256x768xi32>, vector<16xi32>
 // CHECK-DAG:           [[LOAD_RES_1_MEM_:%.+]] = vector.load [[RES_1_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}} : memref<1x16xi32>, vector<16xi32>
-// CHECK:               [[VAR_8_:%.+]] = arith.cmpi sgt, [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : vector<16xi32>
-// CHECK:               [[VAR_9_:%.+]] = arith.select [[VAR_8_]], [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : vector<16xi1>, vector<16xi32>
-// CHECK:               vector.store [[VAR_9_]], [[RES_1_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}} : memref<1x16xi32>, vector<16xi32>
+// CHECK:               [[VAR_8_:%.+]] = arith.maxsi [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : vector<16xi32>
+// CHECK:               vector.store [[VAR_8_]], [[RES_1_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}} : memref<1x16xi32>, vector<16xi32>
 // CHECK:             }
 // CHECK:             [[LOAD_RES_1_MEM_1_:%.+]] = vector.load [[RES_1_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}} : memref<1x16xi32>, vector<16xi32>
 // CHECK:             [[VAR_4_:%.+]] = vector.reduction <maxsi>, [[LOAD_RES_1_MEM_1_]] : vector<16xi32> into i32

--- a/test/mlir/conversion/onnx_to_krnl/Math/Softmax_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Softmax_with_canonicalize.mlir
@@ -3,45 +3,50 @@
 // Adding canonicalize is important here as this is the only way to check the values of the map,
 // which are otherwise before the function, and thus are hard to test.
 
+// -----
+
 // COM: Lower Softmax opset 11.
+
 func.func private @test_softmax_v11(%arg0 : tensor<10x20x30xf32>) -> tensor<*xf32> {
   %0 = "onnx.SoftmaxV11"(%arg0) {axis=1: si64} : (tensor<10x20x30xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
 
-// CHECK:         func private @test_softmax_v11([[arg0_:%.+]]: memref<10x20x30xf32>) -> memref<10x20x30xf32> {
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func private @test_softmax_v11
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<10x20x30xf32>) -> memref<10x20x30xf32> {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_2_:%.+]] = memref.alloc() {{.*}}: memref<10x20x30xf32>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<10x20x30xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 10){
-// CHECK:             [[VAR_4_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]) : (!krnl.loop) -> index
-// CHECK:             [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             [[Iter0Result:%.+]] = krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_1_:%.+]] = 0 to 20, [[LOOP_1_]]#1 -> [[I_2_:%.+]] = 0 to 30) iter_args([[Iter0Arg:%.+]] = [[CST_0_]]) -> (f32){
-// CHECK-DAG:           [[VAR_10_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               [[LOAD_arg0_MEM_:%.+]] = krnl.load [[arg0_]]{{.}}[[VAR_4_]], [[VAR_10_]]#0, [[VAR_10_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_13_:%.+]] = arith.cmpf ogt, [[Iter0Arg]], [[LOAD_arg0_MEM_]] : f32
-// CHECK:               [[VAR_14_:%.+]] = arith.select [[VAR_13_]], [[Iter0Arg]], [[LOAD_arg0_MEM_]] : f32
-// CHECK:               krnl.yield [[VAR_14_]] : f32
+// CHECK-DAG:         [[VAR_1_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]) : (!krnl.loop) -> index
+// CHECK-DAG:         [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_3_:%.+]] = krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[VAR_arg2_:%.+]] = 0 to 20, [[LOOP_1_]]#1 -> [[VAR_arg3_:%.+]] = 0 to 30) iter_args([[VAR_arg4_:%.+]] = [[CST_0_]]) -> (f32){
+// CHECK-DAG:           [[VAR_7_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]], [[VAR_7_]]#0, [[VAR_7_]]#1] : memref<10x20x30xf32>
+// CHECK:               [[VAR_9_:%.+]] = arith.maxnumf [[VAR_arg4_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:               krnl.yield [[VAR_9_]] : f32
 // CHECK:             }
-// CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             [[Iter1Result:%.+]] = krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = 0 to 20, [[LOOP_2_]]#1 -> [[I_4_:%.+]] = 0 to 30) iter_args([[Iter1Arg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
-// CHECK-DAG:           [[VAR_10_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               [[LOAD_arg0_MEM_1_:%.+]] = krnl.load [[arg0_]]{{.}}[[VAR_4_]], [[VAR_10_1_]]#0, [[VAR_10_1_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_13_1_:%.+]] = arith.subf [[LOAD_arg0_MEM_1_]], [[Iter0Result]] : f32
-// CHECK:               [[VAR_14_1_:%.+]] = math.exp [[VAR_13_1_]] : f32
-// CHECK:               [[VAR_15_:%.+]] = arith.addf [[Iter1Arg]], [[VAR_14_1_]] : f32
-// CHECK:               krnl.store [[VAR_14_1_]], [[VAR_2_]]{{.}}[[VAR_4_]], [[VAR_10_1_]]#0, [[VAR_10_1_]]#1] : memref<10x20x30xf32>
-// CHECK:               krnl.yield [[VAR_15_]] : f32
+// CHECK:             [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
+// CHECK-DAG:         [[VAR_5_:%.+]] = krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[VAR_arg2_1_:%.+]] = 0 to 20, [[LOOP_2_]]#1 -> [[VAR_arg3_1_:%.+]] = 0 to 30) iter_args([[VAR_arg4_1_:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
+// CHECK-DAG:           [[VAR_7_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]], [[VAR_7_1_]]#0, [[VAR_7_1_]]#1] : memref<10x20x30xf32>
+// CHECK:               [[VAR_9_1_:%.+]] = arith.subf [[LOAD_PARAM_0_MEM_1_]], [[VAR_3_]] : f32
+// CHECK:               [[VAR_10_:%.+]] = math.exp [[VAR_9_1_]] : f32
+// CHECK:               [[VAR_11_:%.+]] = arith.addf [[VAR_arg4_1_]], [[VAR_10_]] : f32
+// CHECK:               krnl.store [[VAR_10_]], [[RES_]]{{.}}[[VAR_1_]], [[VAR_7_1_]]#0, [[VAR_7_1_]]#1] : memref<10x20x30xf32>
+// CHECK:               krnl.yield [[VAR_11_]] : f32
 // CHECK:             }
-// CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = 0 to 20, [[LOOP_3_]]#1 -> [[I_6_:%.+]] = 0 to 30){
-// CHECK:               [[VAR_10_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               [[LOAD_VAR_0_MEM_2_:%.+]] = krnl.load [[VAR_2_]]{{.}}[[VAR_4_]], [[VAR_10_2_]]#0, [[VAR_10_2_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[LOAD_arg0_MEM_1_:%.+]] = arith.divf [[LOAD_VAR_0_MEM_2_]], [[Iter1Result]] : f32
-// CHECK:               krnl.store [[LOAD_arg0_MEM_1_]], [[VAR_2_]]{{.}}[[VAR_4_]], [[VAR_10_2_]]#0, [[VAR_10_2_]]#1] : memref<10x20x30xf32>
+// CHECK:             [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_1_:%.+]] = 0 to 20, [[LOOP_3_]]#1 -> [[I_2_:%.+]] = 0 to 30){
+// CHECK:               [[VAR_7_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_1_]], [[VAR_7_2_]]#0, [[VAR_7_2_]]#1] : memref<10x20x30xf32>
+// CHECK:               [[VAR_9_2_:%.+]] = arith.divf [[LOAD_PARAM_0_MEM_1_]], [[VAR_5_]] : f32
+// CHECK:               krnl.store [[VAR_9_2_]], [[RES_]]{{.}}[[VAR_1_]], [[VAR_7_2_]]#0, [[VAR_7_2_]]#1] : memref<10x20x30xf32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           return [[VAR_2_]] : memref<10x20x30xf32>
+// CHECK:           return [[RES_]] : memref<10x20x30xf32>
 // CHECK:         }
 }
 
@@ -53,39 +58,42 @@ func.func private @test_softmax_v13(%arg0 : tensor<10x20x30xf32>) -> tensor<*xf3
   %0 = "onnx.Softmax"(%arg0) {axis=1: si64} : (tensor<10x20x30xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
 
-// CHECK:         func private @test_softmax_v13([[arg0_:%.+]]: memref<10x20x30xf32>) -> memref<10x20x30xf32> {
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func private @test_softmax_v13
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<10x20x30xf32>) -> memref<10x20x30xf32> {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_2_:%.+]] = memref.alloc() {{.*}}: memref<10x20x30xf32>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<10x20x30xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 30){
-// CHECK:             [[VAR_4_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
-// CHECK:             [[Iter0Result:%.+]] = krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 20) iter_args([[Iter0Arg:%.+]] = [[CST_0_]]) -> (f32){
-// CHECK-DAG:           [[VAR_10_:%.+]] = krnl.get_induction_var_value([[LOOP_1_]]) : (!krnl.loop) -> index
-// CHECK:               [[LOAD_arg0_MEM_:%.+]] = krnl.load [[arg0_]]{{.}}[[VAR_4_]]#0, [[VAR_10_]], [[VAR_4_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_13_:%.+]] = arith.cmpf ogt, [[Iter0Arg]], [[LOAD_arg0_MEM_]] : f32
-// CHECK:               [[VAR_14_:%.+]] = arith.select [[VAR_13_]], [[Iter0Arg]], [[LOAD_arg0_MEM_]] : f32
-// CHECK:               krnl.yield [[VAR_14_]] : f32
+// CHECK-DAG:         [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:         [[LOOP_1_:%.+]] = krnl.define_loops 1
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_3_:%.+]] = krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[VAR_arg3_:%.+]] = 0 to 20) iter_args([[VAR_arg4_:%.+]] = [[CST_0_]]) -> (f32){
+// CHECK-DAG:           [[VAR_7_:%.+]] = krnl.get_induction_var_value([[LOOP_1_]]) : (!krnl.loop) -> index
+// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_7_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
+// CHECK:               [[VAR_9_:%.+]] = arith.maxnumf [[VAR_arg4_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:               krnl.yield [[VAR_9_]] : f32
 // CHECK:             }
-// CHECK-DAG:         [[LOOP_2_:%.+]] = krnl.define_loops 1
-// CHECK:             [[Iter1Result:%.+]] = krnl.iterate([[LOOP_2_]]) with ([[LOOP_2_]] -> [[I_3_:%.+]] = 0 to 20) iter_args([[Iter1Arg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
-// CHECK-DAG:           [[VAR_10_1_:%.+]] = krnl.get_induction_var_value([[LOOP_2_]]) : (!krnl.loop) -> index
-// CHECK:               [[LOAD_arg0_MEM_1_:%.+]] = krnl.load [[arg0_]]{{.}}[[VAR_4_]]#0, [[VAR_10_1_]], [[VAR_4_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_13_1_:%.+]] = arith.subf [[LOAD_arg0_MEM_1_]], [[Iter0Result]] : f32
-// CHECK:               [[VAR_14_1_:%.+]] = math.exp [[VAR_13_1_]] : f32
-// CHECK:               [[VAR_15_:%.+]] = arith.addf [[Iter1Arg]], [[VAR_14_1_]] : f32
-// CHECK:               krnl.store [[VAR_14_1_]], [[VAR_2_]]{{.}}[[VAR_4_]]#0, [[VAR_10_1_]], [[VAR_4_]]#1] : memref<10x20x30xf32>
-// CHECK:               krnl.yield [[VAR_15_]] : f32
+// CHECK:             [[LOOP_2_:%.+]] = krnl.define_loops 1
+// CHECK-DAG:         [[VAR_5_:%.+]] = krnl.iterate([[LOOP_2_]]) with ([[LOOP_2_]] -> [[VAR_arg3_1_:%.+]] = 0 to 20) iter_args([[VAR_arg4_1_:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
+// CHECK-DAG:           [[VAR_7_1_:%.+]] = krnl.get_induction_var_value([[LOOP_2_]]) : (!krnl.loop) -> index
+// CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_7_1_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
+// CHECK:               [[VAR_9_1_:%.+]] = arith.subf [[LOAD_PARAM_0_MEM_1_]], [[VAR_3_]] : f32
+// CHECK:               [[VAR_10_:%.+]] = math.exp [[VAR_9_1_]] : f32
+// CHECK:               [[VAR_11_:%.+]] = arith.addf [[VAR_arg4_1_]], [[VAR_10_]] : f32
+// CHECK:               krnl.store [[VAR_10_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_1_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
+// CHECK:               krnl.yield [[VAR_11_]] : f32
 // CHECK:             }
-// CHECK-DAG:         [[LOOP_3_:%.+]] = krnl.define_loops 1
-// CHECK:             krnl.iterate([[LOOP_3_]]) with ([[LOOP_3_]] -> [[I_4_:%.+]] = 0 to 20){
-// CHECK:               [[VAR_10_2_:%.+]] = krnl.get_induction_var_value([[LOOP_3_]]) : (!krnl.loop) -> index
-// CHECK:               [[LOAD_VAR_0_MEM_2_:%.+]] = krnl.load [[VAR_2_]]{{.}}[[VAR_4_]]#0, [[VAR_10_2_]], [[VAR_4_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[LOAD_arg0_MEM_1_:%.+]] = arith.divf [[LOAD_VAR_0_MEM_2_]], [[Iter1Result]] : f32
-// CHECK:               krnl.store [[LOAD_arg0_MEM_1_]], [[VAR_2_]]{{.}}[[VAR_4_]]#0, [[VAR_10_2_]], [[VAR_4_]]#1] : memref<10x20x30xf32>
+// CHECK:             [[LOOP_3_:%.+]] = krnl.define_loops 1
+// CHECK:             krnl.iterate([[LOOP_3_]]) with ([[LOOP_3_]] -> [[I_2_:%.+]] = 0 to 20){
+// CHECK:               [[VAR_7_2_:%.+]] = krnl.get_induction_var_value([[LOOP_3_]]) : (!krnl.loop) -> index
+// CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_2_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
+// CHECK:               [[VAR_9_2_:%.+]] = arith.divf [[LOAD_PARAM_0_MEM_1_]], [[VAR_5_]] : f32
+// CHECK:               krnl.store [[VAR_9_2_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_2_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           return [[VAR_2_]] : memref<10x20x30xf32>
+// CHECK:           return [[RES_]] : memref<10x20x30xf32>
 // CHECK:         }
 }
+

--- a/test/mlir/conversion/onnx_to_krnl/Math/Softmax_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Softmax_with_parallel_canonicalize_O3.mlir
@@ -22,29 +22,30 @@ func.func @test_softmax_v13_parallel(%arg0 : tensor<10x20x30xf32>) -> tensor<*xf
 // CHECK:           krnl.parallel([[LOOP_0_]]#0) : !krnl.loop
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 30){
 // CHECK-DAG:         [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
-// CHECK:             [[Iter0Result:%.+]] = krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 20) iter_args([[Iter0Arg:%.+]] = [[CST_0_]]) -> (f32){
+// CHECK-DAG:         [[LOOP_1_:%.+]] = krnl.define_loops 1
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_3_:%.+]] = krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[VAR_arg3_:%.+]] = 0 to 20) iter_args([[VAR_arg4_:%.+]] = [[CST_0_]]) -> (f32){
 // CHECK-DAG:           [[VAR_7_:%.+]] = krnl.get_induction_var_value([[LOOP_1_]]) : (!krnl.loop) -> index
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_7_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_10_:%.+]] = arith.cmpf ogt, [[Iter0Arg]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:               [[VAR_11_:%.+]] = arith.select [[VAR_10_]], [[Iter0Arg]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:               krnl.yield [[VAR_11_]] : f32
+// CHECK:               [[VAR_9_:%.+]] = arith.maxnumf [[VAR_arg4_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:               krnl.yield [[VAR_9_]] : f32
 // CHECK:             }
-// CHECK-DAG:         [[LOOP_2_:%.+]] = krnl.define_loops 1
-// CHECK:             [[Iter1Result:%.+]] = krnl.iterate([[LOOP_2_]]) with ([[LOOP_2_]] -> [[I_3_:%.+]] = 0 to 20) iter_args([[Iter1Arg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
+// CHECK:             [[LOOP_2_:%.+]] = krnl.define_loops 1
+// CHECK-DAG:         [[VAR_5_:%.+]] = krnl.iterate([[LOOP_2_]]) with ([[LOOP_2_]] -> [[VAR_arg3_1_:%.+]] = 0 to 20) iter_args([[VAR_arg4_1_:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK-DAG:           [[VAR_7_1_:%.+]] = krnl.get_induction_var_value([[LOOP_2_]]) : (!krnl.loop) -> index
 // CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_7_1_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_10_1_:%.+]] = arith.subf [[LOAD_PARAM_0_MEM_1_]], [[Iter0Result]] : f32
-// CHECK:               [[VAR_11_1_:%.+]] = math.exp [[VAR_10_1_]] : f32
-// CHECK:               [[VAR_12_:%.+]] = arith.addf [[Iter1Arg]], [[VAR_11_1_]] : f32
-// CHECK:               krnl.store [[VAR_11_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_1_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
-// CHECK:               krnl.yield [[VAR_12_]] : f32
-// CHECK-DAG:         [[LOOP_3_:%.+]] = krnl.define_loops 1
-// CHECK:             krnl.iterate([[LOOP_3_]]) with ([[LOOP_3_]] -> [[I_4_:%.+]] = 0 to 20){
+// CHECK:               [[VAR_9_1_:%.+]] = arith.subf [[LOAD_PARAM_0_MEM_1_]], [[VAR_3_]] : f32
+// CHECK:               [[VAR_10_:%.+]] = math.exp [[VAR_9_1_]] : f32
+// CHECK:               [[VAR_11_:%.+]] = arith.addf [[VAR_arg4_1_]], [[VAR_10_]] : f32
+// CHECK:               krnl.store [[VAR_10_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_1_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
+// CHECK:               krnl.yield [[VAR_11_]] : f32
+// CHECK:             }
+// CHECK:             [[LOOP_3_:%.+]] = krnl.define_loops 1
+// CHECK:             krnl.iterate([[LOOP_3_]]) with ([[LOOP_3_]] -> [[I_2_:%.+]] = 0 to 20){
 // CHECK:               [[VAR_7_2_:%.+]] = krnl.get_induction_var_value([[LOOP_3_]]) : (!krnl.loop) -> index
-// CHECK:               [[LOAD_RES_2_MEM_2_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_2_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]] = arith.divf [[LOAD_RES_2_MEM_2_]], [[Iter1Result]] : f32
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_2_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
+// CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_2_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
+// CHECK:               [[VAR_9_2_:%.+]] = arith.divf [[LOAD_PARAM_0_MEM_1_]], [[VAR_5_]] : f32
+// CHECK:               krnl.store [[VAR_9_2_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_2_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<10x20x30xf32>

--- a/test/mlir/conversion/onnx_to_krnl/NN/Pooling.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/NN/Pooling.mlir
@@ -95,6 +95,7 @@ func.func private @test_averagepool_pooling_operation(%arg0 : tensor<1x3x32x32xf
 
 // -----
 
+
 func.func private @test_maxpool_pooling_operation(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
@@ -185,9 +186,8 @@ func.func private @test_maxpool_pooling_operation(%arg0 : tensor<1x3x32x32xf32>)
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]6, [[VAR_1_]]7] : memref<1x3x32x32xf32>
 // CHECK-DAG:           [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
-// CHECK:               [[VAR_20_:%.+]] = arith.cmpf ogt, [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:               [[VAR_21_:%.+]] = arith.select [[VAR_20_]], [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:               krnl.store [[VAR_21_]], [[RES_1_]][] : memref<f32>
+// CHECK:               [[VAR_20_:%.+]] = arith.maxnumf [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:               krnl.store [[VAR_20_]], [[RES_1_]][] : memref<f32>
 // CHECK:             }
 // CHECK:             [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:             krnl.store [[LOAD_RES_1_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2, [[VAR_1_]]#3] : memref<1x3x31x31xf32>

--- a/test/mlir/conversion/onnx_to_krnl/Quantization/DynamicQuantizeLinear_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Quantization/DynamicQuantizeLinear_with_canonicalize.mlir
@@ -34,24 +34,22 @@ func.func @test_dynamic_quantize_linear(%arg0: tensor<?x2xf32>) -> (tensor<?x2xu
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK-DAG:       [[VAR_dim_11_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_2_]] : memref<?x2xf32>
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_dim_11_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2){
-// CHECK:             [[VAR_33_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_33_]]#0, [[VAR_33_]]#1] : memref<?x2xf32>
+// CHECK:             [[VAR_31_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_31_]]#0, [[VAR_31_]]#1] : memref<?x2xf32>
 // CHECK-DAG:         [[LOAD_RES_5_MEM_:%.+]] = krnl.load [[RES_5_]][] : memref<f32>
-// CHECK:             [[VAR_36_:%.+]] = arith.cmpf ogt, [[LOAD_RES_5_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:             [[VAR_37_:%.+]] = arith.select [[VAR_36_]], [[LOAD_RES_5_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:             krnl.store [[VAR_37_]], [[RES_5_]][] : memref<f32>
+// CHECK:             [[VAR_34_:%.+]] = arith.maxnumf [[LOAD_RES_5_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_34_]], [[RES_5_]][] : memref<f32>
 // CHECK:           }
 // CHECK:           [[RES_6_:%.+]] = memref.alloc() : memref<f32>
 // CHECK:           krnl.memset [[RES_6_]], [[CST_0_]] : memref<f32>
 // CHECK-DAG:       [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
 // CHECK-DAG:       [[VAR_dim_13_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_2_]] : memref<?x2xf32>
 // CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_2_:%.+]] = 0 to [[VAR_dim_13_]], [[LOOP_1_]]#1 -> [[I_3_:%.+]] = 0 to 2){
-// CHECK:             [[VAR_33_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_33_1_]]#0, [[VAR_33_1_]]#1] : memref<?x2xf32>
+// CHECK:             [[VAR_31_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_31_1_]]#0, [[VAR_31_1_]]#1] : memref<?x2xf32>
 // CHECK-DAG:         [[LOAD_RES_5_MEM_1_:%.+]] = krnl.load [[RES_6_]][] : memref<f32>
-// CHECK:             [[VAR_36_1_:%.+]] = arith.cmpf olt, [[LOAD_RES_5_MEM_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK:             [[VAR_37_1_:%.+]] = arith.select [[VAR_36_1_]], [[LOAD_RES_5_MEM_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK:             krnl.store [[VAR_37_1_]], [[RES_6_]][] : memref<f32>
+// CHECK:             [[VAR_34_1_:%.+]] = arith.minnumf [[LOAD_RES_5_MEM_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK:             krnl.store [[VAR_34_1_]], [[RES_6_]][] : memref<f32>
 // CHECK:           }
 // CHECK-DAG:       [[LOAD_RES_5_MEM_2_:%.+]] = krnl.load [[RES_5_]][] : memref<f32>
 // CHECK-DAG:       [[LOAD_RES_6_MEM_:%.+]] = krnl.load [[RES_6_]][] : memref<f32>
@@ -64,58 +62,54 @@ func.func @test_dynamic_quantize_linear(%arg0: tensor<?x2xf32>) -> (tensor<?x2xu
 // CHECK:           krnl.store [[VAR_9_]], [[RES_1_]][] : memref<f32>
 // CHECK:           [[VAR_10_:%.+]] = arith.divf [[VAR_7_]], [[VAR_9_]] : f32
 // CHECK:           [[VAR_11_:%.+]] = arith.subf [[CST_0_dot_000000_]], [[VAR_10_]] : f32
-// CHECK:           [[VAR_12_:%.+]] = arith.cmpf olt, [[VAR_11_]], [[CST_0_dot_000000_]] : f32
-// CHECK:           [[VAR_13_:%.+]] = arith.select [[VAR_12_]], [[CST_0_dot_000000_]], [[VAR_11_]] : f32
-// CHECK:           [[VAR_14_:%.+]] = arith.cmpf olt, [[VAR_13_]], [[CST_2_dot_550000_]] : f32
-// CHECK:           [[VAR_15_:%.+]] = arith.select [[VAR_14_]], [[VAR_13_]], [[CST_2_dot_550000_]] : f32
-// CHECK:           [[VAR_16_:%.+]] = math.floor [[VAR_15_]] : f32
-// CHECK:           [[VAR_17_:%.+]] = arith.subf [[VAR_15_]], [[VAR_16_]] : f32
-// CHECK-DAG:       [[VAR_18_:%.+]] = arith.cmpf ogt, [[VAR_17_]], [[CST_5_dot_000000_]] : f32
-// CHECK-DAG:       [[VAR_19_:%.+]] = arith.addf [[VAR_16_]], [[CST_1_dot_000000_]] : f32
+// CHECK:           [[VAR_12_:%.+]] = arith.maxnumf [[VAR_11_]], [[CST_0_dot_000000_]] : f32
+// CHECK:           [[VAR_13_:%.+]] = arith.minnumf [[VAR_12_]], [[CST_2_dot_550000_]] : f32
+// CHECK:           [[VAR_14_:%.+]] = math.floor [[VAR_13_]] : f32
+// CHECK:           [[VAR_15_:%.+]] = arith.subf [[VAR_13_]], [[VAR_14_]] : f32
+// CHECK-DAG:       [[VAR_16_:%.+]] = arith.cmpf ogt, [[VAR_15_]], [[CST_5_dot_000000_]] : f32
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.addf [[VAR_14_]], [[CST_1_dot_000000_]] : f32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_20_:%.+]] = arith.select [[VAR_18_]], [[VAR_19_]], [[VAR_16_]] : f32
-// CHECK-DAG:       [[VAR_21_:%.+]] = arith.mulf [[VAR_16_]], [[CST_5_dot_000000_]] : f32
-// CHECK:           [[VAR_22_:%.+]] = math.floor [[VAR_21_]] : f32
-// CHECK:           [[VAR_23_:%.+]] = arith.mulf [[VAR_22_]], [[CST_2_dot_000000_]] : f32
-// CHECK:           [[VAR_24_:%.+]] = arith.subf [[VAR_16_]], [[VAR_23_]] : f32
-// CHECK-DAG:       [[VAR_25_:%.+]] = arith.cmpf oeq, [[VAR_24_]], [[CST_1_dot_000000_]] : f32
-// CHECK-DAG:       [[VAR_26_:%.+]] = arith.addf [[VAR_16_]], [[CST_1_dot_000000_]] : f32
+// CHECK-DAG:       [[VAR_18_:%.+]] = arith.select [[VAR_16_]], [[VAR_17_]], [[VAR_14_]] : f32
+// CHECK-DAG:       [[VAR_19_:%.+]] = arith.mulf [[VAR_14_]], [[CST_5_dot_000000_]] : f32
+// CHECK:           [[VAR_20_:%.+]] = math.floor [[VAR_19_]] : f32
+// CHECK:           [[VAR_21_:%.+]] = arith.mulf [[VAR_20_]], [[CST_2_dot_000000_]] : f32
+// CHECK:           [[VAR_22_:%.+]] = arith.subf [[VAR_14_]], [[VAR_21_]] : f32
+// CHECK-DAG:       [[VAR_23_:%.+]] = arith.cmpf oeq, [[VAR_22_]], [[CST_1_dot_000000_]] : f32
+// CHECK-DAG:       [[VAR_24_:%.+]] = arith.addf [[VAR_14_]], [[CST_1_dot_000000_]] : f32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_27_:%.+]] = arith.select [[VAR_25_]], [[VAR_26_]], [[VAR_16_]] : f32
-// CHECK-DAG:       [[VAR_28_:%.+]] = arith.cmpf oeq, [[VAR_17_]], [[CST_5_dot_000000_]] : f32
-// CHECK:           [[VAR_29_:%.+]] = arith.select [[VAR_28_]], [[VAR_27_]], [[VAR_20_]] : f32
-// CHECK:           [[VAR_30_:%.+]] = arith.fptoui [[VAR_29_]] : f32 to i8
-// CHECK:           [[VAR_31_:%.+]] = builtin.unrealized_conversion_cast [[VAR_30_]] : i8 to ui8
-// CHECK:           krnl.store [[VAR_31_]], [[RES_2_]][] : memref<ui8>
+// CHECK-DAG:       [[VAR_25_:%.+]] = arith.select [[VAR_23_]], [[VAR_24_]], [[VAR_14_]] : f32
+// CHECK-DAG:       [[VAR_26_:%.+]] = arith.cmpf oeq, [[VAR_15_]], [[CST_5_dot_000000_]] : f32
+// CHECK:           [[VAR_27_:%.+]] = arith.select [[VAR_26_]], [[VAR_25_]], [[VAR_18_]] : f32
+// CHECK:           [[VAR_28_:%.+]] = arith.fptoui [[VAR_27_]] : f32 to i8
+// CHECK:           [[VAR_29_:%.+]] = builtin.unrealized_conversion_cast [[VAR_28_]] : i8 to ui8
+// CHECK:           krnl.store [[VAR_29_]], [[RES_2_]][] : memref<ui8>
 // CHECK:           [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_4_:%.+]] = 0 to [[MAP_0_]]([[VAR_dim_]]), [[LOOP_2_]]#1 -> [[I_5_:%.+]] = 0 to 2){
-// CHECK:             [[VAR_33_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:             [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_33_2_]]#0, [[VAR_33_2_]]#1] : memref<?x2xf32>
+// CHECK:             [[VAR_31_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:             [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_31_2_]]#0, [[VAR_31_2_]]#1] : memref<?x2xf32>
 // CHECK:             [[LOAD_RES_5_MEM_1_:%.+]] = arith.divf [[LOAD_PARAM_0_MEM_2_]], [[VAR_9_]] : f32
-// CHECK:             [[VAR_36_2_:%.+]] = math.floor [[LOAD_RES_5_MEM_1_]] : f32
-// CHECK:             [[VAR_37_2_:%.+]] = arith.subf [[LOAD_RES_5_MEM_1_]], [[VAR_36_2_]] : f32
-// CHECK-DAG:         [[VAR_38_:%.+]] = arith.cmpf ogt, [[VAR_37_2_]], [[CST_5_dot_000000_]] : f32
-// CHECK-DAG:         [[VAR_39_:%.+]] = arith.addf [[VAR_36_2_]], [[CST_1_dot_000000_]] : f32
+// CHECK:             [[VAR_34_2_:%.+]] = math.floor [[LOAD_RES_5_MEM_1_]] : f32
+// CHECK:             [[VAR_35_:%.+]] = arith.subf [[LOAD_RES_5_MEM_1_]], [[VAR_34_2_]] : f32
+// CHECK-DAG:         [[VAR_36_:%.+]] = arith.cmpf ogt, [[VAR_35_]], [[CST_5_dot_000000_]] : f32
+// CHECK-DAG:         [[VAR_37_:%.+]] = arith.addf [[VAR_34_2_]], [[CST_1_dot_000000_]] : f32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_40_:%.+]] = arith.select [[VAR_38_]], [[VAR_39_]], [[VAR_36_2_]] : f32
-// CHECK-DAG:         [[VAR_41_:%.+]] = arith.mulf [[VAR_36_2_]], [[CST_5_dot_000000_]] : f32
-// CHECK:             [[VAR_42_:%.+]] = math.floor [[VAR_41_]] : f32
-// CHECK:             [[VAR_43_:%.+]] = arith.mulf [[VAR_42_]], [[CST_2_dot_000000_]] : f32
-// CHECK:             [[VAR_44_:%.+]] = arith.subf [[VAR_36_2_]], [[VAR_43_]] : f32
-// CHECK-DAG:         [[VAR_45_:%.+]] = arith.cmpf oeq, [[VAR_44_]], [[CST_1_dot_000000_]] : f32
-// CHECK-DAG:         [[VAR_46_:%.+]] = arith.addf [[VAR_36_2_]], [[CST_1_dot_000000_]] : f32
+// CHECK-DAG:         [[VAR_38_:%.+]] = arith.select [[VAR_36_]], [[VAR_37_]], [[VAR_34_2_]] : f32
+// CHECK-DAG:         [[VAR_39_:%.+]] = arith.mulf [[VAR_34_2_]], [[CST_5_dot_000000_]] : f32
+// CHECK:             [[VAR_40_:%.+]] = math.floor [[VAR_39_]] : f32
+// CHECK:             [[VAR_41_:%.+]] = arith.mulf [[VAR_40_]], [[CST_2_dot_000000_]] : f32
+// CHECK:             [[VAR_42_:%.+]] = arith.subf [[VAR_34_2_]], [[VAR_41_]] : f32
+// CHECK-DAG:         [[VAR_43_:%.+]] = arith.cmpf oeq, [[VAR_42_]], [[CST_1_dot_000000_]] : f32
+// CHECK-DAG:         [[VAR_44_:%.+]] = arith.addf [[VAR_34_2_]], [[CST_1_dot_000000_]] : f32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_47_:%.+]] = arith.select [[VAR_45_]], [[VAR_46_]], [[VAR_36_2_]] : f32
-// CHECK-DAG:         [[VAR_48_:%.+]] = arith.cmpf oeq, [[VAR_37_2_]], [[CST_5_dot_000000_]] : f32
-// CHECK:             [[VAR_49_:%.+]] = arith.select [[VAR_48_]], [[VAR_47_]], [[VAR_40_]] : f32
-// CHECK:             [[VAR_50_:%.+]] = arith.addf [[VAR_49_]], [[VAR_29_]] : f32
-// CHECK:             [[VAR_51_:%.+]] = arith.cmpf olt, [[VAR_50_]], [[CST_0_dot_000000_]] : f32
-// CHECK:             [[VAR_52_:%.+]] = arith.select [[VAR_51_]], [[CST_0_dot_000000_]], [[VAR_50_]] : f32
-// CHECK:             [[VAR_53_:%.+]] = arith.cmpf olt, [[VAR_52_]], [[CST_2_dot_550000_]] : f32
-// CHECK:             [[VAR_54_:%.+]] = arith.select [[VAR_53_]], [[VAR_52_]], [[CST_2_dot_550000_]] : f32
-// CHECK:             [[VAR_55_:%.+]] = arith.fptoui [[VAR_54_]] : f32 to i8
-// CHECK:             [[VAR_56_:%.+]] = builtin.unrealized_conversion_cast [[VAR_55_]] : i8 to ui8
-// CHECK:             krnl.store [[VAR_56_]], [[RES_]]{{.}}[[VAR_33_2_]]#0, [[VAR_33_2_]]#1] : memref<?x2xui8>
+// CHECK-DAG:         [[VAR_45_:%.+]] = arith.select [[VAR_43_]], [[VAR_44_]], [[VAR_34_2_]] : f32
+// CHECK-DAG:         [[VAR_46_:%.+]] = arith.cmpf oeq, [[VAR_35_]], [[CST_5_dot_000000_]] : f32
+// CHECK:             [[VAR_47_:%.+]] = arith.select [[VAR_46_]], [[VAR_45_]], [[VAR_38_]] : f32
+// CHECK:             [[VAR_48_:%.+]] = arith.addf [[VAR_47_]], [[VAR_27_]] : f32
+// CHECK:             [[VAR_49_:%.+]] = arith.maxnumf [[VAR_48_]], [[CST_0_dot_000000_]] : f32
+// CHECK:             [[VAR_50_:%.+]] = arith.minnumf [[VAR_49_]], [[CST_2_dot_550000_]] : f32
+// CHECK:             [[VAR_51_:%.+]] = arith.fptoui [[VAR_50_]] : f32 to i8
+// CHECK:             [[VAR_52_:%.+]] = builtin.unrealized_conversion_cast [[VAR_51_]] : i8 to ui8
+// CHECK:             krnl.store [[VAR_52_]], [[RES_]]{{.}}[[VAR_31_2_]]#0, [[VAR_31_2_]]#1] : memref<?x2xui8>
 // CHECK:           }
 // CHECK:           return [[RES_]], [[RES_]]_6, [[RES_]]_7 : memref<?x2xui8>, memref<f32>, memref<ui8>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_stablehlo/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Math/Elementwise.mlir
@@ -59,7 +59,7 @@ func.func @test_elu(%arg0 : tensor<20x40xf32>) -> tensor<20x40xf32> {
 // CHECK-DAG:       [[VAR_3_:%.+]] = stablehlo.exponential [[PARAM_0_]] : tensor<20x40xf32>
 // CHECK:           [[VAR_4_:%.+]] = stablehlo.subtract [[VAR_3_]], [[VAR_2_]] : tensor<20x40xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = stablehlo.multiply [[VAR_1_]], [[VAR_4_]] : tensor<20x40xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = stablehlo.compare  GE, [[PARAM_0_]], [[VAR_0_]],  NOTYPE : (tensor<20x40xf32>, tensor<20x40xf32>) -> tensor<20x40xi1>
+// CHECK-DAG:       [[VAR_6_:%.+]] = stablehlo.compare  GE, [[PARAM_0_]], [[VAR_0_]] : (tensor<20x40xf32>, tensor<20x40xf32>) -> tensor<20x40xi1>
 // CHECK:           [[VAR_7_:%.+]] = stablehlo.select [[VAR_6_]], [[PARAM_0_]], [[VAR_5_]] : tensor<20x40xi1>, tensor<20x40xf32>
 // CHECK:           return [[VAR_7_]] : tensor<20x40xf32>
 // CHECK:         }
@@ -287,7 +287,7 @@ func.func @test_less(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> tens
 // CHECK:           [[VAR_0_:%.+]] = shape.const_shape [3, 4, 5] : tensor<3xindex>
 // CHECK-DAG:       [[VAR_1_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[PARAM_0_]], [[VAR_0_]], dims = [0, 1, 2] : (tensor<3x4x5xf32>, tensor<3xindex>) -> tensor<3x4x5xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[PARAM_1_]], [[VAR_0_]], dims = [0, 1, 2] : (tensor<3x4x5xf32>, tensor<3xindex>) -> tensor<3x4x5xf32>
-// CHECK:           [[VAR_3_:%.+]] = stablehlo.compare  LT, [[VAR_1_]], [[VAR_2_]],  NOTYPE : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xi1>
+// CHECK:           [[VAR_3_:%.+]] = stablehlo.compare  LT, [[VAR_1_]], [[VAR_2_]] : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xi1>
 // CHECK:           return [[VAR_3_]] : tensor<3x4x5xi1>
 // CHECK:         }
 
@@ -305,7 +305,7 @@ func.func @test_binary_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x5x
 // CHECK:           [[VAR_2_:%.+]] = shape.broadcast [[VAR_0_]], [[VAR_1_]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
 // CHECK-DAG:       [[VAR_3_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[PARAM_0_]], [[VAR_2_]], dims = [0, 1, 2] : (tensor<?x4x5xf32>, tensor<3xindex>) -> tensor<?x4x5xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[PARAM_1_]], [[VAR_2_]], dims = [0, 1, 2] : (tensor<1x?x1xf32>, tensor<3xindex>) -> tensor<?x4x5xf32>
-// CHECK:           [[VAR_5_:%.+]] = stablehlo.compare  LT, [[VAR_3_]], [[VAR_4_]],  NOTYPE : (tensor<?x4x5xf32>, tensor<?x4x5xf32>) -> tensor<?x4x5xi1>
+// CHECK:           [[VAR_5_:%.+]] = stablehlo.compare  LT, [[VAR_3_]], [[VAR_4_]] : (tensor<?x4x5xf32>, tensor<?x4x5xf32>) -> tensor<?x4x5xi1>
 // CHECK:           return [[VAR_5_]] : tensor<?x4x5xi1>
 // CHECK:         }
 
@@ -323,7 +323,7 @@ func.func @test_less_unknown_dims_2(%arg0: tensor<?x?x5xf32>, %arg1: tensor<?x4x
 // CHECK:           [[VAR_2_:%.+]] = shape.broadcast [[VAR_0_]], [[VAR_1_]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
 // CHECK-DAG:       [[VAR_3_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[PARAM_0_]], [[VAR_2_]], dims = [0, 1, 2] : (tensor<?x?x5xf32>, tensor<3xindex>) -> tensor<?x4x5xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[PARAM_1_]], [[VAR_2_]], dims = [0, 1, 2] : (tensor<?x4x5xf32>, tensor<3xindex>) -> tensor<?x4x5xf32>
-// CHECK:           [[VAR_5_:%.+]] = stablehlo.compare  LT, [[VAR_3_]], [[VAR_4_]],  NOTYPE : (tensor<?x4x5xf32>, tensor<?x4x5xf32>) -> tensor<?x4x5xi1>
+// CHECK:           [[VAR_5_:%.+]] = stablehlo.compare  LT, [[VAR_3_]], [[VAR_4_]] : (tensor<?x4x5xf32>, tensor<?x4x5xf32>) -> tensor<?x4x5xi1>
 // CHECK:           return [[VAR_5_]] : tensor<?x4x5xi1>
 // CHECK:         }
 
@@ -447,7 +447,7 @@ func.func @test_leakyrelu_dynamic(%arg0 : tensor<?x10xf32>) -> tensor<?x10xf32> 
 // CHECK-DAG:       [[VAR_4_:%.+]] = stablehlo.multiply [[PARAM_0_]], [[VAR_3_]] : tensor<?x10xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<?x10xf32> -> tensor<2xindex>
 // CHECK:           [[VAR_6_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_0_]], [[VAR_5_]], dims = [] : (tensor<f32>, tensor<2xindex>) -> tensor<?x10xf32>
-// CHECK:           [[VAR_7_:%.+]] = stablehlo.compare  GT, [[PARAM_0_]], [[VAR_6_]],  NOTYPE : (tensor<?x10xf32>, tensor<?x10xf32>) -> tensor<?x10xi1>
+// CHECK:           [[VAR_7_:%.+]] = stablehlo.compare  GT, [[PARAM_0_]], [[VAR_6_]] : (tensor<?x10xf32>, tensor<?x10xf32>) -> tensor<?x10xi1>
 // CHECK:           [[VAR_8_:%.+]] = stablehlo.select [[VAR_7_]], [[PARAM_0_]], [[VAR_4_]] : tensor<?x10xi1>, tensor<?x10xf32>
 // CHECK:           return [[VAR_8_]] : tensor<?x10xf32>
 // CHECK:         }
@@ -469,7 +469,7 @@ func.func @test_prelu_dynamic(%arg0 : tensor<?x10x12x12xf32>, %arg1: tensor<10x1
 // CHECK-DAG:       [[VAR_6_:%.+]] = stablehlo.multiply [[VAR_4_]], [[VAR_5_]] : tensor<?x10x12x12xf32>
 // CHECK-DAG:       [[VAR_7_:%.+]] = shape.shape_of [[VAR_4_]] : tensor<?x10x12x12xf32> -> tensor<4xindex>
 // CHECK:           [[VAR_8_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_0_]], [[VAR_7_]], dims = [] : (tensor<f32>, tensor<4xindex>) -> tensor<?x10x12x12xf32>
-// CHECK:           [[VAR_9_:%.+]] = stablehlo.compare  GT, [[VAR_4_]], [[VAR_8_]],  NOTYPE : (tensor<?x10x12x12xf32>, tensor<?x10x12x12xf32>) -> tensor<?x10x12x12xi1>
+// CHECK:           [[VAR_9_:%.+]] = stablehlo.compare  GT, [[VAR_4_]], [[VAR_8_]] : (tensor<?x10x12x12xf32>, tensor<?x10x12x12xf32>) -> tensor<?x10x12x12xi1>
 // CHECK:           [[VAR_10_:%.+]] = stablehlo.select [[VAR_9_]], [[VAR_4_]], [[VAR_6_]] : tensor<?x10x12x12xi1>, tensor<?x10x12x12xf32>
 // CHECK:           return [[VAR_10_]] : tensor<?x10x12x12xf32>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_stablehlo/RNN/LSTM-loop.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/RNN/LSTM-loop.mlir
@@ -76,7 +76,7 @@ func.func @test_lstm_loop(%arg0 : tensor<128x16x512xf32>, %arg1 : tensor<2x2048x
 // CHECK-DAG:       [[VAR_48_:%.+]] = stablehlo.slice [[VAR_32_]] [1792:2048] : (tensor<2048xf32>) -> tensor<256xf32>
 // CHECK-DAG:       [[VAR_49_:%.+]]:4 = stablehlo.while([[VAR_iterArg_:%.+]] = [[VAR_c_7_]], [[VAR_iterArg_9_:%.+]] = [[VAR_cst_5_]], [[VAR_iterArg_10_:%.+]] = [[VAR_10_]], [[VAR_iterArg_11_:%.+]] = [[VAR_12_]]) : tensor<1xi64>, tensor<128x1x16x256xf32>, tensor<16x256xf32>, tensor<16x256xf32>
 // CHECK:            cond {
-// CHECK:             [[VAR_52_:%.+]] = stablehlo.compare  LT, [[VAR_iterArg_]], [[VAR_c_4_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:             [[VAR_52_:%.+]] = stablehlo.compare  LT, [[VAR_iterArg_]], [[VAR_c_4_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:             [[VAR_53_:%.+]] = stablehlo.reshape [[VAR_52_]] : (tensor<1xi1>) -> tensor<i1>
 // CHECK:             stablehlo.return [[VAR_53_]] : tensor<i1>
 // CHECK:           } do {
@@ -156,7 +156,7 @@ func.func @test_lstm_loop(%arg0 : tensor<128x16x512xf32>, %arg1 : tensor<2x2048x
 // CHECK:           }
 // CHECK:           [[VAR_50_:%.+]]:4 = stablehlo.while([[VAR_iterArg_1_:%.+]] = [[VAR_c_]], [[VAR_iterArg_9_1_:%.+]] = [[VAR_c_]]st_5, [[VAR_iterArg_10_1_:%.+]] = [[VAR_14_]], [[VAR_iterArg_11_1_:%.+]] = [[VAR_16_]]) : tensor<1xi64>, tensor<128x1x16x256xf32>, tensor<16x256xf32>, tensor<16x256xf32>
 // CHECK:            cond {
-// CHECK:             [[VAR_52_2_:%.+]] = stablehlo.compare  GE, [[VAR_iterArg_1_]], [[VAR_c_7_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:             [[VAR_52_2_:%.+]] = stablehlo.compare  GE, [[VAR_iterArg_1_]], [[VAR_c_7_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:             [[VAR_53_2_:%.+]] = stablehlo.reshape [[VAR_52_2_]] : (tensor<1xi1>) -> tensor<i1>
 // CHECK:             stablehlo.return [[VAR_53_2_]] : tensor<i1>
 // CHECK:           } do {

--- a/test/mlir/conversion/onnx_to_stablehlo/Tensor/ArgMax.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Tensor/ArgMax.mlir
@@ -13,9 +13,9 @@ func.func @test_argmax_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64>
 // CHECK:           [[VAR_3_:%.+]] = stablehlo.dynamic_iota [[VAR_0_]], dim = 3 : (tensor<4xindex>) -> tensor<5x5x1x32xi64>
 // CHECK:           [[VAR_4_:%.+]]:2 = stablehlo.reduce(%arg0 init: [[VAR_2_]]), (%1 init: [[VAR_1_]]) across dimensions = [3] : (tensor<5x5x1x32xf32>, tensor<5x5x1x32xi64>, tensor<f32>, tensor<i64>) -> (tensor<5x5x1xf32>, tensor<5x5x1xi64>)
 // CHECK:            reducer(%arg1: tensor<f32>, %arg3: tensor<f32>) (%arg2: tensor<i64>, %arg4: tensor<i64>)  {
-// CHECK:             [[VAR_6_:%.+]] = stablehlo.compare  GE, %arg1, %arg3,  NOTYPE : (tensor<f32>, tensor<f32>) -> tensor<i1>
+// CHECK:             [[VAR_6_:%.+]] = stablehlo.compare  GE, %arg1, %arg3 : (tensor<f32>, tensor<f32>) -> tensor<i1>
 // CHECK-DAG:         [[VAR_7_:%.+]] = stablehlo.select [[VAR_6_]], %arg1, %arg3 : tensor<i1>, tensor<f32>
-// CHECK-DAG:         [[VAR_8_:%.+]] = stablehlo.compare  EQ, %arg1, %arg3,  NOTYPE : (tensor<f32>, tensor<f32>) -> tensor<i1>
+// CHECK-DAG:         [[VAR_8_:%.+]] = stablehlo.compare  EQ, %arg1, %arg3 : (tensor<f32>, tensor<f32>) -> tensor<i1>
 // CHECK-DAG:         [[VAR_9_:%.+]] = stablehlo.minimum %arg2, %arg4 : tensor<i64>
 // CHECK-DAG:         [[VAR_10_:%.+]] = stablehlo.select [[VAR_6_]], %arg2, %arg4 : tensor<i1>, tensor<i64>
 // CHECK:             [[VAR_11_:%.+]] = stablehlo.select [[VAR_8_]], [[VAR_9_]], [[VAR_10_]] : tensor<i1>, tensor<i64>
@@ -43,9 +43,9 @@ func.func @test_argmax_verifier_2(%arg0 : tensor<5x?x1x32xf32>) -> tensor<*xi64>
 // CHECK:           [[VAR_3_:%.+]] = stablehlo.dynamic_iota [[VAR_2_]], dim = 3 : (tensor<4xindex>) -> tensor<5x?x1x32xi64>
 // CHECK:           [[VAR_4_:%.+]]:2 = stablehlo.reduce([[PARAM_0_]] init: [[VAR_0_]]), ([[VAR_3_]] init: [[VAR_1_]]) across dimensions = [3] : (tensor<5x?x1x32xf32>, tensor<5x?x1x32xi64>, tensor<f32>, tensor<i64>) -> (tensor<5x?x1xf32>, tensor<5x?x1xi64>)
 // CHECK:            reducer(%arg1: tensor<f32>, %arg3: tensor<f32>) (%arg2: tensor<i64>, %arg4: tensor<i64>)  {
-// CHECK:             [[VAR_11_:%.+]] = stablehlo.compare  GE, %arg1, %arg3,  NOTYPE : (tensor<f32>, tensor<f32>) -> tensor<i1>
+// CHECK:             [[VAR_11_:%.+]] = stablehlo.compare  GE, %arg1, %arg3 : (tensor<f32>, tensor<f32>) -> tensor<i1>
 // CHECK-DAG:         [[VAR_12_:%.+]] = stablehlo.select [[VAR_11_]], %arg1, %arg3 : tensor<i1>, tensor<f32>
-// CHECK-DAG:         [[VAR_13_:%.+]] = stablehlo.compare  EQ, %arg1, %arg3,  NOTYPE : (tensor<f32>, tensor<f32>) -> tensor<i1>
+// CHECK-DAG:         [[VAR_13_:%.+]] = stablehlo.compare  EQ, %arg1, %arg3 : (tensor<f32>, tensor<f32>) -> tensor<i1>
 // CHECK-DAG:         [[VAR_14_:%.+]] = stablehlo.minimum %arg2, %arg4 : tensor<i64>
 // CHECK-DAG:         [[VAR_15_:%.+]] = stablehlo.select [[VAR_11_]], %arg2, %arg4 : tensor<i1>, tensor<i64>
 // CHECK:             [[VAR_16_:%.+]] = stablehlo.select [[VAR_13_]], [[VAR_14_]], [[VAR_15_]] : tensor<i1>, tensor<i64>

--- a/test/mlir/conversion/onnx_to_stablehlo/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Tensor/Gather.mlir
@@ -12,7 +12,7 @@ func.func @test_gather_axis0(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
 // CHECK-DAG:       [[VAR_1_:%.+]] = stablehlo.constant dense<0> : tensor<2x2xi64>
 // CHECK-DAG:       [[VAR_2_:%.+]] = stablehlo.constant dense<3> : tensor<2x2xi64>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]] = stablehlo.compare  LT, [[VAR_0_]], [[VAR_1_]],  NOTYPE : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi1>
+// CHECK-DAG:       [[VAR_3_:%.+]] = stablehlo.compare  LT, [[VAR_0_]], [[VAR_1_]] : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi1>
 // CHECK-DAG:       [[VAR_4_:%.+]] = stablehlo.add [[VAR_0_]], [[VAR_2_]] : tensor<2x2xi64>
 // CHECK:           [[VAR_5_:%.+]] = stablehlo.select [[VAR_3_]], [[VAR_4_]], [[VAR_0_]] : tensor<2x2xi1>, tensor<2x2xi64>
 // CHECK:           [[VAR_6_:%.+]] = "stablehlo.torch_index_select"([[PARAM_0_]], [[VAR_5_]]) <{batch_dims = 0 : i64, dim = 0 : i64}> : (tensor<3x2xf32>, tensor<2x2xi64>) -> tensor<2x2x2xf32>
@@ -39,7 +39,7 @@ func.func @test_gather_dynamic_axis0(%arg0 : tensor<?x?xf32>) -> tensor<2x2x?xf3
 // CHECK-DAG:       [[DIM_TENSOR_:%.+]] = tensor.from_elements [[DIM_CAST_]] : tensor<i64>
 // CHECK-DAG:       [[VAR_2_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[DIM_TENSOR_]], [[INDICES_SHAPE_]], dims = [] : (tensor<i64>, tensor<2xindex>) -> tensor<2x2xi64>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]] = stablehlo.compare  LT, [[VAR_0_]], [[VAR_1_]],  NOTYPE : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi1>
+// CHECK-DAG:       [[VAR_3_:%.+]] = stablehlo.compare  LT, [[VAR_0_]], [[VAR_1_]] : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi1>
 // CHECK-DAG:       [[VAR_4_:%.+]] = stablehlo.add [[VAR_0_]], [[VAR_2_]] : tensor<2x2xi64>
 // CHECK:           [[VAR_5_:%.+]] = stablehlo.select [[VAR_3_]], [[VAR_4_]], [[VAR_0_]] : tensor<2x2xi1>, tensor<2x2xi64>
 // CHECK:           [[VAR_6_:%.+]] = "stablehlo.torch_index_select"([[PARAM_0_]], [[VAR_5_]]) <{batch_dims = 0 : i64, dim = 0 : i64}> : (tensor<?x?xf32>, tensor<2x2xi64>) -> tensor<2x2x?xf32>
@@ -60,7 +60,7 @@ func.func @test_gather_axis0neg(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
 // CHECK-DAG:       [[VAR_1_:%.+]] = stablehlo.constant dense<0> : tensor<2x2xi64>
 // CHECK-DAG:       [[VAR_2_:%.+]] = stablehlo.constant dense<3> : tensor<2x2xi64>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]] = stablehlo.compare  LT, [[VAR_0_]], [[VAR_1_]],  NOTYPE : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi1>
+// CHECK-DAG:       [[VAR_3_:%.+]] = stablehlo.compare  LT, [[VAR_0_]], [[VAR_1_]] : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi1>
 // CHECK-DAG:       [[VAR_4_:%.+]] = stablehlo.add [[VAR_0_]], [[VAR_2_]] : tensor<2x2xi64>
 // CHECK:           [[VAR_5_:%.+]] = stablehlo.select [[VAR_3_]], [[VAR_4_]], [[VAR_0_]] : tensor<2x2xi1>, tensor<2x2xi64>
 // CHECK:           [[VAR_6_:%.+]] = "stablehlo.torch_index_select"([[PARAM_0_]], [[VAR_5_]]) <{batch_dims = 0 : i64, dim = 0 : i64}> : (tensor<3x2xf32>, tensor<2x2xi64>) -> tensor<2x2x2xf32>
@@ -81,7 +81,7 @@ func.func @test_gather_axis1(%arg0 : tensor<3x3xf32>) -> tensor<3x1x2xf32> {
 // CHECK-DAG:       [[VAR_1_:%.+]] = stablehlo.constant dense<0> : tensor<1x2xi64>
 // CHECK-DAG:       [[VAR_2_:%.+]] = stablehlo.constant dense<3> : tensor<1x2xi64>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]] = stablehlo.compare  LT, [[VAR_0_]], [[VAR_1_]],  NOTYPE : (tensor<1x2xi64>, tensor<1x2xi64>) -> tensor<1x2xi1>
+// CHECK-DAG:       [[VAR_3_:%.+]] = stablehlo.compare  LT, [[VAR_0_]], [[VAR_1_]] : (tensor<1x2xi64>, tensor<1x2xi64>) -> tensor<1x2xi1>
 // CHECK-DAG:       [[VAR_4_:%.+]] = stablehlo.add [[VAR_0_]], [[VAR_2_]] : tensor<1x2xi64>
 // CHECK:           [[VAR_5_:%.+]] = stablehlo.select [[VAR_3_]], [[VAR_4_]], [[VAR_0_]] : tensor<1x2xi1>, tensor<1x2xi64>
 // CHECK:           [[VAR_6_:%.+]] = "stablehlo.torch_index_select"([[PARAM_0_]], [[VAR_5_]]) <{batch_dims = 0 : i64, dim = 1 : i64}> : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<3x1x2xf32>

--- a/test/mlir/conversion/onnx_to_stablehlo/Tensor/GatherElements.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Tensor/GatherElements.mlir
@@ -8,7 +8,7 @@ func.func @main_gather_elements(%arg0: tensor<3x2xf32>, %arg1: tensor<2x2xi64>) 
 // CHECK-DAG:    [[VAR_0_:%.+]] = stablehlo.constant dense<3> : tensor<i64>
 // CHECK-DAG:    [[VAR_1_:%.+]] = stablehlo.constant dense<0> : tensor<2x2xi64>
 // CHECK-DAG:    [[VAR_2_:%.+]] = stablehlo.broadcast_in_dim [[VAR_0_]], dims = [] : (tensor<i64>) -> tensor<2x2xi64>
-// CHECK-DAG:    [[VAR_3_:%.+]] = stablehlo.compare  LT, [[PARAM_1_]], [[VAR_1_]],  NOTYPE : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi1>
+// CHECK-DAG:    [[VAR_3_:%.+]] = stablehlo.compare  LT, [[PARAM_1_]], [[VAR_1_]] : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi1>
 // CHECK-DAG:    [[VAR_4_:%.+]] = stablehlo.add [[PARAM_1_]], [[VAR_2_]] : tensor<2x2xi64>
 // CHECK-NEXT:   [[VAR_5_:%.+]] = stablehlo.select [[VAR_3_]], [[VAR_4_]], [[PARAM_1_]] : tensor<2x2xi1>, tensor<2x2xi64>
 // CHECK-DAG:    [[VAR_6_:%.+]] = stablehlo.dynamic_reshape [[VAR_5_]], [[CST_]] : (tensor<2x2xi64>, tensor<3xindex>) -> tensor<2x2x1xi64>

--- a/test/mlir/conversion/onnx_to_stablehlo/Tensor/OneHot.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Tensor/OneHot.mlir
@@ -16,10 +16,10 @@ func.func @test_onehot(%arg0 : tensor<2x3x4xi64>) -> tensor<*xi64> {
 // CHECK-DAG:       [[VAR_5_:%.+]] = stablehlo.broadcast_in_dim [[VAR_0_]], dims = [] : (tensor<i64>) -> tensor<2x3x4x64xi64>
 // CHECK-DAG:       [[VAR_6_:%.+]] = stablehlo.broadcast_in_dim [[VAR_1_]], dims = [0] : (tensor<1xi64>) -> tensor<2x3x4x64xi64>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_7_:%.+]] = stablehlo.compare  GE, [[VAR_4_]], [[VAR_5_]],  NOTYPE : (tensor<2x3x4x64xi64>, tensor<2x3x4x64xi64>) -> tensor<2x3x4x64xi1>
+// CHECK-DAG:       [[VAR_7_:%.+]] = stablehlo.compare  GE, [[VAR_4_]], [[VAR_5_]] : (tensor<2x3x4x64xi64>, tensor<2x3x4x64xi64>) -> tensor<2x3x4x64xi1>
 // CHECK-DAG:       [[VAR_8_:%.+]] = stablehlo.add [[VAR_4_]], [[VAR_6_]] : tensor<2x3x4x64xi64>
 // CHECK:           [[VAR_9_:%.+]] = stablehlo.select [[VAR_7_]], [[VAR_4_]], [[VAR_8_]] : tensor<2x3x4x64xi1>, tensor<2x3x4x64xi64>
-// CHECK-DAG:       [[VAR_10_:%.+]] = stablehlo.compare  EQ, [[VAR_9_]], [[VAR_3_]],  NOTYPE : (tensor<2x3x4x64xi64>, tensor<2x3x4x64xi64>) -> tensor<2x3x4x64xi1>
+// CHECK-DAG:       [[VAR_10_:%.+]] = stablehlo.compare  EQ, [[VAR_9_]], [[VAR_3_]] : (tensor<2x3x4x64xi64>, tensor<2x3x4x64xi64>) -> tensor<2x3x4x64xi1>
 // CHECK-DAG:       [[VAR_11_:%.+]] = stablehlo.slice [[VAR_2_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_12_:%.+]] = stablehlo.slice [[VAR_2_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs

--- a/test/mlir/conversion/onnx_to_stablehlo/Tensor/Slice.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Tensor/Slice.mlir
@@ -23,7 +23,7 @@ func.func @test_slice_constant_default_axes(%arg0 : tensor<2x4xf32>) -> tensor<*
 // CHECK-DAG:       [[VAR_8_:%.+]] = stablehlo.slice [[VAR_3_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_9_:%.+]] = stablehlo.slice [[VAR_5_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = stablehlo.slice [[VAR_4_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_12_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_11_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_13_:%.+]] = stablehlo.negate [[VAR_9_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_14_:%.+]] = stablehlo.add [[VAR_10_]], [[VAR_7_]] : tensor<1xi64>
@@ -34,20 +34,20 @@ func.func @test_slice_constant_default_axes(%arg0 : tensor<2x4xf32>) -> tensor<*
 // CHECK-DAG:       [[VAR_18_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_15_]], [[VAR_10_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_19_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_13_]], [[VAR_9_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_20_:%.+]] = stablehlo.select [[VAR_12_]], [[VAR_16_]], [[PARAM_0_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_22_:%.+]] = stablehlo.select [[VAR_21_]], [[VAR_2_]], [[VAR_18_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_24_:%.+]] = stablehlo.add [[VAR_22_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_25_:%.+]] = stablehlo.select [[VAR_23_]], [[VAR_24_]], [[VAR_22_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_27_:%.+]] = stablehlo.add [[VAR_17_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_28_:%.+]] = stablehlo.select [[VAR_26_]], [[VAR_27_]], [[VAR_17_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_29_:%.+]] = stablehlo.slice [[VAR_3_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_30_:%.+]] = stablehlo.slice [[VAR_5_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_31_:%.+]] = stablehlo.slice [[VAR_4_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_33_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_32_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_34_:%.+]] = stablehlo.negate [[VAR_30_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_35_:%.+]] = stablehlo.add [[VAR_31_]], [[VAR_7_]] : tensor<1xi64>
@@ -58,13 +58,13 @@ func.func @test_slice_constant_default_axes(%arg0 : tensor<2x4xf32>) -> tensor<*
 // CHECK-DAG:       [[VAR_39_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_36_]], [[VAR_31_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_40_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_34_]], [[VAR_30_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_41_:%.+]] = stablehlo.select [[VAR_33_]], [[VAR_37_]], [[VAR_20_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_43_:%.+]] = stablehlo.select [[VAR_42_]], [[VAR_1_]], [[VAR_39_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_45_:%.+]] = stablehlo.add [[VAR_43_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_46_:%.+]] = stablehlo.select [[VAR_44_]], [[VAR_45_]], [[VAR_43_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_48_:%.+]] = stablehlo.add [[VAR_38_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK:           [[VAR_49_:%.+]] = stablehlo.select [[VAR_47_]], [[VAR_48_]], [[VAR_38_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_50_:%.+]] = stablehlo.concatenate [[VAR_28_]], [[VAR_49_]], dim = 0 : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
@@ -99,7 +99,7 @@ func.func @test_slice_constant_default_steps(%arg0 : tensor<2x4xf32>) -> tensor<
 // CHECK-DAG:       [[VAR_8_:%.+]] = stablehlo.slice [[VAR_3_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_9_:%.+]] = stablehlo.slice [[VAR_5_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = stablehlo.slice [[VAR_4_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_12_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_11_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_13_:%.+]] = stablehlo.negate [[VAR_9_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_14_:%.+]] = stablehlo.add [[VAR_10_]], [[VAR_7_]] : tensor<1xi64>
@@ -110,20 +110,20 @@ func.func @test_slice_constant_default_steps(%arg0 : tensor<2x4xf32>) -> tensor<
 // CHECK-DAG:       [[VAR_18_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_15_]], [[VAR_10_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_19_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_13_]], [[VAR_9_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_20_:%.+]] = stablehlo.select [[VAR_12_]], [[VAR_16_]], [[PARAM_0_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_22_:%.+]] = stablehlo.select [[VAR_21_]], [[VAR_2_]], [[VAR_18_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_24_:%.+]] = stablehlo.add [[VAR_22_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_25_:%.+]] = stablehlo.select [[VAR_23_]], [[VAR_24_]], [[VAR_22_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_27_:%.+]] = stablehlo.add [[VAR_17_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_28_:%.+]] = stablehlo.select [[VAR_26_]], [[VAR_27_]], [[VAR_17_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_29_:%.+]] = stablehlo.slice [[VAR_3_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_30_:%.+]] = stablehlo.slice [[VAR_5_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_31_:%.+]] = stablehlo.slice [[VAR_4_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_33_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_32_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_34_:%.+]] = stablehlo.negate [[VAR_30_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_35_:%.+]] = stablehlo.add [[VAR_31_]], [[VAR_7_]] : tensor<1xi64>
@@ -134,13 +134,13 @@ func.func @test_slice_constant_default_steps(%arg0 : tensor<2x4xf32>) -> tensor<
 // CHECK-DAG:       [[VAR_39_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_36_]], [[VAR_31_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_40_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_34_]], [[VAR_30_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_41_:%.+]] = stablehlo.select [[VAR_33_]], [[VAR_37_]], [[VAR_20_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_43_:%.+]] = stablehlo.select [[VAR_42_]], [[VAR_1_]], [[VAR_39_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_45_:%.+]] = stablehlo.add [[VAR_43_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_46_:%.+]] = stablehlo.select [[VAR_44_]], [[VAR_45_]], [[VAR_43_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_48_:%.+]] = stablehlo.add [[VAR_38_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK:           [[VAR_49_:%.+]] = stablehlo.select [[VAR_47_]], [[VAR_48_]], [[VAR_38_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_50_:%.+]] = stablehlo.concatenate [[VAR_28_]], [[VAR_49_]], dim = 0 : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
@@ -175,7 +175,7 @@ func.func @test_slice_all_constant(%arg0 : tensor<2x4xf32>) -> tensor<*xf32> {
 // CHECK-DAG:       [[VAR_8_:%.+]] = stablehlo.slice [[VAR_3_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_9_:%.+]] = stablehlo.slice [[VAR_5_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = stablehlo.slice [[VAR_4_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_12_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_11_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_13_:%.+]] = stablehlo.negate [[VAR_9_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_14_:%.+]] = stablehlo.add [[VAR_10_]], [[VAR_7_]] : tensor<1xi64>
@@ -186,20 +186,20 @@ func.func @test_slice_all_constant(%arg0 : tensor<2x4xf32>) -> tensor<*xf32> {
 // CHECK-DAG:       [[VAR_18_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_15_]], [[VAR_10_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_19_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_13_]], [[VAR_9_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_20_:%.+]] = stablehlo.select [[VAR_12_]], [[VAR_16_]], [[PARAM_0_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_22_:%.+]] = stablehlo.select [[VAR_21_]], [[VAR_2_]], [[VAR_18_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_24_:%.+]] = stablehlo.add [[VAR_22_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_25_:%.+]] = stablehlo.select [[VAR_23_]], [[VAR_24_]], [[VAR_22_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_27_:%.+]] = stablehlo.add [[VAR_17_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_28_:%.+]] = stablehlo.select [[VAR_26_]], [[VAR_27_]], [[VAR_17_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_29_:%.+]] = stablehlo.slice [[VAR_3_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_30_:%.+]] = stablehlo.slice [[VAR_5_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_31_:%.+]] = stablehlo.slice [[VAR_4_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_33_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_32_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_34_:%.+]] = stablehlo.negate [[VAR_30_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_35_:%.+]] = stablehlo.add [[VAR_31_]], [[VAR_7_]] : tensor<1xi64>
@@ -210,13 +210,13 @@ func.func @test_slice_all_constant(%arg0 : tensor<2x4xf32>) -> tensor<*xf32> {
 // CHECK-DAG:       [[VAR_39_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_36_]], [[VAR_31_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_40_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_34_]], [[VAR_30_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_41_:%.+]] = stablehlo.select [[VAR_33_]], [[VAR_37_]], [[VAR_20_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_43_:%.+]] = stablehlo.select [[VAR_42_]], [[VAR_1_]], [[VAR_39_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_45_:%.+]] = stablehlo.add [[VAR_43_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_46_:%.+]] = stablehlo.select [[VAR_44_]], [[VAR_45_]], [[VAR_43_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_48_:%.+]] = stablehlo.add [[VAR_38_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK:           [[VAR_49_:%.+]] = stablehlo.select [[VAR_47_]], [[VAR_48_]], [[VAR_38_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_50_:%.+]] = stablehlo.concatenate [[VAR_28_]], [[VAR_49_]], dim = 0 : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
@@ -251,7 +251,7 @@ func.func @test_slice_all_constant_negative(%arg0 : tensor<2x4xf32>) -> tensor<*
 // CHECK-DAG:       [[VAR_8_:%.+]] = stablehlo.slice [[VAR_3_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_9_:%.+]] = stablehlo.slice [[VAR_5_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = stablehlo.slice [[VAR_4_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_12_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_11_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_13_:%.+]] = stablehlo.negate [[VAR_9_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_14_:%.+]] = stablehlo.add [[VAR_10_]], [[VAR_7_]] : tensor<1xi64>
@@ -262,20 +262,20 @@ func.func @test_slice_all_constant_negative(%arg0 : tensor<2x4xf32>) -> tensor<*
 // CHECK-DAG:       [[VAR_18_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_15_]], [[VAR_10_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_19_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_13_]], [[VAR_9_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_20_:%.+]] = stablehlo.select [[VAR_12_]], [[VAR_16_]], [[PARAM_0_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_22_:%.+]] = stablehlo.select [[VAR_21_]], [[VAR_2_]], [[VAR_18_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_24_:%.+]] = stablehlo.add [[VAR_22_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_25_:%.+]] = stablehlo.select [[VAR_23_]], [[VAR_24_]], [[VAR_22_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_27_:%.+]] = stablehlo.add [[VAR_17_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_28_:%.+]] = stablehlo.select [[VAR_26_]], [[VAR_27_]], [[VAR_17_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_29_:%.+]] = stablehlo.slice [[VAR_3_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_30_:%.+]] = stablehlo.slice [[VAR_5_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_31_:%.+]] = stablehlo.slice [[VAR_4_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_33_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_32_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_34_:%.+]] = stablehlo.negate [[VAR_30_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_35_:%.+]] = stablehlo.add [[VAR_31_]], [[VAR_7_]] : tensor<1xi64>
@@ -286,13 +286,13 @@ func.func @test_slice_all_constant_negative(%arg0 : tensor<2x4xf32>) -> tensor<*
 // CHECK-DAG:       [[VAR_39_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_36_]], [[VAR_31_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_40_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_34_]], [[VAR_30_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_41_:%.+]] = stablehlo.select [[VAR_33_]], [[VAR_37_]], [[VAR_20_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_43_:%.+]] = stablehlo.select [[VAR_42_]], [[VAR_1_]], [[VAR_39_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_45_:%.+]] = stablehlo.add [[VAR_43_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_46_:%.+]] = stablehlo.select [[VAR_44_]], [[VAR_45_]], [[VAR_43_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_48_:%.+]] = stablehlo.add [[VAR_38_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK:           [[VAR_49_:%.+]] = stablehlo.select [[VAR_47_]], [[VAR_48_]], [[VAR_38_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_50_:%.+]] = stablehlo.concatenate [[VAR_28_]], [[VAR_49_]], dim = 0 : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
@@ -327,7 +327,7 @@ func.func @test_slice_all_constant_end_outofbound(%arg0 : tensor<2x4xf32>) -> te
 // CHECK-DAG:       [[VAR_8_:%.+]] = stablehlo.slice [[VAR_3_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_9_:%.+]] = stablehlo.slice [[VAR_5_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = stablehlo.slice [[VAR_4_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_12_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_11_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_13_:%.+]] = stablehlo.negate [[VAR_9_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_14_:%.+]] = stablehlo.add [[VAR_10_]], [[VAR_7_]] : tensor<1xi64>
@@ -338,20 +338,20 @@ func.func @test_slice_all_constant_end_outofbound(%arg0 : tensor<2x4xf32>) -> te
 // CHECK-DAG:       [[VAR_18_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_15_]], [[VAR_10_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_19_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_13_]], [[VAR_9_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_20_:%.+]] = stablehlo.select [[VAR_12_]], [[VAR_16_]], [[PARAM_0_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_22_:%.+]] = stablehlo.select [[VAR_21_]], [[VAR_2_]], [[VAR_18_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_24_:%.+]] = stablehlo.add [[VAR_22_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_25_:%.+]] = stablehlo.select [[VAR_23_]], [[VAR_24_]], [[VAR_22_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_27_:%.+]] = stablehlo.add [[VAR_17_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_28_:%.+]] = stablehlo.select [[VAR_26_]], [[VAR_27_]], [[VAR_17_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_29_:%.+]] = stablehlo.slice [[VAR_3_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_30_:%.+]] = stablehlo.slice [[VAR_5_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_31_:%.+]] = stablehlo.slice [[VAR_4_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_33_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_32_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_34_:%.+]] = stablehlo.negate [[VAR_30_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_35_:%.+]] = stablehlo.add [[VAR_31_]], [[VAR_7_]] : tensor<1xi64>
@@ -362,13 +362,13 @@ func.func @test_slice_all_constant_end_outofbound(%arg0 : tensor<2x4xf32>) -> te
 // CHECK-DAG:       [[VAR_39_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_36_]], [[VAR_31_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_40_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_34_]], [[VAR_30_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_41_:%.+]] = stablehlo.select [[VAR_33_]], [[VAR_37_]], [[VAR_20_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_43_:%.+]] = stablehlo.select [[VAR_42_]], [[VAR_1_]], [[VAR_39_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_45_:%.+]] = stablehlo.add [[VAR_43_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_46_:%.+]] = stablehlo.select [[VAR_44_]], [[VAR_45_]], [[VAR_43_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_48_:%.+]] = stablehlo.add [[VAR_38_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK:           [[VAR_49_:%.+]] = stablehlo.select [[VAR_47_]], [[VAR_48_]], [[VAR_38_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_50_:%.+]] = stablehlo.concatenate [[VAR_28_]], [[VAR_49_]], dim = 0 : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
@@ -403,7 +403,7 @@ func.func @test_slice_all_constant_negative_steps(%arg0 : tensor<2x4xf32>) -> te
 // CHECK-DAG:       [[VAR_8_:%.+]] = stablehlo.slice [[VAR_3_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_9_:%.+]] = stablehlo.slice [[VAR_5_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = stablehlo.slice [[VAR_4_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_11_:%.+]] = stablehlo.compare  LT, [[VAR_9_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_12_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_11_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_13_:%.+]] = stablehlo.negate [[VAR_9_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_14_:%.+]] = stablehlo.add [[VAR_10_]], [[VAR_7_]] : tensor<1xi64>
@@ -414,20 +414,20 @@ func.func @test_slice_all_constant_negative_steps(%arg0 : tensor<2x4xf32>) -> te
 // CHECK-DAG:       [[VAR_18_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_15_]], [[VAR_10_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_19_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_13_]], [[VAR_9_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_20_:%.+]] = stablehlo.select [[VAR_12_]], [[VAR_16_]], [[PARAM_0_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_21_:%.+]] = stablehlo.compare  GT, [[VAR_18_]], [[VAR_2_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_22_:%.+]] = stablehlo.select [[VAR_21_]], [[VAR_2_]], [[VAR_18_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.compare  LT, [[VAR_22_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_24_:%.+]] = stablehlo.add [[VAR_22_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_25_:%.+]] = stablehlo.select [[VAR_23_]], [[VAR_24_]], [[VAR_22_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_17_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_27_:%.+]] = stablehlo.add [[VAR_17_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_28_:%.+]] = stablehlo.select [[VAR_26_]], [[VAR_27_]], [[VAR_17_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_29_:%.+]] = stablehlo.slice [[VAR_3_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_30_:%.+]] = stablehlo.slice [[VAR_5_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_31_:%.+]] = stablehlo.slice [[VAR_4_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_32_:%.+]] = stablehlo.compare  LT, [[VAR_30_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_33_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_32_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<2xindex>) -> tensor<2x4xi1>
 // CHECK-DAG:       [[VAR_34_:%.+]] = stablehlo.negate [[VAR_30_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_35_:%.+]] = stablehlo.add [[VAR_31_]], [[VAR_7_]] : tensor<1xi64>
@@ -438,13 +438,13 @@ func.func @test_slice_all_constant_negative_steps(%arg0 : tensor<2x4xf32>) -> te
 // CHECK-DAG:       [[VAR_39_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_36_]], [[VAR_31_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_40_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_34_]], [[VAR_30_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_41_:%.+]] = stablehlo.select [[VAR_33_]], [[VAR_37_]], [[VAR_20_]] : tensor<2x4xi1>, tensor<2x4xf32>
-// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_42_:%.+]] = stablehlo.compare  GT, [[VAR_39_]], [[VAR_1_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_43_:%.+]] = stablehlo.select [[VAR_42_]], [[VAR_1_]], [[VAR_39_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.compare  LT, [[VAR_43_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_45_:%.+]] = stablehlo.add [[VAR_43_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_46_:%.+]] = stablehlo.select [[VAR_44_]], [[VAR_45_]], [[VAR_43_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_38_]], [[VAR_6_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_48_:%.+]] = stablehlo.add [[VAR_38_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK:           [[VAR_49_:%.+]] = stablehlo.select [[VAR_47_]], [[VAR_48_]], [[VAR_38_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_50_:%.+]] = stablehlo.concatenate [[VAR_28_]], [[VAR_49_]], dim = 0 : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
@@ -483,7 +483,7 @@ func.func @dyntest_slice_constant_dynshape_not_spliced(%arg0 : tensor<?x4x5xf32>
 // CHECK-DAG:       [[VAR_11_:%.+]] = stablehlo.slice [[VAR_2_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_12_:%.+]] = stablehlo.slice [[VAR_2_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_13_:%.+]] = stablehlo.slice [[VAR_3_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_14_:%.+]] = stablehlo.compare  LT, [[VAR_12_]], [[VAR_4_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_14_:%.+]] = stablehlo.compare  LT, [[VAR_12_]], [[VAR_4_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_15_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_14_]], [[VAR_6_]], dims = [0] : (tensor<1xi1>, tensor<3xindex>) -> tensor<?x4x5xi1>
 // CHECK-DAG:       [[VAR_16_:%.+]] = stablehlo.negate [[VAR_12_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_17_:%.+]] = stablehlo.add [[VAR_13_]], [[VAR_5_]] : tensor<1xi64>
@@ -494,20 +494,20 @@ func.func @dyntest_slice_constant_dynshape_not_spliced(%arg0 : tensor<?x4x5xf32>
 // CHECK-DAG:       [[VAR_21_:%.+]] = stablehlo.select [[VAR_14_]], [[VAR_18_]], [[VAR_13_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_22_:%.+]] = stablehlo.select [[VAR_14_]], [[VAR_16_]], [[VAR_12_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.select [[VAR_15_]], [[VAR_19_]], [[PARAM_0_]] : tensor<?x4x5xi1>, tensor<?x4x5xf32>
-// CHECK:           [[VAR_24_:%.+]] = stablehlo.compare  GT, [[VAR_21_]], [[VAR_1_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_24_:%.+]] = stablehlo.compare  GT, [[VAR_21_]], [[VAR_1_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_25_:%.+]] = stablehlo.select [[VAR_24_]], [[VAR_1_]], [[VAR_21_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_25_]], [[VAR_4_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.compare  LT, [[VAR_25_]], [[VAR_4_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_27_:%.+]] = stablehlo.add [[VAR_25_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_28_:%.+]] = stablehlo.select [[VAR_26_]], [[VAR_27_]], [[VAR_25_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_29_:%.+]] = stablehlo.compare  LT, [[VAR_20_]], [[VAR_4_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_29_:%.+]] = stablehlo.compare  LT, [[VAR_20_]], [[VAR_4_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_30_:%.+]] = stablehlo.add [[VAR_20_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_31_:%.+]] = stablehlo.select [[VAR_29_]], [[VAR_30_]], [[VAR_20_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_32_:%.+]] = stablehlo.slice [[VAR_2_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_33_:%.+]] = stablehlo.slice [[VAR_2_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_34_:%.+]] = stablehlo.slice [[VAR_3_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_35_:%.+]] = stablehlo.compare  LT, [[VAR_33_]], [[VAR_4_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_35_:%.+]] = stablehlo.compare  LT, [[VAR_33_]], [[VAR_4_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_36_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_35_]], [[VAR_6_]], dims = [0] : (tensor<1xi1>, tensor<3xindex>) -> tensor<?x4x5xi1>
 // CHECK-DAG:       [[VAR_37_:%.+]] = stablehlo.negate [[VAR_33_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_38_:%.+]] = stablehlo.add [[VAR_34_]], [[VAR_5_]] : tensor<1xi64>
@@ -518,13 +518,13 @@ func.func @dyntest_slice_constant_dynshape_not_spliced(%arg0 : tensor<?x4x5xf32>
 // CHECK-DAG:       [[VAR_42_:%.+]] = stablehlo.select [[VAR_35_]], [[VAR_39_]], [[VAR_34_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_43_:%.+]] = stablehlo.select [[VAR_35_]], [[VAR_37_]], [[VAR_33_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.select [[VAR_36_]], [[VAR_40_]], [[VAR_23_]] : tensor<?x4x5xi1>, tensor<?x4x5xf32>
-// CHECK:           [[VAR_45_:%.+]] = stablehlo.compare  GT, [[VAR_42_]], [[VAR_0_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_45_:%.+]] = stablehlo.compare  GT, [[VAR_42_]], [[VAR_0_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_46_:%.+]] = stablehlo.select [[VAR_45_]], [[VAR_0_]], [[VAR_42_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_46_]], [[VAR_4_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.compare  LT, [[VAR_46_]], [[VAR_4_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_48_:%.+]] = stablehlo.add [[VAR_46_]], [[VAR_0_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_49_:%.+]] = stablehlo.select [[VAR_47_]], [[VAR_48_]], [[VAR_46_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_50_:%.+]] = stablehlo.compare  LT, [[VAR_41_]], [[VAR_4_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_50_:%.+]] = stablehlo.compare  LT, [[VAR_41_]], [[VAR_4_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_51_:%.+]] = stablehlo.add [[VAR_41_]], [[VAR_0_]] : tensor<1xi64>
 // CHECK:           [[VAR_52_:%.+]] = stablehlo.select [[VAR_50_]], [[VAR_51_]], [[VAR_41_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_53_:%.+]] = stablehlo.concatenate [[VAR_4_]], [[VAR_31_]], [[VAR_52_]], dim = 0 : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
@@ -555,7 +555,7 @@ func.func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %
 // CHECK-DAG:       [[VAR_7_:%.+]] = stablehlo.slice [[PARAM_0_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_8_:%.+]] = stablehlo.slice [[PARAM_2_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_9_:%.+]] = stablehlo.slice [[PARAM_1_]] [1:2] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_10_:%.+]] = stablehlo.compare  LT, [[VAR_8_]], [[VAR_5_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_10_:%.+]] = stablehlo.compare  LT, [[VAR_8_]], [[VAR_5_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_11_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_10_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<3xindex>) -> tensor<3x4x5xi1>
 // CHECK-DAG:       [[VAR_12_:%.+]] = stablehlo.negate [[VAR_8_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_13_:%.+]] = stablehlo.add [[VAR_9_]], [[VAR_6_]] : tensor<1xi64>
@@ -566,20 +566,20 @@ func.func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %
 // CHECK-DAG:       [[VAR_17_:%.+]] = stablehlo.select [[VAR_10_]], [[VAR_14_]], [[VAR_9_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_18_:%.+]] = stablehlo.select [[VAR_10_]], [[VAR_12_]], [[VAR_8_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_19_:%.+]] = stablehlo.select [[VAR_11_]], [[VAR_15_]], [[VAR_4_]] : tensor<3x4x5xi1>, tensor<3x4x5xi64>
-// CHECK:           [[VAR_20_:%.+]] = stablehlo.compare  GT, [[VAR_17_]], [[VAR_2_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_20_:%.+]] = stablehlo.compare  GT, [[VAR_17_]], [[VAR_2_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_21_:%.+]] = stablehlo.select [[VAR_20_]], [[VAR_2_]], [[VAR_17_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_22_:%.+]] = stablehlo.compare  LT, [[VAR_21_]], [[VAR_5_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_22_:%.+]] = stablehlo.compare  LT, [[VAR_21_]], [[VAR_5_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_23_:%.+]] = stablehlo.add [[VAR_21_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_24_:%.+]] = stablehlo.select [[VAR_22_]], [[VAR_23_]], [[VAR_21_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_25_:%.+]] = stablehlo.compare  LT, [[VAR_16_]], [[VAR_5_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_25_:%.+]] = stablehlo.compare  LT, [[VAR_16_]], [[VAR_5_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_26_:%.+]] = stablehlo.add [[VAR_16_]], [[VAR_2_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_27_:%.+]] = stablehlo.select [[VAR_25_]], [[VAR_26_]], [[VAR_16_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_28_:%.+]] = stablehlo.slice [[PARAM_0_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_29_:%.+]] = stablehlo.slice [[PARAM_2_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_30_:%.+]] = stablehlo.slice [[PARAM_1_]] [0:1] : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK:           [[VAR_31_:%.+]] = stablehlo.compare  LT, [[VAR_29_]], [[VAR_5_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_31_:%.+]] = stablehlo.compare  LT, [[VAR_29_]], [[VAR_5_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_32_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_31_]], [[VAR_0_]], dims = [0] : (tensor<1xi1>, tensor<3xindex>) -> tensor<3x4x5xi1>
 // CHECK-DAG:       [[VAR_33_:%.+]] = stablehlo.negate [[VAR_29_]] : tensor<1xi64>
 // CHECK-DAG:       [[VAR_34_:%.+]] = stablehlo.add [[VAR_30_]], [[VAR_6_]] : tensor<1xi64>
@@ -590,13 +590,13 @@ func.func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %
 // CHECK-DAG:       [[VAR_38_:%.+]] = stablehlo.select [[VAR_31_]], [[VAR_35_]], [[VAR_30_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_39_:%.+]] = stablehlo.select [[VAR_31_]], [[VAR_33_]], [[VAR_29_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_40_:%.+]] = stablehlo.select [[VAR_32_]], [[VAR_36_]], [[VAR_19_]] : tensor<3x4x5xi1>, tensor<3x4x5xi64>
-// CHECK:           [[VAR_41_:%.+]] = stablehlo.compare  GT, [[VAR_38_]], [[VAR_1_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK:           [[VAR_41_:%.+]] = stablehlo.compare  GT, [[VAR_38_]], [[VAR_1_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK:           [[VAR_42_:%.+]] = stablehlo.select [[VAR_41_]], [[VAR_1_]], [[VAR_38_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_43_:%.+]] = stablehlo.compare  LT, [[VAR_42_]], [[VAR_5_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_43_:%.+]] = stablehlo.compare  LT, [[VAR_42_]], [[VAR_5_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_44_:%.+]] = stablehlo.add [[VAR_42_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_45_:%.+]] = stablehlo.select [[VAR_43_]], [[VAR_44_]], [[VAR_42_]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:       [[VAR_46_:%.+]] = stablehlo.compare  LT, [[VAR_37_]], [[VAR_5_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:       [[VAR_46_:%.+]] = stablehlo.compare  LT, [[VAR_37_]], [[VAR_5_]] : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
 // CHECK-DAG:       [[VAR_47_:%.+]] = stablehlo.add [[VAR_37_]], [[VAR_1_]] : tensor<1xi64>
 // CHECK:           [[VAR_48_:%.+]] = stablehlo.select [[VAR_46_]], [[VAR_47_]], [[VAR_37_]] : tensor<1xi1>, tensor<1xi64>
 // CHECK-DAG:       [[VAR_49_:%.+]] = stablehlo.concatenate [[VAR_5_]], [[VAR_27_]], [[VAR_48_]], dim = 0 : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 6461b921fd06b1c812f1172685b8b7edc0608af7 && cd ..
+cd llvm-project && git checkout 0913547d0e3939cc420e88ecd037240f33736820 && cd ..


### PR DESCRIPTION
Upstream wants LLVM commit `0913547d`:

```
commit 0913547d0e3939cc420e88ecd037240f33736820
Author: Aaron Ballman <aaron@aaronballman.com>
Date:   Fri Jul 12 06:54:42 2024 -0400

    [C2y] Claim partial conformance to WG14 N3244 (#98525)
    
    This paper had several changes within it, and Clang implements some of
    the changes, but not others. This updates the status accordingly.
```

Again, it looks like ONNX-MLIR compiles without this upgrade, but we should follow suit anyway.