### PR TITLE
Make ONNX to TOSA conversion resistant to dynamic types 

### DIFF
--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -121,7 +121,9 @@ public:
     // Get shapehelper for autopad attributes
     IndexExprBuilderForTosa createTosaIE(rewriter, convOp->getLoc());
     ONNXConvOpShapeHelper shapeHelper(op, operands, &createTosaIE);
-    shapeHelper.computeShapeAndAssertOnFailure();
+    if (shapeHelper.computeShape().failed()) {
+      return rewriter.notifyMatchFailure(convOp, "Could not infer shapes");
+    }
 
     auto weightShape = weightType.getShape();
 

--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -166,9 +166,8 @@ public:
 
       IndexExprBuilderForTosa createTosaIE(rewriter, op->getLoc());
       ONNXBroadcastOpShapeHelper shapeHelper(op, {}, &createTosaIE);
-      shapeHelper.computeShapeAndAssertOnFailure();
-
-      if (shapeHelper.hasRankBroadcast()) {
+      if (shapeHelper.computeShape().succeeded() &&
+          shapeHelper.hasRankBroadcast()) {
         TosaBuilder tosaBuilder(rewriter, loc);
         llvm::SmallVector<Value, 4> newValues =
             tosaBuilder.equalizeRanks({lhs, rhs});

--- a/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
@@ -37,7 +37,9 @@ LogicalResult handleIncludePadAttr(
   IndexExprBuilderForTosa createTosaIE(rewriter, loc);
   ONNXGenericPoolOpShapeHelper<ONNXAveragePoolOp> shapeHelper(
       op, {}, &createTosaIE);
-  shapeHelper.computeShapeAndAssertOnFailure();
+  if (shapeHelper.computeShape().failed()) {
+    return rewriter.notifyMatchFailure(op, "Could not infer shapes");
+  }
 
   auto inputType = input.getType().cast<mlir::TensorType>();
   if (inputType.getShape().size() != 4) {

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
@@ -163,7 +163,9 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
   // Get shape.
   IndexExprBuilderForTosa createTosaIE(rewriter, loc);
   ONNXGenericPoolOpShapeHelper<ONNXPoolOp> shapeHelper(op, {}, &createTosaIE);
-  shapeHelper.computeShapeAndAssertOnFailure();
+  if (shapeHelper.computeShape().failed()) {
+      return rewriter.notifyMatchFailure(op, "Could not infer shapes");
+  }
 
   TosaBuilder tosaBuilder(rewriter, loc);
 

--- a/src/Conversion/ONNXToTOSA/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Transpose.cpp
@@ -40,7 +40,9 @@ public:
 
     IndexExprBuilderForTosa createTosaIE(rewriter, loc);
     ONNXTransposeOpShapeHelper shapeHelper(op, {}, &createTosaIE);
-    shapeHelper.computeShapeAndAssertOnFailure();
+    if (shapeHelper.computeShape().failed()) {
+      return rewriter.notifyMatchFailure(op, "Could not infer shapes");
+    }
 
     TosaBuilder tosaBuilder(rewriter, loc);
 

--- a/src/Dialect/ONNX/ONNXOps/Additional/ConcatShapeTranspose.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/ConcatShapeTranspose.cpp
@@ -77,7 +77,6 @@ LogicalResult ONNXConcatShapeTransposeOpShapeHelper::computeShape() {
     outputConcatDims[dim] = createIE->getShapeAsDim(firstInput, dim);
   }
   IndexExpr cumulativeAxisSize = createIE->getShapeAsDim(firstInput, axisIndex);
-
   // Handle the rest of input
   for (unsigned i = 1; i < numInputs; ++i) {
     Value currInput = operandAdaptor.getInputs()[i];

--- a/src/Dialect/ONNX/ONNXOps/Math/DFT.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/DFT.cpp
@@ -32,7 +32,10 @@ LogicalResult ONNXGenericDFTOpShapeHelper<OP_TYPE>::customComputeShape(
 
   // Get info about input data operand.
   Value input = operandAdaptor.getInput();
-  // Get the rank to compensate for N dimensions.
+  // Get the rank to compensate foqr N dimensions.
+  if (!hasShapeAndRank(input)) {
+    return failure();
+  }
   int64_t rank = createIE->getShapedTypeRank(input);
 
   // Check if the dimension for axis is a literal and in range.

--- a/src/Dialect/ONNX/ONNXOps/Math/MatMul.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/MatMul.cpp
@@ -55,6 +55,9 @@ LogicalResult ONNXGenericMatMulOpShapeHelper<OP_TYPE>::computeShape() {
   std::tie(A, B) = matMulInputs(operandAdaptor);
 
   // Size all the arrays to padded length.
+  if (!hasShapeAndRank(A) || !hasShapeAndRank(B)) {
+    return failure();
+  }
   uint64_t aRank = createIE->getShapedTypeRank(A);
   uint64_t bRank = createIE->getShapedTypeRank(B);
   int paddedRank = std::max(aRank, bRank);

--- a/src/Dialect/ONNX/ONNXOps/Math/TopK.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/TopK.cpp
@@ -31,6 +31,9 @@ LogicalResult ONNXTopKOpShapeHelper::computeShape() {
   // Get info about X and K operands.
   Value X = operandAdaptor.getX();
   Value K = operandAdaptor.getK();
+  if (!hasShapeAndRank(X)) {
+    return failure();
+  }
   int64_t rank = createIE->getShapedTypeRank(X);
 
   // Axis to compute TopK.

--- a/src/Dialect/ONNX/ONNXOps/NN/Conv.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Conv.cpp
@@ -374,6 +374,9 @@ LogicalResult ONNXConvTransposeOpShapeHelper::computeShape() {
   Value wValue = operandAdaptor.getW();
 
   // Basic information.
+  if (!hasShapeAndRank(xValue)) {
+    return failure();
+  }
   int64_t rank = createIE->getShapedTypeRank(xValue);
   int64_t spatialOffset = 2;
   int64_t spatialRank = rank - spatialOffset;

--- a/src/Dialect/ONNX/ONNXOps/NN/NNHelper.cpp.inc
+++ b/src/Dialect/ONNX/ONNXOps/NN/NNHelper.cpp.inc
@@ -31,6 +31,9 @@ LogicalResult ONNXGenericPoolOpShapeHelper<OP_TYPE>::customComputeShape(
     std::optional<ArrayAttr> strideOpt, std::optional<ArrayAttr> dilationOpt,
     bool hasFilter, bool ceilMode) {
   // Basic information.
+  if(!hasShapeAndRank(xValue)) {
+    return failure();
+  }
   int64_t rank = createIE->getShapedTypeRank(xValue);
   int64_t spatialOffset = 2;
   int64_t spatialRank = rank - spatialOffset;

--- a/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
@@ -48,14 +48,18 @@ LogicalResult ONNXGenericGlobalPoolOpShapeHelper<OP_TYPE>::computeShape() {
 template <>
 LogicalResult ONNXMaxRoiPoolOpShapeHelper::computeShape() {
   ONNXMaxRoiPoolOpAdaptor operandAdaptor(operands, op->getAttrDictionary());
-
   IndexExpr channel = createIE->getShapeAsDim(operandAdaptor.getX(), 1);
-  uint64_t roisRank = createIE->getShapedTypeRank(operandAdaptor.getRois());
+
+  const auto rois = operandAdaptor.getRois();
+  if (!hasShapeAndRank(rois)) {
+    return failure();
+  }
+  uint64_t roisRank = createIE->getShapedTypeRank(rois);
   if (roisRank != 2)
     return op->emitError("rois rank is expected to be 2d");
 
   // 2d tensor: (num_rois, 5)
-  IndexExpr numRois = createIE->getShapeAsDim(operandAdaptor.getRois(), 0);
+  IndexExpr numRois = createIE->getShapeAsDim(rois, 0);
   DimsExpr pooledDims;
   createIE->getIntFromArrayAsLiterals(
       operandAdaptor.getPooledShape(), pooledDims);

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
@@ -285,6 +285,11 @@ LogicalResult ONNXBroadcastOpShapeHelper::customComputeShape(
   DimsExpr dimsExpr;
   uint64_t numOfInputs = initialOperands.size();
 
+  if (!llvm::all_of(initialOperands,
+          [](Value initalOperand) { return hasShapeAndRank(initalOperand); })) {
+    return failure();
+  }
+
   // Compute rank of the output. Rank of the output is the maximum rank of all
   // initial operands.
   uint64_t additionalOperRank =

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Compress.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Compress.cpp
@@ -31,6 +31,9 @@ LogicalResult ONNXCompressOpShapeHelper::computeShape() {
   ONNXCompressOpAdaptor operandAdaptor(operands);
   Value input = operandAdaptor.getInput();
   Value cond = operandAdaptor.getCondition();
+  if (!hasShapeAndRank(input)) {
+    return failure();
+  }
   int64_t inputRank = createIE->getShapedTypeRank(input);
   createIE->assertHasShapeAndRank(cond);
   std::optional<int64_t> optionalAxis = compressOp.getAxis();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/DepthToSpace.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/DepthToSpace.cpp
@@ -30,6 +30,9 @@ LogicalResult ONNXDepthToSpaceOpShapeHelper::computeShape() {
   ONNXDepthToSpaceOp depthOp = llvm::cast<ONNXDepthToSpaceOp>(op);
   ONNXDepthToSpaceOpAdaptor operandAdaptor(operands);
   Value input = operandAdaptor.getInput();
+  if (!hasShapeAndRank(input)) {
+    return failure();
+  }
   int64_t inputRank = createIE->getShapedTypeRank(input);
   assert(inputRank == 4 && "Unexpected input tensor rank");
   int64_t blocksize = depthOp.getBlocksize();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/NonZero.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/NonZero.cpp
@@ -27,7 +27,11 @@ namespace onnx_mlir {
 template <>
 LogicalResult ONNXNonZeroOpShapeHelper::computeShape() {
   ONNXNonZeroOpAdaptor operandAdaptor(operands);
-  int64_t xRank = createIE->getShapedTypeRank(operandAdaptor.getX());
+  auto x = operandAdaptor.getX();
+  if (!hasShapeAndRank(x)) {
+    return failure();
+  }
+  int64_t xRank = createIE->getShapedTypeRank(x);
   // Cannot refine shape as we may otherwise loose the dynamic dim.
   return setOutputDimsFromLiterals(
       {xRank, ShapedType::kDynamic}, 0, /*refineShape*/ false);

--- a/src/Dialect/ONNX/ONNXOps/Tensor/OneHot.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/OneHot.cpp
@@ -28,6 +28,9 @@ LogicalResult ONNXOneHotOpShapeHelper::computeShape() {
   ONNXOneHotOp oneHotOp = llvm::cast<ONNXOneHotOp>(op);
   ONNXOneHotOpAdaptor operandAdaptor(operands);
   Value indices = operandAdaptor.getIndices();
+  if (!hasShapeAndRank(indices)) {
+    return failure();
+  }
   int64_t indicesRank = createIE->getShapedTypeRank(indices);
 
   // Axis is a required attribute and should have default value of -1.

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Pad.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Pad.cpp
@@ -33,6 +33,9 @@ LogicalResult ONNXPadOpShapeHelper::computeShape() {
   Value padsOperand = operandAdaptor.getPads();
   Value axesOperand = operandAdaptor.getAxes();
 
+  if (!hasShapeAndRank(dataOperand)) {
+    return failure();
+  }
   uint64_t dataRank = createIE->getShapedTypeRank(dataOperand);
 
   bool isFloat = isa<FloatType>(getElementType(dataOperand.getType()));

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
@@ -48,9 +48,13 @@ LogicalResult ONNXResizeOpShapeHelper::computeShape() {
   ONNXResizeOpAdaptor operandAdaptor(operands, cast<ONNXResizeOp>(op));
   if (operandAdaptor.getAxes().has_value())
     return op->emitOpError("axes are unsupported");
-  uint64_t rank = createIE->getShapedTypeRank(operandAdaptor.getX());
+  const auto x = operandAdaptor.getX();
+  if (!hasShapeAndRank(x)) {
+    return failure();
+  }
+  uint64_t rank = createIE->getShapedTypeRank(x);
   DimsExpr inputDims, outputDims;
-  createIE->getShapeAsDims(operandAdaptor.getX(), inputDims);
+  createIE->getShapeAsDims(x, inputDims);
   bool scalesIsAbsent = isAbsent(operandAdaptor.getScales());
   if (!scalesIsAbsent) {
     // Read and save scales as float.

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Shape.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Shape.cpp
@@ -52,6 +52,9 @@ LogicalResult ONNXShapeOpShapeHelper::computeShape() {
   Value data = operandAdaptor.getData();
 
   // Compute and store start/end in ONNXShapeOpShapeHelper object.
+  if (!hasShapeAndRank(data)) {
+    return failure();
+  }
   int64_t rank = createIE->getShapedTypeRank(data);
   start = shapeOp.getStart();
   start = normalizeClampedPerSpec(start, rank);

--- a/src/Dialect/ONNX/ONNXOps/Tensor/SpaceToDepth.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/SpaceToDepth.cpp
@@ -33,7 +33,9 @@ LogicalResult ONNXSpaceToDepthOpShapeHelper::computeShape() {
   Value input = operandAdaptor.getInput();
   int64_t blocksize = operandAdaptor.getBlocksize();
   assert(blocksize > 0 && "blocksize should be strictly positive");
-
+  if (!hasShapeAndRank(input)) {
+    return failure();
+  }
   int64_t inputRank = createIE->getShapedTypeRank(input);
   assert(inputRank == 4 && "Unexpected input tensor rank");
 

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Split.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Split.cpp
@@ -33,6 +33,9 @@ LogicalResult ONNXCommonSplitOpShapeHelper<OP_TYPE>::customComputeShape(
 
   unsigned int numOfResults = splitOp.getNumResults();
   Value input = operandAdaptor.getInput();
+  if (!hasShapeAndRank(input)) {
+    return failure();
+  }
   int64_t rank = createIE->getShapedTypeRank(input);
 
   // Checking value of axis parameter.

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Squeeze.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Squeeze.cpp
@@ -44,6 +44,9 @@ LogicalResult ONNXCommonSqueezeOpShapeHelper<OP_TYPE>::customComputeShape(
   typename OP_TYPE::Adaptor operandAdaptor(operands, op->getAttrDictionary());
   DimsExpr outputDims;
   Value data = operandAdaptor.getData();
+  if (!hasShapeAndRank(data)) {
+    return failure();
+  }
   int64_t dataRank = createIE->getShapedTypeRank(data);
 
   // Init state.

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Tile.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Tile.cpp
@@ -29,6 +29,9 @@ LogicalResult ONNXTileOpShapeHelper::computeShape() {
   ONNXTileOpAdaptor operandAdaptor(operands);
   // Get info about input data operand.
   Value input = operandAdaptor.getInput();
+  if (!hasShapeAndRank(input)) {
+    return failure();
+  }
   int64_t inputRank = createIE->getShapedTypeRank(input);
   Value repeats = operandAdaptor.getRepeats();
   // Compute outputDims

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Transpose.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Transpose.cpp
@@ -30,6 +30,9 @@ LogicalResult ONNXTransposeOpShapeHelper::computeShape() {
   ONNXTransposeOp transposeOp = llvm::cast<ONNXTransposeOp>(op);
 
   Value data = operandAdaptor.getData();
+  if (!hasShapeAndRank(data)) {
+    return failure();
+  }
   auto rank = createIE->getShapedTypeRank(data);
 
   // Transposition which handles the default case of

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Unique.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Unique.cpp
@@ -22,6 +22,9 @@ LogicalResult ONNXUniqueOpShapeHelper::computeShape() {
   ONNXUniqueOpAdaptor operandAdaptor(operands, op->getAttrDictionary());
   // Get info about X and K operands.
   Value X = operandAdaptor.getX();
+  if (!hasShapeAndRank(X)) {
+    return failure();
+  }
   int64_t rank = createIE->getShapedTypeRank(X);
   std::optional<int64_t> optionalAxis = operandAdaptor.getAxis();
   // Generate the output dims.

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Unsqueeze.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Unsqueeze.cpp
@@ -33,6 +33,9 @@ LogicalResult ONNXCommonUnsqueezeOpShapeHelper<OP_TYPE>::customComputeShape(
   typename OP_TYPE::Adaptor operandAdaptor(operands, op->getAttrDictionary());
   DimsExpr outputDims;
   Value data = operandAdaptor.getData();
+  if (!hasShapeAndRank(data)) {
+    return failure();
+  }
   int64_t dataRank = createIE->getShapedTypeRank(data);
 
   // Init state.

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -181,6 +181,15 @@ func.func @test_onnx_conv2d_dyn_shapes(%arg0: tensor<?x?x?x?xf32>, %arg1 : tenso
 
 // -----
 
+func.func @test_onnx_conv2d_dyn_shapes_no_rank(%arg0: tensor<*xf32>, %arg1 : tensor<*xf32>, %arg2: tensor<*xf32>) ->  tensor<*xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>) ->  tensor<*xf32>
+  return %0 : tensor<*xf32>
+// CHECK-LABEL:  func.func @test_onnx_conv2d_dyn_shapes_no_rank
+// CHECK: onnx.Conv
+}
+
+// -----
+
 func.func @test_onnx_conv2d_dyn_shapes_with_shape_inference(%arg0: tensor<5x3x256x256xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<?x?x?x?xf32> {
   %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<5x3x256x256xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) ->  tensor<?x?x?x?xf32>
   return %0 : tensor<?x?x?x?xf32>

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -159,6 +159,18 @@ func.func @test_add_dyn_shape_and_const(%arg0: tensor<?x1xi64>) -> tensor<?x1xi6
 
 // -----
 
+func.func @test_add_dyn_shape_no_rank(%arg0: tensor<*xi64>) -> tensor<*xi64> {
+  %0 = "onnx.Add"(%arg0, %arg0) : (tensor<*xi64>, tensor<*xi64>) -> tensor<*xi64>
+  "func.return"(%0) : (tensor<*xi64>) -> ()
+// CHECK-LABEL:  test_add_dyn_shape_no_rank
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xi64>) -> tensor<*xi64> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.add [[PARAM_0_]], [[PARAM_0_]] : (tensor<*xi64>, tensor<*xi64>) -> tensor<*xi64>
+// CHECK:           return [[VAR_0_]] : tensor<*xi64>
+// CHECK:         }
+}
+
+// -----
+
 func.func @test_sub(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x1xf32>) -> tensor<13x21x1xf32> {
   %0 = "onnx.Sub"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()

--- a/test/mlir/conversion/onnx_to_tosa/NN/AveragePool.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/AveragePool.mlir
@@ -239,3 +239,17 @@ func.func @test_averagepool_5d(%arg0: tensor<1x1x32x32x32xf32>) -> tensor<1x1x8x
 // CHECK-LABEL: test_averagepool_5d
 // CHECK: onnx.AveragePool
 
+// -----
+
+func.func @test_averagepool_dilations_one_dyn_shape(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
+ %0 = "onnx.AveragePool"(%arg0) { auto_pad = "NOTSET",
+                                  ceil_mode = 1 : si64,
+                                  count_include_pad = 0 : si64,
+                                  dilations = [1, 1],
+                                  kernel_shape = [2, 2],
+                                  strides = [1, 1]} : (tensor<*xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+}
+// CHECK-LABEL: test_averagepool_dilations_one
+// CHECK: onnx.AveragePool
+

--- a/test/mlir/conversion/onnx_to_tosa/NN/MaxPoolSingleOut.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/MaxPoolSingleOut.mlir
@@ -139,3 +139,12 @@ func.func @test_maxpoolsingleout_dilation2(%arg0 : tensor<5x5x32x32xf32>) -> ten
 }
 // CHECK-LABEL: func.func @test_maxpoolsingleout_dilation2(%arg0: tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32> {
 // CHECK: onnx.MaxPoolSingleOut
+
+// -----
+
+func.func @test_maxpoolsingleout_dilation1_dyn(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
+  %0 = "onnx.MaxPoolSingleOut"(%arg0) {kernel_shape = [3,3], dilations = [1,1]} : (tensor<*xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}
+// CHECK-LABEL: func.func @test_maxpoolsingleout_dilation1_dyn
+// CHECK: onnx.MaxPoolSingleOut

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Transpose.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Transpose.mlir
@@ -10,6 +10,8 @@ func.func @test_default_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<32x1x5
 // CHECK:           return %[[VAL_2]] : tensor<32x1x5x5xf32>
 }
 
+// -----
+
 func.func @test_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<5x1x32x5xf32> {
   %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<5x5x1x32xf32>) -> tensor<5x1x32x5xf32>
   "func.return"(%0) : (tensor<5x1x32x5xf32>) -> ()
@@ -20,10 +22,21 @@ func.func @test_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<5x1x32x5xf32> 
 // CHECK:           return %[[VAL_2]] : tensor<5x1x32x5xf32>
 }
 
+// -----
+
 func.func @test_transpose_f64(%arg0 : tensor<5x5x1x32xf64>) -> tensor<5x1x32x5xf64> {
   %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<5x5x1x32xf64>) -> tensor<5x1x32x5xf64>
   return %0 : tensor<5x1x32x5xf64>
 // CHECK-LABEL:   func.func @test_transpose
 // CHECK-NOT:     onnx.Transpose
 // CHECK:         return {{.*}}: tensor<5x1x32x5xf64>
+}
+
+// -----
+
+func.func @test_transpose_dyn(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
+  %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<*xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+// CHECK-LABEL:   func.func @test_transpose_dyn
+// CHECK:         onnx.Transpose
 }


### PR DESCRIPTION
This PR consists out of two parts:

- Use `computeShape` and check its return value instead of  `computeShapeAndAssertOnFailure` in the ONNX to TOSA lowering, to prevent crashes in the presence of dynamic types
- Various shape inference functions call `getShapedTypeRank` . Check in these if the type is ranked and return a failure otherwise. (Not reporting an error, as this does not mean that the operation is malformed, just that its input is not ranked). Maybe upstream this change