### PR TITLE
VAI-9473 feature: Recompose RMSLaynorm from a pattern containing Pow operator

### DIFF
--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -95,7 +95,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     Value noneVal = create.onnx.none();
     Value res;
     if (isRMSLayerNorm) {
-      if (!scale.getImpl()) {
+      if (!scale) {
         // set scale to unity if there is no scale value present in the pattern
         // This is required because RMSLayerNorm mandates passing a scale value
 

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -25,14 +25,13 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/Support/Debug.h"
+#include <mlir/TableGen/Builder.h>
 
 #include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 #include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
 #include "src/Dialect/ONNX/Transforms/Recompose.hpp"
-
-#include "mlir/TableGen/Builder.h"
 #include "src/Pass/Passes.hpp"
 #include "src/Support/TypeUtilities.hpp"
 
@@ -46,6 +45,43 @@ namespace {
 
 struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
   using OpRewritePattern<ONNXMulOp>::OpRewritePattern;
+
+  FailureOr<mlir::Value> createScaleConstOp(const Type &xType,
+      const onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> &builder)
+      const {
+    mlir::Value scale;
+    if (!isa<ShapedType>(xType))
+      return failure();
+    // return {scale, failure(), "Expected Input type to be of type
+    // 'ShapedType', but it is not."};
+
+    auto xShape = mlir::cast<ShapedType>(xType).getShape();
+    auto xInnerMostDim = xShape[xShape.size() - 1];
+
+    // Inner most dim is required
+    if (xInnerMostDim <= 0)
+      return failure();
+    // return {scale, failure(), "The inner most dim of input must be known for
+    // this recomposition."};
+
+    auto scaleType = mlir::RankedTensorType::get(
+        {xInnerMostDim}, getElementTypeOrSelf(xType));
+
+    // For now only float32 type supported
+    mlir::DenseElementsAttr attr;
+    if (onnx_mlir::getEltSizeInBytes(scaleType) == sizeof(float)) {
+      auto scaleVal = SmallVector<float>(xInnerMostDim, 1.0f);
+      attr = mlir::DenseElementsAttr::get(scaleType, ArrayRef(scaleVal));
+    } else {
+      return failure();
+      // return {scale, failure(), "Only type with bit width " +
+      // std::to_string(sizeof(float)) + " supported."};
+    }
+
+    scale = builder.onnx.constant(attr);
+    return success(scale);
+    // return {scale, true, ""};
+  }
 
   LogicalResult matchAndRewrite(
       ONNXMulOp mulOp, PatternRewriter &rewriter) const final {
@@ -67,7 +103,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     Value noneVal = create.onnx.none();
     Value res;
     if (isRMSLayerNorm) {
-      if (scale.getImpl() == nullptr) {
+      if (!scale.getImpl()) {
         // set scale to unity if there is no scale value present in the pattern
         // This is required because RMSLayerNorm mandates passing a scale value
 
@@ -75,14 +111,10 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
         // because the pass that generates RMSNormAdf templated graph requires
         // the scale to be a tensor of dimension same as the inner most
         // dimension of input tensor
-
-        auto xShape = mlir::cast<ShapedType>(xType).getShape();
-        auto xInnerMostDim = xShape[xShape.size() - 1];
-        auto scaleType = mlir::RankedTensorType::get(
-            {xInnerMostDim}, getElementTypeOrSelf(xType));
-        auto scaleVal = SmallVector<float>(xInnerMostDim, 1.0f);
-        auto attr = mlir::DenseElementsAttr::get(scaleType, ArrayRef(scaleVal));
-        scale = create.onnx.constant(attr);
+        auto result = this->createScaleConstOp(xType, create);
+        if (failed(result))
+          return failure();
+        scale = result.value();
       }
       res = create.onnx.RMSLayerNorm(xType, x, scale, noneVal, axis, epsilon);
     } else {
@@ -226,19 +258,18 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
                operandOfOpDefinedBy<ONNXPowOp>(
                    powOp, nsMulOp, d, invStdDev, 1)) {
       // The following pattern is now matched
-      // %invStdDev = "onnx.Pow"(%varEps, %neg_half)
+      // %invStdDev = "onnx.Pow"(%varEps, %negHalf)
       // %norm = "onnx.Mul"(%d, %invStdDev)
 
       // Now verify the value of exponent for pow op
-      mlir::Value neg_half;
-      if (operandOfOpDefinedBy<ONNXAddOp>(
-              veAddOp, powOp, varEps, neg_half, 0)) {
+      mlir::Value negHalf;
+      if (operandOfOpDefinedBy<ONNXAddOp>(veAddOp, powOp, varEps, negHalf, 0)) {
         // Verify if the exponent is floating point scalar with value -0.5
         IndexExprScope scope(nullptr, loc);
         IndexExprBuilderForAnalysis createIE(loc);
-        if (createIE.hasShapeAndRank(neg_half) &&
-            createIE.getArraySize(neg_half, /*static only*/ true) == 1) {
-          IndexExpr floatVal = createIE.getFloatAsNonAffine(neg_half);
+        if (createIE.hasShapeAndRank(negHalf) &&
+            createIE.getArraySize(negHalf, /*static only*/ true) == 1) {
+          IndexExpr floatVal = createIE.getFloatAsNonAffine(negHalf);
           if (!floatVal.isLiteral() || (floatVal.getFloatLiteral() != -0.5)) {
             return reportFailure("RMS missing std dev (via pow(var + eps, "
                                  "-0.5)), exp is not -0.5");
@@ -257,7 +288,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
 
     // extract veAddOp and varEps if sqrt pattern is present instead of pow.
     // In case of pow these values have already been extracted above
-    if (powOp == nullptr) {
+    if (!powOp) {
       // %varEps = "onnx.Add"(%var, %eps)
       // %stdDev = "onnx.Sqrt"(%varEps)
       if (!operandOfOpDefinedBy<ONNXAddOp>(veAddOp, sdSqrtOp, varEps))
@@ -292,9 +323,9 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
       return reportFailure("RMS var reduce has too many uses");
     if (!veAddOp->hasOneUse())
       return reportFailure("RMS var eps add has too many uses");
-    if (sdSqrtOp != nullptr && !sdSqrtOp->hasOneUse())
+    if (sdSqrtOp && !sdSqrtOp->hasOneUse())
       return reportFailure("RMS std dev sqrt has too many uses");
-    if (powOp != nullptr && !powOp->hasOneUse())
+    if (powOp && !powOp->hasOneUse())
       return reportFailure("RMS std dev pow has too many uses");
     // Gate the next 3 ops by being nonnull, as there are multiple paths.
     if (nDivOp && !nDivOp->hasOneUse())
@@ -397,7 +428,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     layerNormLocations.push_back(ddMulOp->getLoc());
     layerNormLocations.push_back(vReduceOp->getLoc());
     layerNormLocations.push_back(veAddOp->getLoc());
-    if (sdSqrtOp != nullptr)
+    if (sdSqrtOp)
       layerNormLocations.push_back(sdSqrtOp->getLoc());
     else
       layerNormLocations.push_back(powOp->getLoc());

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -31,6 +31,8 @@
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 #include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
 #include "src/Dialect/ONNX/Transforms/Recompose.hpp"
+
+#include "mlir/TableGen/Builder.h"
 #include "src/Pass/Passes.hpp"
 #include "src/Support/TypeUtilities.hpp"
 
@@ -64,10 +66,19 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     Type xType = x.getType();
     Value noneVal = create.onnx.none();
     Value res;
-    if (isRMSLayerNorm)
+    if (isRMSLayerNorm) {
+      if (scale.getImpl() == nullptr) {
+        // set scale to 1 if there is no scale value present in the pattern
+        // This is required because RMSLayerNorm mandates passing a scale value
+        auto xTensorType =
+            mlir::RankedTensorType::get({}, getElementTypeOrSelf(xType));
+        auto attr = mlir::DenseElementsAttr::get(xTensorType, 1.0f);
+        scale = create.onnx.constant(attr);
+      }
       res = create.onnx.RMSLayerNorm(xType, x, scale, noneVal, axis, epsilon);
-    else
+    } else {
       res = create.onnx.layerNorm(xType, x, scale, noneVal, axis, epsilon);
+    }
     copySingleResultType(mulOp, res);
     rewriter.replaceOp(mulOp, res);
     return success();
@@ -89,8 +100,14 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     stdDev = sqrt(var + eps)
     Y = mul(scale, X / stdDev)
 
-  As it can be seen here, the RMS LN pattern matches the traditional LN for
-  the bottom 3 statements. In RMS LN, X is the raw input, whereas in the
+  * Third pattern associated with RMSLayerNormalization
+
+    var = reduceMean(X * X)
+    invStdDev = pow(var + eps, -0.5)
+    Y = mul(X, invStdDev)
+
+  As it can be seen here, the secondary RMS LN pattern matches the traditional
+  LN for the bottom 3 statements. In RMS LN, X is the raw input, whereas in the
   traditional LN, the input to the lower 3 statements are D = X - mean(X).
 
   * Variations around the div (for both patterns):
@@ -123,6 +140,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     Operation *vReduceOp = nullptr;
     Operation *mReduceOp = nullptr;
     Operation *dSubOp = nullptr;
+    Operation *powOp = nullptr;
     // after this group, we have defined norm, scale, d, and sdSqrtOp.
     if (operandOfOpDefinedBy<ONNXDivOp>(nDivOp, nsMulOp, norm, scale, 0) ||
         operandOfOpDefinedBy<ONNXDivOp>(nDivOp, nsMulOp, scale, norm, 1)) {
@@ -191,13 +209,48 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
       } else {
         return reportFailure("RMS missing inv std dev, reciprocal op");
       }
+    } else if (operandOfOpDefinedBy<ONNXPowOp>(
+                   powOp, nsMulOp, invStdDev, d, 0) ||
+               operandOfOpDefinedBy<ONNXPowOp>(
+                   powOp, nsMulOp, d, invStdDev, 1)) {
+      // The following pattern is now matched
+      // %invStdDev = "onnx.Pow"(%varEps, %neg_half)
+      // %norm = "onnx.Mul"(%d, %invStdDev)
+
+      // Now verify the value of exponent for pow op
+      mlir::Value neg_half;
+      if (operandOfOpDefinedBy<ONNXAddOp>(
+              veAddOp, powOp, varEps, neg_half, 0)) {
+        // Verify if the exponent is floating point scalar with value -0.5
+        IndexExprScope scope(nullptr, loc);
+        IndexExprBuilderForAnalysis createIE(loc);
+        if (createIE.hasShapeAndRank(neg_half) &&
+            createIE.getArraySize(neg_half, /*static only*/ true) == 1) {
+          IndexExpr floatVal = createIE.getFloatAsNonAffine(neg_half);
+          if (!floatVal.isLiteral() || (floatVal.getFloatLiteral() != -0.5)) {
+            return reportFailure("RMS missing std dev (via pow(var + eps, "
+                                 "-0.5)), exp is not -0.5");
+          }
+        } else {
+          return reportFailure(
+              "missing std dev (via pow(var + eps, -0.5)), not exp of scalar");
+        }
+      } else {
+        return reportFailure("RMS missing std dev (via pow(var + eps, -0.5)), "
+                             "input to pow is not an Add");
+      }
     } else {
-      return reportFailure("RMS missing norm, div or reciprocal op");
+      return reportFailure("RMS missing norm, div, reciprocal or pow op");
     }
-    // %varEps = "onnx.Add"(%var, %eps)
-    // %stdDev = "onnx.Sqrt"(%varEps)
-    if (!operandOfOpDefinedBy<ONNXAddOp>(veAddOp, sdSqrtOp, varEps))
-      return reportFailure("RMS missing var + eps, add op");
+
+    // extract veAddOp and varEps if sqrt pattern is present instead of pow.
+    // In case of pow these values have already been extracted above
+    if (powOp == nullptr) {
+      // %varEps = "onnx.Add"(%var, %eps)
+      // %stdDev = "onnx.Sqrt"(%varEps)
+      if (!operandOfOpDefinedBy<ONNXAddOp>(veAddOp, sdSqrtOp, varEps))
+        return reportFailure("RMS missing var + eps, add op");
+    }
     // %var = "onnx.ReduceMean(V13)"(%dd)
     // %varEps = "onnx.Add"(%var, %eps)
     if ((!operandOfOpDefinedBy<ONNXReduceMeanV13Op>(
@@ -227,8 +280,10 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
       return reportFailure("RMS var reduce has too many uses");
     if (!veAddOp->hasOneUse())
       return reportFailure("RMS var eps add has too many uses");
-    if (!sdSqrtOp->hasOneUse())
+    if (sdSqrtOp != nullptr && !sdSqrtOp->hasOneUse())
       return reportFailure("RMS std dev sqrt has too many uses");
+    if (powOp != nullptr && !powOp->hasOneUse())
+      return reportFailure("RMS std dev pow has too many uses");
     // Gate the next 3 ops by being nonnull, as there are multiple paths.
     if (nDivOp && !nDivOp->hasOneUse())
       return reportFailure("RMS norm div has too many uses");
@@ -330,7 +385,10 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     layerNormLocations.push_back(ddMulOp->getLoc());
     layerNormLocations.push_back(vReduceOp->getLoc());
     layerNormLocations.push_back(veAddOp->getLoc());
-    layerNormLocations.push_back(sdSqrtOp->getLoc());
+    if (sdSqrtOp != nullptr)
+      layerNormLocations.push_back(sdSqrtOp->getLoc());
+    else
+      layerNormLocations.push_back(powOp->getLoc());
     if (isdRecipOp)
       layerNormLocations.push_back(isdRecipOp->getLoc());
     if (nMulOp)

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -94,7 +94,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
      y = mul(scale, D / stdDev)
 
 
-  * Secondary pattern associated with RMSLayerNormalization:
+  * Second pattern associated with RMSLayerNormalization:
 
     var = reduceMean(X * X)
     stdDev = sqrt(var + eps)
@@ -106,7 +106,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     invStdDev = pow(var + eps, -0.5)
     Y = mul(X, invStdDev)
 
-  As it can be seen here, the secondary RMS LN pattern matches the traditional
+  As it can be seen here, the second RMS LN pattern matches the traditional
   LN for the bottom 3 statements. In RMS LN, X is the raw input, whereas in the
   traditional LN, the input to the lower 3 statements are D = X - mean(X).
 
@@ -116,6 +116,9 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
      D * (1 / stdDev)
      D * recip(stdDev)
 
+  * About third pattern: In the third pattern, sqrt and div/recip ops are
+  replaced by a single Pow op with exponent as -0.5. Everything other than the
+  last two lines follows a logic common to primary and secondary pattern.
   */
   static bool matchLayerNormPattern(ONNXMulOp LayerNormOp, Value &x,
       Value &scale, int64_t &axis, FloatAttr &epsilonAttr,

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -25,7 +25,6 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/Support/Debug.h"
-#include <mlir/TableGen/Builder.h>
 
 #include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
@@ -52,8 +51,6 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     mlir::Value scale;
     if (!isa<ShapedType>(xType))
       return failure();
-    // return {scale, failure(), "Expected Input type to be of type
-    // 'ShapedType', but it is not."};
 
     auto xShape = mlir::cast<ShapedType>(xType).getShape();
     auto xInnerMostDim = xShape[xShape.size() - 1];
@@ -61,8 +58,6 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     // Inner most dim is required
     if (xInnerMostDim <= 0)
       return failure();
-    // return {scale, failure(), "The inner most dim of input must be known for
-    // this recomposition."};
 
     auto scaleType = mlir::RankedTensorType::get(
         {xInnerMostDim}, getElementTypeOrSelf(xType));
@@ -74,13 +69,10 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
       attr = mlir::DenseElementsAttr::get(scaleType, ArrayRef(scaleVal));
     } else {
       return failure();
-      // return {scale, failure(), "Only type with bit width " +
-      // std::to_string(sizeof(float)) + " supported."};
     }
 
     scale = builder.onnx.constant(attr);
     return success(scale);
-    // return {scale, true, ""};
   }
 
   LogicalResult matchAndRewrite(

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -68,11 +68,20 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     Value res;
     if (isRMSLayerNorm) {
       if (scale.getImpl() == nullptr) {
-        // set scale to 1 if there is no scale value present in the pattern
+        // set scale to unity if there is no scale value present in the pattern
         // This is required because RMSLayerNorm mandates passing a scale value
-        auto xTensorType =
-            mlir::RankedTensorType::get({}, getElementTypeOrSelf(xType));
-        auto attr = mlir::DenseElementsAttr::get(xTensorType, 1.0f);
+
+        // NOTE: The scale is being passed as a tensor instead of a scalar
+        // because the pass that generates RMSNormAdf templated graph requires
+        // the scale to be a tensor of dimension same as the inner most
+        // dimension of input tensor
+
+        auto xShape = mlir::cast<ShapedType>(xType).getShape();
+        auto xInnerMostDim = xShape[xShape.size() - 1];
+        auto scaleType = mlir::RankedTensorType::get(
+            {xInnerMostDim}, getElementTypeOrSelf(xType));
+        auto scaleVal = SmallVector<float>(xInnerMostDim, 1.0f);
+        auto attr = mlir::DenseElementsAttr::get(scaleType, ArrayRef(scaleVal));
         scale = create.onnx.constant(attr);
       }
       res = create.onnx.RMSLayerNorm(xType, x, scale, noneVal, axis, epsilon);

--- a/test/mlir/onnx/onnx_recompose.mlir
+++ b/test/mlir/onnx/onnx_recompose.mlir
@@ -487,6 +487,30 @@ func.func @rms_layer_norm_v3(%x: tensor<1x384x768xf32>) -> (tensor<1x384x768xf32
 
 // -----
 
+// RMS Layer norm (containing pow(varEps, -0.5))
+
+func.func @rms_layer_norm_v3_dyn_shape(%x: tensor<1x?x768xf32>) -> (tensor<1x?x768xf32>) {
+  %neg_half = onnx.Constant dense<-5.000000e-01> : tensor<f32>
+  %eps = onnx.Constant dense<1.2E+0> : tensor<f32>
+  %xx = "onnx.Mul"(%x, %x) : (tensor<1x?x768xf32>, tensor<1x?x768xf32>) -> tensor<1x?x768xf32>
+  %var = "onnx.ReduceMeanV13"(%xx) {axes = [-1], keepdims = 1 : si64, onnx_node_name = "ReduceMean_42"} : (tensor<1x?x768xf32>) -> tensor<1x?x1xf32>
+  %varEps = "onnx.Add"(%eps, %var) : (tensor<f32>, tensor<1x?x1xf32>) -> tensor<1x?x1xf32>
+  %invStdDev = "onnx.Pow"(%varEps, %neg_half) : (tensor<1x?x1xf32>, tensor<f32>) -> tensor<1x?x1xf32>
+  %Y = "onnx.Mul"(%invStdDev, %x) : (tensor<1x?x1xf32>, tensor<1x?x768xf32>) -> tensor<1x?x768xf32>
+  return %Y : tensor<1x?x768xf32>
+
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @rms_layer_norm_v3_dyn_shape
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x?x768xf32>) -> tensor<1x?x768xf32> {
+// CHECK:           [[PARAM_1_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<768xf32>
+// CHECK:           [[PARAM_2_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[Y_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.RMSLayerNormalization"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]]) {axis = 2 : si64, epsilon = 1.200000e+00 : f32, stash_type = 1 : si64} : (tensor<1x?x768xf32>, tensor<768xf32>, none) -> (tensor<1x?x768xf32>, none)
+// CHECK:           return [[Y_]] : tensor<1x?x768xf32>
+// CHECK:         }
+}
+
+// -----
+
 // COM: QLinearMatMul
 func.func @qlinear_matmul(%arg0: tensor<?x?x768xi8>, %arg1: tensor<f32>, %arg2: tensor<i8>, %arg3: tensor<768x768xi8>, %arg4: tensor<f32>, %arg5: tensor<i8>, %arg6: tensor<f32>, %arg7: tensor<i8>) -> (tensor<?x?x768xi8>) {
     %0 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<?x?x768xi8>, tensor<f32>, tensor<i8>) -> tensor<?x?x768xf32>

--- a/test/mlir/onnx/onnx_recompose.mlir
+++ b/test/mlir/onnx/onnx_recompose.mlir
@@ -478,9 +478,9 @@ func.func @rms_layer_norm_v3(%x: tensor<1x384x768xf32>) -> (tensor<1x384x768xf32
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @rms_layer_norm_v3
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x384x768xf32>) -> tensor<1x384x768xf32> {
-// CHECK:           [[PARAM_1_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK:           [[PARAM_1_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<768xf32>
 // CHECK:           [[PARAM_2_:%.+]] = "onnx.NoValue"() {value} : () -> none
-// CHECK:           [[Y_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.RMSLayerNormalization"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]]) {axis = 2 : si64, epsilon = 1.200000e+00 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<f32>, none) -> (tensor<1x384x768xf32>, none)
+// CHECK:           [[Y_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.RMSLayerNormalization"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]]) {axis = 2 : si64, epsilon = 1.200000e+00 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<768xf32>, none) -> (tensor<1x384x768xf32>, none)
 // CHECK:           return [[Y_]] : tensor<1x384x768xf32>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_recompose.mlir
+++ b/test/mlir/onnx/onnx_recompose.mlir
@@ -463,6 +463,30 @@ func.func @rms_layer_norm_v2(%x: tensor<1x384x768xf32>, %scale: tensor<768xf32>,
 
 // -----
 
+// RMS Layer norm (containing pow(varEps, -0.5))
+
+func.func @rms_layer_norm_v3(%x: tensor<1x384x768xf32>) -> (tensor<1x384x768xf32>) {
+  %neg_half = onnx.Constant dense<-5.000000e-01> : tensor<f32>
+  %eps = onnx.Constant dense<1.2E+0> : tensor<f32>
+  %xx = "onnx.Mul"(%x, %x) : (tensor<1x384x768xf32>, tensor<1x384x768xf32>) -> tensor<1x384x768xf32>
+  %var = "onnx.ReduceMeanV13"(%xx) {axes = [-1], keepdims = 1 : si64, onnx_node_name = "ReduceMean_42"} : (tensor<1x384x768xf32>) -> tensor<1x384x1xf32>
+  %varEps = "onnx.Add"(%eps, %var) : (tensor<f32>, tensor<1x384x1xf32>) -> tensor<1x384x1xf32>
+  %invStdDev = "onnx.Pow"(%varEps, %neg_half) : (tensor<1x384x1xf32>, tensor<f32>) -> tensor<1x384x1xf32>
+  %Y = "onnx.Mul"(%invStdDev, %x) : (tensor<1x384x1xf32>, tensor<1x384x768xf32>) -> tensor<1x384x768xf32>
+  return %Y : tensor<1x384x768xf32>
+
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @rms_layer_norm_v3
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x384x768xf32>) -> tensor<1x384x768xf32> {
+// CHECK:           [[PARAM_1_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK:           [[PARAM_2_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[Y_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.RMSLayerNormalization"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]]) {axis = 2 : si64, epsilon = 1.200000e+00 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<f32>, none) -> (tensor<1x384x768xf32>, none)
+// CHECK:           return [[Y_]] : tensor<1x384x768xf32>
+// CHECK:         }
+}
+
+// -----
+
 // COM: QLinearMatMul
 func.func @qlinear_matmul(%arg0: tensor<?x?x768xi8>, %arg1: tensor<f32>, %arg2: tensor<i8>, %arg3: tensor<768x768xi8>, %arg4: tensor<f32>, %arg5: tensor<i8>, %arg6: tensor<f32>, %arg7: tensor<i8>) -> (tensor<?x?x768xi8>) {
     %0 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<?x?x768xi8>, tensor<f32>, tensor<i8>) -> tensor<?x?x768xf32>


### PR DESCRIPTION
- Currently, the recomposition of RMSLayerNormalization from constituent ops does not handle the case where Pow operator is used instead of sqrt.
- This PR will add support for recomposing RMSLayerNormalization from a patter that uses Pow with exponent as -0.5 instead of a reciprocal of sqrt Op.