### PR TITLE
Decompose ScatterND to split and concat

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -855,7 +855,16 @@ private:
 
 } // namespace
 
-// Decomposes ScatterNDs into a single Split and Concat
+// Decomposes ScatterNDs into a single Split and Concat.
+// We can always split an ScatterNDs by splitting the input tensor together with
+// the indices and their updates belonging to that part of the input tensor,
+// performing the ScatterNDs on each split, and the concatenating the result.
+// Here, we handle certain ScatterNDs where after splitting them into three,
+// the first and last ScatterND have empty indices (because the indices don't
+// affect their parts of the input tensor), and the middle ScatterND overwrites
+// the full input with sequential indices (i.e. can be replaced by a copy of its
+// update).
+//
 // Example:
 // ` %indices = onnx.Constant dense<[[[[0, 1, 0], [0, 1, 1], [0, 1, 2],
 //     [0, 1, 3], [0, 1, 4], [0, 1, 5], [0, 1, 6], [0, 1, 7], [0, 1, 8],

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -835,11 +835,13 @@ public:
 
   void increment() {
     // Increment from the back, carry if necessary
-    for (int64_t i = counter.size() - 1; i >= 0; --i) {
-      if (counter[i] == (shapeToCheck[i] + firstElem[i] - 1)) {
-        counter[i] = firstElem[i]; // Carry and keep an eventual shift in mind
+    for (auto [shapeToCheckDimSize, firstElemDimSize, c] :
+        llvm::zip(llvm::reverse(shapeToCheck), llvm::reverse(firstElem),
+            llvm::reverse(counter))) {
+      if (c == (shapeToCheckDimSize + firstElemDimSize - 1)) {
+        c = firstElemDimSize; // Carry and keep an eventual shift in mind
       } else {
-        counter[i]++;
+        c++;
         break;
       }
     }

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -856,7 +856,7 @@ private:
 } // namespace
 
 // Decomposes ScatterNDs into a single Split and Concat.
-// We can always split an ScatterNDs by splitting the input tensor together with
+// We can always split ScatterNDs by splitting the input tensor together with
 // the indices and their updates belonging to that part of the input tensor,
 // performing the ScatterNDs on each split, and the concatenating the result.
 // Here, we handle certain ScatterNDs where after splitting them into three,
@@ -998,8 +998,8 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
     // -- The expected index is calculated the following way:
     // --- The expected index is initialized with the first index in indices and
     //     then always incremented by one.
-    // --- The increment works like an manual addition, the least significant
-    //     digit/subindex gets incremented by one. If an digit overflows, it
+    // --- The increment works like a manual addition, the least significant
+    //     digit/subindex gets incremented by one. If a digit overflows, it
     //     gets reset to the first index and the addition carries to the next,
     //     more significant digit. The addition overflows, if the index for an
     //     axis is equal to the size of this axis in updates/indices. (By

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -1148,21 +1148,21 @@ func.func @test_scatter_nd_dynamic(%data : tensor<*xf32>, %updates : tensor<1x1x
 // CHECK:        onnx.ScatterND
 
 // -----
-func.func @test_scatter_nd_mulit_dim_differ(%data : tensor<2x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<2x6x10x12xf32> {
+func.func @test_scatter_nd_multi_dim_differ(%data : tensor<2x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<2x6x10x12xf32> {
   %indices = onnx.Constant dense<[[[[0, 1, 0], [0, 1, 1], [0, 1, 2], [0, 1, 3], [0, 1, 4], [0, 1, 5], [0, 1, 6], [0, 1, 7], [0, 1, 8], [0, 1, 9]]]]> : tensor<1x1x10x3xi64>
   %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<2x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<2x6x10x12xf32>
   onnx.Return %0 : tensor<2x6x10x12xf32>
 }
-// CHECK-LABEL:  func.func @test_scatter_nd_mulit_dim_differ
+// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_differ
 // CHECK:        onnx.ScatterND
 
 // -----
-func.func @test_scatter_nd_mulit_dim_differ_multi_shift(%data : tensor<2x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<2x6x10x12xf32> {
+func.func @test_scatter_nd_multi_dim_differ_multi_shift(%data : tensor<2x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<2x6x10x12xf32> {
   %indices = onnx.Constant dense<[[[[1, 1, 0], [1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 1, 4], [1, 1, 5], [1, 1, 6], [1, 1, 7], [1, 1, 8], [1, 1, 9]]]]> : tensor<1x1x10x3xi64>
   %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<2x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<2x6x10x12xf32>
   onnx.Return %0 : tensor<2x6x10x12xf32>
 }
-// CHECK-LABEL:  func.func @test_scatter_nd_mulit_dim_differ_multi_shift
+// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_differ_multi_shift
 // CHECK:        onnx.ScatterND
 
 // -----

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -1068,12 +1068,10 @@ func.func @test_scatter_nd_double_split(%data : tensor<1x6x10x12xf32>, %updates 
 }
 // CHECK-LABEL:  func.func @test_scatter_nd_double_split
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x6x10x12xf32>, [[PARAM_1_:%.+]]: tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 4]> : tensor<2xi64>
-// CHECK:           [[VAR_2_:%.+]]:2 = "onnx.Split"([[PARAM_0_]], [[VAR_1_]]) {axis = 1 : si64} : (tensor<1x6x10x12xf32>, tensor<2xi64>) -> (tensor<1x2x10x12xf32>, tensor<1x4x10x12xf32>)
-// CHECK:           [[VAR_3_:%.+]]:2 = "onnx.Split"([[VAR_2_]]#0, [[VAR_0_]]) {axis = 1 : si64} : (tensor<1x2x10x12xf32>, tensor<2xi64>) -> (tensor<1x1x10x12xf32>, tensor<1x1x10x12xf32>)
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Concat"([[VAR_3_]]#0, [[PARAM_1_]], [[VAR_2_]]#1) {axis = 1 : si64} : (tensor<1x1x10x12xf32>, tensor<1x1x10x12xf32>, tensor<1x4x10x12xf32>) -> tensor<1x6x10x12xf32>
-// CHECK:           onnx.Return [[VAR_4_]] : tensor<1x6x10x12xf32>
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 1, 4]> : tensor<3xi64>
+// CHECK:           [[VAR_1_:%.+]]:3 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 1 : si64} : (tensor<1x6x10x12xf32>, tensor<3xi64>) -> (tensor<1x1x10x12xf32>, tensor<1x1x10x12xf32>, tensor<1x4x10x12xf32>)
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_1_]]#0, [[PARAM_1_]], [[VAR_1_]]#2) {axis = 1 : si64} : (tensor<1x1x10x12xf32>, tensor<1x1x10x12xf32>, tensor<1x4x10x12xf32>) -> tensor<1x6x10x12xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x6x10x12xf32>
 // CHECK:         }
 
 // -----
@@ -1162,12 +1160,10 @@ func.func @test_scatter_nd_multi_dim_shift(%data : tensor<1x4x6xf32>, %updates :
 }
 // CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_shift
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x6xf32>, [[PARAM_1_:%.+]]: tensor<1x4x2xf32>) -> tensor<1x4x6xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<3> : tensor<2xi64>
-// CHECK:           [[VAR_2_:%.+]]:2 = "onnx.Split"([[PARAM_0_]], [[VAR_1_]]) {axis = 2 : si64} : (tensor<1x4x6xf32>, tensor<2xi64>) -> (tensor<1x4x3xf32>, tensor<1x4x3xf32>)
-// CHECK:           [[VAR_3_:%.+]]:2 = "onnx.Split"([[VAR_2_]]#0, [[VAR_0_]]) {axis = 2 : si64} : (tensor<1x4x3xf32>, tensor<2xi64>) -> (tensor<1x4x1xf32>, tensor<1x4x2xf32>)
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Concat"([[VAR_3_]]#0, [[PARAM_1_]], [[VAR_2_]]#1) {axis = 2 : si64} : (tensor<1x4x1xf32>, tensor<1x4x2xf32>, tensor<1x4x3xf32>) -> tensor<1x4x6xf32>
-// CHECK:           onnx.Return [[VAR_4_]] : tensor<1x4x6xf32>
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
+// CHECK:           [[VAR_1_:%.+]]:3 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 2 : si64} : (tensor<1x4x6xf32>, tensor<3xi64>) -> (tensor<1x4x1xf32>, tensor<1x4x2xf32>, tensor<1x4x3xf32>)
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_1_]]#0, [[PARAM_1_]], [[VAR_1_]]#2) {axis = 2 : si64} : (tensor<1x4x1xf32>, tensor<1x4x2xf32>, tensor<1x4x3xf32>) -> tensor<1x4x6xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x4x6xf32>
 // CHECK:         }
 
 // -----

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -1040,9 +1040,9 @@ func.func @test_scatter_nd_single_split_begin(%data : tensor<1x6x10x12xf32>, %up
 }
 // CHECK-LABEL:  func.func @test_scatter_nd_single_split_begin
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x6x10x12xf32>, [[PARAM_1_:%.+]]: tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32> {
-// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 5]> : tensor<2xi64>
-// CHECK:           [[VAR_1_:%.+]]:2 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 1 : si64} : (tensor<1x6x10x12xf32>, tensor<2xi64>) -> (tensor<1x1x10x12xf32>, tensor<1x5x10x12xf32>)
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[PARAM_1_]], [[VAR_1_]]#1) {axis = 1 : si64} : (tensor<1x1x10x12xf32>, tensor<1x5x10x12xf32>) -> tensor<1x6x10x12xf32>
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[0, 1, 5]> : tensor<3xi64>
+// CHECK:           [[VAR_1_:%.+]]:3 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 1 : si64} : (tensor<1x6x10x12xf32>, tensor<3xi64>) -> (tensor<1x0x10x12xf32>, tensor<1x1x10x12xf32>, tensor<1x5x10x12xf32>)
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_1_]]#0, [[PARAM_1_]], [[VAR_1_]]#2) {axis = 1 : si64} : (tensor<1x0x10x12xf32>, tensor<1x1x10x12xf32>, tensor<1x5x10x12xf32>) -> tensor<1x6x10x12xf32>
 // CHECK:           onnx.Return [[VAR_2_]] : tensor<1x6x10x12xf32>
 // CHECK:         }
 
@@ -1054,9 +1054,9 @@ func.func @test_scatter_nd_single_split_end(%data : tensor<1x6x10x12xf32>, %upda
 }
 // CHECK-LABEL:  func.func @test_scatter_nd_single_split_end
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x6x10x12xf32>, [[PARAM_1_:%.+]]: tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32> {
-// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[5, 1]> : tensor<2xi64>
-// CHECK:           [[VAR_1_:%.+]]:2 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 1 : si64} : (tensor<1x6x10x12xf32>, tensor<2xi64>) -> (tensor<1x5x10x12xf32>, tensor<1x1x10x12xf32>)
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_1_]]#0, [[PARAM_1_]]) {axis = 1 : si64} : (tensor<1x5x10x12xf32>, tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32>
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[5, 1, 0]> : tensor<3xi64>
+// CHECK:           [[VAR_1_:%.+]]:3 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 1 : si64} : (tensor<1x6x10x12xf32>, tensor<3xi64>) -> (tensor<1x5x10x12xf32>, tensor<1x1x10x12xf32>, tensor<1x0x10x12xf32>)
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_1_]]#0, [[PARAM_1_]], [[VAR_1_]]#2) {axis = 1 : si64} : (tensor<1x5x10x12xf32>, tensor<1x1x10x12xf32>, tensor<1x0x10x12xf32>) -> tensor<1x6x10x12xf32>
 // CHECK:           onnx.Return [[VAR_2_]] : tensor<1x6x10x12xf32>
 // CHECK:         }
 
@@ -1135,7 +1135,10 @@ func.func @test_scatter_nd_full_overwrite(%data : tensor<1x6x10x12xf32>, %update
 }
 // CHECK-LABEL:  func.func @test_scatter_nd_full_overwrite
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x6x10x12xf32>, [[PARAM_1_:%.+]]: tensor<1x6x10x12xf32>) -> tensor<1x6x10x12xf32> {
-// CHECK:           onnx.Return [[PARAM_1_]] : tensor<1x6x10x12xf32>
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[0, 12, 0]> : tensor<3xi64>
+// CHECK:           [[VAR_1_:%.+]]:3 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 3 : si64} : (tensor<1x6x10x12xf32>, tensor<3xi64>) -> (tensor<1x6x10x0xf32>, tensor<1x6x10x12xf32>, tensor<1x6x10x0xf32>)
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_1_]]#0, [[PARAM_1_]], [[VAR_1_]]#2) {axis = 3 : si64} : (tensor<1x6x10x0xf32>, tensor<1x6x10x12xf32>, tensor<1x6x10x0xf32>) -> tensor<1x6x10x12xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x6x10x12xf32>
 // CHECK:         }
 
 // -----
@@ -1146,9 +1149,9 @@ func.func @test_scatter_nd_multi_dim(%data : tensor<1x4x6xf32>, %updates : tenso
 }
 // CHECK-LABEL:  func.func @test_scatter_nd_multi_dim
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x6xf32>, [[PARAM_1_:%.+]]: tensor<1x4x2xf32>) -> tensor<1x4x6xf32> {
-// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[2, 4]> : tensor<2xi64>
-// CHECK:           [[VAR_1_:%.+]]:2 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 2 : si64} : (tensor<1x4x6xf32>, tensor<2xi64>) -> (tensor<1x4x2xf32>, tensor<1x4x4xf32>)
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[PARAM_1_]], [[VAR_1_]]#1) {axis = 2 : si64} : (tensor<1x4x2xf32>, tensor<1x4x4xf32>) -> tensor<1x4x6xf32>
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[0, 2, 4]> : tensor<3xi64>
+// CHECK:           [[VAR_1_:%.+]]:3 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 2 : si64} : (tensor<1x4x6xf32>, tensor<3xi64>) -> (tensor<1x4x0xf32>, tensor<1x4x2xf32>, tensor<1x4x4xf32>)
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_1_]]#0, [[PARAM_1_]], [[VAR_1_]]#2) {axis = 2 : si64} : (tensor<1x4x0xf32>, tensor<1x4x2xf32>, tensor<1x4x4xf32>) -> tensor<1x4x6xf32>
 // CHECK:           onnx.Return [[VAR_2_]] : tensor<1x4x6xf32>
 // CHECK:         }
 

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -1031,3 +1031,159 @@ func.func @test_pad_slice_dynamic(%data : tensor<*xf32>) -> tensor<*xf32> {
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Pad"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]], [[VAR_1_]]) {mode = "constant"} : (tensor<*xf32>, tensor<4xi64>, none, none) -> tensor<*xf32>
 // CHECK:           onnx.Return [[VAR_2_]] : tensor<*xf32>
+
+// -----
+func.func @test_scatter_nd_single_split_begin(%data : tensor<1x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<1x6x10x12xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 0], [0, 0, 1], [0, 0, 2], [0, 0, 3], [0, 0, 4], [0, 0, 5], [0, 0, 6], [0, 0, 7], [0, 0, 8], [0, 0, 9]]]]> : tensor<1x1x10x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32>
+  onnx.Return %0 : tensor<1x6x10x12xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_single_split_begin
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x6x10x12xf32>, [[PARAM_1_:%.+]]: tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 5]> : tensor<2xi64>
+// CHECK:           [[VAR_1_:%.+]]:2 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 1 : si64} : (tensor<1x6x10x12xf32>, tensor<2xi64>) -> (tensor<1x1x10x12xf32>, tensor<1x5x10x12xf32>)
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[PARAM_1_]], [[VAR_1_]]#1) {axis = 1 : si64} : (tensor<1x1x10x12xf32>, tensor<1x5x10x12xf32>) -> tensor<1x6x10x12xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x6x10x12xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_single_split_end(%data : tensor<1x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<1x6x10x12xf32> {
+  %indices = onnx.Constant dense<[[[[0, 5, 0], [0, 5, 1], [0, 5, 2], [0, 5, 3], [0, 5, 4], [0, 5, 5], [0, 5, 6], [0, 5, 7], [0, 5, 8], [0, 5, 9]]]]> : tensor<1x1x10x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32>
+  onnx.Return %0 : tensor<1x6x10x12xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_single_split_end
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x6x10x12xf32>, [[PARAM_1_:%.+]]: tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[5, 1]> : tensor<2xi64>
+// CHECK:           [[VAR_1_:%.+]]:2 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 1 : si64} : (tensor<1x6x10x12xf32>, tensor<2xi64>) -> (tensor<1x5x10x12xf32>, tensor<1x1x10x12xf32>)
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_1_]]#0, [[PARAM_1_]]) {axis = 1 : si64} : (tensor<1x5x10x12xf32>, tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x6x10x12xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_double_split(%data : tensor<1x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<1x6x10x12xf32> {
+  %indices = onnx.Constant dense<[[[[0, 1, 0], [0, 1, 1], [0, 1, 2], [0, 1, 3], [0, 1, 4], [0, 1, 5], [0, 1, 6], [0, 1, 7], [0, 1, 8], [0, 1, 9]]]]> : tensor<1x1x10x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32>
+  onnx.Return %0 : tensor<1x6x10x12xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_double_split
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x6x10x12xf32>, [[PARAM_1_:%.+]]: tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 4]> : tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]]:2 = "onnx.Split"([[PARAM_0_]], [[VAR_1_]]) {axis = 1 : si64} : (tensor<1x6x10x12xf32>, tensor<2xi64>) -> (tensor<1x2x10x12xf32>, tensor<1x4x10x12xf32>)
+// CHECK:           [[VAR_3_:%.+]]:2 = "onnx.Split"([[VAR_2_]]#0, [[VAR_0_]]) {axis = 1 : si64} : (tensor<1x2x10x12xf32>, tensor<2xi64>) -> (tensor<1x1x10x12xf32>, tensor<1x1x10x12xf32>)
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Concat"([[VAR_3_]]#0, [[PARAM_1_]], [[VAR_2_]]#1) {axis = 1 : si64} : (tensor<1x1x10x12xf32>, tensor<1x1x10x12xf32>, tensor<1x4x10x12xf32>) -> tensor<1x6x10x12xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<1x6x10x12xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_reduction(%data : tensor<1x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<1x6x10x12xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 0], [0, 0, 1], [0, 0, 2], [0, 0, 3], [0, 0, 4], [0, 0, 5], [0, 0, 6], [0, 0, 7], [0, 0, 8], [0, 0, 9]]]]> : tensor<1x1x10x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "add"} : (tensor<1x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32>
+  onnx.Return %0 : tensor<1x6x10x12xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_reduction
+// CHECK:        onnx.ScatterND
+
+// -----
+func.func @test_scatter_nd_not_const(%data : tensor<1x6x10x12xf32>, %updates : tensor<1x1x10x12xf32>, %indices : tensor<1x1x10x3xi64>  ) -> tensor<1x6x10x12xf32> {
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32>
+  onnx.Return %0 : tensor<1x6x10x12xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_not_const
+// CHECK:        onnx.ScatterND
+
+// -----
+func.func @test_scatter_nd_dynamic(%data : tensor<*xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<*xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 0], [0, 0, 1], [0, 0, 2], [0, 0, 3], [0, 0, 4], [0, 0, 5], [0, 0, 6], [0, 0, 7], [0, 0, 8], [0, 0, 9]]]]> : tensor<1x1x10x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<*xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_dynamic
+// CHECK:        onnx.ScatterND
+
+// -----
+func.func @test_scatter_nd_mulit_dim_differ(%data : tensor<2x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<2x6x10x12xf32> {
+  %indices = onnx.Constant dense<[[[[0, 1, 0], [0, 1, 1], [0, 1, 2], [0, 1, 3], [0, 1, 4], [0, 1, 5], [0, 1, 6], [0, 1, 7], [0, 1, 8], [0, 1, 9]]]]> : tensor<1x1x10x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<2x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<2x6x10x12xf32>
+  onnx.Return %0 : tensor<2x6x10x12xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_mulit_dim_differ
+// CHECK:        onnx.ScatterND
+
+// -----
+func.func @test_scatter_nd_mulit_dim_differ_multi_shift(%data : tensor<2x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<2x6x10x12xf32> {
+  %indices = onnx.Constant dense<[[[[1, 1, 0], [1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 1, 4], [1, 1, 5], [1, 1, 6], [1, 1, 7], [1, 1, 8], [1, 1, 9]]]]> : tensor<1x1x10x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<2x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<2x6x10x12xf32>
+  onnx.Return %0 : tensor<2x6x10x12xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_mulit_dim_differ_multi_shift
+// CHECK:        onnx.ScatterND
+
+// -----
+func.func @test_scatter_nd_negative_shift(%data : tensor<1x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<1x6x10x12xf32> {
+  %indices = onnx.Constant dense<[[[[ 0, -1, 0], [ 0, -1, 1], [ 0, -1, 2], [ 0, -1, 3], [ 0, -1, 4], [ 0, -1, 5], [ 0, -1, 6], [ 0, -1, 7], [ 0, -1, 8], [ 0, -1, 9]]]]> : tensor<1x1x10x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32>
+  onnx.Return %0 : tensor<1x6x10x12xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_negative_shift
+// CHECK:        onnx.ScatterND
+
+// -----
+func.func @test_scatter_nd_full_overwrite(%data : tensor<1x6x10x12xf32>, %updates : tensor<1x6x10x12xf32> ) -> tensor<1x6x10x12xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 0], [0, 0, 1], [0, 0, 2], [0, 0, 3], [0, 0, 4], [0, 0, 5], [0, 0, 6], [0, 0, 7], [0, 0, 8], [0, 0, 9]], [[0, 1, 0], [0, 1, 1], [0, 1, 2], [0, 1, 3], [0, 1, 4], [0, 1, 5], [0, 1, 6], [0, 1, 7], [0, 1, 8], [0, 1, 9]], [[0, 2, 0], [0, 2, 1], [0, 2, 2], [0, 2, 3], [0, 2, 4], [0, 2, 5], [0, 2, 6], [0, 2, 7], [0, 2, 8], [0, 2, 9]], [[0, 3, 0], [0, 3, 1], [0, 3, 2], [0, 3, 3], [0, 3, 4], [0, 3, 5], [0, 3, 6], [0, 3, 7], [0, 3, 8], [0, 3, 9]], [[0, 4, 0], [0, 4, 1], [0, 4, 2], [0, 4, 3], [0, 4, 4], [0, 4, 5], [0, 4, 6], [0, 4, 7], [0, 4, 8], [0, 4, 9]], [[0, 5, 0], [0, 5, 1], [0, 5, 2], [0, 5, 3], [0, 5, 4], [0, 5, 5], [0, 5, 6], [0, 5, 7], [0, 5, 8], [0, 5, 9]]]]> : tensor<1x6x10x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x6x10x12xf32>, tensor<1x6x10x3xi64>, tensor<1x6x10x12xf32>) -> tensor<1x6x10x12xf32>
+  onnx.Return %0 : tensor<1x6x10x12xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_full_overwrite
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x6x10x12xf32>, [[PARAM_1_:%.+]]: tensor<1x6x10x12xf32>) -> tensor<1x6x10x12xf32> {
+// CHECK:           onnx.Return [[PARAM_1_]] : tensor<1x6x10x12xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_multi_dim(%data : tensor<1x4x6xf32>, %updates : tensor<1x4x2xf32> ) -> tensor<1x4x6xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 0], [0, 0, 1]], [[0, 1, 0], [0, 1, 1]], [[0, 2, 0], [0, 2, 1]], [[0, 3, 0], [0, 3, 1]]]]> : tensor<1x4x2x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x4x6xf32>, tensor<1x4x2x3xi64>, tensor<1x4x2xf32>) -> tensor<1x4x6xf32>
+  onnx.Return %0 : tensor<1x4x6xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x6xf32>, [[PARAM_1_:%.+]]: tensor<1x4x2xf32>) -> tensor<1x4x6xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[2, 4]> : tensor<2xi64>
+// CHECK:           [[VAR_1_:%.+]]:2 = "onnx.Split"([[PARAM_0_]], [[VAR_0_]]) {axis = 2 : si64} : (tensor<1x4x6xf32>, tensor<2xi64>) -> (tensor<1x4x2xf32>, tensor<1x4x4xf32>)
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[PARAM_1_]], [[VAR_1_]]#1) {axis = 2 : si64} : (tensor<1x4x2xf32>, tensor<1x4x4xf32>) -> tensor<1x4x6xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x4x6xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_multi_dim_shift(%data : tensor<1x4x6xf32>, %updates : tensor<1x4x2xf32> ) -> tensor<1x4x6xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 1], [0, 0, 2]], [[0, 1, 1], [0, 1, 2]], [[0, 2, 1], [0, 2, 2]], [[0, 3, 1], [0, 3, 2]]]]> : tensor<1x4x2x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x4x6xf32>, tensor<1x4x2x3xi64>, tensor<1x4x2xf32>) -> tensor<1x4x6xf32>
+  onnx.Return %0 : tensor<1x4x6xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_shift
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x6xf32>, [[PARAM_1_:%.+]]: tensor<1x4x2xf32>) -> tensor<1x4x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<3> : tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]]:2 = "onnx.Split"([[PARAM_0_]], [[VAR_1_]]) {axis = 2 : si64} : (tensor<1x4x6xf32>, tensor<2xi64>) -> (tensor<1x4x3xf32>, tensor<1x4x3xf32>)
+// CHECK:           [[VAR_3_:%.+]]:2 = "onnx.Split"([[VAR_2_]]#0, [[VAR_0_]]) {axis = 2 : si64} : (tensor<1x4x3xf32>, tensor<2xi64>) -> (tensor<1x4x1xf32>, tensor<1x4x2xf32>)
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Concat"([[VAR_3_]]#0, [[PARAM_1_]], [[VAR_2_]]#1) {axis = 2 : si64} : (tensor<1x4x1xf32>, tensor<1x4x2xf32>, tensor<1x4x3xf32>) -> tensor<1x4x6xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<1x4x6xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_multi_dim_not_in_order(%data : tensor<1x4x6xf32>, %updates : tensor<1x4x2xf32> ) -> tensor<1x4x6xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 0], [0, 1, 1]], [[0, 1, 0], [0, 0, 1]], [[0, 2, 0], [0, 2, 1]], [[0, 3, 0], [0, 3, 1]]]]> : tensor<1x4x2x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x4x6xf32>, tensor<1x4x2x3xi64>, tensor<1x4x2xf32>) -> tensor<1x4x6xf32>
+  onnx.Return %0 : tensor<1x4x6xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_not_in_order
+// CHECK:        onnx.ScatterND
+
+// -----
+func.func @test_scatter_nd_single_not_in_order(%data : tensor<1x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<1x6x10x12xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 0], [0, 0, 2], [0, 0, 1], [0, 0, 3], [0, 0, 4], [0, 0, 5], [0, 0, 6], [0, 0, 7], [0, 0, 8], [0, 0, 9]]]]> : tensor<1x1x10x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32>
+  onnx.Return %0 : tensor<1x6x10x12xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_single_not_in_order
+// CHECK:        onnx.ScatterND


### PR DESCRIPTION
- [x] Port internal python tests to lit
- [x] Optimize case with zero size split/concat
- [x] Optimize double split into one
- [x] Remove debug printing