### PR TITLE
VAI-9492 CumSum support using decomposition

### DIFF
--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -41,6 +41,7 @@ add_onnx_mlir_library(OMONNXRewrite
   ConvOpt.cpp
   Decompose.cpp
   DecomposeEinsum.cpp
+  DecomposeCumSum.cpp
   ScrubDisposablePass.cpp
   SetONNXNodeName.cpp
   Recompose.cpp

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -4,39 +4,43 @@ add_onnx_mlir_rewriter(Decompose)
 add_onnx_mlir_rewriter(ConstProp)
 add_onnx_mlir_rewriter(ConvOpt)
 
-add_onnx_mlir_library(OMShapeInference
+add_onnx_mlir_library(
+  OMShapeInference
   ShapeInference.cpp
-
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PUBLIC
   OMONNXOps
   OMShapeInferenceOpInterface
   MLIRFuncDialect
-  )
+)
 
-add_onnx_mlir_library(OMShapeInferencePass
+add_onnx_mlir_library(
+  OMShapeInferencePass
   ShapeInferencePass.cpp
-
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PUBLIC
   OMONNXOps
   OMShapeInferenceOpInterface
   MLIRFuncDialect
   MLIRPass
   OMShapeInference
-  )
+)
 
-add_onnx_mlir_library(OMInstrumentONNX
+add_onnx_mlir_library(
+  OMInstrumentONNX
   InstrumentONNXSignaturePass.cpp
-
-  INCLUDE_DIRS PUBLIC
+  INCLUDE_DIRS
+  PUBLIC
   ${ONNX_MLIR_SRC_ROOT}/include
-
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PUBLIC
   OMONNXOps
   MLIRPass
   OMOptionUtils
-  )
+)
 
-add_onnx_mlir_library(OMONNXRewrite
+add_onnx_mlir_library(
+  OMONNXRewrite
   ConstProp.cpp
   ConvOpt.cpp
   Decompose.cpp
@@ -45,67 +49,71 @@ add_onnx_mlir_library(OMONNXRewrite
   ScrubDisposablePass.cpp
   SetONNXNodeName.cpp
   Recompose.cpp
-
   DEPENDS
   OMONNXDecomposeIncGen
   OMONNXConstPropIncGen
   OMONNXConvOptIncGen
-
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PUBLIC
   MLIRTransformUtils
   OMONNXOps
-  )
+)
 
-add_onnx_mlir_library(OMOpTransform
+add_onnx_mlir_library(
+  OMOpTransform
   ONNXOpTransformPass.cpp
-
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PUBLIC
   OMONNXOps
   MLIRPass
   OMONNXRewrite
   OMShapeInferencePass
   MLIRTransforms
-  )
+)
 
-add_onnx_mlir_library(OMHybridTransform
+add_onnx_mlir_library(
+  OMHybridTransform
   ONNXHybridTransformPass.cpp
-
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PUBLIC
   OMONNXOps
   OMShapeInferenceOpInterface
   OMONNXRewrite
   MLIRPass
   MLIRTransforms
   OMShapeInference
-  )
+)
 
-add_onnx_mlir_library(OMONNXPreKrnlVerifyONNX
+add_onnx_mlir_library(
+  OMONNXPreKrnlVerifyONNX
   ONNXPreKrnlVerifyPass.cpp
-
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PUBLIC
   OMONNXOps
   MLIRPass
   OMSupport
-  )
+)
 
-add_onnx_mlir_library(OMONNXSimplifyShapeRelatedOps
+add_onnx_mlir_library(
+  OMONNXSimplifyShapeRelatedOps
   SimplifyShapeRelatedOps.cpp
-
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PUBLIC
   OMONNXOps
   OMONNXRewrite
   OMShapeInferencePass
   MLIRFuncDialect
   MLIRPass
   MLIRTransforms
-  )
+)
 
-add_onnx_mlir_library(OMONNXStandardFuncReturnPass
+add_onnx_mlir_library(
+  OMONNXStandardFuncReturnPass
   StandardFuncReturnPass.cpp
-
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PUBLIC
   MLIRTransformUtils
   MLIRFuncDialect
   OMONNXOps
   OMShapeInference
-  )
+)

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -41,8 +41,8 @@
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 #include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
 #include "src/Dialect/ONNX/Transforms/Decompose.hpp"
-#include "src/Dialect/ONNX/Transforms/DecomposeEinsum.hpp"
 #include "src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp"
+#include "src/Dialect/ONNX/Transforms/DecomposeEinsum.hpp"
 #include "src/Pass/Passes.hpp"
 #include "src/Support/TypeUtilities.hpp"
 

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -42,6 +42,7 @@
 #include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
 #include "src/Dialect/ONNX/Transforms/Decompose.hpp"
 #include "src/Dialect/ONNX/Transforms/DecomposeEinsum.hpp"
+#include "src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp"
 #include "src/Pass/Passes.hpp"
 #include "src/Support/TypeUtilities.hpp"
 
@@ -2123,6 +2124,7 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
   patterns.insert<DecomposeBatchNormV9ToBatchNorm>(context);
   patterns.insert<DecomposeSlicePadPattern>(context);
   patterns.insert<DecomposeScatterNDPattern>(context);
+  patterns.insert<DecomposeCumSumPattern>(context);
   patterns.insert<SoftmaxCrossEntropyPattern>(context);
   patterns.insert<SumToAddPattern>(context);
 

--- a/src/Dialect/ONNX/Transforms/DecomposeCumSum.cpp
+++ b/src/Dialect/ONNX/Transforms/DecomposeCumSum.cpp
@@ -1,0 +1,27 @@
+#include "DecomposeCumSum.hpp"
+
+#include "../../../../../../libraries/testing/include/testing/networks/InvalidBlocks.h"
+
+mlir::LogicalResult onnx_mlir::DecomposeCumSum::matchAndRewrite(
+    mlir::ONNXCumSumOp cumSumOp, mlir::PatternRewriter &rewriter) const {
+  auto inputVal = cumSumOp.getX();
+  if (!inputVal) {
+
+  }
+  auto axVal = cumSumOp.getAxis();
+
+  auto inputType = inputVal.getType();
+  auto axType = axVal.getType();
+
+  // batch dimension is required for decomposition
+  if (!mlir::isa<mlir::ShapedType>(inputType))
+    return mlir::failure();
+  auto inputShape = mlir::cast<mlir::ShapedType>(inputType).getShape();
+  assert(inputShape.size() > 0);
+  auto batchDim = inputShape[0];
+
+
+
+  return OpRewritePattern::matchAndRewrite(
+      cumSumOp, rewriter);
+}

--- a/src/Dialect/ONNX/Transforms/DecomposeCumSum.cpp
+++ b/src/Dialect/ONNX/Transforms/DecomposeCumSum.cpp
@@ -1,7 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===----------- DecomposeCumSum.cpp - Decompose CumSum op ----------------===//
+//
+// This file implements the decomposition of ONNX CumSum op to simpler ops (i.e.
+// Slice, Add and Concat)
+//
+//===----------------------------------------------------------------------===//
+
 #include "DecomposeCumSum.hpp"
 #include "src/Dialect/ONNX/DialectBuilder.hpp"
 
-mlir::LogicalResult onnx_mlir::DecomposeCumSumPattern::matchAndRewrite(
+namespace onnx_mlir {
+
+// =============================== NOTE ========================================
+//
+// 1. This decomposition works only when the axis provided to CumSum Op is 0.
+// In all other cases the behaviour is undefined.
+//
+// 2. The reason why this decomposition cannot support dynamic axis is due to
+// the use of concat op. Concat Op takes axis as an attribute and not as input.
+// Therefore, the axis value must be fixed at compile time of the model, hence
+// preventing support for dynamic axis.
+//
+// =============================================================================
+
+mlir::LogicalResult DecomposeCumSumPattern::matchAndRewrite(
     mlir::ONNXCumSumOp cumSumOp, mlir::PatternRewriter &rewriter) const {
   // NOTE: This decomposition is valid only for axis input of 0 for CumSum.
   // The behaviour is undefined for any other axis!
@@ -28,14 +53,16 @@ mlir::LogicalResult onnx_mlir::DecomposeCumSumPattern::matchAndRewrite(
   }
 
   // Get dialect builder to create new onnx ops
-  MultiDialectBuilder<OnnxBuilder> onnxOpBuilder(rewriter, rewriter.getFusedLoc(cumSumOp.getLoc()));
+  MultiDialectBuilder<OnnxBuilder> onnxOpBuilder(
+      rewriter, rewriter.getFusedLoc(cumSumOp.getLoc()));
 
   // Create constants for 'starts' and 'ends' input for slice operator
   llvm::SmallVector<mlir::Value> constVals;
-  for (int i=0; i < batchDim + 1; ++i) {
+  for (int i = 0; i < batchDim + 1; ++i) {
     // create const ops for slice start and end input
     auto constRawVal = llvm::SmallVector<int64_t>(1, i);
-    auto constVal = onnxOpBuilder.onnx.constantInt64(mlir::ArrayRef(constRawVal));
+    auto constVal =
+        onnxOpBuilder.onnx.constantInt64(mlir::ArrayRef(constRawVal));
     constVals.push_back(constVal);
   }
 
@@ -43,8 +70,10 @@ mlir::LogicalResult onnx_mlir::DecomposeCumSumPattern::matchAndRewrite(
   // create slice output type
   llvm::SmallVector<int64_t> sliceOutputShape(1);
   sliceOutputShape[0] = 1;
-  sliceOutputShape.insert(sliceOutputShape.end(), inputShape.begin() + 1, inputShape.end());
-  auto sliceOutputType = mlir::RankedTensorType::get(sliceOutputShape, getElementTypeOrSelf(inputType));
+  sliceOutputShape.insert(
+      sliceOutputShape.end(), inputShape.begin() + 1, inputShape.end());
+  auto sliceOutputType = mlir::RankedTensorType::get(
+      sliceOutputShape, getElementTypeOrSelf(inputType));
 
   // create slice step val
   auto stepRawVal = llvm::SmallVector<int64_t>(1, 1);
@@ -52,8 +81,9 @@ mlir::LogicalResult onnx_mlir::DecomposeCumSumPattern::matchAndRewrite(
 
   // create slice vals
   llvm::SmallVector<mlir::Value> sliceVals;
-  for (int i=0; i < batchDim; ++i) {
-    auto sliceOp = onnxOpBuilder.onnx.slice(sliceOutputType, inputVal, constVals[i], constVals[i+1], axVal, stepVal);
+  for (int i = 0; i < batchDim; ++i) {
+    auto sliceOp = onnxOpBuilder.onnx.slice(sliceOutputType, inputVal,
+        constVals[i], constVals[i + 1], axVal, stepVal);
     sliceVals.push_back(sliceOp);
   }
   // -------------------------------------------
@@ -61,8 +91,8 @@ mlir::LogicalResult onnx_mlir::DecomposeCumSumPattern::matchAndRewrite(
   // -------------- Create Add Ops -------------
   llvm::SmallVector<mlir::Value> addVals;
   addVals.push_back(onnxOpBuilder.onnx.add(sliceVals[0], sliceVals[1]));
-  for (int i=1; i<batchDim-1; ++i) {
-    auto addVal = onnxOpBuilder.onnx.add(addVals[i-1], sliceVals[i+1]);
+  for (int i = 1; i < batchDim - 1; ++i) {
+    auto addVal = onnxOpBuilder.onnx.add(addVals[i - 1], sliceVals[i + 1]);
     addVals.push_back(addVal);
   }
   // -------------------------------------------
@@ -77,3 +107,4 @@ mlir::LogicalResult onnx_mlir::DecomposeCumSumPattern::matchAndRewrite(
   rewriter.replaceOp(cumSumOp, concatVal);
   return llvm::success();
 }
+} // namespace onnx_mlir

--- a/src/Dialect/ONNX/Transforms/DecomposeCumSum.cpp
+++ b/src/Dialect/ONNX/Transforms/DecomposeCumSum.cpp
@@ -24,39 +24,44 @@ namespace onnx_mlir {
 // Therefore, the axis value must be fixed at compile time of the model, hence
 // preventing support for dynamic axis.
 //
+// 3. This is a short-term solution because if the axis along which the
+// operation has to take place is large (let's say 1000), then this pass will
+// spawn 1000 Slices and 1000 Adds which isn't desirable.
+//
+// 4. Proper solution would be to support CumSum kernel.
+//
 // =============================================================================
 
 mlir::LogicalResult DecomposeCumSumPattern::matchAndRewrite(
     mlir::ONNXCumSumOp cumSumOp, mlir::PatternRewriter &rewriter) const {
   // NOTE: This decomposition is valid only for axis input of 0 for CumSum.
-  // The behaviour is undefined for any other axis!
+  // The behaviour is undefined for any other axis value!
 
-  // get inputs
+  // get input
   auto inputVal = cumSumOp.getX();
-  auto axVal = cumSumOp.getAxis();
 
   // get input type
-  auto inputType = inputVal.getType();
-
-  // batch dimension is required for decomposition
-  if (!mlir::isa<mlir::ShapedType>(inputType))
+  if (!mlir::isa<mlir::ShapedType>(inputVal.getType()))
     return mlir::failure();
-  // get batchDim
-  auto inputShape = mlir::cast<mlir::ShapedType>(inputType).getShape();
-  assert(inputShape.size() > 0);
-  auto batchDim = inputShape[0];
+  auto inputType = mlir::cast<mlir::ShapedType>(inputVal.getType());
 
-  // Handle edge Case : If batch dimension is 1 then CumSum Op is redundant
-  if (batchDim == 1) {
-    rewriter.eraseOp(cumSumOp.getOperation());
-    return llvm::success();
-  }
+  // get batchDim - batch dimension is required for decomposition
+  if (!inputType.hasRank() || inputType.getDimSize(0) < 0)
+    return mlir::failure();
+  auto inputShape = inputType.getShape();
+  auto batchDim = inputShape[0];
 
   // Get dialect builder to create new onnx ops
   MultiDialectBuilder<OnnxBuilder> onnxOpBuilder(
       rewriter, rewriter.getFusedLoc(cumSumOp.getLoc()));
 
-  // Create constants for 'starts' and 'ends' input for slice operator
+  // Handle edge Case : If batch dimension is 1 then CumSum Op is redundant
+  if (batchDim == 1) {
+    rewriter.replaceOp(cumSumOp, inputVal);
+    return llvm::success();
+  }
+
+  // Create constants for 'starts' and 'ends' input of slice operator
   llvm::SmallVector<mlir::Value> constVals;
   for (int i = 0; i < batchDim + 1; ++i) {
     // create const ops for slice start and end input
@@ -67,6 +72,16 @@ mlir::LogicalResult DecomposeCumSumPattern::matchAndRewrite(
   }
 
   // ------------ Create slice ops ------------
+
+  // We slice the input tensor into single value tensors along axis 0.
+  // For example - An input X with shape <8x1x384> will led to creation of 8
+  // slice Ops. The ith Slice Op will take the following as inputs:
+  //    - input tensor -> X : <8x1x384>
+  //    - starts -> [i] : <1>
+  //    - ends -> [i+1] : <1>
+  //    - axis -> [0] : <1>
+  //    - step -> [1] : <1>
+
   // create slice output type
   llvm::SmallVector<int64_t> sliceOutputShape(1);
   sliceOutputShape[0] = 1;
@@ -83,12 +98,19 @@ mlir::LogicalResult DecomposeCumSumPattern::matchAndRewrite(
   llvm::SmallVector<mlir::Value> sliceVals;
   for (int i = 0; i < batchDim; ++i) {
     auto sliceOp = onnxOpBuilder.onnx.slice(sliceOutputType, inputVal,
-        constVals[i], constVals[i + 1], axVal, stepVal);
+        constVals[i], constVals[i + 1], constVals[0], stepVal);
     sliceVals.push_back(sliceOp);
   }
   // -------------------------------------------
 
   // -------------- Create Add Ops -------------
+
+  // After getting the slices, we Add the first two slices i.e. slice_0 and
+  // slice_1 to give add_0 output.
+  // Next, we create a chain of Add ops to generate the cumulative sum. For ith
+  // Add op starting from i=1 to batchDim-1, the output is calculated as
+  // follows. add_{i} = Add(add_{i-1}, slice_{i+1})
+
   llvm::SmallVector<mlir::Value> addVals;
   addVals.push_back(onnxOpBuilder.onnx.add(sliceVals[0], sliceVals[1]));
   for (int i = 1; i < batchDim - 1; ++i) {
@@ -98,6 +120,10 @@ mlir::LogicalResult DecomposeCumSumPattern::matchAndRewrite(
   // -------------------------------------------
 
   // ------------- Create concat Op ------------
+
+  // Finally, we concatenate - slice_0, add_0, add_1, .... , add_{batchDim-2}
+  // to give the final output
+
   llvm::SmallVector<mlir::Value> concatInputs;
   concatInputs.push_back(sliceVals[0]);
   concatInputs.insert(concatInputs.end(), addVals.begin(), addVals.end());

--- a/src/Dialect/ONNX/Transforms/DecomposeCumSum.cpp
+++ b/src/Dialect/ONNX/Transforms/DecomposeCumSum.cpp
@@ -41,14 +41,16 @@ mlir::LogicalResult onnx_mlir::DecomposeCumSumPattern::matchAndRewrite(
 
   // ------------ Create slice ops ------------
   // create slice output type
-  llvm::SmallVector<int64_t> sliceOutputShape(inputShape.size());
+  llvm::SmallVector<int64_t> sliceOutputShape(1);
   sliceOutputShape[0] = 1;
   sliceOutputShape.insert(sliceOutputShape.end(), inputShape.begin() + 1, inputShape.end());
+  auto sliceOutputType = mlir::RankedTensorType::get(sliceOutputShape, getElementTypeOrSelf(inputType));
 
   // create slice step val
   auto stepRawVal = llvm::SmallVector<int64_t>(1, 1);
   auto stepVal = onnxOpBuilder.onnx.constantInt64(mlir::ArrayRef(stepRawVal));
-  auto sliceOutputType = mlir::RankedTensorType::get(sliceOutputShape, getElementTypeOrSelf(inputType));
+
+  // create slice vals
   llvm::SmallVector<mlir::Value> sliceVals;
   for (int i=0; i < batchDim; ++i) {
     auto sliceOp = onnxOpBuilder.onnx.slice(sliceOutputType, inputVal, constVals[i], constVals[i+1], axVal, stepVal);

--- a/src/Dialect/ONNX/Transforms/DecomposeCumSum.cpp
+++ b/src/Dialect/ONNX/Transforms/DecomposeCumSum.cpp
@@ -1,27 +1,77 @@
 #include "DecomposeCumSum.hpp"
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
 
-#include "../../../../../../libraries/testing/include/testing/networks/InvalidBlocks.h"
-
-mlir::LogicalResult onnx_mlir::DecomposeCumSum::matchAndRewrite(
+mlir::LogicalResult onnx_mlir::DecomposeCumSumPattern::matchAndRewrite(
     mlir::ONNXCumSumOp cumSumOp, mlir::PatternRewriter &rewriter) const {
-  auto inputVal = cumSumOp.getX();
-  if (!inputVal) {
+  // NOTE: This decomposition is valid only for axis input of 0 for CumSum.
+  // The behaviour is undefined for any other axis!
 
-  }
+  // get inputs
+  auto inputVal = cumSumOp.getX();
   auto axVal = cumSumOp.getAxis();
 
+  // get input type
   auto inputType = inputVal.getType();
-  auto axType = axVal.getType();
 
   // batch dimension is required for decomposition
   if (!mlir::isa<mlir::ShapedType>(inputType))
     return mlir::failure();
+  // get batchDim
   auto inputShape = mlir::cast<mlir::ShapedType>(inputType).getShape();
   assert(inputShape.size() > 0);
   auto batchDim = inputShape[0];
 
+  // Handle edge Case : If batch dimension is 1 then CumSum Op is redundant
+  if (batchDim == 1) {
+    rewriter.eraseOp(cumSumOp.getOperation());
+    return llvm::success();
+  }
 
+  // Get dialect builder to create new onnx ops
+  MultiDialectBuilder<OnnxBuilder> onnxOpBuilder(rewriter, rewriter.getFusedLoc(cumSumOp.getLoc()));
 
-  return OpRewritePattern::matchAndRewrite(
-      cumSumOp, rewriter);
+  // Create constants for 'starts' and 'ends' input for slice operator
+  llvm::SmallVector<mlir::Value> constVals;
+  for (int i=0; i < batchDim + 1; ++i) {
+    // create const ops for slice start and end input
+    auto constRawVal = llvm::SmallVector<int64_t>(1, i);
+    auto constVal = onnxOpBuilder.onnx.constantInt64(mlir::ArrayRef(constRawVal));
+    constVals.push_back(constVal);
+  }
+
+  // ------------ Create slice ops ------------
+  // create slice output type
+  llvm::SmallVector<int64_t> sliceOutputShape(inputShape.size());
+  sliceOutputShape[0] = 1;
+  sliceOutputShape.insert(sliceOutputShape.end(), inputShape.begin() + 1, inputShape.end());
+
+  // create slice step val
+  auto stepRawVal = llvm::SmallVector<int64_t>(1, 1);
+  auto stepVal = onnxOpBuilder.onnx.constantInt64(mlir::ArrayRef(stepRawVal));
+  auto sliceOutputType = mlir::RankedTensorType::get(sliceOutputShape, getElementTypeOrSelf(inputType));
+  llvm::SmallVector<mlir::Value> sliceVals;
+  for (int i=0; i < batchDim; ++i) {
+    auto sliceOp = onnxOpBuilder.onnx.slice(sliceOutputType, inputVal, constVals[i], constVals[i+1], axVal, stepVal);
+    sliceVals.push_back(sliceOp);
+  }
+  // -------------------------------------------
+
+  // -------------- Create Add Ops -------------
+  llvm::SmallVector<mlir::Value> addVals;
+  addVals.push_back(onnxOpBuilder.onnx.add(sliceVals[0], sliceVals[1]));
+  for (int i=1; i<batchDim-1; ++i) {
+    auto addVal = onnxOpBuilder.onnx.add(addVals[i-1], sliceVals[i+1]);
+    addVals.push_back(addVal);
+  }
+  // -------------------------------------------
+
+  // ------------- Create concat Op ------------
+  llvm::SmallVector<mlir::Value> concatInputs;
+  concatInputs.push_back(sliceVals[0]);
+  concatInputs.insert(concatInputs.end(), addVals.begin(), addVals.end());
+  auto concatVal = onnxOpBuilder.onnx.concat(inputType, concatInputs, 0);
+  // -------------------------------------------
+
+  rewriter.replaceOp(cumSumOp, concatVal);
+  return llvm::success();
 }

--- a/src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp
+++ b/src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp
@@ -1,0 +1,14 @@
+
+#ifndef DECOMPOSECUMSUM_H
+#define DECOMPOSECUMSUM_H
+
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+
+namespace onnx_mlir {
+
+class DecomposeCumSum : public mlir::OpRewritePattern<mlir::ONNXCumSumOp> {
+public:
+  mlir::LogicalResult matchAndRewrite(mlir::ONNXCumSumOp cumsumOp, mlir::PatternRewriter &rewriter) const override;
+};
+}
+#endif //DECOMPOSECUMSUM_H

--- a/src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp
+++ b/src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp
@@ -4,7 +4,7 @@
 
 //===----------- DecomposeEinsum.hpp - Decompose Einsum op ----------------===//
 //
-// This file contains declarations for the decomposition for a pattern that
+// This file contains declarations for for a pattern that
 // decomposes onnx CumSum Op into Slice, Add and Concat Ops
 //
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp
+++ b/src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp
@@ -1,3 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===----------- DecomposeEinsum.hpp - Decompose Einsum op ----------------===//
+//
+// This file contains declarations for the decomposition for a pattern that
+// decomposes onnx CumSum Op into Slice, Add and Concat Ops
+//
+//===----------------------------------------------------------------------===//
 
 #ifndef DECOMPOSECUMSUM_H
 #define DECOMPOSECUMSUM_H
@@ -6,10 +16,12 @@
 
 namespace onnx_mlir {
 
-class DecomposeCumSumPattern : public mlir::OpRewritePattern<mlir::ONNXCumSumOp> {
+class DecomposeCumSumPattern
+    : public mlir::OpRewritePattern<mlir::ONNXCumSumOp> {
 public:
   using mlir::OpRewritePattern<mlir::ONNXCumSumOp>::OpRewritePattern;
-  mlir::LogicalResult matchAndRewrite(mlir::ONNXCumSumOp cumsumOp, mlir::PatternRewriter &rewriter) const override;
+  mlir::LogicalResult matchAndRewrite(mlir::ONNXCumSumOp cumsumOp,
+      mlir::PatternRewriter &rewriter) const override;
 };
-}
-#endif //DECOMPOSECUMSUM_H
+} // namespace onnx_mlir
+#endif // DECOMPOSECUMSUM_H

--- a/src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp
+++ b/src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp
@@ -8,7 +8,7 @@ namespace onnx_mlir {
 
 class DecomposeCumSumPattern : public mlir::OpRewritePattern<mlir::ONNXCumSumOp> {
 public:
-  using mlir::OpRewritePattern<mlir::ONNXEinsumOp>::OpRewritePattern;
+  using mlir::OpRewritePattern<mlir::ONNXCumSumOp>::OpRewritePattern;
   mlir::LogicalResult matchAndRewrite(mlir::ONNXCumSumOp cumsumOp, mlir::PatternRewriter &rewriter) const override;
 };
 }

--- a/src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp
+++ b/src/Dialect/ONNX/Transforms/DecomposeCumSum.hpp
@@ -6,8 +6,9 @@
 
 namespace onnx_mlir {
 
-class DecomposeCumSum : public mlir::OpRewritePattern<mlir::ONNXCumSumOp> {
+class DecomposeCumSumPattern : public mlir::OpRewritePattern<mlir::ONNXCumSumOp> {
 public:
+  using mlir::OpRewritePattern<mlir::ONNXEinsumOp>::OpRewritePattern;
   mlir::LogicalResult matchAndRewrite(mlir::ONNXCumSumOp cumsumOp, mlir::PatternRewriter &rewriter) const override;
 };
 }

--- a/test/mlir/onnx/onnx_decompose_cumsum.mlir
+++ b/test/mlir/onnx/onnx_decompose_cumsum.mlir
@@ -1,0 +1,148 @@
+// RUN: onnx-mlir-opt --decompose-onnx %s -split-input-file | FileCheck %s
+
+func.func @cumsum_static_shape_v1(%arg0: tensor<8x1x384xf32>, %arg1: tensor<i64>) -> (tensor<8x1x384xf32>) {
+    %Y = "onnx.CumSum"(%arg0, %arg1) {onnx_node_name = "/CumSum"} : (tensor<8x1x384xf32>, tensor<i64>) -> tensor<8x1x384xf32>
+    return %Y : tensor<8x1x384xf32>
+// CHECK-LABEL: func.func @cumsum_static_shape_v1
+// CHECK-SAME: ([[PARAM_0_:%.+]]: tensor<8x1x384xf32>, [[PARAM_1_:%.+]]: tensor<i64>) -> tensor<8x1x384xf32> {
+// CHECK-NEXT: [[VAR_0_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_1_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_2_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_3_:%.+]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_4_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_5_:%.+]] = onnx.Constant dense<5> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_6_:%.+]] = onnx.Constant dense<6> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_7_:%.+]] = onnx.Constant dense<7> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_8_:%.+]] = onnx.Constant dense<8> : tensor<1xi64>
+
+// CHECK: [[VAR_S0_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x1x384xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_S1_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x1x384xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_S2_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_2_]], [[VAR_3_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x1x384xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_S3_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_3_]], [[VAR_4_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x1x384xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_S4_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_4_]], [[VAR_5_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x1x384xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_S5_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_5_]], [[VAR_6_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x1x384xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_S6_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_6_]], [[VAR_7_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x1x384xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_S7_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_7_]], [[VAR_8_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x1x384xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x1x384xf32>
+
+// CHECK: [[VAR_A0_:%.+]] = "onnx.Add"([[VAR_S0_]], [[VAR_S1_]])
+// CHECK-SAME: : (tensor<1x1x384xf32>, tensor<1x1x384xf32>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_A1_:%.+]] = "onnx.Add"([[VAR_A0_]], [[VAR_S2_]])
+// CHECK-SAME: : (tensor<1x1x384xf32>, tensor<1x1x384xf32>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_A2_:%.+]] = "onnx.Add"([[VAR_A1_]], [[VAR_S3_]])
+// CHECK-SAME: : (tensor<1x1x384xf32>, tensor<1x1x384xf32>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_A3_:%.+]] = "onnx.Add"([[VAR_A2_]], [[VAR_S4_]])
+// CHECK-SAME: : (tensor<1x1x384xf32>, tensor<1x1x384xf32>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_A4_:%.+]] = "onnx.Add"([[VAR_A3_]], [[VAR_S5_]])
+// CHECK-SAME: : (tensor<1x1x384xf32>, tensor<1x1x384xf32>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_A5_:%.+]] = "onnx.Add"([[VAR_A4_]], [[VAR_S6_]])
+// CHECK-SAME: : (tensor<1x1x384xf32>, tensor<1x1x384xf32>) -> tensor<1x1x384xf32>
+// CHECK: [[VAR_A6_:%.+]] = "onnx.Add"([[VAR_A5_]], [[VAR_S7_]])
+// CHECK-SAME: : (tensor<1x1x384xf32>, tensor<1x1x384xf32>) -> tensor<1x1x384xf32>
+
+// CHECK: [[Y_:%.+]] = "onnx.Concat"([[VAR_S0_]], [[VAR_A0_]], [[VAR_A1_]], [[VAR_A2_]], [[VAR_A3_]], [[VAR_A4_]], [[VAR_A5_]], [[VAR_A6_]])
+// CHECK-SAME: axis = 0 : si64
+// CHECK-SAME: : (tensor<1x1x384xf32>, tensor<1x1x384xf32>, tensor<1x1x384xf32>, tensor<1x1x384xf32>, tensor<1x1x384xf32>, tensor<1x1x384xf32>, tensor<1x1x384xf32>, tensor<1x1x384xf32>) -> tensor<8x1x384xf32>
+// CHECK: return [[Y_]] : tensor<8x1x384xf32>
+}
+
+// -----
+
+// Edge case - When the axis 0 dimension is 1, CumSum is redundant
+func.func @cumsum_static_shape_v2(%arg0: tensor<1x1x384xf32>, %arg1: tensor<i64>) -> (tensor<1x1x384xf32>) {
+    %Y = "onnx.CumSum"(%arg0, %arg1) {onnx_node_name = "/CumSum"} : (tensor<1x1x384xf32>, tensor<i64>) -> tensor<1x1x384xf32>
+    return %Y : tensor<1x1x384xf32>
+// CHECK-LABEL: func.func @cumsum_static_shape_v2
+// CHECK-SAME: ([[PARAM_0_:%.+]]: tensor<1x1x384xf32>, [[PARAM_1_:%.+]]: tensor<i64>) -> tensor<1x1x384xf32> {
+//CHECK-NEXT: return [[PARAM_0_]] : tensor<1x1x384xf32>
+}
+
+// -----
+
+func.func @cumsum_dynamic_shape_v1(%arg0: tensor<8x?x?xf32>, %arg1: tensor<i64>) -> (tensor<8x?x?xf32>) {
+    %Y = "onnx.CumSum"(%arg0, %arg1) {onnx_node_name = "/CumSum"} : (tensor<8x?x?xf32>, tensor<i64>) -> tensor<8x?x?xf32>
+    return %Y : tensor<8x?x?xf32>
+// CHECK-LABEL: func.func @cumsum_dynamic_shape_v1
+// CHECK-SAME: ([[PARAM_0_:%.+]]: tensor<8x?x?xf32>, [[PARAM_1_:%.+]]: tensor<i64>) -> tensor<8x?x?xf32> {
+// CHECK-NEXT: [[VAR_0_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_1_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_2_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_3_:%.+]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_4_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_5_:%.+]] = onnx.Constant dense<5> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_6_:%.+]] = onnx.Constant dense<6> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_7_:%.+]] = onnx.Constant dense<7> : tensor<1xi64>
+// CHECK-NEXT: [[VAR_8_:%.+]] = onnx.Constant dense<8> : tensor<1xi64>
+
+// CHECK: [[VAR_S0_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x?x?xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_S1_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x?x?xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_S2_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_2_]], [[VAR_3_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x?x?xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_S3_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_3_]], [[VAR_4_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x?x?xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_S4_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_4_]], [[VAR_5_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x?x?xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_S5_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_5_]], [[VAR_6_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x?x?xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_S6_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_6_]], [[VAR_7_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x?x?xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_S7_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_7_]], [[VAR_8_]], [[VAR_0_]], [[VAR_1_]])
+// CHECK-SAME: : (tensor<8x?x?xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x?x?xf32>
+
+// CHECK: [[VAR_A0_:%.+]] = "onnx.Add"([[VAR_S0_]], [[VAR_S1_]])
+// CHECK-SAME: : (tensor<1x?x?xf32>, tensor<1x?x?xf32>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_A1_:%.+]] = "onnx.Add"([[VAR_A0_]], [[VAR_S2_]])
+// CHECK-SAME: : (tensor<1x?x?xf32>, tensor<1x?x?xf32>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_A2_:%.+]] = "onnx.Add"([[VAR_A1_]], [[VAR_S3_]])
+// CHECK-SAME: : (tensor<1x?x?xf32>, tensor<1x?x?xf32>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_A3_:%.+]] = "onnx.Add"([[VAR_A2_]], [[VAR_S4_]])
+// CHECK-SAME: : (tensor<1x?x?xf32>, tensor<1x?x?xf32>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_A4_:%.+]] = "onnx.Add"([[VAR_A3_]], [[VAR_S5_]])
+// CHECK-SAME: : (tensor<1x?x?xf32>, tensor<1x?x?xf32>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_A5_:%.+]] = "onnx.Add"([[VAR_A4_]], [[VAR_S6_]])
+// CHECK-SAME: : (tensor<1x?x?xf32>, tensor<1x?x?xf32>) -> tensor<1x?x?xf32>
+// CHECK: [[VAR_A6_:%.+]] = "onnx.Add"([[VAR_A5_]], [[VAR_S7_]])
+// CHECK-SAME: : (tensor<1x?x?xf32>, tensor<1x?x?xf32>) -> tensor<1x?x?xf32>
+
+// CHECK: [[Y_:%.+]] = "onnx.Concat"([[VAR_S0_]], [[VAR_A0_]], [[VAR_A1_]], [[VAR_A2_]], [[VAR_A3_]], [[VAR_A4_]], [[VAR_A5_]], [[VAR_A6_]])
+// CHECK-SAME: axis = 0 : si64
+// CHECK-SAME: : (tensor<1x?x?xf32>, tensor<1x?x?xf32>, tensor<1x?x?xf32>, tensor<1x?x?xf32>, tensor<1x?x?xf32>, tensor<1x?x?xf32>, tensor<1x?x?xf32>, tensor<1x?x?xf32>) -> tensor<8x?x?xf32>
+// CHECK: return [[Y_]] : tensor<8x?x?xf32>
+}
+
+// -----
+
+// Batch dimension is required for this decomposition. If it is not available then the pass should simply fail and
+// do nothing to the input mlir.
+func.func @cumsum_dynamic_shape_v2(%arg0: tensor<*xf32>, %arg1: tensor<i64>) -> (tensor<*xf32>) {
+    %Y = "onnx.CumSum"(%arg0, %arg1) {onnx_node_name = "/CumSum"} : (tensor<*xf32>, tensor<i64>) -> tensor<*xf32>
+    return %Y : tensor<*xf32>
+// CHECK-LABEL: func.func @cumsum_dynamic_shape_v2
+// CHECK-SAME: ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<i64>) -> tensor<*xf32> {
+// CHECK-NEXT: [[Y_:%.+]] = "onnx.CumSum"([[PARAM_0_]], [[PARAM_1_]])
+// CHECK-SAME: : (tensor<*xf32>, tensor<i64>) -> tensor<*xf32>
+// CHECK-NEXT: return [[Y_]] : tensor<*xf32>
+}
+
+// -----
+
+// Batch dimension is required for this decomposition. If it is not available then the pass should simply fail and
+// do nothing to the input mlir.
+func.func @cumsum_dynamic_shape_v3(%arg0: tensor<?x1x384xf32>, %arg1: tensor<i64>) -> (tensor<?x1x384xf32>) {
+    %Y = "onnx.CumSum"(%arg0, %arg1) {onnx_node_name = "/CumSum"} : (tensor<?x1x384xf32>, tensor<i64>) -> tensor<?x1x384xf32>
+    return %Y : tensor<?x1x384xf32>
+// CHECK-LABEL: func.func @cumsum_dynamic_shape_v3
+// CHECK-SAME: ([[PARAM_0_:%.+]]: tensor<?x1x384xf32>, [[PARAM_1_:%.+]]: tensor<i64>) -> tensor<?x1x384xf32> {
+// CHECK-NEXT: [[Y_:%.+]] = "onnx.CumSum"([[PARAM_0_]], [[PARAM_1_]])
+// CHECK-SAME: : (tensor<?x1x384xf32>, tensor<i64>) -> tensor<?x1x384xf32>
+// CHECK-NEXT: return [[Y_]] : tensor<?x1x384xf32>
+}


### PR DESCRIPTION
This PR contains a new rewrite pattern that decomposes CumSum op into Slice, Add and Concat Ops to support it on AIE.