### PR TITLE
Use pass options instead of global variables to drive Decompose

### DIFF
--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -67,8 +67,7 @@ void configurePasses() {
 }
 
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
-    bool donotScrubDisposableElementsAttr,
-    OnnxToMlirOptions opts) {
+    bool donotScrubDisposableElementsAttr, OnnxToMlirOptions opts) {
   // This is a transition from previous static passes to full dynamic passes
   // Static passes are kept and the dynamic pass is added as IF-THEN
   // with the static iteration.
@@ -86,8 +85,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
 
   // Decompose first. Eliminates some unsupported ops without shape inference.
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createDecomposeONNXToONNXPass(
-    /*target=*/"",opts.enableConvTransposeDecompose, opts.enableConvTranposeDecomposeToPhasedConv
-  ));
+      /*target=*/"", opts.enableConvTransposeDecompose,
+      opts.enableConvTranposeDecomposeToPhasedConv));
   if (!disableRecomposeOption)
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass());
   if (enableONNXHybridPass) {
@@ -339,12 +338,12 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
   //       the CPU specific transformations.
   if (inputIRLevel <= ONNXLevel && emissionTarget >= EmitONNXIR) {
     OnnxToMlirOptions opts;
-    opts.enableQuarkQuantizedLegalization  = enableQuarkQuantizedLegalization;
+    opts.enableQuarkQuantizedLegalization = enableQuarkQuantizedLegalization;
     opts.enableConvTransposeDecompose = enableConvTransposeDecomposeOption;
-    opts.enableConvTranposeDecomposeToPhasedConv = enableConvTranposeDecomposeToPhasedConv;
+    opts.enableConvTranposeDecomposeToPhasedConv =
+        enableConvTranposeDecomposeToPhasedConv;
     addONNXToMLIRPasses(pm, /*target CPU*/ false,
-        /*donotScrubDisposableElementsAttr=*/false,
-        opts);
+        /*donotScrubDisposableElementsAttr=*/false, opts);
   }
 
   if (emissionTarget >= EmitMLIR) {

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -68,7 +68,7 @@ void configurePasses() {
 
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     bool donotScrubDisposableElementsAttr,
-    bool enableQuarkQuantizedLegalization) {
+    OnnxToMlirOptions opts) {
   // This is a transition from previous static passes to full dynamic passes
   // Static passes are kept and the dynamic pass is added as IF-THEN
   // with the static iteration.
@@ -85,12 +85,14 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         std::make_unique<DisposableGarbageCollector>(pm.getContext()));
 
   // Decompose first. Eliminates some unsupported ops without shape inference.
-  pm.addNestedPass<func::FuncOp>(onnx_mlir::createDecomposeONNXToONNXPass());
+  pm.addNestedPass<func::FuncOp>(onnx_mlir::createDecomposeONNXToONNXPass(
+    /*target=*/"",opts.enableConvTransposeDecompose, opts.enableConvTranposeDecomposeToPhasedConv
+  ));
   if (!disableRecomposeOption)
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass());
   if (enableONNXHybridPass) {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
-        !disableRecomposeOption, enableQuarkQuantizedLegalization));
+        !disableRecomposeOption, opts.enableQuarkQuantizedLegalization));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
@@ -130,13 +132,13 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
 
   // Simplify shape-related ops.
   pm.addPass(onnx_mlir::createSimplifyShapeRelatedOpsPass(
-      enableQuarkQuantizedLegalization));
+      opts.enableQuarkQuantizedLegalization));
 
   // One more call to ONNX shape inference/canonicalization/... to update
   // shape if possible.
   if (enableONNXHybridPass) {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
-        !disableRecomposeOption, enableQuarkQuantizedLegalization));
+        !disableRecomposeOption, opts.enableQuarkQuantizedLegalization));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());
@@ -335,10 +337,15 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
 
   // NOTE: FlexML sets the targetCPU flag to false, as we do not want to run
   //       the CPU specific transformations.
-  if (inputIRLevel <= ONNXLevel && emissionTarget >= EmitONNXIR)
+  if (inputIRLevel <= ONNXLevel && emissionTarget >= EmitONNXIR) {
+    OnnxToMlirOptions opts;
+    opts.enableQuarkQuantizedLegalization  = enableQuarkQuantizedLegalization;
+    opts.enableConvTransposeDecompose = enableConvTransposeDecomposeOption;
+    opts.enableConvTranposeDecomposeToPhasedConv = enableConvTranposeDecomposeToPhasedConv;
     addONNXToMLIRPasses(pm, /*target CPU*/ false,
         /*donotScrubDisposableElementsAttr=*/false,
-        /*enableQuarkQuantizedLegalization=*/enableQuarkQuantizedLegalization);
+        opts);
+  }
 
   if (emissionTarget >= EmitMLIR) {
     if (inputIRLevel <= ONNXLevel)

--- a/src/Compiler/CompilerPasses.hpp
+++ b/src/Compiler/CompilerPasses.hpp
@@ -15,14 +15,25 @@
 #ifndef ONNX_MLIR_COMPILER_PASSES_H
 #define ONNX_MLIR_COMPILER_PASSES_H
 #include "mlir/Pass/PassManager.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "onnx-mlir/Compiler/OMCompilerTypes.h"
+namespace mlir {
+class ModuleOp;
+}
 
 namespace onnx_mlir {
 // Configures passes up front based on command line options.
 void configurePasses();
 
+struct OnnxToMlirOptions {
+    bool enableQuarkQuantizedLegalization = false;
+    bool enableConvTransposeDecompose = false;
+    bool enableConvTranposeDecomposeToPhasedConv = false;
+};
+
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     bool donotScrubDisposableElementsAttr = false,
-    bool enableQuarkQuantizedLegalization = false);
+    OnnxToMlirOptions opts = {});
 void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
     std::string instrumentSignatureString, std::string ONNXOpsStatFilename);
 void addKrnlToAffinePasses(mlir::PassManager &pm);

--- a/src/Compiler/CompilerPasses.hpp
+++ b/src/Compiler/CompilerPasses.hpp
@@ -14,8 +14,8 @@
 
 #ifndef ONNX_MLIR_COMPILER_PASSES_H
 #define ONNX_MLIR_COMPILER_PASSES_H
-#include "mlir/Pass/PassManager.h"
 #include "mlir/IR/OwningOpRef.h"
+#include "mlir/Pass/PassManager.h"
 #include "onnx-mlir/Compiler/OMCompilerTypes.h"
 namespace mlir {
 class ModuleOp;
@@ -26,14 +26,13 @@ namespace onnx_mlir {
 void configurePasses();
 
 struct OnnxToMlirOptions {
-    bool enableQuarkQuantizedLegalization = false;
-    bool enableConvTransposeDecompose = false;
-    bool enableConvTranposeDecomposeToPhasedConv = false;
+  bool enableQuarkQuantizedLegalization = false;
+  bool enableConvTransposeDecompose = false;
+  bool enableConvTranposeDecomposeToPhasedConv = false;
 };
 
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
-    bool donotScrubDisposableElementsAttr = false,
-    OnnxToMlirOptions opts = {});
+    bool donotScrubDisposableElementsAttr = false, OnnxToMlirOptions opts = {});
 void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
     std::string instrumentSignatureString, std::string ONNXOpsStatFilename);
 void addKrnlToAffinePasses(mlir::PassManager &pm);

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2846,5 +2846,6 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
 std::unique_ptr<mlir::Pass> onnx_mlir::createDecomposeONNXToONNXPass(
     const std::string &target, bool enableConvTransposeDecompose,
     bool enableConvTranposeDecomposeToPhasedConv) {
-  return std::make_unique<DecomposeONNXToONNXPass>(target);
+  return std::make_unique<DecomposeONNXToONNXPass>(target,
+      enableConvTransposeDecompose, enableConvTranposeDecomposeToPhasedConv);
 }

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -50,9 +50,9 @@
 using namespace mlir;
 
 namespace {
-  thread_local bool localEnableConvTransposeDecompose = false;
-  thread_local bool localEnableConvTranposeDecomposeToPhasedConv = false;
-}
+thread_local bool localEnableConvTransposeDecompose = false;
+thread_local bool localEnableConvTranposeDecomposeToPhasedConv = false;
+} // namespace
 namespace onnx_mlir {
 
 // Create an DenseElementsAttr of ArrayAttr.
@@ -2703,7 +2703,8 @@ struct DecomposeONNXToONNXPass
       : mlir::PassWrapper<DecomposeONNXToONNXPass,
             OperationPass<func::FuncOp>>() {
     this->target = pass.target.getValue();
-    this->enableConvTransposeDecompose = pass.enableConvTransposeDecompose.getValue();
+    this->enableConvTransposeDecompose =
+        pass.enableConvTransposeDecompose.getValue();
     this->enableConvTranposeDecomposeToPhasedConv =
         pass.enableConvTranposeDecomposeToPhasedConv.getValue();
   }
@@ -2718,13 +2719,12 @@ struct DecomposeONNXToONNXPass
   Option<std::string> target{*this, "target",
       llvm::cl::desc("Target Dialect to decompose into"), ::llvm::cl::init("")};
 
-  Option<bool> enableConvTransposeDecompose{*this,
-      "enableConvTransposeDecompose",
+  Option<bool> enableConvTransposeDecompose{*this, "enable-convtranspose",
       llvm::cl::desc("Enable decomposition of ConvTranspose"),
       ::llvm::cl::init(false)};
 
   Option<bool> enableConvTranposeDecomposeToPhasedConv{*this,
-      "enableConvTranposeDecomposeToPhasedConv",
+      "enable-convtranspose-phased",
       llvm::cl::desc("Enable decomposition of ONNX ConvTranspose operator to 4 "
                      "phased Conv"),
       ::llvm::cl::init(false)};
@@ -2750,7 +2750,8 @@ void DecomposeONNXToONNXPass::runOnOperation() {
 
   // Set thread locals to affect native functions called by .td patterns.
   localEnableConvTransposeDecompose = enableConvTransposeDecompose;
-  localEnableConvTranposeDecomposeToPhasedConv = enableConvTranposeDecomposeToPhasedConv;
+  localEnableConvTranposeDecomposeToPhasedConv =
+      enableConvTranposeDecomposeToPhasedConv;
 
   auto status = applyPatternsAndFoldGreedily(function, std::move(patterns));
 

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -38,8 +38,8 @@ std::unique_ptr<mlir::Pass> createONNXOpTransformPass(int threshold,
 
 /// Pass for rewriting inside frontend dialect.
 std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
-    const std::string &target = "",
-    bool enableConvTransposeDecompose = false, bool enableConvTranposeDecomposeToPhasedConv = false);
+    const std::string &target = "", bool enableConvTransposeDecompose = false,
+    bool enableConvTranposeDecomposeToPhasedConv = false);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "");
 

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -38,7 +38,8 @@ std::unique_ptr<mlir::Pass> createONNXOpTransformPass(int threshold,
 
 /// Pass for rewriting inside frontend dialect.
 std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
-    const std::string &target = "");
+    const std::string &target = "",
+    bool enableConvTransposeDecompose = false, bool enableConvTranposeDecomposeToPhasedConv = false);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "");
 

--- a/test/mlir/onnx/onnx_decompose_convtranspose.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --shape-inference --decompose-onnx --enable-convtranspose-decompose %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --decompose-onnx=enable-convtranspose %s -split-input-file | FileCheck %s
 // RUN: onnx-mlir-opt --shape-inference --decompose-onnx %s -split-input-file | FileCheck %s --check-prefix=DISABLED
 
 // -----

--- a/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --shape-inference --decompose-onnx --enable-convtranspose-decompose-phased-conv %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --decompose-onnx=enable-convtranspose-phased %s -split-input-file | FileCheck %s
 
 func.func @test_convtrans_4phase_kernel_shape_66(%arg0: tensor<1x512x10x16xf32>, %arg1: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {    
   %0 = "onnx.Constant" () { value= dense<0.02> : tensor<256xf32>} : ()-> tensor<256xf32>


### PR DESCRIPTION
This allows to set them as part of a library-like implementation instead of just using onnx-mlir as tool.