### PR TITLE
[AutoBump] Merge with fixes of f11a21c6 (Aug 6) (26) (needs thorough review)

### DIFF
--- a/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.cpp
@@ -29,7 +29,8 @@ llvm::cl::opt<NNPAEmissionTargetType> nnpaEmissionTarget(
 llvm::cl::opt<bool> nnpaClipToDLFloatRange("nnpa-clip-to-dlfloat-range",
     llvm::cl::desc("Clip CPU tensors to dlfloat range before stickification to "
                    "avoid out-of-range. Only clip Softmax inputs at this "
-                   "moment. Default is true."),
+                   "moment. Default is true. This option will be removed and "
+                   "replaced by --nnpa-saturation in the future."),
     llvm::cl::init(true), llvm::cl::cat(OnnxMlirOptions));
 
 llvm::cl::opt<bool> nnpaEnableZHighToOnnx("enable-zhigh-to-onnx",
@@ -55,7 +56,7 @@ llvm::cl::opt<bool> nnpaEnableCompilerStickUnstick(
     "enable-compiler-stick-unstick",
     llvm::cl::desc("[Experimental feature] Enable the compiler generate some "
                    "stick/unstick code. Default is true."),
-    llvm::cl::init(true), llvm::cl::cat(OnnxMlirOptions));
+    llvm::cl::init(true), llvm::cl::cat(OnnxMlirCommonOptions));
 
 llvm::cl::opt<bool> nnpaEnableScalarBcastBinary(
     "nnpa-enable-scalar-bcast-binary",

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -103,7 +103,8 @@ void addONNXToZHighPasses(mlir::PassManager &pm) {
   // Clip zhigh.Stick inputs if required. This is to avoid out-of-range of
   // dlfloat. Do constant propagation after clipping to remove ONNX ops used for
   // clipping such as ONNXMax if applicable.
-  if (nnpaClipToDLFloatRange) {
+  // This pass will be removed and replaced by nnpa-saturation in the future.
+  if (!nnpaEnableSaturation && nnpaClipToDLFloatRange) {
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::zhigh::createZHighClipToDLFloatPass());
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -606,6 +606,25 @@ static llvm::cl::opt<bool, true> enable_bound_check("enable-bound-check",
     llvm::cl::location(enableBoundCheck), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 
+#if defined(_DEBUG)
+// Option only available in debug mode: set using command options.
+static llvm::cl::opt<bool, true> test_compiler_opt("test-compiler-opt",
+    llvm::cl::desc(
+        "Help compiler writers test a new (small) optimization. When false, "
+        "the old approach should be used. When true, the new opt should be "
+        "used. Utilities such as CheckONNXModel.py can then verify that the "
+        "new opt deliver the same results.\n"
+        "E.g. CheckONNXModel.py -m test.mlir -t -O3 -a test-compiler-opt=true\n"
+        "Once the new opt works, it should not rely this option any more.\n"
+        "Only defined in DEBUG build and default to false.\n"),
+    llvm::cl::location(debugTestCompilerOpt), llvm::cl::init(false),
+    llvm::cl::cat(OnnxMlirOptions));
+bool debugTestCompilerOpt;
+#else
+// Option only available in debug mode: disable when not in debug.
+bool debugTestCompilerOpt = false;
+#endif
+
 // Options for onnx-mlir-opt only
 static llvm::cl::opt<bool, true> split_input_file_opt("split-input-file",
     llvm::cl::desc("Split the input file into pieces and process each "

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -132,6 +132,8 @@ extern OptReport optReport;                                   // onnx-mlir only
 extern bool useOldBufferization;                              // onnx-mlir only
 extern bool enableTiming;                                     // onnx-mlir only
 extern bool enableBoundCheck;                                 // onnx-mlir only
+extern bool debugTestCompilerOpt;                             // onnx-mlir only
+
 extern bool split_input_file;          // onnx-mlir-opt only
 extern bool verify_diagnostics;        // onnx-mlir-opt only
 extern bool verify_passes;             // onnx-mlir-opt only

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Debug.h"
@@ -122,6 +123,16 @@ Value createReplacingConstantOp(
 template <typename T>
 using EnableNotBool = std::enable_if_t<!std::is_same_v<T, bool>>;
 
+template <typename T>
+using EnableBool = std::enable_if_t<std::is_same_v<T, bool>>;
+
+template <typename T>
+using EnableInteger =
+    std::enable_if_t<std::is_integral_v<T> && !std::is_same_v<T, bool>>;
+
+template <typename T>
+using EnableFloatingPoint = std::enable_if_t<std::is_floating_point_v<T>>;
+
 /// Checks whether a variadic value is produced by dense ONNXConstantOps.
 bool isVariadicOperandFromDenseONNXConstantOp(ValueRange operands) {
   return llvm::all_of(operands, [](Value v) { return isDenseONNXConstant(v); });
@@ -132,6 +143,47 @@ Value ConstZeroTensor(
   return OnnxBuilder(rewriter, loc)
       .constant(DenseElementsAttr::get(
           type, rewriter.getZeroAttr(type.getElementType())));
+}
+
+template <typename GetFPConstFunc =
+              std::function<APFloat(const llvm::fltSemantics &, bool)>,
+    typename GetIntConstFunc = std::function<APInt(unsigned)>>
+Value getClipConstantOfType(PatternRewriter &rewriter, ShapedType type,
+    Location loc, GetFPConstFunc fpConstantFunc, bool isNegative,
+    GetIntConstFunc intConstantFunc) {
+  OnnxBuilder create(rewriter, loc);
+  auto elemType = type.getElementType();
+  if (auto floatType = dyn_cast<FloatType>(elemType)) {
+    auto fpValue =
+        fpConstantFunc(floatType.getFloatSemantics(), /*Negative=*/isNegative);
+    return create.constant(DenseElementsAttr::get(
+        RankedTensorType::get({}, elemType), llvm::ArrayRef(fpValue)));
+  }
+  auto intValue = intConstantFunc(elemType.getIntOrFloatBitWidth());
+  return create.constant(DenseElementsAttr::get(
+      RankedTensorType::get({}, elemType), llvm::ArrayRef(intValue)));
+}
+
+Value createMaximumValueForClip(
+    PatternRewriter &rewriter, ShapedType type, Value value) {
+
+  // Return 'value' if exists, as there is no need to clip to largest.
+  if (!isNoneValue(value))
+    return value;
+
+  return getClipConstantOfType(rewriter, type, value.getLoc(),
+      llvm::APFloat::getLargest, false, llvm::APInt::getMaxValue);
+}
+
+Value createMinimumValueForClip(
+    PatternRewriter &rewriter, ShapedType type, Value value) {
+
+  // Return 'value' if exists, as there is no need to clip to lowest.
+  if (!isNoneValue(value))
+    return value;
+
+  return getClipConstantOfType(rewriter, type, value.getLoc(),
+      llvm::APFloat::getLargest, true, llvm::APInt::getMinValue);
 }
 
 WideNum asWideNum(double n, Type elemType) {
@@ -203,7 +255,41 @@ struct ElementWiseBinaryOpImpl<ONNXMulOp, T, EnableNotBool<T>> {
 
 template <typename T>
 struct ElementWiseBinaryOpImpl<ONNXDivOp, T, EnableNotBool<T>> {
-  static T eval(T lhs, T rhs) { return lhs / rhs; }
+  static T eval(T lhs, T rhs) {
+    if constexpr (std::is_integral_v<T>) {
+      if (rhs == 0) {
+        // Undefined behavior. We can return any value.
+        // Performing the divison would crash.
+        return lhs;
+      }
+    }
+    return lhs / rhs;
+  }
+};
+
+template <typename T>
+struct ElementWiseBinaryOpImpl<ONNXBitwiseAndOp, T, EnableInteger<T>> {
+  static T eval(T lhs, T rhs) { return lhs & rhs; }
+};
+
+template <typename T>
+struct ElementWiseBinaryOpImpl<ONNXBitwiseOrOp, T, EnableInteger<T>> {
+  static T eval(T lhs, T rhs) { return lhs | rhs; }
+};
+
+template <typename T>
+struct ElementWiseBinaryOpImpl<ONNXAndOp, T, EnableBool<T>> {
+  static T eval(T lhs, T rhs) { return lhs && rhs; }
+};
+
+template <typename T>
+struct ElementWiseBinaryOpImpl<ONNXOrOp, T, EnableBool<T>> {
+  static T eval(T lhs, T rhs) { return lhs || rhs; }
+};
+
+template <typename T>
+struct ElementWiseBinaryOpImpl<ONNXXorOp, T, EnableBool<T>> {
+  static T eval(T lhs, T rhs) { return lhs != rhs; }
 };
 
 template <typename T>
@@ -341,8 +427,53 @@ struct ElementWiseUnaryOpImpl {
 };
 
 template <typename T>
+struct ElementWiseUnaryOpImpl<ONNXBitwiseNotOp, T, EnableInteger<T>> {
+  static T eval(T val) { return ~val; }
+};
+
+template <typename T>
+struct ElementWiseUnaryOpImpl<ONNXCeilOp, T, EnableNotBool<T>> {
+  static T eval(T val) { return ceil(val); }
+};
+
+template <typename T>
+struct ElementWiseUnaryOpImpl<ONNXCosOp, T, EnableFloatingPoint<T>> {
+  static T eval(T val) { return cos(val); }
+};
+
+template <typename T>
+struct ElementWiseUnaryOpImpl<ONNXErfOp, T, EnableNotBool<T>> {
+  static T eval(T val) { return std::erf(val); }
+};
+
+template <typename T>
+struct ElementWiseUnaryOpImpl<ONNXExpOp, T, EnableFloatingPoint<T>> {
+  static T eval(T val) { return std::exp(val); }
+};
+
+template <typename T>
+struct ElementWiseUnaryOpImpl<ONNXFloorOp, T, EnableNotBool<T>> {
+  static T eval(T val) { return floor(val); }
+};
+
+template <typename T>
+struct ElementWiseUnaryOpImpl<ONNXLogOp, T, EnableFloatingPoint<T>> {
+  static T eval(T val) { return std::log(val); }
+};
+
+template <typename T>
 struct ElementWiseUnaryOpImpl<ONNXNegOp, T, EnableNotBool<T>> {
   static T eval(T val) { return -val; }
+};
+
+template <typename T>
+struct ElementWiseUnaryOpImpl<ONNXNotOp, T, EnableBool<T>> {
+  static T eval(T val) { return !val; }
+};
+
+template <typename T>
+struct ElementWiseUnaryOpImpl<ONNXSinOp, T, EnableFloatingPoint<T>> {
+  static T eval(T val) { return sin(val); }
 };
 
 template <>

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -111,6 +111,17 @@ class EqualString<string s> : Constraint<CPred<"$0 == \"" # s # "\"">>;
 
 // Creation helpers:
 
+def CreateMaximumValueForClip: NativeCodeCall<
+  "createMaximumValueForClip($_builder, cast<mlir::ShapedType>($0.getType()), $1)"
+>;
+
+def CreateMinimumValueForClip: NativeCodeCall<
+  "createMinimumValueForClip($_builder, cast<mlir::ShapedType>($0.getType()), $1)"
+>;
+
+def CreateONNXMinOp : NativeCodeCall<"$_builder.create<ONNXMinOp>($_loc, $0.getType(), ValueRange({$1, $2}))">;
+def CreateONNXMaxOp : NativeCodeCall<"$_builder.create<ONNXMaxOp>($_loc, $0.getType(), ValueRange({$1, $2}))">;
+
 def CreateZeroTensorOfType: NativeCodeCall<
   "ConstZeroTensor($_builder, $_loc, mlir::cast<mlir::ShapedType>($0.getType()))"
 >;
@@ -124,8 +135,35 @@ def CreateSubOfTwoConst :
 def CreateCastOfConst :
    NativeCodeCall<"ConstPropCast($_builder, $0, $1, $2, $3)">;
 
+def CreateBitwiseNotOfConst :
+   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXBitwiseNotOp>($_builder, $0, $1)">;
+
+def CreateCeilOfConst :
+   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXCeilOp>($_builder, $0, $1)">;
+
+def CreateCosOfConst :
+   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXCosOp>($_builder, $0, $1)">;
+
+def CreateErfOfConst :
+   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXErfOp>($_builder, $0, $1)">;
+
+def CreateExpOfConst :
+   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXExpOp>($_builder, $0, $1)">;
+
+def CreateFloorOfConst :
+   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXFloorOp>($_builder, $0, $1)">;
+
+def CreateLogOfConst :
+   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXLogOp>($_builder, $0, $1)">;
+
 def CreateNegOfConst :
    NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXNegOp>($_builder, $0, $1)">;
+
+def CreateNotOfConst :
+   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXNotOp>($_builder, $0, $1)">;
+
+def CreateSinOfConst :
+   NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXSinOp>($_builder, $0, $1)">;
 
 def CreateSqrtOfConst :
    NativeCodeCall<"ConstPropElementwiseUnary<mlir::ONNXSqrtOp>($_builder, $0, $1)">;
@@ -165,6 +203,21 @@ def CreateLessOrEqualOfTwoConst :
 
 def CreateGreaterOrEqualOfTwoConst :
    NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXGreaterOrEqualOp>($_builder, $0, $1, $2)">;
+
+def CreateBitwiseAndOfTwoConst :
+   NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXBitwiseAndOp>($_builder, $0, $1, $2)">;
+
+def CreateBitwiseOrOfTwoConst :
+   NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXBitwiseOrOp>($_builder, $0, $1, $2)">;
+
+def CreateAndOfTwoConst :
+   NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXAndOp>($_builder, $0, $1, $2)">;
+
+def CreateOrOfTwoConst :
+   NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXOrOp>($_builder, $0, $1, $2)">;
+
+def CreateXorOfTwoConst :
+   NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXXorOp>($_builder, $0, $1, $2)">;
 
 def CreatePowOfTwoConst :
    NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXPowOp>($_builder, $0, $1, $2)">;
@@ -351,12 +404,92 @@ def CastofConst : NamedPat<"CastofConst",
     (CreateCastOfConst $castOp, $input, $saturate, $to),
     [(IsFromDenseONNXConstantOp:$input)]>;
 
+// Constant Propagation for BitwiseNot
+def BitwiseNotConstProp : NamedPat<"BitwiseNotofConst",
+    // From bitwise_not(c).
+    (ONNXBitwiseNotOp:$bitwiseNotOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To ~c
+    (CreateBitwiseNotOfConst $bitwiseNotOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
+// Constant Propagation for Ceil
+def CeilConstProp : NamedPat<"CeilofConst",
+    // From ceil(c).
+    (ONNXCeilOp:$ceilOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To new_c
+    (CreateCeilOfConst $ceilOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
+// Constant Propagation for Cos
+def CosConstProp : NamedPat<"CosofConst",
+    // From cos(c).
+    (ONNXCosOp:$cosOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To new_c.
+    (CreateCosOfConst $cosOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
+// Constant Propagation for Erf
+def ErfConstProp : NamedPat<"ErfofConst",
+    // From erf(c)
+    (ONNXErfOp:$erfOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To new_c.
+    (CreateErfOfConst $erfOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
+// Constant Propagation for Exp
+def ExpConstProp : NamedPat<"ExpofConst",
+    // From exp(c).
+    (ONNXExpOp:$expOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To new_c.
+    (CreateExpOfConst $expOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
+// Constant Propagation for Floor
+def FloorConstProp : NamedPat<"FloorofConst",
+    // From floor(c).
+    (ONNXFloorOp:$floorOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To new_c.
+    (CreateFloorOfConst $floorOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
+// Constant Propagation for Log
+def LogConstProp : NamedPat<"LogofConst",
+    // From log(c)
+    (ONNXLogOp:$logOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To new_c.
+    (CreateLogOfConst $logOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
 // Neg of constant is simply -const
 def NegofConst : NamedPat<"NegofConst",
     // From - (c)
     (ONNXNegOp:$negOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To (-c)
     (CreateNegOfConst $negOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
+// Not of constant is simply !const
+def NotofConst : NamedPat<"NotofConst",
+    // From c
+    (ONNXNotOp:$notOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To !c
+    (CreateNotOfConst $notOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
+// Constant Propagation for Sin
+def SinConstProp : NamedPat<"SinofConst",
+    // From sin(c).
+    (ONNXSinOp:$sinOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To new_c
+    (CreateSinOfConst $sinOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
+
+// Constant Propagation for Reciprocal
+def ReciprocalConstProp : NamedPat<"ReciprocalofConst",
+    // From 1/c.
+    (ONNXReciprocalOp:$reciprocalOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To new_c
+    (CreateReciprocalOfConst $reciprocalOp, $input),
     [(IsFromDenseONNXConstantOp:$input)]>;
 
 // Change a subtraction of a constant c by an addition of -c. Helpfull to combine
@@ -536,6 +669,66 @@ def DivOnesOnRhs : NamedPat<"DivOnesOnRhs",
     ]>;
 
 //===----------------------------------------------------------------------===//
+// Constant propagation for ONNXBitwiseAndOp
+//===----------------------------------------------------------------------===//
+
+def BitwiseAndConstPropPattern : NamedPat<"BitwiseAndConstPropPattern",
+    (ONNXBitwiseAndOp:$result
+      (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
+      (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
+    (CreateBitwiseAndOfTwoConst $result, $lhs, $rhs),
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$result)]>;
+
+//===----------------------------------------------------------------------===//
+// Constant propagation for ONNXBitwiseOrOp
+//===----------------------------------------------------------------------===//
+
+def BitwiseOrConstPropPattern : NamedPat<"BitwiseOrConstPropPattern",
+    (ONNXBitwiseOrOp:$result
+      (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
+      (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
+    (CreateBitwiseOrOfTwoConst $result, $lhs, $rhs),
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$result)]>;
+
+//===----------------------------------------------------------------------===//
+// Constant propagation for ONNXAndOp
+//===----------------------------------------------------------------------===//
+
+def AndConstPropPattern : NamedPat<"AndConstPropPattern",
+    (ONNXAndOp:$result
+      (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
+      (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
+    (CreateAndOfTwoConst $result, $lhs, $rhs),
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$result)]>;
+
+//===----------------------------------------------------------------------===//
+// Constant propagation for ONNXOrOp
+//===----------------------------------------------------------------------===//
+
+def OrConstPropPattern : NamedPat<"OrConstPropPattern",
+    (ONNXOrOp:$result
+      (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
+      (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
+    (CreateOrOfTwoConst $result, $lhs, $rhs),
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$result)]>;
+
+//===----------------------------------------------------------------------===//
+// Constant propagation for ONNXorOp
+//===----------------------------------------------------------------------===//
+
+def XorConstPropPattern : NamedPat<"XorConstPropPattern",
+    (ONNXXorOp:$result
+      (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
+      (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
+    (CreateXorOfTwoConst $result, $lhs, $rhs),
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$result)]>;
+
+//===----------------------------------------------------------------------===//
 // Constant propagation for ONNXEqualOp
 //===----------------------------------------------------------------------===//
 
@@ -610,6 +803,29 @@ def ModConstPropPattern : NamedPat<"ModConstPropPattern",
     (CreateModOfTwoConst  $modOp, $A, $B),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B),
     (SatisfiesExpansionBound:$modOp)]>;
+
+//===----------------------------------------------------------------------===//
+// Pattern for Clip.
+// Converts clip into min(max(c0, c1), c2) as Min and Max
+// already have their own foldings.
+// If c1 or c2 isn't defined, default max to numeric_limits::max() and
+// min to numeric_limits::lowest() values according to the element type.
+//===----------------------------------------------------------------------===//
+
+// Constant Propagation for Clip
+def ClipConstProp : NamedPat<"ClipConstProp",
+    // From clip(c0, c1, c2).
+    (ONNXClipOp:$clipOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_),
+                         $min, $max),
+    // To min(max(c0, c1), c2).
+    (CreateONNXMinOp
+      $clipOp,
+      (CreateONNXMaxOp $clipOp, $input, (CreateMinimumValueForClip $input, $min)),
+      (CreateMaximumValueForClip $input, $max)),
+    // Clip constraints
+    [(IsFromDenseONNXConstantOp:$input),
+     (IsFromDenseONNXConstantOpOrNone:$min), (IsFromDenseONNXConstantOpOrNone:$max),
+     (SatisfiesExpansionBound:$clipOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns for Where.

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -103,9 +103,6 @@ def IsMatMulIntegerRhsZero: Constraint<
 def SatisfiesExpansionBound: Constraint<
   CPred<"satisfiesExpansionBound($_self)">>;
 
-def SatisfiesMinLessThanMaxRequirement: Constraint<
-  CPred<"satisfiesMinLessThanMaxRequirement(cast<mlir::ShapedType>($0.getType()), $1, $2)">>;
-
 class IsNotDisabled<string name>: Constraint<
   CPred<"isNotDisabled(\"" # name # "\")">>;
 
@@ -119,11 +116,11 @@ class EqualString<string s> : Constraint<CPred<"$0 == \"" # s # "\"">>;
 // Creation helpers:
 
 def CreateMaximumValueForClip: NativeCodeCall<
-  "CreateMaximumValueForClip($_builder, cast<mlir::ShapedType>($0.getType()), $1)"
+  "createMaximumValueForClip($_builder, cast<mlir::ShapedType>($0.getType()), $1)"
 >;
 
 def CreateMinimumValueForClip: NativeCodeCall<
-  "CreateMinimumValueForClip($_builder, cast<mlir::ShapedType>($0.getType()), $1)"
+  "createMinimumValueForClip($_builder, cast<mlir::ShapedType>($0.getType()), $1)"
 >;
 
 def CreateONNXMinOp : NativeCodeCall<"$_builder.create<ONNXMinOp>($_loc, $0.getType(), ValueRange({$1, $2}))">;
@@ -852,7 +849,6 @@ def ClipConstProp : NamedPat<"ClipConstProp",
     // Clip constraints
     [(IsFromDenseONNXConstantOp:$input),
      (IsFromDenseONNXConstantOpOrNone:$min), (IsFromDenseONNXConstantOpOrNone:$max),
-     (SatisfiesMinLessThanMaxRequirement $input, $min, $max),
      (SatisfiesExpansionBound:$clipOp)]>;
 
 //===----------------------------------------------------------------------===//

--- a/test/accelerators/NNPA/backend/CMakeLists.txt
+++ b/test/accelerators/NNPA/backend/CMakeLists.txt
@@ -362,12 +362,12 @@ set(NNPA_TEST_LIST
     # ==LIM== Input tensor must be less than or equal to 4 dimensions.
 
     # Model
-    # test_densenet121_cpu  #  accurary error
-    #test_inception_v1_cpu,zdnn_conv2d
-    #test_resnet50_cpu,zdnn_conv2d
-    #test_shufflenet_cpu,zdnn_matmul_op_ext
-    #test_squeezenet_cpu,zdnn_conv
-    #test_vgg19_cpu,zdnn_conv
+    test_densenet121_cpu,zdnn_conv2d
+    test_inception_v1_cpu,zdnn_conv2d
+    test_resnet50_cpu,zdnn_conv2d
+    test_shufflenet_cpu,zdnn_matmul_op_ext
+    # test_squeezenet_cpu,zdnn_conv # got NaN results
+    test_vgg19_cpu,zdnn_conv
 )
 set(ENV_TEST_CASE_BY_USER "")
 foreach(test_name IN LISTS NNPA_TEST_LIST)
@@ -394,6 +394,9 @@ add_custom_target(check-onnx-backend-nnpa
   COMMAND
     TEST_INSTRUCTION_CHECK=true
     ONNX_HOME=${FILE_GENERATE_DIR}/check-onnx-backend-nnpa
+    # Needed for convolution models to avoid NaN outputs.
+    # Remove this if saturation is enabled by default.
+    TEST_COMPILE_ARGS="--nnpa-saturation=true"
     ${NNPA_TESTS_ENVS} ${BACKEND_TEST_COMMAND} ${BACKEND_TEST_ARGS} ${FILE_GENERATE_DIR}/test.py
   DEPENDS
     ${FILE_GENERATE_DIR}/test.py
@@ -405,6 +408,9 @@ add_custom_target(check-onnx-backend-dynamic-nnpa
     ONNX_HOME=${FILE_GENERATE_DIR}/check-onnx-backend-dynamic-nnpa
     TEST_INSTRUCTION_CHECK=true
     TEST_DYNAMIC=true
+    # Needed for convolution models to avoid NaN outputs.
+    # Remove this if saturation is enabled by default.
+    TEST_COMPILE_ARGS="--nnpa-saturation=true"
     ${NNPA_TESTS_ENVS_DYNAMIC} ${BACKEND_TEST_COMMAND} ${BACKEND_TEST_ARGS} ${FILE_GENERATE_DIR}/test.py
   DEPENDS
     ${FILE_GENERATE_DIR}/test.py
@@ -418,6 +424,9 @@ add_custom_target(check-onnx-backend-constant-nnpa
     # TEST_INSTRUCTION_CHECK=true
     ONNX_HOME=${FILE_GENERATE_DIR}/check-onnx-backend-constant-nnpa
     TEST_CONSTANT=true
+    # Needed for convolution models to avoid NaN outputs.
+    # Remove this if saturation is enabled by default.
+    TEST_COMPILE_ARGS="--nnpa-saturation=true" 
     ${NNPA_TESTS_ENVS} ${BACKEND_TEST_COMMAND} ${BACKEND_TEST_ARGS} ${FILE_GENERATE_DIR}/test.py
   DEPENDS
     ${FILE_GENERATE_DIR}/test.py
@@ -427,6 +436,9 @@ add_custom_target(check-onnx-backend-constant-nnpa
 add_custom_target(check-onnx-backend-compilerlib-nnpa
   COMMAND
     TEST_COMPILERLIB=true ONNX_HOME=${CMAKE_CURRENT_BINARY_DIR}
+    # Needed for convolution models to avoid NaN outputs.
+    # Remove this if saturation is enabled by default.
+    TEST_COMPILE_ARGS="--nnpa-saturation=true" 
     ${NNPA_TESTS_ENVS} ${BACKEND_TEST_COMMAND} ${BACKEND_TEST_ARGS} ${FILE_GENERATE_DIR}/test.py
   DEPENDS
     ${FILE_GENERATE_DIR}/test.py

--- a/test/backend/common.py
+++ b/test/backend/common.py
@@ -142,6 +142,13 @@ def compile_model(model, emit):
     command_list.append(model_name)
     command_list.append("-o=" + exec_base)
 
+    # Additional args passed in by TEST_COMPILE_ARGS
+    # Args are separated by ';'
+    additional_args = os.getenv("TEST_COMPILE_ARGS")
+    if additional_args is not None:
+        compile_args = additional_args.split(";")
+        command_list += compile_args
+
     # Call frontend to process model_name.onnx, bit code will be generated.
     dynamic_inputs_dims = determine_dynamic_parameters(name)
     if args.verbose:

--- a/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/compiler-stick-unstick.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/compiler-stick-unstick.mlir
@@ -1,0 +1,76 @@
+// RUN: onnx-mlir-opt --mcpu=z16 --maccel=NNPA --enable-compiler-stick-unstick=true --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
+
+func.func @should_lower_to_zlow(%arg0: tensor<1x3x5x7xf32>) -> tensor<*xf32> {
+  %0 = "zhigh.Stick"(%arg0) {layout = "NHWC"} : (tensor<1x3x5x7xf32>) -> tensor<*xf16>
+  %1 = "zhigh.Unstick"(%0) : (tensor<*xf16>) -> tensor<*xf32>
+  return %1 : tensor<*xf32>
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3 floordiv 64, d1, d2 floordiv 32, d2 mod 32, d3 mod 64)>
+// CHECK-LABEL:  func.func @should_lower_to_zlow
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<1x3x5x7xf32>) -> memref<1x3x5x7xf32> {
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<1x5x7x3xf16, #map>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x5x7x3xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:4 = krnl.define_loops 4
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5, [[LOOP_0_]]#3 -> [[I_3_:%.+]] = 0 to 7){
+// CHECK:             [[VAR_2_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_2_]]#2, [[VAR_2_]]#3] : memref<1x3x5x7xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_1_]]{{.}}[[VAR_2_]]#0, [[VAR_2_]]#2, [[VAR_2_]]#3, [[VAR_2_]]#1] : memref<1x5x7x3xf32>
+// CHECK:           }
+// CHECK:           "zlow.stick"([[RES_1_]], [[RES_]]) {layout = "NHWC"} : (memref<1x5x7x3xf32>, memref<1x5x7x3xf16, #map>) -> ()
+// CHECK:           [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<1x5x7x3xf32>
+// CHECK:           "zlow.unstick"([[RES_]], [[RES_]]_1) {layout = "NHWC"} : (memref<1x5x7x3xf16, #map>, memref<1x5x7x3xf32>) -> ()
+// CHECK-DAG:       [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<1x3x5x7xf32>
+// CHECK-DAG:       [[LOOP_1_:%.+]]:4 = krnl.define_loops 4
+// CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2, [[LOOP_1_]]#3) with ([[LOOP_1_]]#0 -> [[I_4_:%.+]] = 0 to 1, [[LOOP_1_]]#1 -> [[I_5_:%.+]] = 0 to 5, [[LOOP_1_]]#2 -> [[I_6_:%.+]] = 0 to 7, [[LOOP_1_]]#3 -> [[I_7_:%.+]] = 0 to 3){
+// CHECK:             [[VAR_2_1_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2, [[LOOP_1_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
+// CHECK:             [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_2_]]{{.}}[[VAR_2_1_]]#0, [[VAR_2_1_]]#1, [[VAR_2_1_]]#2, [[VAR_2_1_]]#3] : memref<1x5x7x3xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_1_]], [[RES_3_]]{{.}}[[VAR_2_1_]]#0, [[VAR_2_1_]]#3, [[VAR_2_1_]]#1, [[VAR_2_1_]]#2] : memref<1x3x5x7xf32>
+// CHECK:           }
+// CHECK:           return [[RES_3_]] : memref<1x3x5x7xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @should_lower_to_zlow_unknown_dims(%arg0: tensor<1x?x?x7xf32>) -> tensor<*xf32> {
+  %0 = "zhigh.Stick"(%arg0) {layout = "NHWC"} : (tensor<1x?x?x7xf32>) -> tensor<*xf16>
+  %1 = "zhigh.Unstick"(%0) : (tensor<*xf16>) -> tensor<*xf32>
+  return %1 : tensor<*xf32>
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3 floordiv 64, d1, d2 floordiv 32, d2 mod 32, d3 mod 64)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1) -> (d1)>
+// CHECK-LABEL:  func.func @should_lower_to_zlow_unknown_dims
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<1x?x?x7xf32>) -> memref<1x?x?x7xf32> {
+// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_dim_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<1x?x?x7xf32>
+// CHECK-DAG:       [[VAR_dim_0_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<1x?x?x7xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc([[VAR_dim_0_]], [[VAR_dim_]]) {{.*}}: memref<1x?x7x?xf16, #map>
+// CHECK-DAG:       [[VAR_dim_1_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<1x?x?x7xf32>
+// CHECK-DAG:       [[VAR_dim_2_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<1x?x?x7xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc([[VAR_dim_1_]], [[VAR_dim_2_]]) {{.*}}: memref<1x?x7x?xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:4 = krnl.define_loops 4
+// CHECK-DAG:       [[VAR_dim_4_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<1x?x?x7xf32>
+// CHECK-DAG:       [[VAR_dim_5_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<1x?x?x7xf32>
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to [[MAP_1_]]([[VAR_dim_4_]]), [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to [[MAP_2_]]([[VAR_dim_4_]], [[VAR_dim_5_]]), [[LOOP_0_]]#3 -> [[I_3_:%.+]] = 0 to 7){
+// CHECK:             [[VAR_2_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_2_]]#2, [[VAR_2_]]#3] : memref<1x?x?x7xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_1_]]{{.}}[[VAR_2_]]#0, [[VAR_2_]]#2, [[VAR_2_]]#3, [[VAR_2_]]#1] : memref<1x?x7x?xf32>
+// CHECK:           }
+// CHECK:           "zlow.stick"([[RES_1_]], [[RES_]]) {layout = "NHWC"} : (memref<1x?x7x?xf32>, memref<1x?x7x?xf16, #map>) -> ()
+// CHECK:           [[RES_2_:%.+]] = memref.alloc([[VAR_dim_0_]], [[VAR_dim_]]) {{.*}}: memref<1x?x7x?xf32>
+// CHECK:           "zlow.unstick"([[RES_]], [[RES_]]_6) {layout = "NHWC"} : (memref<1x?x7x?xf16, #map>, memref<1x?x7x?xf32>) -> ()
+// CHECK-DAG:       [[RES_3_:%.+]] = memref.alloc([[VAR_dim_]], [[VAR_dim_]]_0) {{.*}}: memref<1x?x?x7xf32>
+// CHECK-DAG:       [[LOOP_1_:%.+]]:4 = krnl.define_loops 4
+// CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2, [[LOOP_1_]]#3) with ([[LOOP_1_]]#0 -> [[I_4_:%.+]] = 0 to 1, [[LOOP_1_]]#1 -> [[I_5_:%.+]] = 0 to [[MAP_1_]]([[VAR_dim_0_]]), [[LOOP_1_]]#2 -> [[I_6_:%.+]] = 0 to 7, [[LOOP_1_]]#3 -> [[I_7_:%.+]] = 0 to [[MAP_2_]]([[VAR_dim_0_]], [[VAR_dim_]])){
+// CHECK:             [[VAR_2_1_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2, [[LOOP_1_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
+// CHECK:             [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_2_]]{{.}}[[VAR_2_1_]]#0, [[VAR_2_1_]]#1, [[VAR_2_1_]]#2, [[VAR_2_1_]]#3] : memref<1x?x7x?xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_1_]], [[RES_3_]]{{.}}[[VAR_2_1_]]#0, [[VAR_2_1_]]#3, [[VAR_2_1_]]#1, [[VAR_2_1_]]#2] : memref<1x?x?x7xf32>
+// CHECK:           }
+// CHECK:           return [[RES_3_]] : memref<1x?x?x7xf32>
+// CHECK:         }
+}

--- a/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/stick-unstick.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/stick-unstick.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --mcpu=z16 --maccel=NNPA --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --mcpu=z16 --maccel=NNPA --enable-compiler-stick-unstick=false --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
 
 func.func @should_lower_to_zlow(%arg0: tensor<1x3x5x7xf32>) -> tensor<*xf32> {
   %0 = "zhigh.Stick"(%arg0) {layout = "NHWC"} : (tensor<1x3x5x7xf32>) -> tensor<*xf16>

--- a/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/test-datalayout.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/test-datalayout.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --mcpu=z16 --maccel=NNPA --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --mcpu=z16 --maccel=NNPA --enable-compiler-stick-unstick=false --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
 
 func.func @should_lower_to_zlow_1d(%arg0: tensor<7xf32>) -> tensor<*xf16> {
   %0 = "zhigh.Stick"(%arg0) {layout = "1D"} : (tensor<7xf32>) -> tensor<*xf16>

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -591,30 +591,6 @@ func.func @test_clip_no_max() -> tensor<3x2xbf16> {
   // CHECK-NOT: {{.*}} = "onnx.Clip"
 }
 
-// CHECK-LABEL:  func @test_clip_multiple_min
-func.func @test_clip_multiple_min() -> tensor<3x2xbf16> {
-  // Test Positive Clamped, Negative Clamped, In range, NaN, -Inf,  +Inf
-  %cst = onnx.Constant dense<[[2.125, -2.125], [0.0, 0x7FC0], [0xFF80, 0x7F80]]> : tensor<3x2xbf16>
-  %min = onnx.Constant dense<[[5.000, 2.000], [-1.0, 0.0], [0.0, 0.125]]> : tensor<3x2xbf16>
-  %max = onnx.Constant {value = dense<[10.0]> : tensor<1xbf16>} : tensor<1xbf16>
-  %0 = "onnx.Clip"(%cst, %min, %max) : (tensor<3x2xbf16>, tensor<3x2xbf16>, tensor<1xbf16>) -> tensor<3x2xbf16>
-  return %0 : tensor<3x2xbf16>
-  // CHECK: {{.*}} = onnx.Constant dense<{{.}}[5.000000e+00, 2.000000e+00], [0.000000e+00, 0x7FC0], [0.000000e+00, 1.000000e+01]]>
-  // CHECK-NOT: {{.*}} = "onnx.Clip"
-}
-
-// CHECK-LABEL:  func @test_clip_multiple_max
-func.func @test_clip_multiple_max() -> tensor<3x2xbf16> {
-  // Test Positive Clamped, Negative Clamped, In range, NaN, -Inf,  +Inf
-  %cst = onnx.Constant dense<[[2.125, -2.125], [0.0, 0x7FC0], [0xFF80, 0x7F80]]> : tensor<3x2xbf16>
-  %min = onnx.Constant {value = dense<-2.0> : tensor<bf16>} : tensor<bf16>
-  %max = onnx.Constant dense<[[5.000, 2.000], [-1.0, 0.0], [0.0, 0.125]]> : tensor<3x2xbf16>
-  %0 = "onnx.Clip"(%cst, %min, %max) : (tensor<3x2xbf16>, tensor<bf16>, tensor<3x2xbf16>) -> tensor<3x2xbf16>
-  return %0 : tensor<3x2xbf16>
-  // CHECK: {{.*}} = onnx.Constant dense<{{.}}[2.125000e+00, -2.000000e+00], [-1.000000e+00, 0x7FC0], [-2.000000e+00, 1.250000e-01]]>
-  // CHECK-NOT: {{.*}} = "onnx.Clip"
-}
-
 // CHECK-LABEL:  func @test_clip_no_min_no_max
 func.func @test_clip_no_min_no_max() -> tensor<3x2xbf16> {
   // Test Positive Clamped, Negative Clamped, In range, NaN, -Inf,  +Inf

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -318,6 +318,120 @@ func.func @test_neg_3(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
   // CHECK-NEXT: [[ADD1:%.+]] = "onnx.Add"(%arg0, [[CONST1]]) : (tensor<3x2xi32>, tensor<3x2xi32>) -> tensor<3x2xi32>
 }
 
+// -----
+
+// CHECK-LABEL: @test_ceil() -> tensor<3x2xbf16>
+func.func @test_ceil() -> tensor<3x2xbf16> {
+  // Test Positive, Negative, Zero, NaN, +Inf, -Inf
+  %0 = onnx.Constant dense<[[12.2, -12.2], [0.0, 0x7FC0], [0x7F80, 0xFF80]]> : tensor<3x2xbf16>
+  %1 = "onnx.Ceil"(%0) : (tensor<3x2xbf16>) -> tensor<3x2xbf16>
+  "onnx.Return"(%1) : (tensor<3x2xbf16>) -> ()
+  // CHECK: onnx.Constant dense<{{.}}[1.300000e+01, -1.200000e+01], [0.000000e+00, 0x7FC0], [0x7F80, 0xFF80]]>
+  // CHECK-NOT: "onnx.Ceil"
+}
+
+// -----
+
+// CHECK-LABEL: @test_cos() -> tensor<3x2xf32>
+func.func @test_cos() -> tensor<3x2xf32> {
+  // Test Positive, Negative, Zero, NaN, +Inf, -Inf
+  // Results: Positive, Positive, One, NaN, +/-NaN, +/-NaN
+  // Note: Implementations of cos can output either NaN and -NaN for +/-Inf numbers.
+  %0 = onnx.Constant dense<[[0.625, -0.625], [0.0, 0x7FC00000], [0x7F800000, 0xFF800000]]> : tensor<3x2xf32>
+  %1 = "onnx.Cos"(%0) : (tensor<3x2xf32>) -> tensor<3x2xf32>
+  "onnx.Return"(%1) : (tensor<3x2xf32>) -> ()
+  // CHECK: onnx.Constant dense<{{.}}[0.810963094, 0.810963094], [1.000000e+00, 0x7FC00000], [0x{{F|7}}FC00000, 0x{{F|7}}FC00000]]>
+  // CHECK-NOT: "onnx.Cos"
+}
+
+// -----
+
+// CHECK-LABEL: @test_erf() -> tensor<3x2xbf16>
+func.func @test_erf() -> tensor<3x2xbf16> {
+  // Test Positive, Negative, Zero, NaN, +Inf, -Inf
+  %0 = onnx.Constant dense<[[0.0625, -1.0], [0.0, 0x7FC0], [0x7F80, 0xFF80]]> : tensor<3x2xbf16>
+  %1 = "onnx.Erf"(%0) : (tensor<3x2xbf16>) -> tensor<3x2xbf16>
+  "onnx.Return"(%1) : (tensor<3x2xbf16>) -> ()
+  // CHECK: onnx.Constant dense<{{.}}[7.031250e-02, -8.437500e-01], [0.000000e+00, 0x7FC0], [1.000000e+00, -1.000000e+00]]>
+  // CHECK-NOT: "onnx.Erf"
+}
+
+// -----
+
+// CHECK-LABEL: @test_exp() -> tensor<3x2xbf16>
+func.func @test_exp() -> tensor<3x2xbf16> {
+  // Test Positive, Negative, Zero, NaN, +Inf, -Inf
+  %0 = onnx.Constant dense<[[0.0625, -1.0], [0.0, 0x7FC0], [0x7F80, 0xFF80]]> : tensor<3x2xbf16>
+  %1 = "onnx.Exp"(%0) : (tensor<3x2xbf16>) -> tensor<3x2xbf16>
+  "onnx.Return"(%1) : (tensor<3x2xbf16>) -> ()
+  // CHECK: onnx.Constant dense<{{.}}[1.062500e+00, 3.671880e-01], [1.000000e+00, 0x7FC0], [0x7F80, 0.000000e+00]]>
+  // CHECK-NOT: "onnx.Exp"
+}
+
+// -----
+
+// CHECK-LABEL: @test_floor() -> tensor<3x2xbf16>
+func.func @test_floor() -> tensor<3x2xbf16> {
+  // Test Positive, Negative, Zero, NaN, +Inf, -Inf 
+  %0 = onnx.Constant dense<[[12.2, -12.2], [0.0, 0x7FC0], [0x7F80, 0xFF80]]> : tensor<3x2xbf16>
+  %1 = "onnx.Floor"(%0) : (tensor<3x2xbf16>) -> tensor<3x2xbf16>
+  "onnx.Return"(%1) : (tensor<3x2xbf16>) -> ()
+  // CHECK: onnx.Constant dense<{{.}}[1.200000e+01, -1.300000e+01], [0.000000e+00, 0x7FC0], [0x7F80, 0xFF80]]>
+  // CHECK-NOT: "onnx.Floor"
+}
+
+// -----
+
+// CHECK-LABEL: @test_log() -> tensor<3x2xbf16>
+func.func @test_log() -> tensor<3x2xbf16> {
+  // Test Positive, Negative, Zero, NaN, +Inf, -Inf
+  %0 = onnx.Constant dense<[[0.0625, -1.0], [0.0, 0x7FC0], [0x7F80, 0xFF80]]> : tensor<3x2xbf16>
+  %1 = "onnx.Log"(%0) : (tensor<3x2xbf16>) -> tensor<3x2xbf16>
+  "onnx.Return"(%1) : (tensor<3x2xbf16>) -> ()
+  // Note: Implementations of log can output either NaN and -NaN for negative and -Inf numbers.
+  // CHECK: onnx.Constant dense<{{.}}[-2.765630e+00, 0x{{F|7}}FC0], [0xFF80, 0x7FC0], [0x7F80, 0x{{F|7}}FC0]]>
+  // CHECK-NOT: "onnx.Log"
+}
+
+// -----
+
+// CHECK-LABEL: @test_not() -> tensor<2xi1>
+func.func @test_not() -> tensor<2xi1> {
+  // Test Positive, Negative, Zero, NaN, +Inf, -Inf
+  %0 = onnx.Constant dense<[false, true]> : tensor<2xi1>
+  %1 = "onnx.Not"(%0) : (tensor<2xi1>) -> tensor<2xi1>
+  "onnx.Return"(%1) : (tensor<2xi1>) -> ()
+  // CHECK: onnx.Constant dense<[true, false]>
+  // CHECK-NOT: "onnx.Not"
+}
+
+// -----
+
+// CHECK-LABEL: @test_reciprocal() -> tensor<3x2xbf16>
+func.func @test_reciprocal() -> tensor<3x2xbf16> {
+  // Test Positive, Negative, Zero, NaN, +Inf, -Inf
+  // Results: Positive, Positive, One, NaN, -NaN, -NaN
+  %0 = onnx.Constant dense<[[0.25, -0.25], [0.0, 0x7FC0], [0x7F80, 0xFF80]]> : tensor<3x2xbf16>
+  %1 = "onnx.Reciprocal"(%0) : (tensor<3x2xbf16>) -> tensor<3x2xbf16>
+  "onnx.Return"(%1) : (tensor<3x2xbf16>) -> ()
+  // CHECK: onnx.Constant dense<{{.}}[4.000000e+00, -4.000000e+00], [0x7F80, 0x7FC0], [0.000000e+00, -0.000000e+00]]>
+  // CHECK-NOT: "onnx.Reciprocal"
+}
+
+// -----
+
+// CHECK-LABEL: @test_sin() -> tensor<3x2xf32>
+func.func @test_sin() -> tensor<3x2xf32> {
+  // Test Positive, Negative, Zero, NaN, +Inf, -Inf
+  // Results: Positive, Positive, One, NaN, +/-NaN, +/-NaN
+  // Note: Implementations of sin can output either NaN and -NaN for +/-Inf numbers.
+  %0 = onnx.Constant dense<[[0.625, -0.625], [0.0, 0x7FC00000], [0x7F800000, 0xFF800000]]> : tensor<3x2xf32>
+  %1 = "onnx.Sin"(%0) : (tensor<3x2xf32>) -> tensor<3x2xf32>
+  "onnx.Return"(%1) : (tensor<3x2xf32>) -> ()
+  // CHECK: onnx.Constant dense<{{.}}[0.585097253, -0.585097253], [0.000000e+00, 0x7FC00000], [0x{{F|7}}FC00000, 0x{{F|7}}FC00000]]>
+  // CHECK-NOT: "onnx.Sin"
+}
+
 //===----------------------------------------------------------------------===//
 /// Transpose tests.
 
@@ -377,6 +491,233 @@ func.func @test_div_ones(%arg0 : tensor<1x2xui8>) -> tensor<1x2xui8> {
   %1 = "onnx.Div"(%arg0, %0) : (tensor<1x2xui8> , tensor<1x2xui8>) -> tensor<1x2xui8>
   onnx.Return %1 : tensor<1x2xui8>
   // CHECK: onnx.Return %arg0 : tensor<1x2xui8>
+}
+
+// -----
+
+// CHECK-LABEL: test_div_by_zero()
+func.func @test_div_by_zero() -> tensor<2xui32> {
+  %0 = onnx.Constant dense<[2, 4]> : tensor<2xui32>
+  %1 = onnx.Constant dense<[0]> : tensor<1xui32>
+  %2 = "onnx.Div"(%0, %1) : (tensor<2xui32>, tensor<1xui32>) -> tensor<2xui32>
+  "onnx.Return"(%2) : (tensor<2xui32>) -> ()
+  // The behavior is undefined, so the value don't matter. Just don't crash.
+  // CHECK-NOT: {{.*}} = "onnx.Div"{{.*}}
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Clip's test
+
+func.func @test_clip_max_and_min() -> tensor<3x2xbf16> {
+  // Test Positive Clamped, Negative Clamped, In range, NaN, -Inf,  +Inf
+  %cst = onnx.Constant dense<[[2.125, -2.125], [0.0, 0x7FC0], [0xFF80, 0x7F80]]> : tensor<3x2xbf16>
+  %min = onnx.Constant {value = dense<-2.0> : tensor<bf16>} : tensor<bf16>
+  %max = onnx.Constant {value = dense<2.0> : tensor<bf16>} : tensor<bf16>
+  %0 = "onnx.Clip"(%cst, %min, %max) : (tensor<3x2xbf16>, tensor<bf16>, tensor<bf16>) -> tensor<3x2xbf16>
+  return %0 : tensor<3x2xbf16>
+// CHECK-LABEL:  func @test_clip_max_and_min
+  // CHECK: {{.*}} = onnx.Constant dense<{{.}}[2.000000e+00, -2.000000e+00], [0.000000e+00, 0x7FC0], [-2.000000e+00, 2.000000e+00]]>
+  // CHECK-NOT: {{.*}} = "onnx.Clip"
+}
+
+// CHECK-LABEL:  func @test_clip_no_min
+func.func @test_clip_no_min() -> tensor<3x2xbf16> {
+  // Test Positive Clamped, Negative Clamped, In range, NaN, -Inf,  +Inf
+  %cst = onnx.Constant dense<[[2.1, -2.125], [0.0, 0x7FC0], [0xFF80, 0x7F80]]> : tensor<3x2xbf16>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %max = onnx.Constant {value = dense<2.0> : tensor<bf16>} : tensor<bf16>
+  %0 = "onnx.Clip"(%cst, %none, %max) : (tensor<3x2xbf16>, none, tensor<bf16>) -> tensor<3x2xbf16>
+  return %0 : tensor<3x2xbf16>
+  // CHECK: {{.*}} = onnx.Constant dense<{{.}}[2.000000e+00, -2.125000e+00], [0.000000e+00, 0x7FC0], [-3.389530e+38, 2.000000e+00]]>
+  // CHECK-NOT: {{.*}} = "onnx.Clip"
+}
+
+// CHECK-LABEL:  func @test_clip_no_max
+func.func @test_clip_no_max() -> tensor<3x2xbf16> {
+  // Test Positive Clamped, Negative Clamped, In range, NaN, -Inf,  +Inf
+  %cst = onnx.Constant dense<[[2.125, -2.125], [0.0, 0x7FC0], [0xFF80, 0x7F80]]> : tensor<3x2xbf16>
+  %min = onnx.Constant {value = dense<-2.0> : tensor<bf16>} : tensor<bf16>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.Clip"(%cst, %min, %none) : (tensor<3x2xbf16>, tensor<bf16>, none) -> tensor<3x2xbf16>
+  return %0 : tensor<3x2xbf16>
+  // CHECK: {{.*}} = onnx.Constant dense<{{.}}[2.125000e+00, -2.000000e+00], [0.000000e+00, 0x7FC0], [-2.000000e+00, 3.389530e+38]]>
+  // CHECK-NOT: {{.*}} = "onnx.Clip"
+}
+
+// CHECK-LABEL:  func @test_clip_no_min_no_max
+func.func @test_clip_no_min_no_max() -> tensor<3x2xbf16> {
+  // Test Positive Clamped, Negative Clamped, In range, NaN, -Inf,  +Inf
+  %cst = onnx.Constant dense<[[2.125, -2.125], [0.0, 0x7FC0], [0xFF80, 0x7F80]]> : tensor<3x2xbf16>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.Clip"(%cst, %none, %none) : (tensor<3x2xbf16>, none, none) -> tensor<3x2xbf16>
+  return %0 : tensor<3x2xbf16>
+  // CHECK: {{.*}} = onnx.Constant dense<{{.}}[2.125000e+00, -2.125000e+00], [0.000000e+00, 0x7FC0], [-3.389530e+38, 3.389530e+38]]>
+  // CHECK-NOT: {{.*}} = "onnx.Clip"
+}
+
+// ONNX Specification does define what happens when min > max.
+// Use numpy's specification as discussed in https://github.com/onnx/onnx/issues/6165
+
+// CHECK-LABEL:  func @test_clip_min_greater_than_max1
+func.func @test_clip_min_greater_than_max1() -> tensor<3x2xbf16> {
+  %cst = onnx.Constant dense<[[2.125, -2.125], [0.0, 0x7FC0], [0xFF80, 0x7F80]]> : tensor<3x2xbf16>
+  %min = onnx.Constant {value = dense<8.0> : tensor<bf16>} : tensor<bf16>
+  %max = onnx.Constant {value = dense<1.0> : tensor<bf16>} : tensor<bf16>
+  %0 = "onnx.Clip"(%cst, %min, %max) : (tensor<3x2xbf16>, tensor<bf16>, tensor<bf16>) -> tensor<3x2xbf16>
+  return %0 : tensor<3x2xbf16>
+  // CHECK: {{.*}} = onnx.Constant dense<{{.}}[1.000000e+00, 1.000000e+00], [1.000000e+00, 0x7FC0], [1.000000e+00, 1.000000e+00]]>
+  // CHECK-NOT: {{.*}} = "onnx.Clip"
+}
+
+// CHECK-LABEL:  func @test_clip_min_greater_than_max2
+func.func @test_clip_min_greater_than_max2() -> tensor<3x2xi32> {
+  %cst = onnx.Constant dense<[[0, 1], [2, 3], [4, 5]]> : tensor<3x2xi32>
+  %min = onnx.Constant {value = dense<8> : tensor<i32>} : tensor<i32>
+  %max = onnx.Constant {value = dense<1> : tensor<i32>} : tensor<i32>
+  %0 = "onnx.Clip"(%cst, %min, %max) : (tensor<3x2xi32>, tensor<i32>, tensor<i32>) -> tensor<3x2xi32>
+  return %0 : tensor<3x2xi32>
+  // CHECK: {{.*}} = onnx.Constant dense<1>
+  // CHECK-NOT: {{.*}} = "onnx.Clip"
+}
+
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Bitwise's test
+
+// CHECK-LABEL: @test_bitwise_not() -> tensor<4xi32>
+func.func @test_bitwise_not() -> tensor<4xi32> {
+  %0 = onnx.Constant dense<[0, 0xFFFFFFFF, 0xFFFFFFFE, 0x000000FF]> : tensor<4xi32>
+  %1 = "onnx.BitwiseNot"(%0) : (tensor<4xi32>) -> tensor<4xi32>
+  "onnx.Return"(%1) : (tensor<4xi32>) -> ()
+  // CHECK: onnx.Constant dense<[-1, 0, 1, -256]>
+  // CHECK-NOT: "onnx.BitwiseNot"
+}
+
+// -----
+
+// CHECK-LABEL: @test_bitwise_and() -> tensor<3xi32>
+func.func @test_bitwise_and() -> tensor<3xi32> {
+  %0 = onnx.Constant dense<[0xFFFFFFFE, 0xFFFF0000, 256]> : tensor<3xi32>
+  %1 = onnx.Constant dense<0xFFFFFFFF> : tensor<i32>
+  %2 = "onnx.BitwiseAnd"(%0, %1) : (tensor<3xi32>, tensor<i32>) -> tensor<3xi32>
+  "onnx.Return"(%2) : (tensor<3xi32>) -> ()
+  // CHECK: onnx.Constant dense<[-2, -65536, 256]>
+  // CHECK-NOT: "onnx.BitwiseAnd"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_bitwise_and() -> tensor<3xi32>
+func.func @test_bitwise_and() -> tensor<3xi32> {
+  %0 = onnx.Constant dense<[-2, 15, 0x0000FFFF]> : tensor<3xi32>
+  %1 = onnx.Constant dense<[0xFFFFFFFF]> : tensor<1xi32>
+  %2 = "onnx.BitwiseAnd"(%0, %1) : (tensor<3xi32>, tensor<1xi32>) -> tensor<3xi32>
+  "onnx.Return"(%2) : (tensor<3xi32>) -> ()
+  // CHECK: onnx.Constant dense<[-2, 15, 65535]>
+  // CHECK-NOT: "onnx.BitwiseAnd"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_bitwise_and() -> tensor<3xi32>
+func.func @test_bitwise_and() -> tensor<3xi32> {
+  %0 = onnx.Constant dense<[0xFFFFFFFE, 15, 255]> : tensor<3xi32>
+  %1 = onnx.Constant dense<[0xFFFFFFFF, 0xFFFFFFF0, 0x0000000F]> : tensor<3xi32>
+  %2 = "onnx.BitwiseAnd"(%0, %1) : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi32>
+  "onnx.Return"(%2) : (tensor<3xi32>) -> ()
+  // CHECK: onnx.Constant dense<[-2, 0, 15]>
+  // CHECK-NOT: "onnx.BitwiseAnd"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_bitwise_or() -> tensor<3xi32>
+func.func @test_bitwise_or() -> tensor<3xi32> {
+  %0 = onnx.Constant dense<[0xFFFFFFFE, 0xFFFFFFF0, 0xFFFFFF00]> : tensor<3xi32>
+  %1 = onnx.Constant dense<[0xFFFFFFF1, 1, 2]> : tensor<3xi32>
+  %2 = "onnx.BitwiseOr"(%0, %1) : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi32>
+  "onnx.Return"(%2) : (tensor<3xi32>) -> ()
+  // CHECK: onnx.Constant dense<[-1, -15, -254]>
+  // CHECK-NOT: "onnx.BitwiseOr"{{.*}}
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Bitwise's test
+
+// CHECK-LABEL: @test_and() -> tensor<3xi1>
+func.func @test_and() -> tensor<3xi1> {
+  %0 = onnx.Constant dense<[true, true, false]> : tensor<3xi1>
+  %1 = onnx.Constant dense<true> : tensor<i1>
+  %2 = "onnx.And"(%0, %1) : (tensor<3xi1>, tensor<i1>) -> tensor<3xi1>
+  "onnx.Return"(%2) : (tensor<3xi1>) -> ()
+  // CHECK: onnx.Constant dense<[true, true, false]>
+  // CHECK-NOT: "onnx.And"{{.*}}
+}
+
+// CHECK-LABEL: @test_and2() -> tensor<3xi1>
+func.func @test_and2() -> tensor<3xi1> {
+  %0 = onnx.Constant dense<[true, true, false]> : tensor<3xi1>
+  %1 = onnx.Constant dense<[false, true, false]> : tensor<3xi1>
+  %2 = "onnx.And"(%0, %1) : (tensor<3xi1>, tensor<3xi1>) -> tensor<3xi1>
+  "onnx.Return"(%2) : (tensor<3xi1>) -> ()
+  // CHECK: onnx.Constant dense<[false, true, false]>
+  // CHECK-NOT: "onnx.And"{{.*}}
+}
+
+// CHECK-LABEL: @test_and3() -> tensor<3xi1>
+func.func @test_and3() -> tensor<3xi1> {
+  %0 = onnx.Constant dense<[true, true, false]> : tensor<3xi1>
+  %1 = onnx.Constant dense<false> : tensor<i1>
+  %2 = "onnx.And"(%0, %1) : (tensor<3xi1>, tensor<i1>) -> tensor<3xi1>
+  "onnx.Return"(%2) : (tensor<3xi1>) -> ()
+  // CHECK: onnx.Constant dense<false>
+  // CHECK-NOT: "onnx.And"{{.*}}
+}
+
+// CHECK-LABEL: @test_or() -> tensor<3xi1>
+func.func @test_or() -> tensor<3xi1> {
+  %0 = onnx.Constant dense<[true, true, false]> : tensor<3xi1>
+  %1 = onnx.Constant dense<true> : tensor<i1>
+  %2 = "onnx.Or"(%0, %1) : (tensor<3xi1>, tensor<i1>) -> tensor<3xi1>
+  "onnx.Return"(%2) : (tensor<3xi1>) -> ()
+  // CHECK: onnx.Constant dense<true>
+  // CHECK-NOT: "onnx.Or"{{.*}}
+}
+
+// CHECK-LABEL: @test_or2() -> tensor<3xi1>
+func.func @test_or2() -> tensor<3xi1> {
+  %0 = onnx.Constant dense<[true, true, false]> : tensor<3xi1>
+  %1 = onnx.Constant dense<[false, true, false]> : tensor<3xi1>
+  %2 = "onnx.Or"(%0, %1) : (tensor<3xi1>, tensor<3xi1>) -> tensor<3xi1>
+  "onnx.Return"(%2) : (tensor<3xi1>) -> ()
+  // CHECK: onnx.Constant dense<[true, true, false]>
+  // CHECK-NOT: "onnx.Or"{{.*}}
+}
+
+// CHECK-LABEL: @test_xor() -> tensor<3xi1>
+func.func @test_xor() -> tensor<3xi1> {
+  %0 = onnx.Constant dense<[true, true, false]> : tensor<3xi1>
+  %1 = onnx.Constant dense<true> : tensor<i1>
+  %2 = "onnx.Xor"(%0, %1) : (tensor<3xi1>, tensor<i1>) -> tensor<3xi1>
+  "onnx.Return"(%2) : (tensor<3xi1>) -> ()
+  // CHECK: onnx.Constant dense<[false, false, true]>
+  // CHECK-NOT: "onnx.Xor"{{.*}}
+}
+
+// CHECK-LABEL: @test_xor2() -> tensor<3xi1>
+func.func @test_xor2() -> tensor<3xi1> {
+  %0 = onnx.Constant dense<[true, true, false]> : tensor<3xi1>
+  %1 = onnx.Constant dense<[false, true, false]> : tensor<3xi1>
+  %2 = "onnx.Xor"(%0, %1) : (tensor<3xi1>, tensor<3xi1>) -> tensor<3xi1>
+  "onnx.Return"(%2) : (tensor<3xi1>) -> ()
+  // CHECK: onnx.Constant dense<[true, false, false]>
+  // CHECK-NOT: "onnx.Xor"{{.*}}
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This bump PR overrides the behavior of `ClipConstProp` from this fork and uses the one from upstream commit f11a21c6cb3777e435beb596744363655b0da9ae.

Could you please advise on whether this override is right?