### PR TITLE
[Backport] Addressing two more convtranspose usecases

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -668,7 +668,39 @@ bool shouldDecomposeConvTransposeOp(Value convTransposeResult) {
   return hasShapeAndRank(convTransposeResult) &&
          hasStaticSpatialDims(op.getX()) && hasStaticSpatialDims(op.getW());
 }
-bool shouldDecomposeConvTransposeOpTo4Conv(Value convTransposeResult,
+
+SmallVector<int64_t> getIntVectorFromArrayAttr(ArrayAttr arrayAttr) {
+  assert(mlir::dyn_cast<IntegerAttr>(arrayAttr.getValue()[0]) &&
+         "Attribute must be integer");
+  SmallVector<int64_t> elements;
+  llvm::transform(arrayAttr.getValue().vec(), std::back_inserter(elements),
+      [](auto attr) { return cast<IntegerAttr>(attr).getInt(); });
+  return elements;
+}
+
+bool hasDefaultDilation(ArrayAttr dilation) {
+  if (dilation == nullptr)
+    return true;
+  SmallVector<int64_t, 3> vDilation = getIntVectorFromArrayAttr(dilation);
+  return llvm::all_of(vDilation, [](int64_t d) { return d == 1; });
+}
+
+// This decomposition currently do not support all possible convtranspose
+// operations. Below are the supported usecases.
+// 1) stride[1,1] where convtranspose will decompose to one conv operation.
+// 2) stride [2,2], kernel [6,6], pads [2,2,2,2] where it will decompose into 4
+// conv operations each conv with [3,3] phase kernel.
+// 3) stride [2,2], kernel [4,4], pads [1,1,1,1] where it will decompose into 4
+// conv operations each conv with [2,2] phase kernel.
+// 4) stride [2,2], kernel [3,3], pads [0,0,1,1] OR [1,1,0,0] where it will
+// decompose into 4 conv operations. In this case, the original weights are
+// padded at bottom right, to make it as [4,4] kernel and the four phased-conv
+// operations will use [2,2] kernel.
+// 5) stride [3,3], and kernel [3,3] pads [0,0,0,0] where it will decompose into
+// 9 conv operations each phased conv will use [1,1] kernel
+// 6) stride [2,2] and kernel [2,2] pads [0,0,0,0] where it will decompose into
+// 4 conv operations each phased conv will use [1,1] kernel
+bool ShouldDecomposeConvTransposeOpToPhasedConvs(Value convTransposeResult,
     ArrayAttr kernelShapeAttr, ArrayAttr padsShapeAttr,
     ArrayAttr stridesShapeAttr) {
   if (!onnx_mlir::enableConvTranposeDecomposeTo4Conv) {
@@ -694,12 +726,620 @@ bool shouldDecomposeConvTransposeOpTo4Conv(Value convTransposeResult,
 
   ONNXConvTransposeOp op =
       mlir::cast<ONNXConvTransposeOp>(convTransposeResult.getDefiningOp());
-  return hasShapeAndRank(convTransposeResult) &&
-         hasStaticSpatialDims(op.getX()) && hasStaticSpatialDims(op.getW()) &&
-         isSymmetricEvenAttribute(kernelShapeAttr, false) &&
-         isSymmetricEvenAttribute(padsShapeAttr, true) &&
-         isSymmetricEvenAttribute(stridesShapeAttr, false);
+  bool areSpatialDimsStatic = hasShapeAndRank(convTransposeResult) &&
+                              hasStaticSpatialDims(op.getX()) &&
+                              hasStaticSpatialDims(op.getW());
+  if (!areSpatialDimsStatic)
+    return false;
+  // kernel shape is required for decomposition, Not supporting the case where
+  // kernel shape can be inferred. Not supporting the case where pad values are
+  // to be inferred automatically from outputShape.
+  if (!kernelShapeAttr || outputShapeAttr) {
+    return false;
+  }
+
+  auto kernelShape = getIntVectorFromArrayAttr(kernelShapeAttr);
+  auto padsShape = (padsShapeAttr) ? getIntVectorFromArrayAttr(padsShapeAttr)
+                                   : SmallVector<int64_t>({0, 0, 0, 0});
+  auto stridesShape = (stridesShapeAttr)
+                          ? getIntVectorFromArrayAttr(stridesShapeAttr)
+                          : SmallVector<int64_t>({1, 1});
+
+  RankedTensorType outputType =
+      mlir::cast<RankedTensorType>(convTransposeResult.getType());
+  auto outputShape = outputType.getShape();
+  // Checking to ensure only convtranspose with 2D spatial dims are supported.
+  if ((outputShape.size() != 4) || (stridesShape.size() != 2) ||
+      (padsShape.size() != 4) || (stridesShape[0] != stridesShape[1]) ||
+      (stridesShape[0] > 3))
+    return false;
+  bool hDivisisbleByStride =
+      (outputShape[outputShape.size() - 2] % stridesShape[0] == 0);
+  bool wDivisisbleByStride =
+      (outputShape[outputShape.size() - 1] % stridesShape[0] == 0);
+  if (!hDivisisbleByStride || !wDivisisbleByStride) {
+    return false;
+  }
+
+  // one Phase Decomposition
+  if (stridesShape[0] == 1) {
+    return true;
+  }
+  // If the stride is not 1, the kernel shape should be symmetric.
+  if (!llvm::all_equal(kernelShape))
+    return false;
+  bool fourPhaseDecomposition = (stridesShape[0] == 2);
+  bool ninePhaseDecomposition = (stridesShape[0] == 3);
+  if (fourPhaseDecomposition) {
+    if (kernelShape[0] == 6 && padsShape[0] == 2 &&
+        llvm::all_equal(padsShape)) {
+      // Currently support only with pads [2, 2, 2, 2]
+      return true;
+    }
+    if (kernelShape[0] == 3) {
+      // Supports [0,0,1,1] , [1,1,0,0] padding only.
+      if (padsShape == SmallVector<int64_t>{0, 0, 1, 1} ||
+          padsShape == SmallVector<int64_t>{1, 1, 0, 0})
+        return true;
+    }
+    // Supports only with padding [0, 0, 0, 0]
+    if (kernelShape[0] == 2 && llvm::all_equal(padsShape) &&
+        padsShape[0] == 0) {
+      return true;
+    }
+    // Supports only with padding [1,1,1,1]
+    if (kernelShape[0] == 4 && llvm::all_equal(padsShape) &&
+        padsShape[0] == 1) {
+      return true;
+    }
+  }
+  if (ninePhaseDecomposition) {
+    // Supports only with padding [0, 0, 0, 0]
+    if (kernelShape[0] == 3 && llvm::all_equal(padsShape) &&
+        padsShape[0] == 0) {
+      return true;
+    }
+  }
+  return false;
 }
+
+// Convtranpose can be decomposed into phased convolutions.
+// The phased convolutions are then merged to get the final output.
+// The number of phases is determined by the strides of the convtranspose op.
+// The num of phases = stride_x * stride_y.
+// The phased convolutions are weights are created by slicing the weights of the
+// convolution in the specified manner and output of convolutions are stiched
+// together to get the final output. If the case where original weights cannot
+// be sliced into conv weights directly, they are padded to make them compatible
+// with the slicing. and subsequently the extra ofm generated by the padded
+// weights are removed.
+// Below shows the high level view of the decomposition.
+// clang-format off
+/*
+ * +---------------+       +-----------+ 
+ * | ConvT         |       |           | 
+ * |               |       |   Conv    | 
+ * |stride [1,1]   +--->   |           | 
+ * |               |       |           | 
+ * +---------------+       +-----------+ 
+ *                                       
+ *                                       
+ *                                       
+ *                                       
+ *                         +-------+-------+-------+-------+-- --------------+  
+ * +----------------+      | conv1 |conv3  | conv1 |conv3  |                 |
+ * |  ConvT         |      |       |       |       |       |                 |
+ * |                |      +-------+-------+-------+-------+                 |
+ * |stride [2,2]    +--    |conv4  |conv2  |conv4  |conv2  |                 |
+ * |                |      |       |       |       |       |                 |
+ * +----------------+      +-------+-------+-------+-------+-                |
+ *                         | conv1 |conv3  | conv1 |conv3  |                 |
+ *                         |       |       |       |       |                 |
+ *                         +-------+-------+-------+-------+                 |
+ * convT weights sliced    |conv4  |conv2  |conv4  |conv2  |                 |
+ * to get 4 conv weights   |       |       |       |       |                 |
+ *                         +-------+-------+-------+-------+                 |
+ *                         |               |                                 |
+ *                         |                                                 |
+ *                         |                                                 |
+ *                         +-------------------------------------------------+
+ *                                                                            
+ *                                                                            
+ *                                 4 conv ofms merged                         
+ *                                                                            
+ *                                                                            
+ * +-------------------+         +--------+-------+------+--------+-------+------+-+
+ * |                   |         |conv1   |conv2  |conv7 |conv1   |conv2  |conv7 | |
+ * |convT              |         |        |       |      |        |       |      | |
+ * |                   |         +--------+-------+------+--------+-------+------+ |
+ * |stride [3,3]       |         |conv4   |conv5  |conv6 |conv4   |conv5  |conv6 | |
+ * |                   |         |        |       |      |        |       |      | |
+ * |                   |   -     +--------+-------+------+--------+-------+------+ |
+ * +-------------------+         |conv3   |conv8  |conv9 |conv3   |conv8  |conv9 | |
+ *                               |        |       |      |        |       |      | |
+ * conT weights sliced           +--------+-------+------+--------+-------+------+-+
+ *                               |conv1   |conv2  |conv7 |conv1   |conv2  |conv7 | |
+ * to get 9 conv weights         |        |       |      |        |       |      | |
+ *                               +--------+-------+------+--------+-------+------+ |
+ *                               |conv4   |conv5  |conv6 |conv4   |conv5  |conv6 | |
+ *                               |        |       |      |        |       |      | |
+ *                               +--------+-------+------+--------+-------+------+ |
+ *                               |conv3   |conv8  |conv9 |conv3   |conv8  |conv9 | |
+ *                               |        |       |      |        |       |      | |
+ *                               +--------+-------+------+--------+-------+------+ |
+ *                               |                                                 |
+ *                               |                                                 |
+ *                               |                                                 |
+ *                               +-------------------------------------------------+
+ *                               9 conv ofms are merged                             
+ */
+// clang-format on
+Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
+    ONNXConvTransposeOp op, Value convTransposeResult, Value input,
+    Value weights, Value bias, ArrayAttr dilations, IntegerAttr group,
+    ArrayAttr kernel_shape, ArrayAttr pads, ArrayAttr strides) {
+
+  RankedTensorType weightsType =
+      mlir::cast<RankedTensorType>(weights.getType());
+  assert(weightsType.hasRank() && "Weight tensor must have rank.");
+  Type elementType = getElementType(op.getType());
+  RankedTensorType outputType =
+      mlir::cast<RankedTensorType>(convTransposeResult.getType());
+  auto convTransposeOutputShape = outputType.getShape();
+  auto kernelShape = getIntVectorFromArrayAttr(kernel_shape);
+  auto padsShape = (pads) ? getIntVectorFromArrayAttr(pads)
+                          : SmallVector<int64_t>({0, 0, 0, 0});
+  auto stridesShape = (strides) ? getIntVectorFromArrayAttr(strides)
+                                : SmallVector<int64_t>({1, 1});
+
+  int numPhases = stridesShape[0] * stridesShape[1];
+  if (numPhases == 1) {
+    const std::array<int64_t, 4> convPadsShape = {
+        (kernelShape[0] - 1 - padsShape[0]),
+        (kernelShape[1] - 1 - padsShape[1]),
+        (kernelShape[0] - 1 - padsShape[2]),
+        (kernelShape[1] - 1 - padsShape[3])};
+
+    auto convPadsArrayAttr = rewriter.getI64ArrayAttr(convPadsShape);
+
+    return rewriter.create<ONNXConvOp>(loc, op.getY().getType(), input, weights,
+        bias, mlir::StringAttr(), dilations, group, kernel_shape,
+        convPadsArrayAttr, strides);
+  }
+
+  auto int64Type = rewriter.getIntegerType(64);
+  auto getONNXConstOpFromVector =
+      [&](ArrayRef<int64_t> values) -> ONNXConstantOp {
+    SmallVector<mlir::Attribute> elements;
+    transform(values, std::back_inserter(elements),
+        [&](int64_t val) { return rewriter.getI64IntegerAttr(val); });
+    auto constType = RankedTensorType::get(values.size(), int64Type);
+    return rewriter.create<ONNXConstantOp>(loc, mlir::Attribute(),
+        DenseElementsAttr::get(constType, llvm::ArrayRef(elements)));
+  };
+  onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(rewriter, loc);
+  // If the convTranspose kernel is 3x3, then the weights needs to be padded to
+  // 4x4
+  bool needWeightsPadding = (kernelShape[0] == 3 && stridesShape[0] == 2);
+  if (needWeightsPadding) {
+    std::array<int64_t, 8> weightsPadValue = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    assert((padsShape == SmallVector<int64_t>{0, 0, 1, 1}) ||
+           (padsShape == SmallVector<int64_t>{1, 1, 0, 0}));
+    // Supports [0,0,1,1] , [1,1,0,0] padding only.
+    if (padsShape[0] == 1) {
+      weightsPadValue[2] = 1;
+      weightsPadValue[3] = 1;
+    }
+    if (padsShape[2] == 1) {
+      weightsPadValue[6] = 1;
+      weightsPadValue[7] = 1;
+    }
+    auto onnxPadsValueConstant = getONNXConstOpFromVector(weightsPadValue);
+    RankedTensorType scalarTy = RankedTensorType::get({}, elementType);
+    Value onnxPaddingConstantZero = create.onnx.constant(
+        DenseElementsAttr::get(scalarTy, rewriter.getZeroAttr(elementType)));
+
+    auto onnxAxisValueConstantNone = create.onnx.none();
+    auto wts_shape = weightsType.getShape();
+    // Padding the orignal weights at the bottom and right with zeros.
+    auto paddedWeightsShapedType = weightsType.get(
+        {wts_shape[0], wts_shape[1], wts_shape[2] + 1, wts_shape[3] + 1},
+        weightsType.getElementType());
+    weightsType = paddedWeightsShapedType;
+
+    weights = rewriter.create<ONNXPadOp>(loc, paddedWeightsShapedType, weights,
+        onnxPadsValueConstant, onnxPaddingConstantZero,
+        onnxAxisValueConstantNone, rewriter.getStringAttr("constant"));
+    kernelShape = {4, 4};
+  }
+
+  SmallVector<mlir::Value> weightSlices;
+  int step = stridesShape[0];
+  int convKernelSize = kernelShape[0] / stridesShape[0];
+
+  auto axisOnnxConstant = getONNXConstOpFromVector({2, 3});
+  auto stepOnnxConstant = getONNXConstOpFromVector({step, step});
+  auto weightsShape = weightsType.getShape();
+  auto convWeightsShapedType = weightsType.get(
+      {weightsShape[0], weightsShape[1], convKernelSize, convKernelSize},
+      weightsType.getElementType());
+  int64_t maxIndex = stridesShape[0];
+  for (int column = 0; column < maxIndex; column++) {
+    for (int row = 0; row < maxIndex; row++) {
+      int rowEnd = (convKernelSize * step) + row;
+      int columnEnd = (convKernelSize * step) + column;
+      llvm::SmallVector<int64_t> startVector({row, column});
+      llvm::SmallVector<int64_t> endVector({rowEnd, columnEnd});
+      auto startOnnxConstant = getONNXConstOpFromVector(startVector);
+      auto endOnnxConstant = getONNXConstOpFromVector(endVector);
+      weightSlices.push_back(
+          create.onnx.slice(convWeightsShapedType, weights, startOnnxConstant,
+              endOnnxConstant, axisOnnxConstant, stepOnnxConstant));
+    }
+  }
+  auto convKernelShapeArrayAttr =
+      rewriter.getI64ArrayAttr({convKernelSize, convKernelSize});
+  // This is the shape of the output from each conv, which contributes to the
+  // final ofm.
+  SmallVector<int64_t> convOutputShape(convTransposeOutputShape);
+  convOutputShape[convOutputShape.size() - 1] =
+      convOutputShape[convOutputShape.size() - 1] / stridesShape[0];
+  convOutputShape[convOutputShape.size() - 2] =
+      convOutputShape[convOutputShape.size() - 2] / stridesShape[0];
+  ShapedType convTransposeOutputType =
+      mlir::cast<ShapedType>(op.getY().getType());
+  // In the case where weights are padded, we will get the extra output from
+  // conv.
+  auto convOutputType = RankedTensorType::get(
+      (needWeightsPadding)
+          ? SmallVector<int64_t>({convOutputShape[0], convOutputShape[1],
+                convOutputShape[2] + 1, convOutputShape[3] + 1})
+          : convOutputShape,
+      convTransposeOutputType.getElementType());
+  if (numPhases == 4) {
+    auto getPadsArrayAttr = [&](int64_t kernelSize, int64_t convSequence,
+                                bool weightsPadded) {
+      // weights are padded for case, kernel[3,3], stride[2,2] and pads either
+      // [0,0,1,1] or [1,1,0,0]
+      if (weightsPadded) {
+        return rewriter.getI64ArrayAttr({1, 1, 1, 1});
+      }
+      // for kernel [2,2], stride [2,2] and pads [0,0,0,0]
+      if (kernelSize == 2)
+        return rewriter.getI64ArrayAttr({0, 0, 0, 0});
+      if (kernelSize == 4) {
+        // for kernel [4,4], stride [2,2] and pads [1,1,1,1]
+        switch (convSequence) {
+        case 1:
+          return rewriter.getI64ArrayAttr({0, 0, 1, 1});
+        case 2:
+          return rewriter.getI64ArrayAttr({1, 1, 0, 0});
+        case 3:
+          return rewriter.getI64ArrayAttr({0, 1, 1, 0});
+        case 4:
+          return rewriter.getI64ArrayAttr({1, 0, 0, 1});
+        default:
+          llvm_unreachable("Invalid conv sequence.");
+        }
+      } else {
+        // for kernel [6,6], stride [2,2] and pads [2,2,2,2]
+        if (kernelSize == 6) {
+          return rewriter.getI64ArrayAttr({1, 1, 1, 1});
+        } else {
+          llvm_unreachable("Invalid conv sequence.");
+        }
+      }
+    };
+    auto stridesArrayAttr = rewriter.getI64ArrayAttr({1, 1});
+
+    Value conv1 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[3], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr,
+        getPadsArrayAttr(kernelShape[0], 1, needWeightsPadding),
+        stridesArrayAttr);
+    Value conv2 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[0], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr,
+        getPadsArrayAttr(kernelShape[0], 2, needWeightsPadding),
+        stridesArrayAttr);
+    Value conv3 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[1], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr,
+        getPadsArrayAttr(kernelShape[0], 3, needWeightsPadding),
+        stridesArrayAttr);
+    Value conv4 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[2], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr,
+        getPadsArrayAttr(kernelShape[0], 4, needWeightsPadding),
+        stridesArrayAttr);
+
+    // Need to remove excess the ofm  when weights are padded.
+    if (needWeightsPadding) {
+      auto startOnnxConstant = getONNXConstOpFromVector({1, 1});
+      auto endOnnxConstant = getONNXConstOpFromVector(
+          {convOutputShape[convOutputShape.size() - 2] + 2,
+              convOutputShape[convOutputShape.size() - 1] + 2});
+      auto axisOnnxConstant = getONNXConstOpFromVector({2, 3});
+      auto stepOnnxConstant = getONNXConstOpFromVector({1, 1});
+      auto convSliceOutputType = RankedTensorType::get(
+          convOutputShape, convTransposeOutputType.getElementType());
+      conv1 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv1,
+          startOnnxConstant, endOnnxConstant, axisOnnxConstant,
+          stepOnnxConstant);
+
+      startOnnxConstant = getONNXConstOpFromVector({0, 0});
+      endOnnxConstant =
+          getONNXConstOpFromVector({convOutputShape[convOutputShape.size() - 2],
+              convOutputShape[convOutputShape.size() - 1]});
+      conv2 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv2,
+          startOnnxConstant, endOnnxConstant, axisOnnxConstant,
+          stepOnnxConstant);
+
+      startOnnxConstant = getONNXConstOpFromVector({1, 0});
+      endOnnxConstant = getONNXConstOpFromVector(
+          {convOutputShape[convOutputShape.size() - 2] + 2,
+              convOutputShape[convOutputShape.size() - 1]});
+      conv3 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv3,
+          startOnnxConstant, endOnnxConstant, axisOnnxConstant,
+          stepOnnxConstant);
+
+      startOnnxConstant = getONNXConstOpFromVector({0, 1});
+      endOnnxConstant =
+          getONNXConstOpFromVector({convOutputShape[convOutputShape.size() - 2],
+              convOutputShape[convOutputShape.size() - 1] + 2});
+      conv4 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv4,
+          startOnnxConstant, endOnnxConstant, axisOnnxConstant,
+          stepOnnxConstant);
+    }
+
+    // The four convOutputs are adjusted to add an extra dimension at the
+    // innermost level.
+    SmallVector<int64_t> outputShapePlusOneDim(convOutputShape);
+    outputShapePlusOneDim.push_back(1);
+    auto onnxConstForReshapeAddOneDim =
+        getONNXConstOpFromVector(outputShapePlusOneDim);
+
+    auto reshapeOutputType =
+        RankedTensorType::get(outputShapePlusOneDim, elementType);
+
+    auto reshapeOutputAddOneDimConv1 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv1, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv2 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv2, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv3 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv3, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv4 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv4, onnxConstForReshapeAddOneDim);
+
+    SmallVector<int64_t> outputShapeLevel1Concat(outputShapePlusOneDim);
+    outputShapeLevel1Concat[outputShapeLevel1Concat.size() - 1] = 2;
+    auto level1ConcatOutputType =
+        RankedTensorType::get(outputShapeLevel1Concat, elementType);
+    // for the case where convtranspose kernel is [4, 4] and with pads [1, 1, 1,
+    // 1] The phased convs output are to be concatenated in the reverse order.
+    // This is observed by looking at the phased conv outputs with respect to
+    // convtranspose output.
+    bool reverseConcatOrder = (needWeightsPadding || (kernelShape[0] == 4));
+    // Below concats result will have the innermost dim as 2.
+    auto firstConcat =
+        (reverseConcatOrder)
+            ? rewriter.create<ONNXConcatOp>(loc, level1ConcatOutputType,
+                  ValueRange{
+                      reshapeOutputAddOneDimConv3, reshapeOutputAddOneDimConv1},
+                  -1)
+            : rewriter.create<ONNXConcatOp>(loc, level1ConcatOutputType,
+                  ValueRange{
+                      reshapeOutputAddOneDimConv1, reshapeOutputAddOneDimConv3},
+                  -1);
+    auto secondConcat =
+        (reverseConcatOrder)
+            ? rewriter.create<ONNXConcatOp>(loc, level1ConcatOutputType,
+                  ValueRange{
+                      reshapeOutputAddOneDimConv2, reshapeOutputAddOneDimConv4},
+                  -1)
+            : rewriter.create<ONNXConcatOp>(loc, level1ConcatOutputType,
+                  ValueRange{
+                      reshapeOutputAddOneDimConv4, reshapeOutputAddOneDimConv2},
+                  -1);
+
+    // Reshaping to modify the two innermost levels,ensuring the second
+    // innermost level is set to 1
+    SmallVector<int64_t> outputShapeForDimAdjust(convOutputShape);
+    auto dimValueAtLastIndex = convOutputShape[convOutputShape.size() - 1] * 2;
+    outputShapeForDimAdjust[outputShapeForDimAdjust.size() - 1] = 1;
+    outputShapeForDimAdjust.push_back(dimValueAtLastIndex);
+
+    auto onnxConstForReshapeDimAdjust =
+        getONNXConstOpFromVector(outputShapeForDimAdjust);
+
+    auto reshapeOutputForDimAdjustType =
+        RankedTensorType::get(outputShapeForDimAdjust, elementType);
+    auto reshapeOutputDimAdjustOfFirstConcat =
+        rewriter.create<ONNXReshapeOp>(loc, reshapeOutputForDimAdjustType,
+            firstConcat, onnxConstForReshapeDimAdjust);
+    auto reshapeOutputDimAdjustOfSecondConcat =
+        rewriter.create<ONNXReshapeOp>(loc, reshapeOutputForDimAdjustType,
+            secondConcat, onnxConstForReshapeDimAdjust);
+
+    SmallVector<int64_t> outputShapeForFinalConcat(outputShapeForDimAdjust);
+    outputShapeForFinalConcat[outputShapeForFinalConcat.size() - 2] = 2;
+
+    auto finalConcatOutputType =
+        RankedTensorType::get(outputShapeForFinalConcat, elementType);
+
+    // Final Concat is performed on the two reshaped outputs at the
+    // second innermost level
+    auto finalConcat =
+        (reverseConcatOrder)
+            ? rewriter.create<ONNXConcatOp>(loc, finalConcatOutputType,
+                  ValueRange{reshapeOutputDimAdjustOfSecondConcat,
+                      reshapeOutputDimAdjustOfFirstConcat},
+                  -2)
+            : rewriter.create<ONNXConcatOp>(loc, finalConcatOutputType,
+                  ValueRange{reshapeOutputDimAdjustOfFirstConcat,
+                      reshapeOutputDimAdjustOfSecondConcat},
+                  -2);
+
+    SmallVector<int64_t> outputShapeForResult(convOutputShape);
+    dimValueAtLastIndex = convOutputShape[convOutputShape.size() - 1] * 2;
+    auto dimValueAtSecondLastIndex =
+        convOutputShape[convOutputShape.size() - 2] * 2;
+    outputShapeForResult[outputShapeForResult.size() - 2] =
+        dimValueAtSecondLastIndex;
+    outputShapeForResult[outputShapeForResult.size() - 1] = dimValueAtLastIndex;
+
+    auto onnxConstForLastReshape =
+        getONNXConstOpFromVector(outputShapeForResult);
+
+    auto finalOutputType =
+        RankedTensorType::get(outputShapeForResult, elementType);
+    // Result is reshaped back to match the original convtranspose output
+    // dimensions
+    auto finalOutput = rewriter.create<ONNXReshapeOp>(
+        loc, finalOutputType, finalConcat, onnxConstForLastReshape);
+    return finalOutput;
+  }
+  if (numPhases == 9) {
+    auto padsArrayAttr = rewriter.getI64ArrayAttr({0, 0, 0, 0});
+    auto stridesArrayAttr = rewriter.getI64ArrayAttr({1, 1});
+
+    auto conv1 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[8], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
+    auto conv2 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[5], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
+    auto conv3 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[6], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
+    auto conv4 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[7], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
+    auto conv5 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[4], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
+    auto conv6 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[1], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
+    auto conv7 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[2], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
+    auto conv8 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[3], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
+    auto conv9 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
+        weightSlices[0], bias, mlir::StringAttr(), dilations, group,
+        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
+
+    // The nine convOutputs are adjusted to add an extra dimension at the
+    // innermost level.
+    SmallVector<int64_t> outputShapePlusOneDim(convOutputShape);
+    outputShapePlusOneDim.push_back(1);
+    auto onnxConstForReshapeAddOneDim =
+        getONNXConstOpFromVector(outputShapePlusOneDim);
+
+    auto reshapeOutputType =
+        RankedTensorType::get(outputShapePlusOneDim, elementType);
+
+    auto reshapeOutputAddOneDimConv1 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv1, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv2 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv2, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv3 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv3, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv4 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv4, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv5 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv5, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv6 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv6, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv7 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv7, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv8 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv8, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv9 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv9, onnxConstForReshapeAddOneDim);
+
+    SmallVector<int64_t> outputShapeForLevel1Concat(outputShapePlusOneDim);
+    outputShapeForLevel1Concat[outputShapeForLevel1Concat.size() - 1] = 3;
+    auto level1ConcatOutputType =
+        RankedTensorType::get(outputShapeForLevel1Concat, elementType);
+
+    // Below concats result will have the innermost dim as 2.
+    auto firstRowConcat =
+        rewriter.create<ONNXConcatOp>(loc, level1ConcatOutputType,
+            ValueRange{reshapeOutputAddOneDimConv1, reshapeOutputAddOneDimConv2,
+                reshapeOutputAddOneDimConv7},
+            -1);
+    auto secondRowConcat =
+        rewriter.create<ONNXConcatOp>(loc, level1ConcatOutputType,
+            ValueRange{reshapeOutputAddOneDimConv4, reshapeOutputAddOneDimConv5,
+                reshapeOutputAddOneDimConv6},
+            -1);
+    auto thirdRowConcat =
+        rewriter.create<ONNXConcatOp>(loc, level1ConcatOutputType,
+            ValueRange{reshapeOutputAddOneDimConv3, reshapeOutputAddOneDimConv8,
+                reshapeOutputAddOneDimConv9},
+            -1);
+
+    // Reshaping to modify the two innermost levels,ensuring the second
+    // innermost level is set to 1
+    SmallVector<int64_t> outputShapeForDimAdjust(convOutputShape);
+    auto dimValueAtLastIndex = convOutputShape[convOutputShape.size() - 1] * 3;
+    outputShapeForDimAdjust[outputShapeForDimAdjust.size() - 1] = 1;
+    outputShapeForDimAdjust.push_back(dimValueAtLastIndex);
+
+    auto onnxConstForReshapeDimAdjust =
+        getONNXConstOpFromVector(outputShapeForDimAdjust);
+    auto reshapeOutputForDimAdjustType =
+        RankedTensorType::get(outputShapeForDimAdjust, elementType);
+
+    auto reshapeOutputDimAdjustOfFirstConcat =
+        rewriter.create<ONNXReshapeOp>(loc, reshapeOutputForDimAdjustType,
+            firstRowConcat, onnxConstForReshapeDimAdjust);
+    auto reshapeOutputDimAdjustOfSecondConcat =
+        rewriter.create<ONNXReshapeOp>(loc, reshapeOutputForDimAdjustType,
+            secondRowConcat, onnxConstForReshapeDimAdjust);
+    auto reshapeOutputDimAdjustOfThirdConcat =
+        rewriter.create<ONNXReshapeOp>(loc, reshapeOutputForDimAdjustType,
+            thirdRowConcat, onnxConstForReshapeDimAdjust);
+
+    SmallVector<int64_t> outputShapeForFinalConcat(outputShapeForDimAdjust);
+    outputShapeForFinalConcat[outputShapeForFinalConcat.size() - 2] = 3;
+
+    auto finalConcatOutputType =
+        RankedTensorType::get(outputShapeForFinalConcat, elementType);
+
+    // Final Concat is performed on the three reshaped outputs at the
+    // second innermost level
+    auto finalConcat = rewriter.create<ONNXConcatOp>(loc, finalConcatOutputType,
+        ValueRange{reshapeOutputDimAdjustOfFirstConcat,
+            reshapeOutputDimAdjustOfSecondConcat,
+            reshapeOutputDimAdjustOfThirdConcat},
+        -2);
+    SmallVector<int64_t> outputShapeForResult(convOutputShape);
+    dimValueAtLastIndex = convOutputShape[convOutputShape.size() - 1] * 3;
+    auto dimValueAtSecondLastIndex =
+        convOutputShape[convOutputShape.size() - 2] * 3;
+    outputShapeForResult[outputShapeForResult.size() - 2] =
+        dimValueAtSecondLastIndex;
+    outputShapeForResult[outputShapeForResult.size() - 1] = dimValueAtLastIndex;
+
+    auto onnxConstForLastReshape =
+        getONNXConstOpFromVector(outputShapeForResult);
+
+    auto finalOutputType =
+        RankedTensorType::get(outputShapeForResult, elementType);
+    // Result is reshaped back to match the original convtranspose output
+    // dimensions
+    auto finalOutput = rewriter.create<ONNXReshapeOp>(
+        loc, finalOutputType, finalConcat, onnxConstForLastReshape);
+    return finalOutput;
+  }
+  llvm_unreachable("Unsupported convtranspose decomposition");
+}
+
 // Split on the specified axis. The length of each output is one.
 ValueRange emitSplitAxisOutputLength1(
     PatternRewriter &rewriter, Location loc, Value input, int64_t axis) {

--- a/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv.mlir
@@ -1,0 +1,564 @@
+// RUN: onnx-mlir-opt --shape-inference --decompose-onnx --enable-convtranspose-decompose-phased-conv %s -split-input-file | FileCheck %s
+
+func.func @test_convtrans_4phase_kernel_shape_66(%arg0: tensor<1x512x10x16xf32>, %arg1: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<256xf32>} : ()-> tensor<256xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [6, 6], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [2, 2, 2, 2], strides = [2, 2]} : (tensor<1x512x10x16xf32>, tensor<512x256x6x6xf32>, tensor<256xf32>) -> tensor<1x256x20x32xf32>
+  onnx.Return %1 : tensor<1x256x20x32xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_66(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
+// CHECK-SAME:                                                     %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 256, 10, 1, 32]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 256, 10, 16, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<7> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.ReverseSequence"(%[[VAL_18]], %[[VAL_15]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Transpose"(%[[VAL_20]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_8]], %[[VAL_7]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_6]], %[[VAL_5]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_25]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Reshape"(%[[VAL_26]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Reshape"(%[[VAL_27]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Reshape"(%[[VAL_28]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Reshape"(%[[VAL_29]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Concat"(%[[VAL_30]], %[[VAL_32]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Concat"(%[[VAL_33]], %[[VAL_31]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Reshape"(%[[VAL_34]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x10x16x2xf32>, tensor<5xi64>) -> tensor<1x256x10x1x32xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_35]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x10x16x2xf32>, tensor<5xi64>) -> tensor<1x256x10x1x32xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Concat"(%[[VAL_36]], %[[VAL_37]]) {axis = -2 : si64} : (tensor<1x256x10x1x32xf32>, tensor<1x256x10x1x32xf32>) -> tensor<1x256x10x2x32xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x256x10x2x32xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
+// CHECK:           onnx.Return %[[VAL_39]] : tensor<1x256x20x32xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_4phase_kernel_shape_66_nobias(%arg0: tensor<1x512x10x16xf32>, %arg1: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {      
+  %0 = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [6, 6], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [2, 2, 2, 2], strides = [2, 2]} : (tensor<1x512x10x16xf32>, tensor<512x256x6x6xf32>, none) -> tensor<1x256x20x32xf32>
+  onnx.Return %1 : tensor<1x256x20x32xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_66_nobias(
+// CHECK-SAME:                                                            %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
+// CHECK-SAME:                                                            %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 256, 10, 1, 32]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 256, 10, 16, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<7> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK:           %[[VAL_16:.*]] = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none
+// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.ReverseSequence"(%[[VAL_18]], %[[VAL_15]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Transpose"(%[[VAL_20]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_8]], %[[VAL_7]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_6]], %[[VAL_5]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_25]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, none) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, none) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, none) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, none) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Reshape"(%[[VAL_26]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Reshape"(%[[VAL_27]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Reshape"(%[[VAL_28]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Reshape"(%[[VAL_29]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Concat"(%[[VAL_30]], %[[VAL_32]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Concat"(%[[VAL_33]], %[[VAL_31]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Reshape"(%[[VAL_34]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x10x16x2xf32>, tensor<5xi64>) -> tensor<1x256x10x1x32xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_35]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x10x16x2xf32>, tensor<5xi64>) -> tensor<1x256x10x1x32xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Concat"(%[[VAL_36]], %[[VAL_37]]) {axis = -2 : si64} : (tensor<1x256x10x1x32xf32>, tensor<1x256x10x1x32xf32>) -> tensor<1x256x10x2x32xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x256x10x2x32xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
+// CHECK:           onnx.Return %[[VAL_39]] : tensor<1x256x20x32xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_1phase_pads_1111(%arg0: tensor<1x1x12x44xf32>, %arg1: tensor<1x1x4x16xf32>) -> tensor<1x1x13x57xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<1xf32>} : ()-> tensor<1xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x13x57xf32>
+  onnx.Return %1 : tensor<1x1x13x57xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_1phase_pads_1111(
+// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<1x1x12x44xf32>,
+// CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<1x1x4x16xf32>) -> tensor<1x1x13x57xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<16> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<4> : tensor<16xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK:           %[[VAL_5:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x4x16xf32>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_6:.*]] = "onnx.ReverseSequence"(%[[VAL_5]], %[[VAL_3]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x16x1x1xf32>, tensor<16xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_7:.*]] = "onnx.ReverseSequence"(%[[VAL_6]], %[[VAL_2]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<4x16x1x1xf32>, tensor<4xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_8:.*]] = "onnx.Transpose"(%[[VAL_7]]) {perm = [2, 3, 0, 1]} : (tensor<4x16x1x1xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_9:.*]] = "onnx.Transpose"(%[[VAL_8]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x4x16xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_10:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_9]], %[[VAL_4]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], pads = [2, 14, 2, 14], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x13x57xf32>
+// CHECK:           onnx.Return %[[VAL_10]] : tensor<1x1x13x57xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_1phase_pads_1100(%arg0: tensor<1x1x12x44xf32>, %arg1: tensor<1x1x4x16xf32>) -> tensor<1x1x14x58xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<1xf32>} : ()-> tensor<1xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [1, 1, 0, 0], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x14x58xf32>
+  onnx.Return %1 : tensor<1x1x14x58xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_1phase_pads_1100(
+// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<1x1x12x44xf32>,
+// CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<1x1x4x16xf32>) -> tensor<1x1x14x58xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<16> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<4> : tensor<16xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK:           %[[VAL_5:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x4x16xf32>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_6:.*]] = "onnx.ReverseSequence"(%[[VAL_5]], %[[VAL_3]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x16x1x1xf32>, tensor<16xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_7:.*]] = "onnx.ReverseSequence"(%[[VAL_6]], %[[VAL_2]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<4x16x1x1xf32>, tensor<4xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_8:.*]] = "onnx.Transpose"(%[[VAL_7]]) {perm = [2, 3, 0, 1]} : (tensor<4x16x1x1xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_9:.*]] = "onnx.Transpose"(%[[VAL_8]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x4x16xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_10:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_9]], %[[VAL_4]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], pads = [2, 14, 3, 15], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x14x58xf32>
+// CHECK:           onnx.Return %[[VAL_10]] : tensor<1x1x14x58xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_1phase_pads_1000(%arg0: tensor<1x1x12x44xf32>, %arg1: tensor<1x1x4x16xf32>) -> tensor<1x1x14x59xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<1xf32>} : ()-> tensor<1xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [1, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x14x59xf32>
+  onnx.Return %1 : tensor<1x1x14x59xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_1phase_pads_1000(
+// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<1x1x12x44xf32>,
+// CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<1x1x4x16xf32>) -> tensor<1x1x14x59xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<16> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<4> : tensor<16xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK:           %[[VAL_5:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x4x16xf32>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_6:.*]] = "onnx.ReverseSequence"(%[[VAL_5]], %[[VAL_3]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x16x1x1xf32>, tensor<16xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_7:.*]] = "onnx.ReverseSequence"(%[[VAL_6]], %[[VAL_2]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<4x16x1x1xf32>, tensor<4xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_8:.*]] = "onnx.Transpose"(%[[VAL_7]]) {perm = [2, 3, 0, 1]} : (tensor<4x16x1x1xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_9:.*]] = "onnx.Transpose"(%[[VAL_8]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x4x16xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_10:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_9]], %[[VAL_4]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], pads = [2, 15, 3, 15], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x14x59xf32>
+// CHECK:           onnx.Return %[[VAL_10]] : tensor<1x1x14x59xf32>
+// CHECK:         }
+}
+  
+// -----
+
+func.func @test_convtrans_1phase_pads_1010(%arg0: tensor<1x1x12x44xf32>, %arg1: tensor<1x1x4x16xf32>) -> tensor<1x1x13x59xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<1xf32>} : ()-> tensor<1xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [1, 0, 1, 0], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x13x59xf32>
+  onnx.Return %1 : tensor<1x1x13x59xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_1phase_pads_1010(
+// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<1x1x12x44xf32>,
+// CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<1x1x4x16xf32>) -> tensor<1x1x13x59xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<16> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<4> : tensor<16xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK:           %[[VAL_5:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x4x16xf32>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_6:.*]] = "onnx.ReverseSequence"(%[[VAL_5]], %[[VAL_3]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x16x1x1xf32>, tensor<16xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_7:.*]] = "onnx.ReverseSequence"(%[[VAL_6]], %[[VAL_2]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<4x16x1x1xf32>, tensor<4xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_8:.*]] = "onnx.Transpose"(%[[VAL_7]]) {perm = [2, 3, 0, 1]} : (tensor<4x16x1x1xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_9:.*]] = "onnx.Transpose"(%[[VAL_8]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x4x16xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_10:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_9]], %[[VAL_4]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], pads = [2, 15, 2, 15], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x13x59xf32>
+// CHECK:           onnx.Return %[[VAL_10]] : tensor<1x1x13x59xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_1phase_pads_0000(%arg0: tensor<1x1x27x110xf32>, %arg1: tensor<1x1x2x8xf32>) -> tensor<1x1x28x117xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<1xf32>} : ()-> tensor<1xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 8], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x27x110xf32>, tensor<1x1x2x8xf32>, tensor<1xf32>) -> tensor<1x1x28x117xf32>
+  onnx.Return %1 : tensor<1x1x28x117xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_1phase_pads_0000(
+// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<1x1x27x110xf32>,
+// CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<1x1x2x8xf32>) -> tensor<1x1x28x117xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<8> : tensor<2xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<2> : tensor<8xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK:           %[[VAL_5:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x2x8xf32>) -> tensor<2x8x1x1xf32>
+// CHECK:           %[[VAL_6:.*]] = "onnx.ReverseSequence"(%[[VAL_5]], %[[VAL_3]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<2x8x1x1xf32>, tensor<8xi64>) -> tensor<2x8x1x1xf32>
+// CHECK:           %[[VAL_7:.*]] = "onnx.ReverseSequence"(%[[VAL_6]], %[[VAL_2]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<2x8x1x1xf32>, tensor<2xi64>) -> tensor<2x8x1x1xf32>
+// CHECK:           %[[VAL_8:.*]] = "onnx.Transpose"(%[[VAL_7]]) {perm = [2, 3, 0, 1]} : (tensor<2x8x1x1xf32>) -> tensor<1x1x2x8xf32>
+// CHECK:           %[[VAL_9:.*]] = "onnx.Transpose"(%[[VAL_8]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x2x8xf32>) -> tensor<1x1x2x8xf32>
+// CHECK:           %[[VAL_10:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_9]], %[[VAL_4]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 8], pads = [1, 7, 1, 7], strides = [1, 1]} : (tensor<1x1x27x110xf32>, tensor<1x1x2x8xf32>, tensor<1xf32>) -> tensor<1x1x28x117xf32>
+// CHECK:           onnx.Return %[[VAL_10]] : tensor<1x1x28x117xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_9phase(%arg0: tensor<1x1x18x74xf32>, %arg1: tensor<1x1x3x3xf32>) -> tensor<1x1x54x222xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<1xf32>} : ()-> tensor<1xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [0, 0, 0, 0], strides = [3, 3]} : (tensor<1x1x18x74xf32>, tensor<1x1x3x3xf32>, tensor<1xf32>) -> tensor<1x1x54x222xf32>
+  onnx.Return %1 : tensor<1x1x54x222xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_9phase(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: tensor<1x1x18x74xf32>,
+// CHECK-SAME:                                     %[[VAL_1:.*]]: tensor<1x1x3x3xf32>) -> tensor<1x1x54x222xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<5> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[3, 5]> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<2xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<[3, 4]> : tensor<2xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<[5, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<[4, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<3> : tensor<2xi64>
+// CHECK:           %[[VAL_23:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_24:.*]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK:           %[[VAL_25:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xf32>) -> tensor<3x3x1x1xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.ReverseSequence"(%[[VAL_26]], %[[VAL_24]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.ReverseSequence"(%[[VAL_27]], %[[VAL_24]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Transpose"(%[[VAL_28]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xf32>) -> tensor<1x1x3x3xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Transpose"(%[[VAL_29]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_21]], %[[VAL_22]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_20]], %[[VAL_19]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_18]], %[[VAL_17]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_16]], %[[VAL_15]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_14]], %[[VAL_13]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_12]], %[[VAL_11]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_10]], %[[VAL_9]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_8]], %[[VAL_7]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_6]], %[[VAL_5]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_39]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_36]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_37]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_43:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_38]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_44:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_35]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_45:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_32]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_46:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_33]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_47:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_34]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_48:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_31]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_49:.*]] = "onnx.Reshape"(%[[VAL_40]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_50:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_51:.*]] = "onnx.Reshape"(%[[VAL_42]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_52:.*]] = "onnx.Reshape"(%[[VAL_43]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_53:.*]] = "onnx.Reshape"(%[[VAL_44]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_54:.*]] = "onnx.Reshape"(%[[VAL_45]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_55:.*]] = "onnx.Reshape"(%[[VAL_46]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_56:.*]] = "onnx.Reshape"(%[[VAL_47]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_57:.*]] = "onnx.Reshape"(%[[VAL_48]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_58:.*]] = "onnx.Concat"(%[[VAL_49]], %[[VAL_50]], %[[VAL_55]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK:           %[[VAL_59:.*]] = "onnx.Concat"(%[[VAL_52]], %[[VAL_53]], %[[VAL_54]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK:           %[[VAL_60:.*]] = "onnx.Concat"(%[[VAL_51]], %[[VAL_56]], %[[VAL_57]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK:           %[[VAL_61:.*]] = "onnx.Reshape"(%[[VAL_58]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           %[[VAL_62:.*]] = "onnx.Reshape"(%[[VAL_59]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           %[[VAL_63:.*]] = "onnx.Reshape"(%[[VAL_60]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           %[[VAL_64:.*]] = "onnx.Concat"(%[[VAL_61]], %[[VAL_62]], %[[VAL_63]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
+// CHECK:           %[[VAL_65:.*]] = "onnx.Reshape"(%[[VAL_64]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
+// CHECK:           onnx.Return %[[VAL_65]] : tensor<1x1x54x222xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_4phase_pads_0011(%arg0: tensor<1x128x10x16xf32>, %arg1: tensor<128x32x3x3xf32>) -> tensor<1x32x20x32xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<32xf32>} : ()-> tensor<32xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [0, 0, 1, 1], strides = [2, 2]} : (tensor<1x128x10x16xf32>, tensor<128x32x3x3xf32>, tensor<32xf32>) -> tensor<1x32x20x32xf32>
+  onnx.Return %1 : tensor<1x32x20x32xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_4phase_pads_0011(
+// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<1x128x10x16xf32>,
+// CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<128x32x3x3xf32>) -> tensor<1x32x20x32xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 32, 20, 32]> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 32, 10, 1, 32]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 32, 10, 16, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<[10, 18]> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[12, 16]> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[10, 16]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[12, 18]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<5> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<4> : tensor<2xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_19:.*]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<0.000000e+00> : tensor<f32>
+// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<[0, 0, 0, 0, 0, 0, 1, 1]> : tensor<8xi64>
+// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK:           %[[VAL_23:.*]] = onnx.Constant dense<2.000000e-02> : tensor<32xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<128x32x3x3xf32>) -> tensor<3x3x128x32xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.ReverseSequence"(%[[VAL_24]], %[[VAL_22]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.ReverseSequence"(%[[VAL_25]], %[[VAL_22]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Transpose"(%[[VAL_26]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x128x32xf32>) -> tensor<128x32x3x3xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Transpose"(%[[VAL_27]]) {perm = [1, 0, 2, 3]} : (tensor<128x32x3x3xf32>) -> tensor<32x128x3x3xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Pad"(%[[VAL_28]], %[[VAL_21]], %[[VAL_20]], %[[VAL_19]]) {mode = "constant"} : (tensor<32x128x3x3xf32>, tensor<8xi64>, tensor<f32>, none) -> tensor<32x128x4x4xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_16]], %[[VAL_15]], %[[VAL_18]], %[[VAL_17]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_14]], %[[VAL_13]], %[[VAL_18]], %[[VAL_17]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_12]], %[[VAL_11]], %[[VAL_18]], %[[VAL_17]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_10]], %[[VAL_9]], %[[VAL_18]], %[[VAL_17]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_33]], %[[VAL_23]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_30]], %[[VAL_23]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_31]], %[[VAL_23]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_32]], %[[VAL_23]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Slice"(%[[VAL_34]], %[[VAL_10]], %[[VAL_8]], %[[VAL_18]], %[[VAL_10]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_35]], %[[VAL_16]], %[[VAL_7]], %[[VAL_18]], %[[VAL_10]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.Slice"(%[[VAL_36]], %[[VAL_14]], %[[VAL_6]], %[[VAL_18]], %[[VAL_10]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.Slice"(%[[VAL_37]], %[[VAL_12]], %[[VAL_5]], %[[VAL_18]], %[[VAL_10]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x32x10x16xf32>, tensor<5xi64>) -> tensor<1x32x10x16x1xf32>
+// CHECK:           %[[VAL_43:.*]] = "onnx.Reshape"(%[[VAL_39]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x32x10x16xf32>, tensor<5xi64>) -> tensor<1x32x10x16x1xf32>
+// CHECK:           %[[VAL_44:.*]] = "onnx.Reshape"(%[[VAL_40]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x32x10x16xf32>, tensor<5xi64>) -> tensor<1x32x10x16x1xf32>
+// CHECK:           %[[VAL_45:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x32x10x16xf32>, tensor<5xi64>) -> tensor<1x32x10x16x1xf32>
+// CHECK:           %[[VAL_46:.*]] = "onnx.Concat"(%[[VAL_44]], %[[VAL_42]]) {axis = -1 : si64} : (tensor<1x32x10x16x1xf32>, tensor<1x32x10x16x1xf32>) -> tensor<1x32x10x16x2xf32>
+// CHECK:           %[[VAL_47:.*]] = "onnx.Concat"(%[[VAL_43]], %[[VAL_45]]) {axis = -1 : si64} : (tensor<1x32x10x16x1xf32>, tensor<1x32x10x16x1xf32>) -> tensor<1x32x10x16x2xf32>
+// CHECK:           %[[VAL_48:.*]] = "onnx.Reshape"(%[[VAL_46]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x32x10x16x2xf32>, tensor<5xi64>) -> tensor<1x32x10x1x32xf32>
+// CHECK:           %[[VAL_49:.*]] = "onnx.Reshape"(%[[VAL_47]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x32x10x16x2xf32>, tensor<5xi64>) -> tensor<1x32x10x1x32xf32>
+// CHECK:           %[[VAL_50:.*]] = "onnx.Concat"(%[[VAL_49]], %[[VAL_48]]) {axis = -2 : si64} : (tensor<1x32x10x1x32xf32>, tensor<1x32x10x1x32xf32>) -> tensor<1x32x10x2x32xf32>
+// CHECK:           %[[VAL_51:.*]] = "onnx.Reshape"(%[[VAL_50]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x32x10x2x32xf32>, tensor<4xi64>) -> tensor<1x32x20x32xf32>
+// CHECK:           onnx.Return %[[VAL_51]] : tensor<1x32x20x32xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_4phase_pads_1100(%arg0: tensor<1x128x10x16xf32>, %arg1: tensor<128x32x3x3xf32>) -> tensor<1x32x20x32xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<32xf32>} : ()-> tensor<32xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [1, 1, 0, 0], strides = [2, 2]} : (tensor<1x128x10x16xf32>, tensor<128x32x3x3xf32>, tensor<32xf32>) -> tensor<1x32x20x32xf32>
+  onnx.Return %1 : tensor<1x32x20x32xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_4phase_pads_1100(
+// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<1x128x10x16xf32>,
+// CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<128x32x3x3xf32>) -> tensor<1x32x20x32xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 32, 20, 32]> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 32, 10, 1, 32]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 32, 10, 16, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<[10, 18]> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[12, 16]> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[10, 16]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[12, 18]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<5> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<4> : tensor<2xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_19:.*]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<0.000000e+00> : tensor<f32>
+// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<[0, 0, 1, 1, 0, 0, 0, 0]> : tensor<8xi64>
+// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK:           %[[VAL_23:.*]] = onnx.Constant dense<2.000000e-02> : tensor<32xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<128x32x3x3xf32>) -> tensor<3x3x128x32xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.ReverseSequence"(%[[VAL_24]], %[[VAL_22]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.ReverseSequence"(%[[VAL_25]], %[[VAL_22]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Transpose"(%[[VAL_26]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x128x32xf32>) -> tensor<128x32x3x3xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Transpose"(%[[VAL_27]]) {perm = [1, 0, 2, 3]} : (tensor<128x32x3x3xf32>) -> tensor<32x128x3x3xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Pad"(%[[VAL_28]], %[[VAL_21]], %[[VAL_20]], %[[VAL_19]]) {mode = "constant"} : (tensor<32x128x3x3xf32>, tensor<8xi64>, tensor<f32>, none) -> tensor<32x128x4x4xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_16]], %[[VAL_15]], %[[VAL_18]], %[[VAL_17]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_14]], %[[VAL_13]], %[[VAL_18]], %[[VAL_17]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_12]], %[[VAL_11]], %[[VAL_18]], %[[VAL_17]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_10]], %[[VAL_9]], %[[VAL_18]], %[[VAL_17]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_33]], %[[VAL_23]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_30]], %[[VAL_23]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_31]], %[[VAL_23]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_32]], %[[VAL_23]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Slice"(%[[VAL_34]], %[[VAL_10]], %[[VAL_8]], %[[VAL_18]], %[[VAL_10]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_35]], %[[VAL_16]], %[[VAL_7]], %[[VAL_18]], %[[VAL_10]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.Slice"(%[[VAL_36]], %[[VAL_14]], %[[VAL_6]], %[[VAL_18]], %[[VAL_10]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.Slice"(%[[VAL_37]], %[[VAL_12]], %[[VAL_5]], %[[VAL_18]], %[[VAL_10]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x32x10x16xf32>, tensor<5xi64>) -> tensor<1x32x10x16x1xf32>
+// CHECK:           %[[VAL_43:.*]] = "onnx.Reshape"(%[[VAL_39]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x32x10x16xf32>, tensor<5xi64>) -> tensor<1x32x10x16x1xf32>
+// CHECK:           %[[VAL_44:.*]] = "onnx.Reshape"(%[[VAL_40]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x32x10x16xf32>, tensor<5xi64>) -> tensor<1x32x10x16x1xf32>
+// CHECK:           %[[VAL_45:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x32x10x16xf32>, tensor<5xi64>) -> tensor<1x32x10x16x1xf32>
+// CHECK:           %[[VAL_46:.*]] = "onnx.Concat"(%[[VAL_44]], %[[VAL_42]]) {axis = -1 : si64} : (tensor<1x32x10x16x1xf32>, tensor<1x32x10x16x1xf32>) -> tensor<1x32x10x16x2xf32>
+// CHECK:           %[[VAL_47:.*]] = "onnx.Concat"(%[[VAL_43]], %[[VAL_45]]) {axis = -1 : si64} : (tensor<1x32x10x16x1xf32>, tensor<1x32x10x16x1xf32>) -> tensor<1x32x10x16x2xf32>
+// CHECK:           %[[VAL_48:.*]] = "onnx.Reshape"(%[[VAL_46]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x32x10x16x2xf32>, tensor<5xi64>) -> tensor<1x32x10x1x32xf32>
+// CHECK:           %[[VAL_49:.*]] = "onnx.Reshape"(%[[VAL_47]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x32x10x16x2xf32>, tensor<5xi64>) -> tensor<1x32x10x1x32xf32>
+// CHECK:           %[[VAL_50:.*]] = "onnx.Concat"(%[[VAL_49]], %[[VAL_48]]) {axis = -2 : si64} : (tensor<1x32x10x1x32xf32>, tensor<1x32x10x1x32xf32>) -> tensor<1x32x10x2x32xf32>
+// CHECK:           %[[VAL_51:.*]] = "onnx.Reshape"(%[[VAL_50]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x32x10x2x32xf32>, tensor<4xi64>) -> tensor<1x32x20x32xf32>
+// CHECK:           onnx.Return %[[VAL_51]] : tensor<1x32x20x32xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_4phase_kernel_dilation2(%arg0: tensor<1x512x10x16xf32>, %arg1: tensor<512x256x6x6xf32>) -> tensor<1x256x25x37xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<256xf32>} : ()-> tensor<256xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [2, 2], group = 1 : si64, kernel_shape = [6, 6], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [2, 2, 2, 2], strides = [2, 2]} : (tensor<1x512x10x16xf32>, tensor<512x256x6x6xf32>, tensor<256xf32>) -> tensor<1x256x25x37xf32>
+  onnx.Return %1 : tensor<1x256x25x37xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_dilation2(
+// CHECK-SAME:                                                      %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
+// CHECK-SAME:                                                      %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x25x37xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
+// CHECK:           %[[VAL_3:.*]] = "onnx.ConvTranspose"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {auto_pad = "NOTSET", dilations = [2, 2], group = 1 : si64, kernel_shape = [6, 6], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [2, 2, 2, 2], strides = [2, 2]} : (tensor<1x512x10x16xf32>, tensor<512x256x6x6xf32>, tensor<256xf32>) -> tensor<1x256x25x37xf32>
+// CHECK:           onnx.Return %[[VAL_3]] : tensor<1x256x25x37xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_1phase_pads_0000_nodilation(%arg0: tensor<1x1x27x110xf32>, %arg1: tensor<1x1x2x8xf32>) -> tensor<1x1x28x117xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<1xf32>} : ()-> tensor<1xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2, 8], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x27x110xf32>, tensor<1x1x2x8xf32>, tensor<1xf32>) -> tensor<1x1x28x117xf32>
+  onnx.Return %1 : tensor<1x1x28x117xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_1phase_pads_0000_nodilation(
+// CHECK-SAME:                                                          %[[VAL_0:.*]]: tensor<1x1x27x110xf32>,
+// CHECK-SAME:                                                          %[[VAL_1:.*]]: tensor<1x1x2x8xf32>) -> tensor<1x1x28x117xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<8> : tensor<2xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<2> : tensor<8xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK:           %[[VAL_5:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x2x8xf32>) -> tensor<2x8x1x1xf32>
+// CHECK:           %[[VAL_6:.*]] = "onnx.ReverseSequence"(%[[VAL_5]], %[[VAL_3]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<2x8x1x1xf32>, tensor<8xi64>) -> tensor<2x8x1x1xf32>
+// CHECK:           %[[VAL_7:.*]] = "onnx.ReverseSequence"(%[[VAL_6]], %[[VAL_2]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<2x8x1x1xf32>, tensor<2xi64>) -> tensor<2x8x1x1xf32>
+// CHECK:           %[[VAL_8:.*]] = "onnx.Transpose"(%[[VAL_7]]) {perm = [2, 3, 0, 1]} : (tensor<2x8x1x1xf32>) -> tensor<1x1x2x8xf32>
+// CHECK:           %[[VAL_9:.*]] = "onnx.Transpose"(%[[VAL_8]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x2x8xf32>) -> tensor<1x1x2x8xf32>
+// CHECK:           %[[VAL_10:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_9]], %[[VAL_4]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2, 8], pads = [1, 7, 1, 7], strides = [1, 1]} : (tensor<1x1x27x110xf32>, tensor<1x1x2x8xf32>, tensor<1xf32>) -> tensor<1x1x28x117xf32>
+// CHECK:           onnx.Return %[[VAL_10]] : tensor<1x1x28x117xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_4phase_kernel_shape_22(%arg0: tensor<1x288x8x96xf32>, %arg1: tensor<288x240x2x2xf32>) -> tensor<1x240x16x192xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<240xf32>} : ()-> tensor<240xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2,2], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [0,0,0,0], strides = [2, 2]} : (tensor<1x288x8x96xf32>, tensor<288x240x2x2xf32>, tensor<240xf32>) -> tensor<1x240x16x192xf32>
+  onnx.Return %1 : tensor<1x240x16x192xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_22(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<1x288x8x96xf32>,
+// CHECK-SAME:                                                     %[[VAL_1:.*]]: tensor<288x240x2x2xf32>) -> tensor<1x240x16x192xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 240, 16, 192]> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 240, 8, 1, 192]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 240, 8, 96, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<3> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[3, 2]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<2.000000e-02> : tensor<240xf32>
+// CHECK:           %[[VAL_14:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<288x240x2x2xf32>) -> tensor<2x2x288x240xf32>
+// CHECK:           %[[VAL_15:.*]] = "onnx.ReverseSequence"(%[[VAL_14]], %[[VAL_12]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<2x2x288x240xf32>, tensor<2xi64>) -> tensor<2x2x288x240xf32>
+// CHECK:           %[[VAL_16:.*]] = "onnx.ReverseSequence"(%[[VAL_15]], %[[VAL_12]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<2x2x288x240xf32>, tensor<2xi64>) -> tensor<2x2x288x240xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_16]]) {perm = [2, 3, 0, 1]} : (tensor<2x2x288x240xf32>) -> tensor<288x240x2x2xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.Transpose"(%[[VAL_17]]) {perm = [1, 0, 2, 3]} : (tensor<288x240x2x2xf32>) -> tensor<240x288x2x2xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.Slice"(%[[VAL_18]], %[[VAL_10]], %[[VAL_12]], %[[VAL_11]], %[[VAL_12]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Slice"(%[[VAL_18]], %[[VAL_9]], %[[VAL_8]], %[[VAL_11]], %[[VAL_12]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_18]], %[[VAL_7]], %[[VAL_11]], %[[VAL_11]], %[[VAL_12]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_18]], %[[VAL_6]], %[[VAL_5]], %[[VAL_11]], %[[VAL_12]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_13]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x288x8x96xf32>, tensor<240x288x1x1xf32>, tensor<240xf32>) -> tensor<1x240x8x96xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_19]], %[[VAL_13]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x288x8x96xf32>, tensor<240x288x1x1xf32>, tensor<240xf32>) -> tensor<1x240x8x96xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_20]], %[[VAL_13]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x288x8x96xf32>, tensor<240x288x1x1xf32>, tensor<240xf32>) -> tensor<1x240x8x96xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_13]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x288x8x96xf32>, tensor<240x288x1x1xf32>, tensor<240xf32>) -> tensor<1x240x8x96xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Reshape"(%[[VAL_23]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x240x8x96xf32>, tensor<5xi64>) -> tensor<1x240x8x96x1xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Reshape"(%[[VAL_24]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x240x8x96xf32>, tensor<5xi64>) -> tensor<1x240x8x96x1xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x240x8x96xf32>, tensor<5xi64>) -> tensor<1x240x8x96x1xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Reshape"(%[[VAL_26]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x240x8x96xf32>, tensor<5xi64>) -> tensor<1x240x8x96x1xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Concat"(%[[VAL_27]], %[[VAL_29]]) {axis = -1 : si64} : (tensor<1x240x8x96x1xf32>, tensor<1x240x8x96x1xf32>) -> tensor<1x240x8x96x2xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Concat"(%[[VAL_30]], %[[VAL_28]]) {axis = -1 : si64} : (tensor<1x240x8x96x1xf32>, tensor<1x240x8x96x1xf32>) -> tensor<1x240x8x96x2xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x240x8x96x2xf32>, tensor<5xi64>) -> tensor<1x240x8x1x192xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Reshape"(%[[VAL_32]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x240x8x96x2xf32>, tensor<5xi64>) -> tensor<1x240x8x1x192xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Concat"(%[[VAL_33]], %[[VAL_34]]) {axis = -2 : si64} : (tensor<1x240x8x1x192xf32>, tensor<1x240x8x1x192xf32>) -> tensor<1x240x8x2x192xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Reshape"(%[[VAL_35]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x240x8x2x192xf32>, tensor<4xi64>) -> tensor<1x240x16x192xf32>
+// CHECK:           onnx.Return %[[VAL_36]] : tensor<1x240x16x192xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_4phase_kernel_shape_44(%arg0: tensor<1x512x8x8xf32>, %arg1: tensor<512x512x4x4xf32>) -> tensor<1x512x16x16xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<512xf32>} : ()-> tensor<512xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4,4], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [1,1,1,1], strides = [2, 2]} : (tensor<1x512x8x8xf32>, tensor<512x512x4x4xf32>, tensor<512xf32>) -> tensor<1x512x16x16xf32>
+  onnx.Return %1 : tensor<1x512x16x16xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_44(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<1x512x8x8xf32>,
+// CHECK-SAME:                                                     %[[VAL_1:.*]]: tensor<512x512x4x4xf32>) -> tensor<1x512x16x16xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 512, 16, 16]> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 512, 8, 1, 16]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 512, 8, 8, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<5> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<4> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<4> : tensor<4xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<512xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x512x4x4xf32>) -> tensor<4x4x512x512xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x4x512x512xf32>, tensor<4xi64>) -> tensor<4x4x512x512xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.ReverseSequence"(%[[VAL_18]], %[[VAL_15]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<4x4x512x512xf32>, tensor<4xi64>) -> tensor<4x4x512x512xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [2, 3, 0, 1]} : (tensor<4x4x512x512xf32>) -> tensor<512x512x4x4xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Transpose"(%[[VAL_20]]) {perm = [1, 0, 2, 3]} : (tensor<512x512x4x4xf32>) -> tensor<512x512x4x4xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_8]], %[[VAL_7]], %[[VAL_14]], %[[VAL_13]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_6]], %[[VAL_5]], %[[VAL_14]], %[[VAL_13]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_25]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [0, 0, 1, 1], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 0, 0], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [0, 1, 1, 0], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 0, 0, 1], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Reshape"(%[[VAL_26]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x512x8x8xf32>, tensor<5xi64>) -> tensor<1x512x8x8x1xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Reshape"(%[[VAL_27]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x512x8x8xf32>, tensor<5xi64>) -> tensor<1x512x8x8x1xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Reshape"(%[[VAL_28]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x512x8x8xf32>, tensor<5xi64>) -> tensor<1x512x8x8x1xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Reshape"(%[[VAL_29]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x512x8x8xf32>, tensor<5xi64>) -> tensor<1x512x8x8x1xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Concat"(%[[VAL_32]], %[[VAL_30]]) {axis = -1 : si64} : (tensor<1x512x8x8x1xf32>, tensor<1x512x8x8x1xf32>) -> tensor<1x512x8x8x2xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Concat"(%[[VAL_31]], %[[VAL_33]]) {axis = -1 : si64} : (tensor<1x512x8x8x1xf32>, tensor<1x512x8x8x1xf32>) -> tensor<1x512x8x8x2xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Reshape"(%[[VAL_34]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x512x8x8x2xf32>, tensor<5xi64>) -> tensor<1x512x8x1x16xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_35]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x512x8x8x2xf32>, tensor<5xi64>) -> tensor<1x512x8x1x16xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Concat"(%[[VAL_37]], %[[VAL_36]]) {axis = -2 : si64} : (tensor<1x512x8x1x16xf32>, tensor<1x512x8x1x16xf32>) -> tensor<1x512x8x2x16xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x512x8x2x16xf32>, tensor<4xi64>) -> tensor<1x512x16x16xf32>
+// CHECK:           onnx.Return %[[VAL_39]] : tensor<1x512x16x16xf32>
+// CHECK:         }
+}


### PR DESCRIPTION
[Backport] Addressing below usecases

kernel is [2,2] and stride is [2,2], with pads [0,0,0,0], gets decomposed to 4 conv2d operations each with kernel [1,1]
kernel [4,4] and stride [2,2], with pads [1,1,1,1], gets decomposed to 4 conv2d operations each with kernel [2,2]