### PR TITLE
Make ONNX to TOSA lowering more resistant to dynamic shapes and unranked types.

### DIFF
--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -91,8 +91,7 @@ struct TosaBuilder : DialectBuilder {
   // The tensor will have the same rank as shape but all dimensions will
   // have size 1 (differs from tensorflow impl.)
   // If dtype is provided, it also cast the value to the appropriate dtype.
-  mlir::Value getSplattedConst(
-      float val, mlir::Type dtype, llvm::ArrayRef<int64_t> shape = {});
+  mlir::Value getSplattedConst(float val, mlir::Type dtype, int64_t rank);
 
   // Creates a constant of shape <1x1x...x1> of rank `rank` with all values set
   // to `value`.

--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -239,12 +239,12 @@ static LogicalResult legalizeFloatingPointPrelu(Operation *op,
   auto loc = op->getLoc();
   TosaBuilder tosaBuilder(rewriter, loc);
   Value constZero = tosaBuilder.getSplattedConst(
-      0.0, outputType.getElementType(), outputType.getShape());
+      0.0, outputType.getElementType(), outputType.getRank());
 
   auto mul = tosaBuilder.mul(input, alphaOrSlope);
   auto greaterEqual = tosaBuilder.greaterEqual(input, constZero);
   auto select = tosaBuilder.select(greaterEqual, input, mul);
-
+  copySingleResultType(op, select);
   rewriter.replaceOp(op, {select});
   return success();
 }
@@ -274,7 +274,7 @@ public:
     TosaBuilder tosaBuilder(rewriter, loc);
     return legalizeFloatingPointPrelu(op, rewriter, adaptor.getX(),
         tosaBuilder.getSplattedConst(
-            alpha, outputType.getElementType(), outputType.getShape()),
+            alpha, outputType.getElementType(), outputType.getRank()),
         outputType);
   }
 };
@@ -312,6 +312,7 @@ public:
     } else if constexpr (std::is_same_v<OnnxCompOp, ONNXLessOp>) {
       res = tosaBuilder.less(input1, input2);
     }
+    copySingleResultType(op, res);
     rewriter.replaceOp(op, {res});
     return success();
   }
@@ -393,7 +394,7 @@ public:
       // onnx.Cast and tosa.cast.
       if (resultTy.getElementType().getIntOrFloatBitWidth() != 1) {
         auto zero = tosaBuilder.getSplattedConst(
-            0.0f, inputTy.getElementType(), resultTy.getShape());
+            0.0f, inputTy.getElementType(), resultTy.getRank());
         auto positive = tosaBuilder.greaterEqual(input, zero);
 
         auto floor = tosaBuilder.unaryOp<mlir::tosa::FloorOp>(input);
@@ -421,6 +422,7 @@ public:
 
     if (isa<IntegerType>(resultElementType)) {
       Value divOp = tosaBuilder.intdiv(lhs, rhs);
+      copySingleResultType(op, divOp);
       rewriter.replaceOp(op, {divOp});
       return success();
     }
@@ -428,6 +430,7 @@ public:
     // tosa::ReciprocalOp and tosa::MulOp.
     Value reciprocalOp = tosaBuilder.unaryOp<mlir::tosa::ReciprocalOp>(rhs);
     Value mulOp = tosaBuilder.mul(lhs, reciprocalOp);
+    copySingleResultType(op, mulOp);
     rewriter.replaceOp(op, {mulOp});
     return success();
   }
@@ -472,20 +475,21 @@ public:
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
 
     Value one = tosaBuilder.getSplattedConst(
-        1.0, resultTensorType.getElementType(), resultTensorType.getShape());
+        1.0, resultTensorType.getElementType(), resultTensorType.getRank());
     Value alpha =
         tosaBuilder.getSplattedConst(adaptor.getAlpha().convertToDouble(),
-            resultTensorType.getElementType(), resultTensorType.getShape());
+            resultTensorType.getElementType(), resultTensorType.getRank());
     Value constZero = tosaBuilder.getSplattedConst(
-        0.0, resultTensorType.getElementType(), resultTensorType.getShape());
+        0.0, resultTensorType.getElementType(), resultTensorType.getRank());
 
     Value exp = tosaBuilder.unaryOp<mlir::tosa::ExpOp>(input);
+    copySingleResultType(op, exp);
     Value expMinusOne = tosaBuilder.binaryOp<mlir::tosa::SubOp>(exp, one);
     Value alphaTimesExpMinusOne = tosaBuilder.mul(expMinusOne, alpha);
     Value greaterEqual = tosaBuilder.greaterEqual(input, constZero);
     auto select =
         tosaBuilder.select(greaterEqual, input, alphaTimesExpMinusOne);
-
+    copySingleResultType(op, select);
     rewriter.replaceOp(op, {select});
     return success();
   }
@@ -516,11 +520,16 @@ public:
     APFloat oneOverAlpha(alpha.getSemantics(), 1);
     oneOverAlpha.divide(alpha, APFloat::rmNearestTiesToEven);
 
+    if (!resultType.hasRank()) {
+      return rewriter.notifyMatchFailure(
+          op, "HardSigmoid: Static shape required to create splatted const");
+    }
+
     Value constBetaOverAlpha =
         tosaBuilder.getSplattedConst(betaOverAlpha.convertToDouble(),
-            resultElementType, resultType.getShape());
+            resultElementType, resultType.getRank());
     Value constAlpha = tosaBuilder.getSplattedConst(
-        alpha.convertToDouble(), resultElementType, resultType.getShape());
+        alpha.convertToDouble(), resultElementType, resultType.getRank());
 
     auto addOp =
         tosaBuilder.binaryOp<mlir::tosa::AddOp>(input, constBetaOverAlpha);
@@ -530,7 +539,7 @@ public:
         rewriter.getF32FloatAttr(0),
         rewriter.getF32FloatAttr(oneOverAlpha.convertToDouble()));
     auto mulOp = tosaBuilder.mul(clampOp, constAlpha);
-
+    copySingleResultType(op, mulOp);
     rewriter.replaceOp(op, {mulOp});
     return success();
   }
@@ -565,14 +574,19 @@ public:
     if (failed(IsFloat::checkType(rewriter, outputType.getElementType(), op))) {
       return failure();
     }
+    if (!outputType.hasRank()) {
+      return rewriter.notifyMatchFailure(
+          op, "ONNXSoftplusOp: Rank required to create splatted const");
+    }
 
     Value input = adaptor.getX();
 
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
     auto one = tosaBuilder.getSplattedConst(
-        1.0, outputType.getElementType(), outputType.getShape());
+        1.0, outputType.getElementType(), outputType.getRank());
 
     auto expOp = tosaBuilder.unaryOp<mlir::tosa::ExpOp>(input);
+    copySingleResultType(op, expOp);
     auto expPlusOne = tosaBuilder.binaryOp<mlir::tosa::AddOp>(expOp, one);
     auto logOp = tosaBuilder.unaryOp<mlir::tosa::LogOp>(expPlusOne);
     rewriter.replaceOp(op, {logOp});
@@ -594,15 +608,19 @@ public:
     Value input = adaptor.getX();
 
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
+    if (!outputType.hasRank()) {
+      return rewriter.notifyMatchFailure(
+          op, "ONNXSeluOp: Rank required to create splatted const");
+    }
 
     Value alpha =
         tosaBuilder.getSplattedConst(adaptor.getAlpha().convertToDouble(),
-            outputType.getElementType(), outputType.getShape());
+            outputType.getElementType(), outputType.getRank());
     Value gamma =
         tosaBuilder.getSplattedConst(adaptor.getGamma().convertToDouble(),
-            outputType.getElementType(), outputType.getShape());
+            outputType.getElementType(), outputType.getRank());
     Value constZero = tosaBuilder.getSplattedConst(
-        0.0, outputType.getElementType(), outputType.getShape());
+        0.0, outputType.getElementType(), outputType.getRank());
 
     Value exp = tosaBuilder.unaryOp<mlir::tosa::ExpOp>(input);
     Value expTimesAlpha = tosaBuilder.mul(exp, alpha);
@@ -630,15 +648,19 @@ public:
             rewriter, outputType.getElementType(), op))) {
       return failure();
     }
+    if (!outputType.hasRank()) {
+      return rewriter.notifyMatchFailure(
+          op, "ONNXThresholdedReluOp: Rank required to create splatted const");
+    }
 
     Value input = adaptor.getX();
 
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
     auto alpha =
         tosaBuilder.getSplattedConst(adaptor.getAlpha().convertToDouble(),
-            outputType.getElementType(), outputType.getShape());
+            outputType.getElementType(), outputType.getRank());
     auto zero = tosaBuilder.getSplattedConst(
-        0.0, outputType.getElementType(), outputType.getShape());
+        0.0, outputType.getElementType(), outputType.getRank());
 
     auto greater = tosaBuilder.greater(input, alpha);
     auto select = tosaBuilder.select(greater, input, zero);

--- a/src/Conversion/ONNXToTOSA/Math/Reduce.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Reduce.cpp
@@ -179,7 +179,7 @@ LogicalResult reduceMeanLowering(ONNXReduceMeanOp op,
 
   TosaBuilder tosaBuilder(rewriter, op->getLoc());
   Value divConst = tosaBuilder.getSplattedConst(
-      divScale, outputType.getElementType(), outputType.getShape());
+      divScale, outputType.getElementType(), outputType.getRank());
   auto output = tosaBuilder.mul(val, divConst);
 
   if (!output) {

--- a/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
@@ -56,7 +56,7 @@ LogicalResult handleIncludePadAttr(
   Value padding = tosa::buildOnnxToTosaPaddingConstOp(
       rewriter, pads, loc, {0, 0, 0, 0}, {});
   auto constTosaTensor =
-      tosaBuilder.getSplattedConst(0.0, inputType.getElementType());
+      tosaBuilder.getSplattedConst(0.0, inputType.getElementType(), 0);
 
   auto padOp = tosa::CreateOpAndInfer<mlir::tosa::PadOp>(rewriter, loc,
       mlir::RankedTensorType::get(

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.cpp
@@ -418,7 +418,7 @@ std::optional<Value> convertReduceMeanOp(PatternRewriter &rewriter,
 
   if (!input_is_qtype) {
     Value div_const = tosaBuilder.getSplattedConst(
-        div_scale, output_type.getElementType(), output_type.getShape());
+        div_scale, output_type.getElementType(), output_type.getRank());
     return tosaBuilder.mul(val.value(), div_const);
   }
 

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
@@ -56,9 +56,9 @@ llvm::SmallVector<int64_t> createInt64VectorFromIndexExpr(
 }
 
 mlir::RankedTensorType reduceAxisToOne(
-    llvm::ArrayRef<int64_t> shape, Type elementType, Attribute encoding) {
+    int64_t rank, Type elementType, Attribute encoding) {
   return mlir::RankedTensorType::get(
-      llvm::SmallVector<int64_t, 4>(shape.size(), 1), elementType, encoding);
+      llvm::SmallVector<int64_t, 4>(rank, 1), elementType, encoding);
 }
 
 mlir::ElementsAttr getElementsAttrFromConst(mlir::Value &val) {

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
@@ -39,9 +39,9 @@ int64_t convertNegativeAxis(int64_t axis, int64_t inputRank);
 llvm::SmallVector<int64_t> createInt64VectorFromIndexExpr(
     llvm::ArrayRef<IndexExpr> indexVector);
 
-// Create a RankedTensorType with shape and all elements being 1
-mlir::RankedTensorType reduceAxisToOne(llvm::ArrayRef<int64_t> shape,
-    mlir::Type elementType, mlir::Attribute encoding = {});
+// Create a RankedTensorType with the given rank and all dims being 1
+mlir::RankedTensorType reduceAxisToOne(
+    int64_t rank, mlir::Type elementType, mlir::Attribute encoding = {});
 
 // Returns the value TOSA ConstOp
 template <typename T>

--- a/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
@@ -85,12 +85,12 @@ public:
 
     // Create an 1x..x1 constant containing the size of the gathered dimension.
     auto dimSize = tosaBuilder.getSplattedConst(
-        inputShape[axis], indicesType.getElementType(), indicesType.getShape());
+        inputShape[axis], indicesType.getElementType(), indicesType.getRank());
     auto indicesPlusDimSize =
         tosaBuilder.binaryOp<mlir::tosa::AddOp>(indices, dimSize);
 
     auto zero = tosaBuilder.getSplattedConst(
-        (int64_t)0, indicesType.getElementType(), indicesType.getShape());
+        (int64_t)0, indicesType.getElementType(), indicesType.getRank());
     auto indicesPositive = tosaBuilder.greaterEqual(indices, zero);
 
     auto newIndices =

--- a/src/Conversion/ONNXToTOSA/Tensor/PaddingOp.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/PaddingOp.cpp
@@ -98,7 +98,7 @@ public:
         auto valueIt = valueAttr.getValues<FloatAttr>().begin();
         const float valueFloat = cast<FloatAttr>(*valueIt).getValueAsDouble();
         constTosaTensor = tosaBuilder.getSplattedConst(
-            valueFloat, valueAttr.getElementType());
+            valueFloat, valueAttr.getElementType(), 0);
       } else {
         assert(isTOSAInt(elementDtype) && "Already validated");
         auto valueIt = valueAttr.getValues<IntegerAttr>().begin();
@@ -106,10 +106,10 @@ public:
         auto asIntegerTy = cast<IntegerType>(valueAttr.getElementType());
         if (asIntegerTy.isUnsigned()) {
           constTosaTensor = tosaBuilder.getSplattedConst(
-              valueAsAPInt.getZExtValue(), asIntegerTy);
+              valueAsAPInt.getZExtValue(), asIntegerTy, 0);
         } else {
           constTosaTensor = tosaBuilder.getSplattedConst(
-              valueAsAPInt.getSExtValue(), asIntegerTy);
+              valueAsAPInt.getSExtValue(), asIntegerTy, 0);
         }
       }
       rewriter.replaceOpWithNewOp<mlir::tosa::PadOp>(

--- a/src/Conversion/ONNXToTOSA/Tensor/Shrink.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Shrink.cpp
@@ -48,13 +48,13 @@ public:
     const float lambdAsFloat = lambd.getValue().convertToFloat();
     const float biasAsFloat = bias.getValue().convertToFloat();
     auto lambdConstOp = tosaBuilder.getSplattedConst(lambdAsFloat,
-        inputRankedTensorTy.getElementType(), inputRankedTensorTy.getShape());
+        inputRankedTensorTy.getElementType(), inputRankedTensorTy.getRank());
     auto negatedLambdConstOp = tosaBuilder.getSplattedConst(-lambdAsFloat,
-        inputRankedTensorTy.getElementType(), inputRankedTensorTy.getShape());
+        inputRankedTensorTy.getElementType(), inputRankedTensorTy.getRank());
     auto biasConstOp = tosaBuilder.getSplattedConst(biasAsFloat,
-        inputRankedTensorTy.getElementType(), inputRankedTensorTy.getShape());
-    auto zeroConstOp = tosaBuilder.getSplattedConst(0,
-        inputRankedTensorTy.getElementType(), inputRankedTensorTy.getShape());
+        inputRankedTensorTy.getElementType(), inputRankedTensorTy.getRank());
+    auto zeroConstOp = tosaBuilder.getSplattedConst(
+        0, inputRankedTensorTy.getElementType(), inputRankedTensorTy.getRank());
 
     // Formula to be implemented:
     // { x < -lambd, then y = x + bias


### PR DESCRIPTION


- Add checks for types being ranked in various lowerings
- Refactor getSplattedConst to only require a type and not a rank
- Manually annotate the return type for some tosa ops to prevent type mismatches
  - In some cases to result type of an op can not be inferred just from its inputs, in these cases the annotation is always necessary  
  - In some cases the TOSA shape inference does not infer types even if it is possible, especially in the presence of non-static dimensions.  This is something I want to improve in another PR for MLIR.