### PR TITLE
Fix return type of recomposed ops

### DIFF
--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -108,14 +108,6 @@ LogicalResult checkBasicTosaRequirementsForBinaryOps(
   return success();
 }
 
-namespace {
-template <typename OnnxOp>
-void copySingleResultType(OnnxOp opToCopyFrom, Value &valueToCopyTo) {
-  assert(opToCopyFrom->getNumResults() == 1);
-  valueToCopyTo.setType(opToCopyFrom->getResult(0).getType());
-}
-} // namespace
-
 // Element-wise unary ops lowering to TOSA dialect.
 //===----------------------------------------------------------------------===//
 template <typename ElementwiseUnaryOpONNX, typename ElementwiseUnaryOpTOSA,

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -334,5 +334,11 @@ protected:
 // Include inline code definitions.
 #include "DialectBuilder.hpp.inc"
 
+template <typename OnnxOp>
+void copySingleResultType(OnnxOp opToCopyFrom, mlir::Value &valueToCopyTo) {
+  assert(opToCopyFrom->getNumResults() == 1);
+  valueToCopyTo.setType(opToCopyFrom->getResult(0).getType());
+}
+
 } // namespace onnx_mlir
 #endif

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -68,6 +68,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
       res = create.onnx.RMSLayerNorm(xType, x, scale, noneVal, axis, epsilon);
     else
       res = create.onnx.layerNorm(xType, x, scale, noneVal, axis, epsilon);
+    copySingleResultType(mulOp, res);
     rewriter.replaceOp(mulOp, res);
     return success();
   }
@@ -429,6 +430,7 @@ struct RecomposeGeluFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     StringAttr approximateAttr =
         rewriter.getStringAttr(isExactGelu ? "none" : "tanh");
     Value res = create.onnx.gelu(x, approximateAttr);
+    copySingleResultType(mulOp, res);
     rewriter.replaceOp(mulOp, res);
     return success();
   }
@@ -625,6 +627,7 @@ struct RecomposeQLinearMatMulFromQuantizeLinearPattern
         aZeroPoint, b, bScale, bZeroPoint, outScale, outZeroPoint);
 
     rewriter.replaceOp(qlOp, res);
+    copySingleResultType(qlOp, res);
     return success();
   }
 


### PR DESCRIPTION
Recomposition of onnx ops happens before shape inference.
This is generally no problem and intended, but can cause problems if the recompose operation is the last one before a return.
The  return type can be know based on the onnx-model, so if the op before the return is replaced with an unshaped one, we will get a type mismatch.