### PR TITLE
Skip over uninitialized DenseResourceAttrs in verifiers

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Math/Scatter.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/Scatter.cpp
@@ -76,6 +76,10 @@ LogicalResult ONNXScatterElementsOp::verify() {
   if (dataDimAtAxis >= 0) {
     if (ElementsAttr valueAttribute =
             getElementAttributeFromONNXValue(indices)) {
+      if (isElementAttrUninitializedDenseResource(valueAttribute)) {
+        return success(); // Return success to allow the parsing of MLIR with
+                          // elided attributes
+      }
       for (IntegerAttr value : valueAttribute.getValues<IntegerAttr>()) {
         int64_t index = value.getInt();
         if (index >= -dataDimAtAxis && index < dataDimAtAxis)

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -14,6 +14,7 @@
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/DialectResourceBlobManager.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Path.h"
@@ -894,6 +895,17 @@ std::string getNodeNameInPresenceOfOpt(Operation *op, bool useFileLine) {
     }
   }
   return "NOTSET";
+}
+
+//===----------------------------------------------------------------------===//
+// Support for DenseElementsAttr.
+//===----------------------------------------------------------------------===//
+
+bool isElementAttrUninitializedDenseResource(mlir::ElementsAttr elementsAttr) {
+  const auto denseResourceElementsAttr =
+      mlir::dyn_cast<DenseResourceElementsAttr>(elementsAttr);
+  return denseResourceElementsAttr &&
+         !denseResourceElementsAttr.getRawHandle().getBlob();
 }
 
 } // namespace onnx_mlir

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -363,6 +363,14 @@ bool isIdentityReshape(mlir::Value input, mlir::Value output,
 std::string getNodeNameInPresenceOfOpt(
     mlir::Operation *op, bool useFileLine = true);
 
+//===----------------------------------------------------------------------===//
+// Support for DenseElementsAttr.
+//===----------------------------------------------------------------------===//
+
+/// Returns true if elementsAttr is a DenseResourceAttr with a blob that can not
+/// be received
+bool isElementAttrUninitializedDenseResource(mlir::ElementsAttr elementsAttr);
+
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp.inc"
 
 } // namespace onnx_mlir

--- a/src/Dialect/ONNX/ONNXOps/Sequence/SplitToSequence.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Sequence/SplitToSequence.cpp
@@ -58,6 +58,10 @@ LogicalResult ONNXSplitToSequenceOp::verify() {
   if (splitRank > 1)
     return emitOpError() << ": split has rank " << splitRank << " > 1";
   if (ElementsAttr entries = getElementAttributeFromONNXValue(splitValue)) {
+    if (isElementAttrUninitializedDenseResource(entries)) {
+      return success(); // Return success to allow the parsing of MLIR with
+                        // elided attributes
+    }
     if (splitRank == 0) {
       auto scalar = getScalarValue<int64_t>(entries, splitType);
       if (scalar <= 0)

--- a/src/Dialect/ONNX/ONNXOps/Tensor/ConstantOfShape.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/ConstantOfShape.cpp
@@ -70,6 +70,10 @@ LogicalResult ONNXConstantOfShapeOp::verify() {
   if (auto constantOp = getONNXConstantOp(input)) {
     ElementsAttr valueAttribute =
         mlir::cast<ElementsAttr>(constantOp.getValueAttr());
+    if (isElementAttrUninitializedDenseResource(valueAttribute)) {
+      return success(); // Return success to allow the parsing of MLIR with
+                        // elided attributes
+    }
     // Get repeat values from valueAttribute.
     auto valueIt = valueAttribute.getValues<IntegerAttr>().begin();
     for (int i = 0; i < inputShape[0]; ++i) {

--- a/src/Dialect/ONNX/ONNXOps/Tensor/GatherND.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/GatherND.cpp
@@ -144,6 +144,10 @@ LogicalResult ONNXGatherNDOp::verify() {
   // All values in 'indices' are expected to satisfy the inequality:
   //   -data.shape[b + i] <= indices[...,i] <= (data.shape[b + i]-1)].
   if (ElementsAttr valueAttribute = getElementAttributeFromONNXValue(indices)) {
+    if (isElementAttrUninitializedDenseResource(valueAttribute)) {
+      return success(); // Return success to allow the parsing of MLIR with
+                        // elided attributes
+    }
     int flatIndex = 0;
     for (IntegerAttr value : valueAttribute.getValues<IntegerAttr>()) {
       int64_t indexValue = value.getInt();

--- a/test/mlir/onnx/invalid.mlir
+++ b/test/mlir/onnx/invalid.mlir
@@ -182,6 +182,15 @@ func.func @test_constantofshape_verifier_4() -> tensor<2xi64> {
 
 // -----
 
+func.func @test_constantofshape_elided() -> tensor<2xi64> {
+   // Tests that we do not crash on elided elements
+   %0 = onnx.Constant dense_resource<__elided__> : tensor<2xi64>
+   %1 = "onnx.ConstantOfShape"(%0) : (tensor<2xi64>) -> tensor<2xi64>
+  "onnx.Return"(%1) : (tensor<2xi64>) -> ()
+}
+
+// -----
+
 func.func @test_flatten_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.Flatten: 'axis' value is 5, accepted range is [-4, 4]}}
   %1 = "onnx.Flatten"(%arg0) {axis = 5 : si64} : (tensor<5x5x1x32xf32>) -> tensor<*xf32>
@@ -210,6 +219,15 @@ func.func @test_gatherElements_verifier_2(%data: tensor<2x2xf32>, %indices: tens
   // expected-error @+1 {{onnx.GatherElements: 'axis' value is 2, accepted range is [-2, 1]}}
   %1 = "onnx.GatherElements"(%data, %indices) {axis = 2 : si64} : (tensor<2x2xf32>, tensor<2x2xi64>) -> tensor<*xf32>
   "onnx.Return"(%1) : (tensor<*xf32>) -> ()
+}
+
+// -----
+
+func.func @test_gatherElements_verifier_elided(%data: tensor<12x14x1024xf32>) -> tensor<12x14x14xf32> {
+  // Tests that we do not crash on elided elements
+  %indices = onnx.Constant dense_resource<__elided__> : tensor<12x14x14xi64>
+  %1 = "onnx.GatherElements"(%data, %indices) {axis = -1 : si64} : (tensor<12x14x1024xf32>, tensor<12x14x14xi64>) -> tensor<12x14x14xf32>
+  "onnx.Return"(%1) : (tensor<12x14x14xf32>) -> ()
 }
 
 // -----
@@ -307,6 +325,16 @@ func.func @test_gatherND_verifier_6(%arg0 : tensor<3x4x4x4xf32>) -> tensor<*xf32
   // expected-error @+2 {{onnx.GatherND: 'indices[0]' value is 3, accepted range is [-3, 2]}}
   %indices = "onnx.Constant"() {value = dense<[3,2,2]> : tensor<3xi64>} : () -> tensor<3x3x2xi64>
   %1 = "onnx.GatherND"(%arg0, %indices) : (tensor<3x4x4x4xf32>, tensor<3x3x2xi64>)  -> tensor<*xf32>
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
+}
+
+// -----
+
+func.func @test_gatherND_verifier_elided(%arg0 : tensor<3x4x4x4xf32>) -> tensor<*xf32> {
+  // Test that we do not crash on elided elements
+  %indices = onnx.Constant dense_resource<__elided__> : tensor<3x3x2xi64>
+  %1 = "onnx.GatherND"(%arg0, %indices) : (tensor<3x4x4x4xf32>, tensor<3x3x2xi64>)  -> tensor<*xf32>
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -575,6 +603,15 @@ func.func @test_splitToSequence_verifier_6(%arg0: tensor<2x2xf32>) -> !onnx.Seq<
   // expected-error @+2 {{'onnx.SplitToSequence' op : split tensor entries sum to 1 != axis dimension size 2}}
   %0 = "onnx.Constant"(){value = dense<[0, 1]> : tensor<2xi64>} : () -> tensor<2xi64>
   %1 = "onnx.SplitToSequence"(%arg0, %0) : (tensor<2x2xf32>, tensor<2xi64>) -> !onnx.Seq<tensor<*xf32>>
+  "onnx.Return"(%1) : (!onnx.Seq<tensor<*xf32>>) -> ()
+}
+
+// -----
+
+func.func @test_splitToSequence_verifier_elided(%arg0: tensor<2x2xf32>) -> !onnx.Seq<tensor<*xf32>> {
+  // Tests that we do not crash on elided elements
+  %0 = onnx.Constant dense_resource<__elided__> : tensor<i64>
+  %1 = "onnx.SplitToSequence"(%arg0, %0) : (tensor<2x2xf32>, tensor<i64>) -> !onnx.Seq<tensor<*xf32>>
   "onnx.Return"(%1) : (!onnx.Seq<tensor<*xf32>>) -> ()
 }
 


### PR DESCRIPTION
Elided elements are uninitialized DenseResourceAttrs, without these changes MLIR containing them can not be parsed, as the verifiers crash when encountering them.

I plan to upstream this