### PR TITLE
Fuse also the location of LayerNorm and Bias when fusing/recomposing the ops

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -1542,7 +1542,6 @@ struct PropagateBiasIntoLayerNormRewritePattern
     Value y, bias;
     Operation *yLayerNormOp;
     Operation *ywbAddOp = addOp.getOperation();
-    Location loc = addOp.getLoc();
     // Match
     // %noBias = "onnx.NoValue"()
     // %y, %mean, %invStdDev = "onnx.LayerNormalization"(%x, %scale, %noBias)
@@ -1568,7 +1567,8 @@ struct PropagateBiasIntoLayerNormRewritePattern
     LLVM_DEBUG(llvm::dbgs() << "LayerNorm from add, axis : " << axis << "\n");
 
     // Replace
-    MultiDialectBuilder<OnnxBuilder> create(rewriter, loc);
+    MultiDialectBuilder<OnnxBuilder> create(
+        rewriter, rewriter.getFusedLoc({lnOp.getLoc(), addOp->getLoc()}));
     Type xType = x.getType();
     Value res;
     if constexpr (std::is_same<OP_TYPE, ONNXLayerNormalizationOp>::value)

--- a/test/mlir/onnx/onnx_canonicalization_locations.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_locations.mlir
@@ -1,0 +1,19 @@
+// RUN: onnx-mlir-opt --shape-inference --canonicalize="test-convergence=true" --shape-inference --cse %s -split-input-file --mlir-print-debuginfo | FileCheck %s
+
+
+
+// CHECK-LABEL:  func.func @layernorm_with_bias
+func.func @layernorm_with_bias(%arg0: tensor<1x384x768xf32>, %arg1: tensor<768xf32>, %arg3: tensor<768xf32>) -> tensor<1x384x768xf32> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %y, %mean, %stddev = "onnx.LayerNormalization"(%arg0, %arg1, %none) {axis = 2 : si64, epsilon = 9.99999974E-6 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<768xf32>, none) -> (tensor<1x384x768xf32>, none, none) loc("LN")
+  %ret = "onnx.Add"(%y, %arg3) : (tensor<1x384x768xf32>, tensor<768xf32>) -> tensor<1x384x768xf32> loc("Bias")
+  return %ret : tensor<1x384x768xf32>
+  // CHECK:           [[Y_:%.+]], [[Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"(%arg0, %arg1, %arg2) {axis = 2 : si64, epsilon = 9.99999974E-6 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<768xf32>, tensor<768xf32>) -> (tensor<1x384x768xf32>, none, none) loc([[LOC_FUSED:#.+]])
+  // CHECK:           return [[Y_]] : tensor<1x384x768xf32>
+  // CHECK-DAG:       [[LOC_LN:#.+]] = loc("LN")
+  // CHECK-DAG:       [[LOC_BIAS:#.+]] = loc("Bias")
+  // CHECK:           [[LOC_FUSED]] = loc(fused[[[LOC_LN]], [[LOC_BIAS]]]) 
+}
+
+
+

--- a/test/mlir/onnx/onnx_canonicalization_locations.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_locations.mlir
@@ -1,7 +1,5 @@
 // RUN: onnx-mlir-opt --shape-inference --canonicalize="test-convergence=true" --shape-inference --cse %s -split-input-file --mlir-print-debuginfo | FileCheck %s
 
-
-
 // CHECK-LABEL:  func.func @layernorm_with_bias
 func.func @layernorm_with_bias(%arg0: tensor<1x384x768xf32>, %arg1: tensor<768xf32>, %arg3: tensor<768xf32>) -> tensor<1x384x768xf32> {
   %none = "onnx.NoValue"() {value} : () -> none

--- a/test/mlir/onnx/onnx_recompose_locations.mlir
+++ b/test/mlir/onnx/onnx_recompose_locations.mlir
@@ -1,0 +1,27 @@
+// RUN: onnx-mlir-opt --recompose-onnx --canonicalize %s --mlir-print-debuginfo -split-input-file | FileCheck %s
+
+// CHECK-LABEL:  func.func @layernorm_without_bias
+func.func @layernorm_without_bias(%x: tensor<1x384x768xf32>, %scale: tensor<768xf32>, %bias: tensor<768xf32>) -> (tensor<1x384x768xf32>) {
+  %eps = onnx.Constant dense<9.99999974E-6> : tensor<f32>
+  %mean = "onnx.ReduceMeanV13"(%x) {axes = [-1], keepdims = 1 : si64} : (tensor<1x384x768xf32>) -> tensor<1x384x1xf32> loc("mReduce")
+  %d = "onnx.Sub"(%x, %mean) : (tensor<1x384x768xf32>, tensor<1x384x1xf32>) -> tensor<1x384x768xf32> loc("sub")
+  %dd = "onnx.Mul"(%d, %d) : (tensor<1x384x768xf32>, tensor<1x384x768xf32>) -> tensor<1x384x768xf32> loc("ddMul")
+  %var = "onnx.ReduceMeanV13"(%dd) {axes = [-1], keepdims = 1 : si64} : (tensor<1x384x768xf32>) -> tensor<1x384x1xf32> loc("vReduce")
+  %varEps = "onnx.Add"(%var, %eps) : (tensor<1x384x1xf32>, tensor<f32>) -> tensor<1x384x1xf32> loc("add")
+  %StdDev = "onnx.Sqrt"(%varEps) : (tensor<1x384x1xf32>) -> tensor<1x384x1xf32> loc("sqrt")
+  %Norm = "onnx.Div"(%d, %StdDev) : (tensor<1x384x768xf32>, tensor<1x384x1xf32>) -> tensor<1x384x768xf32> loc("div")
+  %Y = "onnx.Mul"(%Norm, %scale) : (tensor<1x384x768xf32>, tensor<768xf32>) -> tensor<1x384x768xf32> loc("lnMul")
+  return %Y : tensor<1x384x768xf32> loc("return")
+// CHECK:           [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"(%arg0, %arg1, %0) {axis = 2 : si64, epsilon = 9.99999974E-6 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<768xf32>, none) -> (tensor<1x384x768xf32>, none, none) loc([[LOC_FUSED:#.+]])
+// CHECK:           return [[VAR_Y_]] : tensor<1x384x768xf32>
+// CHECK-DAG:       [[LOC_M_REDUCE:#.+]] = loc("mReduce")
+// CHECK-DAG:       [[LOC_SUB:#.+]] = loc("sub")
+// CHECK-DAG:       [[LOC_DD_MUL:#.+]] = loc("ddMul")
+// CHECK-DAG:       [[LOC_V_REDUCE:#.+]] = loc("vReduce")
+// CHECK-DAG:       [[LOC_ADD:#.+]] = loc("add")
+// CHECK-DAG:       [[LOC_SQRT:#.+]] = loc("sqrt")
+// CHECK-DAG:       [[LOC_DIV:#.+]] = loc("div")
+// CHECK-DAG:       [[LOC_LN_MUL:#.+]] = loc("lnMul")
+// CHECK:           [[LOC_FUSED]] = loc(fused[[[LOC_M_REDUCE]], [[LOC_SUB]], [[LOC_DD_MUL]], [[LOC_V_REDUCE]], [[LOC_ADD]], [[LOC_SQRT]], [[LOC_DIV]], [[LOC_LN_MUL]]]) 
+}


### PR DESCRIPTION
This is required to mark ops correctly as supported or unsupported when partitioning

I plan to upstream this