### PR TITLE
VAI-7388 making the conv output shapes explicit

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -453,6 +453,29 @@ Value sliceOfWeightTensorForPhase(
       endOnnxConst, axisOnnxConst, stepOnnxConst);
   return sliceOp;
 }
+Value convOpForConvTranspose(PatternRewriter &rewriter, Location loc,
+    Value input, Value weights, Value bias, ArrayAttr dilations,
+    IntegerAttr group, ArrayAttr kernel_shape, ArrayAttr pads,
+    ArrayAttr strides) {
+
+  auto convOp = rewriter.create<ONNXConvOp>(loc, input, weights, bias,
+      mlir::StringAttr(), dilations, group, kernel_shape, pads, strides);
+  ONNXConvOpShapeHelper convShapeHelper(convOp.getOperation(), {});
+  Type elementType = getElementType(input.getType());
+  (void)convShapeHelper.computeShapeAndUpdateType(elementType);
+  int outputRank = convShapeHelper.getOutputDims().size();
+  SmallVector<int64_t, 4> convOutputShape;
+  for (int i = 0; i < outputRank; ++i) {
+    int64_t d = convShapeHelper.getOutputDims()[i].isLiteral()
+                    ? convShapeHelper.getOutputDims()[i].getLiteral()
+                    : ShapedType::kDynamic;
+    convOutputShape.emplace_back(d);
+  }
+  auto outputType = RankedTensorType::get(convOutputShape, elementType);
+
+  return rewriter.create<ONNXConvOp>(loc, outputType, input, weights, bias,
+      mlir::StringAttr(), dilations, group, kernel_shape, pads, strides);
+}
 Value ph1WeightTensor(PatternRewriter &rewriter, Location loc, Value input) {
   return sliceOfWeightTensorForPhase(rewriter, loc, input, 1);
 }

--- a/src/Dialect/ONNX/Transforms/Decompose.td
+++ b/src/Dialect/ONNX/Transforms/Decompose.td
@@ -531,6 +531,9 @@ def reverseWeightConvTranspose: NativeCodeCall<
 def getFinalOutputFromFourConvOutput: NativeCodeCall<
   "onnx_mlir::getFinalOutputFromFourConvOutput($_builder, $_loc, $0.getDefiningOp<ONNXConvOp>(),$0,$1,$2,$3)">;
 
+def convOpForConvTranspose: NativeCodeCall<
+  "onnx_mlir::convOpForConvTranspose($_builder, $_loc, $0, $1, $2, $3, $4, $5, $6, $7)">;
+
 def ph1WeightForConv: NativeCodeCall<
   "onnx_mlir::ph1WeightTensor($_builder, $_loc, $0)">;
 
@@ -587,15 +590,14 @@ def ConvTransposeOpAsConv2dPattern1: Pattern<
     (getAttrForPhaseConv:$new_kernel $kernel_shape),
     (getAttrForPhaseConv:$new_pads $pads),
     (getAttrForPhaseConv:$new_strides $strides),
-    (ONNXConvOp:$conv_res1 $x, $ph1_w, $b,
-       (GetNullStringAttr), $dilation, $group, $new_kernel, $new_pads, $new_strides),
-    (ONNXConvOp:$conv_res2 $x, $ph2_w, $b,
-      (GetNullStringAttr), $dilation, $group, $new_kernel, $new_pads, $new_strides),
-    (ONNXConvOp:$conv_res3 $x, $ph3_w, $b,
-      (GetNullStringAttr), $dilation, $group, $new_kernel, $new_pads, $new_strides),
-    (ONNXConvOp:$conv_res4 $x, $ph4_w, $b,
-      (GetNullStringAttr), $dilation, $group, $new_kernel, $new_pads, $new_strides),    
-    (getFinalOutputFromFourConvOutput:$output  $conv_res1, $conv_res2, $conv_res3, $conv_res4),  
+    (convOpForConvTranspose:$conv_res1 $x, $ph1_w, $b,
+        $dilation, $group, $new_kernel, $new_pads, $new_strides),
+    (convOpForConvTranspose:$conv_res2 $x, $ph2_w, $b,$dilation, $group, $new_kernel, $new_pads, $new_strides),
+    (convOpForConvTranspose:$conv_res3 $x, $ph3_w, $b,
+       $dilation, $group, $new_kernel, $new_pads, $new_strides),
+    (convOpForConvTranspose:$conv_res4 $x, $ph4_w, $b,
+      $dilation, $group, $new_kernel, $new_pads, $new_strides),
+    (getFinalOutputFromFourConvOutput:$output  $conv_res1, $conv_res2, $conv_res3, $conv_res4),
    ],
    [(HasRankAndShape:$res), (ShouldDecomposeConvTransposeOpTo4Conv:$res $kernel_shape,$pads,$strides)], [],
    (addBenefit 0)

--- a/test/mlir/onnx/onnx_decompose_convtranspose_4conv2d.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose_4conv2d.mlir
@@ -7,9 +7,9 @@
     %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [6, 6], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [2, 2, 2, 2], strides = [2, 2]} : (tensor<1x512x10x16xf32>, tensor<512x256x6x6xf32>, tensor<256xf32>) -> tensor<1x256x20x32xf32>
     onnx.Return %1 : tensor<1x256x20x32xf32>
   }
-  // CHECK-LABEL:   func.func @test_convtrans_even_kernel(
-// CHECK-SAME:                                     %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
-// CHECK-SAME:                                     %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
+// CHECK-LABEL:   func.func @test_convtrans_even_kernel(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
+// CHECK-SAME:                                          %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
 // CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
 // CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 256, 10, 1, 32]> : tensor<5xi64>
 // CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 256, 10, 16, 1]> : tensor<5xi64>
@@ -32,13 +32,13 @@
 // CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_18]], %[[VAL_6]], %[[VAL_10]], %[[VAL_8]], %[[VAL_9]]) : (tensor<256x512x6x6xf32>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) -> tensor<256x512x3x3xf32>
 // CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_18]], %[[VAL_5]], %[[VAL_10]], %[[VAL_8]], %[[VAL_9]]) : (tensor<256x512x6x6xf32>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) -> tensor<256x512x3x3xf32>
 // CHECK:           %[[VAL_23:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_19]], %[[VAL_13]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_20]], %[[VAL_13]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<*xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_13]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<*xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_13]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<*xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_20]], %[[VAL_13]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_13]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_13]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
 // CHECK:           %[[VAL_27:.*]] = "onnx.Reshape"(%[[VAL_23]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Reshape"(%[[VAL_24]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<*xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<*xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Reshape"(%[[VAL_26]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<*xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Reshape"(%[[VAL_24]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Reshape"(%[[VAL_26]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
 // CHECK:           %[[VAL_31:.*]] = "onnx.Concat"(%[[VAL_27]], %[[VAL_29]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
 // CHECK:           %[[VAL_32:.*]] = "onnx.Concat"(%[[VAL_30]], %[[VAL_28]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
 // CHECK:           %[[VAL_33:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x10x16x2xf32>, tensor<5xi64>) -> tensor<1x256x10x1x32xf32>


### PR DESCRIPTION
The conv output are getting written without the output shape. 
This change is helping to fix it.

(tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<*xf32>

https://github.com/Xilinx/onnx-mlir/blob/18561f513cbd8f1253ed2eff3d850119dacbe205/test/mlir/onnx/onnx_decompose_convtranspose_4conv2d.mlir#L35