### PR TITLE
CR-1228648 Add type inference for RandomNormalLike op

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -6280,7 +6280,7 @@ def ONNXRandomNormalOp:ONNX_Op<"RandomNormal",
 }
 
 def ONNXRandomNormalLikeOp:ONNX_Op<"RandomNormalLike",
-  [Pure, OpVersionTrait<22>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  [Pure, OpVersionTrait<22>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>, DeclareOpInterfaceMethods<ResultTypeInferenceOpInterface>]> {
   let summary = "ONNX RandomNormalLike operation";
   let description = [{
   Generate a tensor with random values drawn from a normal distribution.

--- a/src/Dialect/ONNX/ONNXOps/Math/RandomNormalLike.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/RandomNormalLike.cpp
@@ -38,18 +38,34 @@ LogicalResult ONNXRandomNormalLikeOp::verify() {
 
   auto elementTypeIDDType = operandAdaptor.getDtype();
   if (elementTypeIDDType) {
-    int64_t elementTypeID = elementTypeIDDType.value();
-    if (elementTypeID < 0 || elementTypeID > 2) {
-      return emitOpError("dtype not 0, 1 or 2.");
+    const auto elementTypeID =
+        static_cast<onnx::TensorProto_DataType>(*elementTypeIDDType);
+    if (elementTypeID !=
+            onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16 &&
+        elementTypeID !=
+            onnx::TensorProto_DataType::TensorProto_DataType_FLOAT &&
+        elementTypeID !=
+            onnx::TensorProto_DataType::TensorProto_DataType_DOUBLE &&
+        elementTypeID !=
+            onnx::TensorProto_DataType::TensorProto_DataType_BFLOAT16) {
+      return emitOpError("dtype not float16, float, double or bfloat16");
     }
-    if (elementTypeID == 0 && outputType != FloatType::getF16(getContext()))
-      return emitOpError("output tensor does match 0 dtype.");
-    else if (elementTypeID == 1 &&
+    if (elementTypeID ==
+            onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16 &&
+        outputType != FloatType::getF16(getContext()))
+      return emitOpError("output tensor does not match float16 dtype.");
+    else if (elementTypeID ==
+                 onnx::TensorProto_DataType::TensorProto_DataType_FLOAT &&
              outputType != FloatType::getF32(getContext()))
-      return emitOpError("output tensor does match 1 dtype.");
-    else if (elementTypeID == 2 &&
+      return emitOpError("output tensor does not match float dtype.");
+    else if (elementTypeID ==
+                 onnx::TensorProto_DataType::TensorProto_DataType_DOUBLE &&
              outputType != FloatType::getF64(getContext()))
-      return emitOpError("output tensor does match 2 dtype.");
+      return emitOpError("output tensor does not match double dtype.");
+    else if (elementTypeID ==
+                 onnx::TensorProto_DataType::TensorProto_DataType_BFLOAT16 &&
+             outputType != FloatType::getBF16(getContext()))
+      return emitOpError("output tensor does not match bfloat16 dtype.");
   } else if (inputType != outputType) {
     return emitOpError("output and input element types do not match.");
   }

--- a/src/Dialect/ONNX/ONNXOps/Math/RandomNormalLike.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/RandomNormalLike.cpp
@@ -57,6 +57,34 @@ LogicalResult ONNXRandomNormalLikeOp::verify() {
   return success();
 }
 
+static Type getRandomNormalLikeOutputElementType(ONNXRandomNormalLikeOp op) {
+  auto inputType = mlir::cast<TensorType>(op.getInput().getType());
+  Type elementType = inputType.getElementType();
+  if (op.getDtypeAttr()) {
+    auto builder = OpBuilder(op.getContext());
+    elementType = convertONNXTypeToMLIRType(
+        builder, static_cast<onnx::TensorProto_DataType>(
+                     op.getDtypeAttr().getValue().getSExtValue()));
+  }
+  return elementType;
+}
+
+//===----------------------------------------------------------------------===//
+// Type Inference
+//===----------------------------------------------------------------------===//
+
+std::vector<Type> ONNXRandomNormalLikeOp::resultTypeInference() {
+  Type elementType = getRandomNormalLikeOutputElementType(*this);
+  std::vector<Type> resultTypes;
+  if (auto rankedInputType =
+          mlir::dyn_cast<RankedTensorType>(getInput().getType())) {
+    resultTypes.push_back(rankedInputType.clone(elementType));
+  } else {
+    resultTypes.push_back(UnrankedTensorType::get(elementType));
+  }
+  return resultTypes;
+}
+
 //===----------------------------------------------------------------------===//
 // Shape Inference
 //===----------------------------------------------------------------------===//
@@ -65,24 +93,6 @@ LogicalResult ONNXRandomNormalLikeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   if (!hasShapeAndRank(getInput()))
     return success();
-  auto inputType = mlir::cast<RankedTensorType>(getInput().getType());
-  auto elementTypeIDDType = getDtype();
-
-  // Default output tensor type in all cases is the input tensor type.
-  Type elementType;
-  if (!elementTypeIDDType) {
-    elementType = inputType.getElementType();
-  } else {
-    int64_t elementTypeID = elementTypeIDDType.value();
-    if (elementTypeID == 0)
-      elementType = FloatType::getF16(getContext());
-    else if (elementTypeID == 1)
-      elementType = FloatType::getF32(getContext());
-    else if (elementTypeID == 2)
-      elementType = FloatType::getF64(getContext());
-    else
-      return emitError("dtype attribute is invalid (use: 0, 1 or 2)");
-  }
-
+  Type elementType = getRandomNormalLikeOutputElementType(*this);
   return inferShapeForUnaryOps(getOperation(), elementType);
 }

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -3018,12 +3018,12 @@ func.func @test_onehot_dynamic(%arg0: tensor<?x2xi64>, %arg1: tensor<i64>, %arg2
 
 // Test RandomNormal static
 
-func.func @test_random_normal_static_f16() -> tensor<*xf32> {
-  %0 = "onnx.RandomNormal"() {shape = [3, 4, 5], dtype = 0 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : () -> tensor<*xf32>
-  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
+func.func @test_random_normal_static_f16() -> tensor<*xf16> {
+  %0 = "onnx.RandomNormal"() {shape = [3, 4, 5], dtype = 10 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : () -> tensor<*xf16>
+  "onnx.Return"(%0) : (tensor<*xf16 >) -> ()
 
   // CHECK-LABEL: @test_random_normal_static_f16
-  // CHECK: [[R0:%.+]] = "onnx.RandomNormal"() {dtype = 0 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32, shape = [3, 4, 5]} : () -> tensor<3x4x5xf16>
+  // CHECK: [[R0:%.+]] = "onnx.RandomNormal"() {dtype = 10 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32, shape = [3, 4, 5]} : () -> tensor<3x4x5xf16>
 }
 
 // -----
@@ -3038,12 +3038,22 @@ func.func @test_random_normal_static_f32() -> tensor<*xf32> {
 
 // -----
 
-func.func @test_random_normal_static_f64() -> tensor<*xf32> {
-  %0 = "onnx.RandomNormal"() {shape = [3, 4, 5], dtype = 2 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : () -> tensor<*xf32>
-  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
+func.func @test_random_normal_static_f64() -> tensor<*xf64> {
+  %0 = "onnx.RandomNormal"() {shape = [3, 4, 5], dtype = 11 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : () -> tensor<*xf64>
+  "onnx.Return"(%0) : (tensor<*xf64>) -> ()
 
   // CHECK-LABEL: @test_random_normal_static_f64
-  // CHECK: [[R0:%.+]] = "onnx.RandomNormal"() {dtype = 2 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32, shape = [3, 4, 5]} : () -> tensor<3x4x5xf64>
+  // CHECK: [[R0:%.+]] = "onnx.RandomNormal"() {dtype = 11 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32, shape = [3, 4, 5]} : () -> tensor<3x4x5xf64>
+}
+
+// -----
+
+func.func @test_random_normal_static_bf16() -> tensor<*xbf16> {
+  %0 = "onnx.RandomNormal"() {shape = [3, 4, 5], dtype = 16 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : () -> tensor<*xbf16>
+  "onnx.Return"(%0) : (tensor<*xbf16>) -> ()
+
+  // CHECK-LABEL: @test_random_normal_static_bf16
+  // CHECK: [[R0:%.+]] = "onnx.RandomNormal"() {dtype = 16 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32, shape = [3, 4, 5]} : () -> tensor<3x4x5xbf16>
 }
 
 //===----------------------------------------------------------------------===//
@@ -3052,12 +3062,12 @@ func.func @test_random_normal_static_f64() -> tensor<*xf32> {
 
 // Test RandomNormalLike static
 
-func.func @test_random_normal_like_static_f16(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
-  %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 0 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x28xf32>) -> tensor<*xf32>
-  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
+func.func @test_random_normal_like_static_f16(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf16> {
+  %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 10 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x28xf32>) -> tensor<*xf16>
+  "onnx.Return"(%0) : (tensor<*xf16>) -> ()
 
   // CHECK-LABEL: @test_random_normal_like_static_f16
-  // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 0 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x28xf32>) -> tensor<1x1x28x28xf16>
+  // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 10 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x28xf32>) -> tensor<1x1x28x28xf16>
 }
 
 // -----
@@ -3072,24 +3082,34 @@ func.func @test_random_normal_like_static_f32(%arg0: tensor<1x1x28x28xf32>) -> t
 
 // -----
 
-func.func @test_random_normal_like_static_f64(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
-  %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 2 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x28xf32>) -> tensor<*xf32>
-  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
+func.func @test_random_normal_like_static_f64(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf64> {
+  %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 11 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x28xf32>) -> tensor<*xf64>
+  "onnx.Return"(%0) : (tensor<*xf64>) -> ()
 
   // CHECK-LABEL: @test_random_normal_like_static_f64
-  // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 2 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x28xf32>) -> tensor<1x1x28x28xf64>
+  // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 11 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x28xf32>) -> tensor<1x1x28x28xf64>
+}
+
+// -----
+
+func.func @test_random_normal_like_static_bf16(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xbf16> {
+  %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 16 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x28xf32>) -> tensor<*xbf16>
+  "onnx.Return"(%0) : (tensor<*xbf16>) -> ()
+
+  // CHECK-LABEL: @test_random_normal_like_static_bf16
+  // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 16 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x28xf32>) -> tensor<1x1x28x28xbf16>
 }
 
 // -----
 
 // Test RandomNormalLike dynamic
 
-func.func @test_random_normal_like_dynamic_f16(%arg0: tensor<1x?x28x28xf32>) -> tensor<*xf32> {
-  %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 0 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x?x28x28xf32>) -> tensor<*xf32>
-  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
+func.func @test_random_normal_like_dynamic_f16(%arg0: tensor<1x?x28x28xf32>) -> tensor<*xf16> {
+  %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 10 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x?x28x28xf32>) -> tensor<*xf16>
+  "onnx.Return"(%0) : (tensor<*xf16>) -> ()
 
   // CHECK-LABEL: @test_random_normal_like_dynamic_f16
-  // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 0 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x?x28x28xf32>) -> tensor<1x?x28x28xf16>
+  // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 10 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x?x28x28xf32>) -> tensor<1x?x28x28xf16>
 }
 
 // -----
@@ -3104,12 +3124,12 @@ func.func @test_random_normal_like_dynamic_f32(%arg0: tensor<1x1x?x28xf32>) -> t
 
 // -----
 
-func.func @test_random_normal_like_dynamic_f64(%arg0: tensor<1x1x28x?xf32>) -> tensor<*xf32> {
-  %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 2 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x?xf32>) -> tensor<*xf32>
-  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
+func.func @test_random_normal_like_dynamic_f64(%arg0: tensor<1x1x28x?xf32>) -> tensor<*xf64> {
+  %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 11 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x?xf32>) -> tensor<*xf64>
+  "onnx.Return"(%0) : (tensor<*xf64>) -> ()
 
   // CHECK-LABEL: @test_random_normal_like_dynamic_f64
-  // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 2 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x?xf32>) -> tensor<1x1x28x?xf64>
+  // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 11 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x?xf32>) -> tensor<1x1x28x?xf64>
 }
 
 // -----

--- a/test/mlir/onnx/parse/random_normal_like_dtype_bf16.onnxtext
+++ b/test/mlir/onnx/parse/random_normal_like_dtype_bf16.onnxtext
@@ -1,0 +1,19 @@
+// RUN: onnx-mlir --EmitONNXBasic --useOnnxModelTypes=false --printIR %s | FileCheck %s
+
+// Test output type inference of RandomNormalLike ignoring the types from the model using --useOnnxModelTypes=false
+// Output type should be bf16 as dtype = 16 eventhough the output type specified in model is float32
+
+<
+   ir_version: 4,
+   opset_import: ["" : 22]
+>
+test_random_normal_like_dtype (float[unk__a,unk__b] RandomNormalLike_in) => (float[] RandomNormalLike_out) 
+{
+   RandomNormalLike_out = RandomNormalLike<dtype: int = 16, mean: float = 0.0, scale: float = 1.0, seed: float = 2.0> (RandomNormalLike_in)
+}
+
+// CHECK-LABEL:   func.func @main_graph(
+// CHECK-SAME:    %[[VAL_0:.*]]: tensor<?x?xf32> {onnx.dim_params = "0:unk__a,1:unk__b", onnx.name = "RandomNormalLike_in"}) -> (tensor<?x?xbf16> {onnx.name = "RandomNormalLike_out"}) {
+// CHECK:           %[[VAL_1:.*]] = "onnx.RandomNormalLike"(%[[VAL_0]]) {dtype = 16 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<?x?xf32>) -> tensor<?x?xbf16>
+// CHECK:           onnx.Return %[[VAL_1]] : tensor<?x?xbf16>
+// CHECK:         }

--- a/test/mlir/onnx/parse/random_normal_like_dtype_f32.onnxtext
+++ b/test/mlir/onnx/parse/random_normal_like_dtype_f32.onnxtext
@@ -1,0 +1,15 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+<
+   ir_version: 4,
+   opset_import: ["" : 22]
+>
+test_random_normal_like_dtype (float[unk__a,unk__b] RandomNormalLike_in) => (float[] RandomNormalLike_out) 
+{
+   RandomNormalLike_out = RandomNormalLike<dtype: int = 1, mean: float = 0.0, scale: float = 1.0, seed: float = 2.0> (RandomNormalLike_in)
+}
+
+// CHECK-LABEL:   func.func @main_graph(
+// CHECK-SAME:    %[[VAL_0:.*]]: tensor<?x?xf32> {onnx.dim_params = "0:unk__a,1:unk__b", onnx.name = "RandomNormalLike_in"}) -> (tensor<?x?xf32> {onnx.dim_params = "0:unk__a,1:unk__b", onnx.name = "RandomNormalLike_out"}) {
+// CHECK:           %[[VAL_1:.*]] = "onnx.RandomNormalLike"(%[[VAL_0]]) {dtype = 1 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:           onnx.Return %[[VAL_1]] : tensor<?x?xf32>
+// CHECK:         }

--- a/test/mlir/onnx/parse/random_normal_like_no_dtype.onnxtext
+++ b/test/mlir/onnx/parse/random_normal_like_no_dtype.onnxtext
@@ -1,0 +1,16 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+<
+   ir_version: 4,
+   opset_import: ["" : 22]
+>
+test_random_normal_like_dtype (float[unk__a,unk__b] RandomNormalLike_in) => (float[] RandomNormalLike_out) 
+{
+   RandomNormalLike_out = RandomNormalLike<mean: float = 0.0, scale: float = 1.0, seed: float = 2.0> (RandomNormalLike_in)
+}
+
+// CHECK-LABEL:   func.func @main_graph(
+// CHECK-SAME:    %[[VAL_0:.*]]: tensor<?x?xf32> {onnx.dim_params = "0:unk__a,1:unk__b", onnx.name = "RandomNormalLike_in"}) -> (tensor<?x?xf32> {onnx.dim_params = "0:unk__a,1:unk__b", onnx.name = "RandomNormalLike_out"}) {
+// CHECK:           %[[VAL_1:.*]] = "onnx.RandomNormalLike"(%[[VAL_0]]) {mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:           onnx.Return %[[VAL_1]] : tensor<?x?xf32>
+// CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -479,6 +479,7 @@ OpsWithResultTypeInference = [
     "If",
     "Loop",
     "RandomNormal",
+    "RandomNormalLike",
     "Scan",
 ]
 


### PR DESCRIPTION
onnx-mlir fails for RandomNormalLike Op as it is missing type inference. 