### PR TITLE
Replace deprecated use of .cast/dyn_cast/isa with the mlir freestanding functions and misc cleanups.

### DIFF
--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -176,7 +176,8 @@ std::optional<Value> TosaBuilder::gather(Value resultValue, Value inputValue,
     Value indicesValue, int32_t batchDims, int32_t axis) {
   return tosa::convertGatherOp(rewriter(), loc(), resultValue, inputValue,
       indicesValue, batchDims, axis);
-};
+}
+
 Value TosaBuilder::reshape(mlir::Value value, llvm::ArrayRef<int64_t> shape) {
   auto shapeAttr = rewriter().getDenseI64ArrayAttr(shape);
   auto valueType = mlir::cast<ShapedType>(value.getType());
@@ -246,7 +247,7 @@ template Value TosaBuilder::binaryOp<mlir::tosa::PowOp>(
 
 template <typename T>
 Value TosaBuilder::unaryOp(mlir::Value &input) {
-  auto inputType = input.getType().cast<ShapedType>();
+  auto inputType = cast<ShapedType>(input.getType());
   Type newValueType = RankedTensorType::get(
       llvm::SmallVector<int64_t, 4>(inputType.getRank(), ShapedType::kDynamic),
       inputType.getElementType());
@@ -304,7 +305,7 @@ Value TosaBuilder::select(
     lhs = valueVec[1];
     rhs = valueVec[2];
   }
-  auto lhsType = lhs.getType().cast<ShapedType>();
+  auto lhsType = cast<ShapedType>(lhs.getType());
   Type newValueType = RankedTensorType::get(
       llvm::SmallVector<int64_t, 4>(lhsType.getRank(), ShapedType::kDynamic),
       lhsType.getElementType());
@@ -326,7 +327,7 @@ mlir::Value TosaBuilder::castToNewTensorElementType(
 }
 
 Value TosaBuilder::sqrt(mlir::Value &input) {
-  auto inputType = input.getType().cast<ShapedType>();
+  auto inputType = cast<ShapedType>(input.getType());
   auto oneHalf = this->getSplattedConst(
       0.5, inputType.getElementType(), inputType.getShape());
   return this->binaryOp<mlir::tosa::PowOp>(input, oneHalf);

--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -101,7 +101,7 @@ public:
       ConversionPatternRewriter &rewriter) const final {
     OpAdaptor adaptor(operands, op->getAttrDictionary());
     auto loc = op->getLoc();
-    auto convOp = llvm::cast<ONNXConvOp>(op);
+    auto convOp = mlir::cast<ONNXConvOp>(op);
 
     TosaBuilder tosaBuilder(rewriter, loc);
 

--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -80,12 +80,12 @@ LogicalResult checkBasicTosaRequirementsForBinaryOps(
     ConversionPatternRewriter &rewriter, Operation *op, OpAdaptorT adaptor,
     Type resultType) {
   Value lhs = adaptor.getOperands()[0];
-  auto lhsType = lhs.getType().dyn_cast<TensorType>();
+  auto lhsType = dyn_cast<TensorType>(lhs.getType());
 
   Value rhs = adaptor.getOperands()[1];
-  auto rhsType = rhs.getType().dyn_cast<TensorType>();
+  auto rhsType = dyn_cast<TensorType>(rhs.getType());
 
-  auto resultTensorType = resultType.dyn_cast<TensorType>();
+  auto resultTensorType = dyn_cast<TensorType>(resultType);
   if (!lhsType || !rhsType || !resultTensorType) {
     return rewriter.notifyMatchFailure(op, "Tosa only supports TensorTypes");
   }
@@ -121,9 +121,9 @@ public:
       ConversionPatternRewriter &rewriter) const override {
 
     Value input = *adaptor.getODSOperands(0).begin();
-    auto inputType = input.getType().dyn_cast<TensorType>();
+    auto inputType = dyn_cast<TensorType>(input.getType());
     Value output = op.getResult();
-    auto outputType = output.getType().dyn_cast<TensorType>();
+    auto outputType = dyn_cast<TensorType>(output.getType());
 
     if (!inputType || !outputType) {
       return rewriter.notifyMatchFailure(op, "Tosa only supports TensorTypes");
@@ -249,7 +249,7 @@ public:
   LogicalResult matchAndRewrite(ONNXLeakyReluOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
 
-    auto outputType = op.getResult().getType().cast<TensorType>();
+    auto outputType = cast<TensorType>(op.getResult().getType());
     if (failed(IsIntOrFloat::checkType(
             rewriter, outputType.getElementType(), op))) {
       return failure();
@@ -280,15 +280,13 @@ public:
       ConversionPatternRewriter &rewriter) const override {
 
     Value input1 = adaptor.getA();
-    auto input1ElemType =
-        input1.getType().template cast<TensorType>().getElementType();
+    auto input1ElemType = cast<TensorType>(input1.getType()).getElementType();
     if (failed(IsIntOrFloat::checkType(rewriter, input1ElemType, op))) {
       return failure();
     }
 
     Value input2 = adaptor.getB();
-    auto input2ElemType =
-        input2.getType().template cast<TensorType>().getElementType();
+    auto input2ElemType = cast<TensorType>(input2.getType()).getElementType();
     if (input1ElemType != input2ElemType) {
       return failure();
     }
@@ -433,7 +431,7 @@ public:
   LogicalResult matchAndRewrite(ONNXSqrtOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
 
-    auto resultTensorType = op.getResult().getType().cast<TensorType>();
+    auto resultTensorType = cast<TensorType>(op.getResult().getType());
     if (failed(IsFloat::checkType(
             rewriter, resultTensorType.getElementType(), op))) {
       return failure();
@@ -455,7 +453,7 @@ public:
     // ELU(x) = x                     if x >= 0
     //         alpha * (exp(x) - 1.)  if x <  0
 
-    auto resultTensorType = op.getResult().getType().cast<TensorType>();
+    auto resultTensorType = cast<TensorType>(op.getResult().getType());
     if (failed(IsFloat::checkType(
             rewriter, resultTensorType.getElementType(), op))) {
       return failure();
@@ -497,7 +495,7 @@ public:
     // - tosa.mul(clamp, alpha)
     Value input = adaptor.getX();
 
-    auto resultType = op.getResult().getType().template cast<TensorType>();
+    auto resultType = cast<TensorType>(op.getResult().getType());
     auto resultElementType = resultType.getElementType();
 
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
@@ -537,7 +535,7 @@ public:
   LogicalResult matchAndRewrite(ONNXPReluOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
 
-    auto outputType = op.getResult().getType().cast<TensorType>();
+    auto outputType = cast<TensorType>(op.getResult().getType());
     if (failed(IsIntOrFloat::checkType(
             rewriter, outputType.getElementType(), op))) {
       return failure();
@@ -555,7 +553,7 @@ public:
   LogicalResult matchAndRewrite(ONNXSoftplusOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
 
-    auto outputType = op.getResult().getType().cast<TensorType>();
+    auto outputType = cast<TensorType>(op.getResult().getType());
     if (failed(IsFloat::checkType(rewriter, outputType.getElementType(), op))) {
       return failure();
     }
@@ -580,7 +578,7 @@ public:
   LogicalResult matchAndRewrite(ONNXSeluOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
 
-    auto outputType = op.getResult().getType().cast<TensorType>();
+    auto outputType = cast<TensorType>(op.getResult().getType());
     if (failed(IsFloat::checkType(rewriter, outputType.getElementType(), op))) {
       return failure();
     }
@@ -619,7 +617,7 @@ public:
   LogicalResult matchAndRewrite(ONNXThresholdedReluOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
 
-    auto outputType = op.getResult().getType().cast<TensorType>();
+    auto outputType = cast<TensorType>(op.getResult().getType());
     if (failed(IsIntOrFloat::checkType(
             rewriter, outputType.getElementType(), op))) {
       return failure();

--- a/src/Conversion/ONNXToTOSA/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/MatMul.cpp
@@ -50,7 +50,7 @@ Value reshapeUpTo3DTensor(Value tensor, TosaBuilder &builder) {
   }
 
   return builder.reshape(tensor, newShape);
-};
+}
 
 // Obtaining the rank broadcasted shapes of tensors makes it easier to
 // construct the input and output reshaping logic.

--- a/src/Conversion/ONNXToTOSA/Math/Reduce.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Reduce.cpp
@@ -43,7 +43,7 @@ DenseIntElementsAttr getAxesLatestsVersionAttr(ONNXReduceOp op) {
     if (noOpIfAxesEmpty == 0) {
       // Default behaviour when "axes" is none and "noop_with_empty_axes" is
       // set to false, it is to reduce all dims
-      const int64_t numberOfAxes = input.getType().cast<ShapedType>().getRank();
+      const int64_t numberOfAxes = cast<ShapedType>(input.getType()).getRank();
       auto iotaRange =
           llvm::iota_range<int64_t>(0, numberOfAxes, /*Inclusive=*/false);
       targetAxes = SmallVector<int64_t>(iotaRange.begin(), iotaRange.end());
@@ -86,7 +86,7 @@ DenseIntElementsAttr getAxesLegacyVersionAttr(ONNXReduceOp op) {
   SmallVector<int64_t> targetAxes;
   if (!axes) {
     // if not present all axes are reduced
-    const int64_t numberOfAxes = input.getType().cast<ShapedType>().getRank();
+    const int64_t numberOfAxes = cast<ShapedType>(input.getType()).getRank();
     auto iotaRange =
         llvm::iota_range<int64_t>(0, numberOfAxes, /*Inclusive=*/false);
     targetAxes = SmallVector<int64_t>(iotaRange.begin(), iotaRange.end());
@@ -111,14 +111,12 @@ public:
   LogicalResult matchAndRewrite(ONNXReduceOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
 
-    auto inputType =
-        adaptor.getData().getType().template dyn_cast<RankedTensorType>();
+    auto inputType = dyn_cast<RankedTensorType>(adaptor.getData().getType());
     if (!inputType)
       return rewriter.notifyMatchFailure(op, "input type not a ranked tensor.");
 
-    auto outputType = this->getTypeConverter()
-                          ->convertType(op.getResult().getType())
-                          .template cast<RankedTensorType>();
+    auto outputType = cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getResult().getType()));
 
     return (*lowerFn)(op, inputType, outputType, rewriter);
   }

--- a/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
@@ -39,14 +39,14 @@ LogicalResult handleIncludePadAttr(
       op, {}, &createTosaIE);
   shapeHelper.computeShapeAndAssertOnFailure();
 
-  auto inputType = input.getType().cast<mlir::TensorType>();
+  auto inputType = cast<mlir::TensorType>(input.getType());
   if (inputType.getShape().size() != 4) {
     return rewriter.notifyMatchFailure(op, "TOSA only supports 2d pooling");
   }
 
   llvm::SmallVector<int64_t, 4> pads =
       tosa::createOrderedPadAttrForWindowBasedOps(rewriter,
-          input.getType().cast<mlir::TensorType>().getShape(), shapeHelper,
+          cast<mlir::TensorType>(input.getType()).getShape(), shapeHelper,
           /*ceilMode*/ 0, {0, 1, 2, 3});
 
   // Create Padding and ConstPad tosa::ConstOp's

--- a/src/Conversion/ONNXToTOSA/NN/MaxPoolSingleOut.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/MaxPoolSingleOut.cpp
@@ -36,7 +36,7 @@ public:
   using OpAdaptor = typename ONNXMaxPoolSingleOutOp::Adaptor;
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
-    auto maxpoolOp = llvm::cast<ONNXMaxPoolSingleOutOp>(op);
+    auto maxpoolOp = mlir::cast<ONNXMaxPoolSingleOutOp>(op);
     OpAdaptor adaptor(operands, op->getAttrDictionary());
 
     Value input = adaptor.getX();

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -87,12 +87,12 @@ namespace onnx_mlir {
 //===----------------------------------------------------------------------===//
 
 inline bool isTOSABool(mlir::Type type) {
-  mlir::IntegerType intType = type.dyn_cast<mlir::IntegerType>();
+  mlir::IntegerType intType = mlir::dyn_cast<mlir::IntegerType>(type);
   return intType && intType.isSignless() && intType.getWidth() == 1;
 }
 
 inline bool isTOSAInt(mlir::Type type) {
-  mlir::IntegerType intType = type.dyn_cast<mlir::IntegerType>();
+  mlir::IntegerType intType = mlir::dyn_cast<mlir::IntegerType>(type);
   std::set<unsigned> intWidth{1, 8, 16, 32, 48, 64};
   return intType && (intType.isSignless() || intType.isUnsignedInteger()) &&
          (intWidth.find(intType.getWidth()) != intWidth.end());

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
@@ -126,13 +126,13 @@ llvm::SmallVector<int64_t, 4> createOrderedPadAttrForWindowBasedOps(
 
 inline mlir::LogicalResult getAvgPool2dAccType(mlir::PatternRewriter &rewriter,
     mlir::Value input, mlir::TypeAttr &accType) {
-  auto inputTy = llvm::dyn_cast<mlir::ShapedType>(input.getType());
+  auto inputTy = mlir::dyn_cast<mlir::ShapedType>(input.getType());
   if (!inputTy)
     return mlir::failure();
   auto inputETy = inputTy.getElementType();
 
   if (auto quantType =
-          llvm::dyn_cast<mlir::quant::UniformQuantizedType>(inputETy))
+          mlir::dyn_cast<mlir::quant::UniformQuantizedType>(inputETy))
     inputETy = quantType.getStorageType();
 
   // Tosa supports FP16 and FP32 accumulator type for FP16 input. When the time
@@ -178,7 +178,7 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
   llvm::SmallVector<int64_t, 4> kernelShapeVec;
   llvm::transform(kernelShape, std::back_inserter(kernelShapeVec),
       [](const mlir::Attribute &pad) {
-        return pad.cast<mlir::IntegerAttr>().getInt();
+        return  mlir::cast<mlir::IntegerAttr>(pad).getInt();
       });
 
   const int64_t ceilMode = adaptor.getCeilMode();
@@ -214,7 +214,7 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
       pads[0], pads[2] + ceilConstants[0], pads[1], pads[3] + ceilConstants[1]};
 
   mlir::FailureOr<mlir::Value> resizedInput = tosaBuilder.resizeWindowBasedOps(
-      input, input.getType().cast<mlir::RankedTensorType>().getShape(),
+      input, mlir::cast<mlir::RankedTensorType>(input.getType()).getShape(),
       {kernelShapeVec[0], kernelShapeVec[1]}, reorderedPads,
       shapeHelper.strides, shapeHelper.dilations);
 
@@ -255,4 +255,4 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
   // Construct the old result shape out of the new one
   mlir::Value transpose = tosaBuilder.transpose(input, {0, 3, 1, 2});
   return transpose;
-};
+}

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
@@ -99,7 +99,7 @@ Value buildRescale(PatternRewriter &rewriter, Operation *op,
 Value buildRescaleToInt32(PatternRewriter &rewriter, Operation *op,
     Value input_val, double input_scale, int64_t input_zp) {
   // Output is always int32 type
-  auto input_type = input_val.getType().dyn_cast<mlir::ShapedType>();
+  auto input_type = dyn_cast<mlir::ShapedType>(input_val.getType());
   assert(input_type);
   auto output_type = input_type.clone(rewriter.getI32Type());
 

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
@@ -67,7 +67,7 @@ TosaOp CreateOpAndInfer(mlir::PatternRewriter &rewriter, mlir::Location loc,
   auto op = rewriter.create<TosaOp>(loc, result_ty, args...);
 
   mlir::InferShapedTypeOpInterface shapeInterface =
-      llvm::dyn_cast<mlir::InferShapedTypeOpInterface>(op.getOperation());
+      mlir::dyn_cast<mlir::InferShapedTypeOpInterface>(op.getOperation());
   if (!shapeInterface)
     return op;
 

--- a/src/Conversion/ONNXToTOSA/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Concat.cpp
@@ -46,7 +46,7 @@ public:
 
     Type newConcatOutputType = RankedTensorType::get(
         llvm::SmallVector<int64_t, 4>(inputRank, ShapedType::kDynamic),
-        resultType.cast<ShapedType>().getElementType());
+        cast<ShapedType>(resultType).getElementType());
 
     tosa::CreateReplaceOpAndInfer<mlir::tosa::ConcatOp>(
         rewriter, op, newConcatOutputType, inputs, axis);

--- a/src/Conversion/ONNXToTOSA/Tensor/Expand.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Expand.cpp
@@ -60,9 +60,9 @@ public:
         castArrayRef<int64_t, WideNum>(shapeWideNums.get());
 
     auto inputType =
-        llvm::dyn_cast_or_null<RankedTensorType>(adaptor.getInput().getType());
+        mlir::dyn_cast_or_null<RankedTensorType>(adaptor.getInput().getType());
     auto outputType =
-        llvm::dyn_cast_or_null<RankedTensorType>(op.getResult().getType());
+        mlir::dyn_cast_or_null<RankedTensorType>(op.getResult().getType());
     if (!inputType || !outputType || !inputType.hasStaticShape() ||
         !outputType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(

--- a/src/Conversion/ONNXToTOSA/Tensor/Flatten.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Flatten.cpp
@@ -44,7 +44,7 @@ public:
     TosaBuilder tosaBuilder(rewriter, loc);
 
     int64_t axis = adaptor.getAxis();
-    auto inputType = input.getType().cast<ShapedType>();
+    auto inputType = cast<ShapedType>(input.getType());
 
     // onnx allows values beetween [-r, r] where r is the rank.
     if (axis == inputType.getRank()) {

--- a/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
@@ -57,7 +57,7 @@ public:
     // onnx allows values beetween [-r, r-1] where r is the rank
     axis = tosa::convertNegativeAxis(axis, inputRank);
 
-    auto indicesType = indices.getType().cast<ShapedType>();
+    auto indicesType = cast<ShapedType>(indices.getType());
 
     APInt indicesVal;
     if (indicesType.getRank() == 0 &&
@@ -76,7 +76,7 @@ public:
     SmallVector<int32_t, 4> newIndicesValues;
     newIndicesValues.resize(indicesType.getNumElements());
 
-    ArrayRef<int64_t> inputShape = inputType.cast<ShapedType>().getShape();
+    ArrayRef<int64_t> inputShape = cast<ShapedType>(inputType).getShape();
 
     // ONNX allows negative indices and TOSA doesn't.
     // We will emit ops to compute

--- a/src/Conversion/ONNXToTOSA/Tensor/PaddingOp.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/PaddingOp.cpp
@@ -79,11 +79,11 @@ public:
         getTypeConverter()->convertType(op.getResult().getType());
 
     float valueFloat = 0.0F;
-    if (!constValue.getType().dyn_cast<NoneType>()) {
+    if (!isa<NoneType>(constValue.getType())) {
       auto valueAttr = tosa::getValueFromTosaConst<ElementsAttr>(constValue);
       auto valueIt = valueAttr.getValues<FloatAttr>().begin();
       // Need float for F32 Type
-      float valueFloat = (*valueIt).cast<FloatAttr>().getValueAsDouble();
+      float valueFloat = cast<FloatAttr>(*valueIt).getValueAsDouble();
 
       TosaBuilder tosaBuilder(rewriter, loc);
       Value constTosaTensor =

--- a/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
@@ -70,7 +70,7 @@ ScaleHelper normalize(int64_t output, int64_t input, bool pytorchHalfPixel,
   // We can compute this directly based on previous values.
   border = denominator * (output - 1) - numerator * (input - 1) + offset;
   return ScaleHelper(numerator, denominator, offset, border);
-};
+}
 
 void valuesFromAxis(ArrayAttr *axis, llvm::SmallVectorImpl<int64_t> &axisVec) {
   auto axisRange = axis->getAsRange<IntegerAttr>();
@@ -172,7 +172,7 @@ public:
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
-    auto resizeOp = llvm::cast<ONNXResizeOp>(op);
+    auto resizeOp = mlir::cast<ONNXResizeOp>(op);
     Location loc = op->getLoc();
     OpAdaptor adaptor(operands, op->getAttrDictionary());
 

--- a/src/Conversion/ONNXToTOSA/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Transpose.cpp
@@ -46,7 +46,7 @@ public:
 
     Value input = adaptor.getData();
 
-    auto inputType = input.getType().dyn_cast<TensorType>();
+    auto inputType = dyn_cast<TensorType>(input.getType());
 
     if (!inputType)
       return rewriter.notifyMatchFailure(op, "input not a ranked tensor");
@@ -59,7 +59,7 @@ public:
           op, "input element type not supported");
     }
 
-    auto outputType = op.getResult().getType().dyn_cast<TensorType>();
+    auto outputType = dyn_cast<TensorType>(op.getResult().getType());
 
     if (!outputType)
       return rewriter.notifyMatchFailure(op, "output not a ranked tensor");


### PR DESCRIPTION

Also remove some unecessary semicolons and standardize to use mlir instead of llvm casts