### PR TITLE
feat: support disposable dense attribute representations for constants in allowzero reshape canonicalization.

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -329,7 +329,15 @@ bool isConstantOpWithNoZeroElements(Value constVal) {
     return false;
 
   ONNXConstantOp constOp = constVal.getDefiningOp<ONNXConstantOp>();
-  auto intElemsAttr = cast<mlir::DenseIntElementsAttr>(constOp.getValueAttr());
+  DenseElementsAttr intElemsAttr;
+  if (auto elms =
+          dyn_cast<mlir::DenseIntElementsAttr>(constOp.getValueAttr())) {
+    intElemsAttr = elms;
+  } else if (auto elms = dyn_cast<mlir::DisposableElementsAttr>(
+                 constOp.getValueAttr())) {
+    intElemsAttr = dyn_cast_or_null<mlir::DenseIntElementsAttr>(
+        elms.toDenseElementsAttr());
+  }
   if (!intElemsAttr)
     return false;
 


### PR DESCRIPTION
This is also needed for models to work properly. It seems like that we come from ONNX models, and the constant is marked as `initializer` the storage becomes `DisposableDense` (internal representation in onnx-mlir). So we also need to make sure that this is supported by the canonicalization.
Too bad I couldn't figure out how to write a test for this. 😢 . I'll try in another PR.