### PR TITLE
fix(ONNXToTosa): use the correct dtype to create the zero bias on convolutions.

### DIFF
--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -146,6 +146,18 @@ Value TosaBuilder::getSplattedConst(float val, Type dtype, int64_t rank) {
       loc(), RankedTensorType::get(constType.getShape(), dtype), constOp);
 }
 
+mlir::Value TosaBuilder::getSingleValueConst(
+    float val, mlir::Type dtype, ArrayRef<int64_t> shape) {
+  auto constType = RankedTensorType::get(shape, rewriter().getF32Type());
+  auto constAttr = DenseElementsAttr::get(
+      RankedTensorType::get(shape, rewriter().getF32Type()), {val});
+
+  auto constOp =
+      rewriter().create<mlir::tosa::ConstOp>(loc(), constType, constAttr);
+  return rewriter().createOrFold<mlir::tosa::CastOp>(
+      loc(), RankedTensorType::get(constType.getShape(), dtype), constOp);
+}
+
 Value TosaBuilder::transpose(Value &value, llvm::ArrayRef<int32_t> perm) {
   int64_t valueRank = mlir::cast<RankedTensorType>(value.getType()).getRank();
   assert((valueRank == static_cast<int64_t>(perm.size())) &&

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -87,14 +87,20 @@ struct TosaBuilder : DialectBuilder {
       llvm::ArrayRef<int8_t> vec, llvm::ArrayRef<int64_t> shape);
   mlir::Value getConst(
       llvm::ArrayRef<float> vec, llvm::ArrayRef<int64_t> shape);
-  // Create a floating-point constant operator from a float
-  // The tensor will have the same rank as shape but all dimensions will
-  // have size 1 (differs from tensorflow impl.)
-  // If dtype is provided, it also cast the value to the appropriate dtype.
+
+  /// Create a floating-point constant operator from a float
+  /// The tensor will have the same rank as shape but all dimensions will
+  /// have size 1 (differs from tensorflow impl.)
+  /// If dtype is provided, it also cast the value to the appropriate dtype.
   mlir::Value getSplattedConst(float val, mlir::Type dtype, int64_t rank);
 
-  // Creates a constant of shape <1x1x...x1> of rank `rank` with all values set
-  // to `value`.
+  /// Create a single-valued constant of \p dtype element type and
+  /// \p shape shape.
+  mlir::Value getSingleValueConst(
+      float val, mlir::Type dtype, llvm::ArrayRef<int64_t> shape);
+
+  /// Creates a constant of shape <1x1x...x1> of rank `rank` with all values
+  /// set to `value`.
   template <typename T>
   mlir::Value getSplattedConst(T value, size_t rank) {
     llvm::SmallVector<int64_t, 4> tmpTensor(rank, 1);

--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -129,11 +129,8 @@ public:
     Value newWeight = tosaBuilder.transpose(weights, {0, 2, 3, 1});
 
     if (mlir::isa<NoneType>(bias.getType())) {
-      DenseElementsAttr newBiasAttr = DenseElementsAttr::get(
-          RankedTensorType::get({weightShape[0]}, rewriter.getF32Type()),
-          {0.0F});
-      bias = rewriter.create<mlir::tosa::ConstOp>(
-          convOp->getLoc(), newBiasAttr.getType(), newBiasAttr);
+      bias = tosaBuilder.getSingleValueConst(
+          0.0F, inputType.getElementType(), {weightShape[0]});
     }
 
     DenseI64ArrayAttr dilations =

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -56,11 +56,11 @@ func.func @test_onnx_conv2d_no_dilation_pad(%arg0: tensor<5x3x256x256xf32>, %arg
 }
 
 // -----
-func.func @test_onnx_conv2d_bf16(%arg0: tensor<5x3x256x256xbf16>, %arg1 : tensor<7x3x64x64xbf16>) ->   tensor<5x7x15x15xbf16> {
+func.func @test_onnx_conv2d_bf16_no_bias(%arg0: tensor<5x3x256x256xbf16>, %arg1 : tensor<7x3x64x64xbf16>) ->   tensor<5x7x15x15xbf16> {
   %none = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %none) {strides = [13, 13]} : (tensor<5x3x256x256xbf16>, tensor<7x3x64x64xbf16>, none) ->  tensor<5x7x15x15xbf16>
   return %0 :  tensor<5x7x15x15xbf16>
-// CHECK-LABEL:   func.func @test_onnx_conv2d_bf16(
+// CHECK-LABEL:   func.func @test_onnx_conv2d_bf16_no_bias(
 // CHECK-SAME:                                                %[[VAL_0:.*]]: tensor<5x3x256x256xbf16>,
 // CHECK-SAME:                                                %[[VAL_1:.*]]: tensor<7x3x64x64xbf16>) -> tensor<5x7x15x15xbf16> {
 // CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
@@ -72,6 +72,25 @@ func.func @test_onnx_conv2d_bf16(%arg0: tensor<5x3x256x256xbf16>, %arg1 : tensor
 // CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
 // CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_7]], %[[VAL_8]] : (tensor<5x15x15x7xbf16>, tensor<4xi32>) -> tensor<5x7x15x15xbf16>
 // CHECK:           return %[[VAL_9]] : tensor<5x7x15x15xbf16>
+}
+
+// -----
+func.func @test_onnx_conv2d_f16_no_bias(%arg0: tensor<5x3x256x256xf16>, %arg1 : tensor<7x3x64x64xf16>) ->   tensor<5x7x15x15xf16> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.Conv"(%arg0, %arg1, %none) {strides = [13, 13]} : (tensor<5x3x256x256xf16>, tensor<7x3x64x64xf16>, none) ->  tensor<5x7x15x15xf16>
+  return %0 :  tensor<5x7x15x15xf16>
+// CHECK-LABEL:   func.func @test_onnx_conv2d_f16_no_bias(
+// CHECK-SAME:                                                %[[VAL_0:.*]]: tensor<5x3x256x256xf16>,
+// CHECK-SAME:                                                %[[VAL_1:.*]]: tensor<7x3x64x64xf16>) -> tensor<5x7x15x15xf16> {
+// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       %[[VAL_3:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_2]] : (tensor<5x3x256x256xf16>, tensor<4xi32>) -> tensor<5x256x256x3xf16>
+// CHECK-DAG:       %[[VAL_4:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_2]] : (tensor<7x3x64x64xf16>, tensor<4xi32>) -> tensor<7x64x64x3xf16>
+// CHECK-DAG:       %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<7xf16>}> : () -> tensor<7xf16>
+// CHECK:           %[[VAL_6:.*]] = tosa.slice %[[VAL_3]] {size = array<i64: 5, 246, 246, 3>, start = array<i64: 0, 0, 0, 0>} : (tensor<5x256x256x3xf16>) -> tensor<5x246x246x3xf16>
+// CHECK:           %[[VAL_7:.*]] = tosa.conv2d %[[VAL_6]], %[[VAL_4]], %[[VAL_5]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 13, 13>} : (tensor<5x246x246x3xf16>, tensor<7x64x64x3xf16>, tensor<7xf16>) -> tensor<5x15x15x7xf16>
+// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_7]], %[[VAL_8]] : (tensor<5x15x15x7xf16>, tensor<4xi32>) -> tensor<5x7x15x15xf16>
+// CHECK:           return %[[VAL_9]] : tensor<5x7x15x15xf16>
 }
 
 // -----

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -56,6 +56,25 @@ func.func @test_onnx_conv2d_no_dilation_pad(%arg0: tensor<5x3x256x256xf32>, %arg
 }
 
 // -----
+func.func @test_onnx_conv2d_bf16(%arg0: tensor<5x3x256x256xbf16>, %arg1 : tensor<7x3x64x64xbf16>) ->   tensor<5x7x15x15xbf16> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.Conv"(%arg0, %arg1, %none) {strides = [13, 13]} : (tensor<5x3x256x256xbf16>, tensor<7x3x64x64xbf16>, none) ->  tensor<5x7x15x15xbf16>
+  return %0 :  tensor<5x7x15x15xbf16>
+// CHECK-LABEL:   func.func @test_onnx_conv2d_bf16(
+// CHECK-SAME:                                                %[[VAL_0:.*]]: tensor<5x3x256x256xbf16>,
+// CHECK-SAME:                                                %[[VAL_1:.*]]: tensor<7x3x64x64xbf16>) -> tensor<5x7x15x15xbf16> {
+// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       %[[VAL_3:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_2]] : (tensor<5x3x256x256xbf16>, tensor<4xi32>) -> tensor<5x256x256x3xbf16>
+// CHECK-DAG:       %[[VAL_4:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_2]] : (tensor<7x3x64x64xbf16>, tensor<4xi32>) -> tensor<7x64x64x3xbf16>
+// CHECK-DAG:       %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<7xbf16>}> : () -> tensor<7xbf16>
+// CHECK:           %[[VAL_6:.*]] = tosa.slice %[[VAL_3]] {size = array<i64: 5, 246, 246, 3>, start = array<i64: 0, 0, 0, 0>} : (tensor<5x256x256x3xbf16>) -> tensor<5x246x246x3xbf16>
+// CHECK:           %[[VAL_7:.*]] = tosa.conv2d %[[VAL_6]], %[[VAL_4]], %[[VAL_5]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 13, 13>} : (tensor<5x246x246x3xbf16>, tensor<7x64x64x3xbf16>, tensor<7xbf16>) -> tensor<5x15x15x7xbf16>
+// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_7]], %[[VAL_8]] : (tensor<5x15x15x7xbf16>, tensor<4xi32>) -> tensor<5x7x15x15xbf16>
+// CHECK:           return %[[VAL_9]] : tensor<5x7x15x15xbf16>
+}
+
+// -----
 func.func @test_onnx_conv2d_no_dilation_pad_stride(%arg0: tensor<5x3x256x260xf32>, %arg1 : tensor<2x3x60x64xf32>) ->  tensor<5x2x197x197xf32> {
   %none = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %none) : (tensor<5x3x256x260xf32>, tensor<2x3x60x64xf32>, none) ->  tensor<5x2x197x197xf32>


### PR DESCRIPTION
We were creating any Zero constant with `F32` type. This fails when the type is different, like BF16 or F16.