### PR TITLE
Ensure that constant propagation patterns that rely on types having static shapes are only run if the types have a static shape

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -187,6 +187,7 @@ ElementsAttr ElementsAttrBuilder::fromWideNums(
 //       demonstrates a speedup.
 ElementsAttr ElementsAttrBuilder::combine(ElementsAttr lhs, ElementsAttr rhs,
     ShapedType combinedType, WideNum (*combiner)(WideNum, WideNum)) {
+  assert(combinedType.hasStaticShape());
   if (lhs.isSplat()) {
     WideNum lhsNum = getElementsSplatWideNum(lhs);
     return expandAndTransform(rhs, combinedType,
@@ -227,6 +228,7 @@ ElementsAttr ElementsAttrBuilder::combine(ElementsAttr lhs, ElementsAttr rhs,
 
 ElementsAttr ElementsAttrBuilder::where(ElementsAttr cond, ElementsAttr lhs,
     ElementsAttr rhs, ShapedType combinedType) {
+  assert(combinedType.hasStaticShape());
   assert(cond.getElementType().isInteger(1));
   assert(lhs.getElementType() == rhs.getElementType());
   assert(lhs.getElementType() == combinedType.getElementType());

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -894,6 +894,7 @@ Value ConstPropTranspose(
 
 Value ConstPropUnsqueeze(
     PatternRewriter &rewriter, Value replacingValue, Value input) {
+  assert(llvm::cast<ShapedType>(replacingValue.getType()).hasStaticShape());
   ArrayRef<int64_t> reshapedShape = getShape(replacingValue.getType());
   ElementsAttr reshapedElements =
       ConstPropReshapeImpl(rewriter, replacingValue, input, reshapedShape);
@@ -906,6 +907,7 @@ Value ConstPropUnsqueeze(
 
 Value ConstPropSqueeze(
     PatternRewriter &rewriter, Value replacingValue, Value input) {
+  assert(llvm::cast<ShapedType>(replacingValue.getType()).hasStaticShape());
   ArrayRef<int64_t> reshapedShape = getShape(replacingValue.getType());
   ElementsAttr reshapedElements =
       ConstPropReshapeImpl(rewriter, replacingValue, input, reshapedShape);
@@ -1069,6 +1071,7 @@ Value ConstPropGather(PatternRewriter &rewriter, Value replacingValue,
 
 Value ConstPropReshape(
     PatternRewriter &rewriter, Value replacingValue, Value constValue) {
+  assert(llvm::cast<ShapedType>(replacingValue.getType()).hasStaticShape());
   ArrayRef<int64_t> reshapedShape = getShape(replacingValue.getType());
   ElementsAttr reshapedElements =
       ConstPropReshapeImpl(rewriter, replacingValue, constValue, reshapedShape);

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -71,6 +71,11 @@ def HasStaticShape: Constraint<CPred<
   "A value has static shape"
 >;
 
+def IsRankedShapedType: Constraint<CPred<
+  "isRankedShapedType($_self.getType())">,
+  "A value has a rank"
+>;
+
 def HasIntegerElementType: Constraint<CPred<
   "isa<IntegerType>(getElementType($_self.getType()))">,
   "A value has integer element type"
@@ -368,7 +373,7 @@ def AddConstProp : NamedPat<"AddConstProp",
     (CreateAddOfTwoConst $addOp, $lhs, $rhs),
     // Additional constraints (dense)
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$addOp)]>;
+     (SatisfiesExpansionBound:$addOp), (HasStaticShape:$addOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
 def AddZerosOnRhs : NamedPat<"AddZerosOnRhs",
@@ -393,7 +398,7 @@ def SubConstProp : NamedPat<"SubConstProp",
     // To c1-c2
     (CreateSubOfTwoConst $subOp, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$subOp)]>;
+     (SatisfiesExpansionBound:$subOp), (HasStaticShape:$subOp)]>;
 
 // TODO: Expand $a to $result's shape instead of requiring ValuesHaveSameType.
 def SubZerosOnRhs : NamedPat<"SubZerosOnRhs",
@@ -561,7 +566,7 @@ def MaxConstProp : NamedPat<"MaxConstProp",
     (CreateMaxOfConst $maxOp, $operandList),
     // Constraints
     [(IsVariadicOperandDenseONNXConstantOp:$operandList),
-     (SatisfiesExpansionBound:$maxOp)]>;
+     (SatisfiesExpansionBound:$maxOp), (HasStaticShape:$maxOp)]>;
 
 // Constant Propagation for Min
 def MinConstProp : NamedPat<"MinConstProp",
@@ -571,7 +576,7 @@ def MinConstProp : NamedPat<"MinConstProp",
     (CreateMinOfConst $minOp, $operandList),
     // Constraints
     [(IsVariadicOperandDenseONNXConstantOp:$operandList),
-     (SatisfiesExpansionBound:$minOp)]>;
+     (SatisfiesExpansionBound:$minOp), (HasStaticShape:$minOp)]>;
 
 // Constant Propagation for Sum
 def SumConstProp : NamedPat<"SumConstProp",
@@ -581,7 +586,7 @@ def SumConstProp : NamedPat<"SumConstProp",
     (CreateSumOfConst $sumOp, $operandList),
     // Constraints
     [(IsVariadicOperandDenseONNXConstantOp:$operandList),
-     (SatisfiesExpansionBound:$sumOp)]>;
+     (SatisfiesExpansionBound:$sumOp), (HasStaticShape:$sumOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with elementwise MUL operations.
@@ -651,7 +656,7 @@ def MulConstProp : NamedPat<"MulConstProp",
     (CreateMulOfTwoConst $mulOp, $lhs, $rhs),
     // Multiplication constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$mulOp)]>;
+     (SatisfiesExpansionBound:$mulOp), (HasStaticShape:$mulOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
 def MulOnesOnRhs : NamedPat<"MulOnesOnRhs",
@@ -676,7 +681,7 @@ def DivConstProp : NamedPat<"DivConstProp",
     (CreateDivOfTwoConst $divOp, $lhs, $rhs),
     // Division constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$divOp)]>;
+     (SatisfiesExpansionBound:$divOp), (HasStaticShape:$divOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
 def DivOnesOnRhs : NamedPat<"DivOnesOnRhs",
@@ -702,7 +707,7 @@ def BitwiseAndConstPropPattern : NamedPat<"BitwiseAndConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateBitwiseAndOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$result)]>;
+     (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagation for ONNXBitwiseOrOp
@@ -714,7 +719,7 @@ def BitwiseOrConstPropPattern : NamedPat<"BitwiseOrConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateBitwiseOrOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$result)]>;
+     (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagation for ONNXAndOp
@@ -726,7 +731,7 @@ def AndConstPropPattern : NamedPat<"AndConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateAndOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$result)]>;
+     (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagation for ONNXOrOp
@@ -738,7 +743,7 @@ def OrConstPropPattern : NamedPat<"OrConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateOrOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$result)]>;
+     (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagation for ONNXorOp
@@ -750,7 +755,7 @@ def XorConstPropPattern : NamedPat<"XorConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateXorOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$result)]>;
+     (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagation for ONNXEqualOp
@@ -765,7 +770,7 @@ def EqualConstProp : NamedPat<"EqualConstProp",
     (CreateEqualOfTwoConst $result, $lhs, $rhs),
     // constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs), (SatisfiesExpansionBound:$result)]>;
+     (IsIntOrFloatType:$lhs), (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagation for ONNXLessOp
@@ -777,7 +782,7 @@ def LessConstPropPattern : NamedPat<"LessConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateLessOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$result)]>;
+     (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagation for ONNXGreaterOp
@@ -789,7 +794,7 @@ def GreaterConstPropPattern : NamedPat<"GreaterConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateGreaterOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$result)]>;
+     (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagation for ONNXLessOrEqualOp
@@ -801,7 +806,7 @@ def LessOrEqualConstPropPattern : NamedPat<"LessOrEqualConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateLessOrEqualOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$result)]>;
+     (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagation for ONNXGreaterOrEqualOp
@@ -813,7 +818,7 @@ def GreaterOrEqualConstPropPattern : NamedPat<"GreaterOrEqualConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateGreaterOrEqualOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$result)]>;
+     (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
 //  Constant propagation for ONNXModOp
@@ -826,7 +831,7 @@ def ModConstPropPattern : NamedPat<"ModConstPropPattern",
       $fmod),
     (CreateModOfTwoConst  $modOp, $A, $B),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B),
-    (SatisfiesExpansionBound:$modOp)]>;
+    (SatisfiesExpansionBound:$modOp), (HasStaticShape:$modOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Pattern for Clip.
@@ -866,7 +871,7 @@ def WhereConstProp : NamedPat<"WhereConstProp",
     // Where constraints
     [(IsFromDenseONNXConstantOp:$condition),
      (IsFromDenseONNXConstantOp:$X), (IsFromDenseONNXConstantOp:$Y),
-     (SatisfiesExpansionBound:$whereOp)]>;
+     (SatisfiesExpansionBound:$whereOp), (HasStaticShape:$whereOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns for Reduce ops.
@@ -1009,7 +1014,7 @@ def GemmConstProp : NamedPat<"GemmConstProp",
     (CreateGemmOfConsts $gemmOp, $A, $B, $C),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B),
      (IsFromDenseONNXConstantOpOrNone:$C),
-     (SatisfiesExpansionBound:$gemmOp)]>;
+     (SatisfiesExpansionBound:$gemmOp), (HasStaticShape:$gemmOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Transpose operations.
@@ -1031,14 +1036,14 @@ def UnsqueezeofConst : NamedPat<"UnsqueezeofConst",
     (ONNXUnsqueezeOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
     (CreateUnsqueezeOfConst $resOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp)]>;
 
 def UnsqueezeV11ofConst : NamedPat<"UnsqueezeV11ofConst",
     // From Unsqueeze (c, axis)
     (ONNXUnsqueezeV11Op:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
     (CreateUnsqueezeOfConst $resOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Squeeze operations.
@@ -1049,14 +1054,14 @@ def SqueezeofConst : NamedPat<"SqueezeofConst",
     (ONNXSqueezeOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
     (CreateSqueezeOfConst $resOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp)]>;
 
 def SqueezeV11ofConst : NamedPat<"SqueezeV11ofConst",
     // From Squeeze (c, axis)
     (ONNXSqueezeV11Op:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
     (CreateSqueezeOfConst $resOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Slice operations.
@@ -1095,7 +1100,7 @@ def PadOfConst : NamedPat<"PadOfConst",
 def ConcatofConst : NamedPat<"ConcatofConst",
   (ONNXConcatOp:$resOp $input, $axis),
   (CreateConcatOfConst $resOp, $input, $axis),
-  [(IsVariadicOperandDenseONNXConstantOp:$input)]
+  [(IsVariadicOperandDenseONNXConstantOp:$input), (IsRankedShapedType:$resOp)]
 >;
 
 //===----------------------------------------------------------------------===//
@@ -1204,6 +1209,7 @@ def PowConstProp : NamedPat<"PowConstProp",
     (CreatePowOfTwoConst $powOp, $lhs, $rhs),
     // Power constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$powOp), (ValuesHaveSameDType $lhs, $rhs)]>;
+     (SatisfiesExpansionBound:$powOp), (ValuesHaveSameDType $lhs, $rhs),
+     (HasStaticShape:$powOp)]>;
 
 #endif // ONNX_CONSTPROP

--- a/test/mlir/onnx/onnx_constprop_no_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_constprop_no_shape_inference.mlir
@@ -99,3 +99,287 @@ func.func @test_scatternd_i32() -> (tensor<4x4x4xi32>) {
 }
 
 // -----
+
+//===----------------------------------------------------------------------===//
+/// Checks to ensure that constprop does not crash on non static shapes.
+/// This does only checks the absence of crashes, not that constants get folded
+
+// binary ops
+// CHECK-LABEL: @test_add_dynamic_result
+func.func @test_add_dynamic_result() -> (tensor<*xi32>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi32> } : tensor<4x4x4xi32>
+  %1 = "onnx.Add"(%0, %0) : (tensor<4x4x4xi32>, tensor<4x4x4xi32>) -> tensor<*xi32>
+  onnx.Return %1 : tensor<*xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_sub_dynamic_result
+func.func @test_sub_dynamic_result() -> (tensor<*xi32>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi32> } : tensor<4x4x4xi32>
+  %1 = "onnx.Sub"(%0, %0) : (tensor<4x4x4xi32>, tensor<4x4x4xi32>) -> tensor<*xi32>
+  onnx.Return %1 : tensor<*xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_mul_dynamic_result
+func.func @test_mul_dynamic_result() -> (tensor<*xi32>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi32> } : tensor<4x4x4xi32>
+  %1 = "onnx.Mul"(%0, %0) : (tensor<4x4x4xi32>, tensor<4x4x4xi32>) -> tensor<*xi32>
+  onnx.Return %1 : tensor<*xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_div_dynamic_result
+func.func @test_div_dynamic_result() -> (tensor<*xi32>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi32> } : tensor<4x4x4xi32>
+  %1 = "onnx.Div"(%0, %0) : (tensor<4x4x4xi32>, tensor<4x4x4xi32>) -> tensor<*xi32>
+  onnx.Return %1 : tensor<*xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_bitwise_and_dynamic_result
+func.func @test_bitwise_and_dynamic_result() -> (tensor<*xi32>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi32> } : tensor<4x4x4xi32>
+  %1 = "onnx.BitwiseAnd"(%0, %0) : (tensor<4x4x4xi32>, tensor<4x4x4xi32>) -> tensor<*xi32>
+  onnx.Return %1 : tensor<*xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_bitwise_or_dynamic_result
+func.func @test_bitwise_or_dynamic_result() -> (tensor<*xi32>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi32> } : tensor<4x4x4xi32>
+  %1 = "onnx.BitwiseOr"(%0, %0) : (tensor<4x4x4xi32>, tensor<4x4x4xi32>) -> tensor<*xi32>
+  onnx.Return %1 : tensor<*xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_and_dynamic_result
+func.func @test_and_dynamic_result() -> (tensor<*xi1>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi1> } : tensor<4x4x4xi1>
+  %1 = "onnx.And"(%0, %0) : (tensor<4x4x4xi1>, tensor<4x4x4xi1>) -> tensor<*xi1>
+  onnx.Return %1 : tensor<*xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @test_or_dynamic_result
+func.func @test_or_dynamic_result() -> (tensor<*xi1>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi1> } : tensor<4x4x4xi1>
+  %1 = "onnx.Or"(%0, %0) : (tensor<4x4x4xi1>, tensor<4x4x4xi1>) -> tensor<*xi1>
+  onnx.Return %1 : tensor<*xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @test_xor_dynamic_result
+func.func @test_xor_dynamic_result() -> (tensor<*xi1>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi1> } : tensor<4x4x4xi1>
+  %1 = "onnx.And"(%0, %0) : (tensor<4x4x4xi1>, tensor<4x4x4xi1>) -> tensor<*xi1>
+  onnx.Return %1 : tensor<*xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @test_eq_dynamic_result
+func.func @test_eq_dynamic_result() -> (tensor<*xi1>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi1> } : tensor<4x4x4xi1>
+  %1 = "onnx.Equal"(%0, %0) : (tensor<4x4x4xi1>, tensor<4x4x4xi1>) -> tensor<*xi1>
+  onnx.Return %1 : tensor<*xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @test_less_dynamic_result
+func.func @test_less_dynamic_result() -> (tensor<*xi1>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi32> } : tensor<4x4x4xi32>
+  %1 = "onnx.Less"(%0, %0) : (tensor<4x4x4xi32>, tensor<4x4x4xi32>) -> tensor<*xi1>
+  onnx.Return %1 : tensor<*xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @test_greater_dynamic_result
+func.func @test_greater_dynamic_result() -> (tensor<*xi1>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi32> } : tensor<4x4x4xi32>
+  %1 = "onnx.Greater"(%0, %0) : (tensor<4x4x4xi32>, tensor<4x4x4xi32>) -> tensor<*xi1>
+  onnx.Return %1 : tensor<*xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @test_less_or_equal_dynamic_result
+func.func @test_less_or_equal_dynamic_result() -> (tensor<*xi1>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi32> } : tensor<4x4x4xi32>
+  %1 = "onnx.LessOrEqual"(%0, %0) : (tensor<4x4x4xi32>, tensor<4x4x4xi32>) -> tensor<*xi1>
+  onnx.Return %1 : tensor<*xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @test_greater_or_equal_dynamic_result
+func.func @test_greater_or_equal_dynamic_result() -> (tensor<*xi1>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi32> } : tensor<4x4x4xi32>
+  %1 = "onnx.GreaterOrEqual"(%0, %0) : (tensor<4x4x4xi32>, tensor<4x4x4xi32>) -> tensor<*xi1>
+  onnx.Return %1 : tensor<*xi1>
+}
+
+// -----
+
+// CHECK-LABEL: @test_mod_dynamic_result
+func.func @test_mod_dynamic_result() -> (tensor<*xi32>) {
+  %0 = onnx.Constant { value = dense<1>: tensor<4x4x4xi32> } : tensor<4x4x4xi32>
+  %1 = "onnx.Mod"(%0, %0) : (tensor<4x4x4xi32>, tensor<4x4x4xi32>) -> tensor<*xi32>
+  onnx.Return %1 : tensor<*xi32>
+}
+
+// -----
+// misc ops
+
+// CHECK-LABEL: @test_where_dynamic_result()
+func.func @test_where_dynamic_result() -> tensor<*xf32> {
+  %0 = onnx.Constant dense<[true, false]> : tensor<2xi1>
+  %1 = onnx.Constant dense<[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]> : tensor<3x2xf32>
+  %2 = onnx.Constant dense<[[2.0]]> : tensor<1x1xf32>
+  %3 = "onnx.Where"(%0, %1, %2) : (tensor<2xi1>, tensor<3x2xf32>, tensor<1x1xf32>) -> tensor<*xf32>
+  "onnx.Return"(%3) : (tensor<*xf32>) -> ()
+}
+
+// -----
+
+// CHECK-LABEL: @test_matmul_2d_dynamic_result()
+func.func @test_matmul_2d_dynamic_result() -> (tensor<*xf32>) {
+  %0 = "onnx.Constant"() {value = dense<1.> : tensor<2x3xf32>} : () -> tensor<2x3xf32>
+  %1 = "onnx.Constant"() {value = dense<1.> : tensor<3x1xf32>} : () -> tensor<3x1xf32>
+  %3 = "onnx.MatMul"(%0, %1) : (tensor<2x3xf32>, tensor<3x1xf32>) -> tensor<*xf32>
+  onnx.Return %3 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_gemm_dynamic_result()
+func.func @test_gemm_dynamic_result() -> (tensor<*xi32>) {
+  %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
+  %1 = "onnx.Constant"() {value = dense<[[10, 20], [30, 40]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
+  %2 = "onnx.Constant"() {value = dense<[[1000, 2000], [3000, 4000]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
+  %3 = "onnx.Gemm"(%0, %1, %2) : (tensor<2x2xi32>, tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<*xi32>
+  onnx.Return %3 : tensor<*xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_squeeze_dynamic_result()
+func.func @test_squeeze_dynamic_result() -> tensor<*xf32> {
+  %0 = onnx.Constant dense<[[[4.0]], [[16.0]]]> : tensor<2x1x1xf32>
+  %1 = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+  %2 = "onnx.Squeeze"(%0, %1) : (tensor<2x1x1xf32>, tensor<2xi64>) -> tensor<*xf32>
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
+}
+
+// -----
+
+// CHECK-LABEL: @test_unsqueeze_dynamic_result()
+func.func @test_unsqueeze_dynamic_result() -> tensor<*xf32> {
+  %0 = onnx.Constant dense<[4.0, 16.0]> : tensor<2xf32>
+  %1 = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+  %2 = "onnx.Unsqueeze"(%0, %1) : (tensor<2xf32>, tensor<2xi64>) -> tensor<*xf32>
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
+}
+
+// -----
+
+// CHECK-LABEL:  @test_pad_dynamic_result()
+func.func @test_pad_dynamic_result() -> tensor<*xf32> {
+  %data = onnx.Constant dense<[[1.0, 1.2], [2.3, 3.4], [4.5, 5.7]]> : tensor<3x2xf32>
+  %pads = onnx.Constant dense<[0, 2, 0, 0]> : tensor<4xi64>
+  %non = "onnx.NoValue"() {value} : () -> none
+  %1 = "onnx.Pad"(%data, %pads, %non, %non) { mode = "constant" } : (tensor<3x2xf32>, tensor<4xi64>, none, none) -> tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL:  @test_concat_negative_axis_dynamic_result()
+func.func @test_concat_negative_axis_dynamic_result() -> tensor<*xf32>{
+  %0 = onnx.Constant dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]> : tensor<3x2xf32>
+  %1 = onnx.Constant dense<[[11.0, 12.0], [13.0, 14.0], [15.0, 16.0]]> : tensor<3x2xf32>
+  %2 = "onnx.Concat"(%0, %1) {axis = -1 : si64} : (tensor<3x2xf32>, tensor<3x2xf32>) -> tensor<*xf32>
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
+}
+
+// -----
+
+// CHECK-LABEL:  @test_gather_axis_0_dynamic_result()
+func.func @test_gather_axis_0_dynamic_result() -> tensor<*xf32>{
+  %0 = onnx.Constant dense<[[1.0, 1.2], [2.3, 3.4], [4.5, 5.7]]> : tensor<3x2xf32>
+  %1 = onnx.Constant dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>
+  %2 = "onnx.Gather"(%0, %1) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<2x2xi64>) -> tensor<*xf32>
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
+}
+
+// -----
+
+// CHECK-LABEL:  @test_nonzero_dynamic_result()
+func.func @test_nonzero_dynamic_result() -> tensor<*xi64> {
+  %0 = "onnx.Constant"() {value = dense<[[2, 1], [0, 2], [0, 1]]> : tensor<3x2xi8>} : () -> tensor<3x2xi8>
+  %1 = "onnx.NonZero"(%0) : (tensor<3x2xi8>) -> tensor<*xi64>
+  onnx.Return %1 : tensor<*xi64>
+}
+
+// -----
+
+// CHECK-LABEL: @test_scatternd_f32_dynamic_result()
+func.func @test_scatternd_f32_dynamic_result() -> (tensor<*xf32>) {
+  %0 = onnx.Constant { name = "constant.0", value = dense<[1., 2., 3., 4., 5., 6., 7., 8.]>:tensor<8xf32> } : tensor<8xf32>
+  %1 = onnx.Constant { name = "constant.1", value = dense< [[4], [3], [1], [7]]>:tensor<4x1xi64> } : tensor<4x1xi64>
+  %2 = onnx.Constant { name = "constant.2", value = dense<[9., 10., 11., 12.]>:tensor<4xf32> } : tensor<4xf32>
+  %3 = "onnx.ScatterND"(%0, %1, %2) {node_name = "ScatterND_6467", node_type = "ScatterND"} : (tensor<8xf32>, tensor<4x1xi64>, tensor<4xf32>) -> tensor<*xf32>
+  onnx.Return %3 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_pow_dynamic_result()
+func.func @test_pow_dynamic_result() -> tensor<*xf32> {
+  %0 = onnx.Constant dense<64.0> : tensor<2x2xf32>
+  %1 = onnx.Constant dense<0.5> : tensor<f32>
+  %2 = "onnx.Pow"(%0, %1) : (tensor<2x2xf32> , tensor<f32>) -> tensor<*xf32>
+  onnx.Return %2 : tensor<*xf32>
+}
+
+
+// -----
+
+/// variadic ops
+
+// CHECK-LABEL: @test_max_dynamic_result
+func.func @test_max_dynamic_result() -> tensor<*xi32> {
+  %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
+  %1 = "onnx.Max"(%0) : (tensor<2x2xi32>) -> tensor<*xi32>
+  "onnx.Return"(%1) : (tensor<*xi32>) -> ()
+}
+
+// -----
+
+// CHECK-LABEL: @test_min_dynamic_result
+func.func @test_min_dynamic_result() -> tensor<*xi32> {
+  %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
+  %1 = "onnx.Min"(%0) : (tensor<2x2xi32>) -> tensor<*xi32>
+  "onnx.Return"(%1) : (tensor<*xi32>) -> ()
+}
+
+// -----
+
+// CHECK-LABEL: @test_sum_dynamic_result
+func.func @test_sum_dynamic_result() -> tensor<*xf32> {
+  %0 = "onnx.Constant"() {value = dense<0.5> : tensor<2x2xf32>} : () -> tensor<2x2xf32>
+  %1 = "onnx.Sum"(%0) : (tensor<2x2xf32>) -> tensor<*xf32>
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
+}
+
+// -----


### PR DESCRIPTION
Otherwise these constprop patterns will crash

I plan to upstream this
