### PR TITLE
[Backport] #325 from Xilinx/chaitany.keep_activation_close_to…

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -25,7 +25,6 @@
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeRange.h"
 #include "mlir/IR/Value.h"
@@ -686,6 +685,17 @@ bool hasDefaultDilation(ArrayAttr dilation) {
   return llvm::all_of(vDilation, [](int64_t d) { return d == 1; });
 }
 
+// Check if the result of ConvTranspose is not single use, OR if single use
+// not used by leakyRelu Or Relu.
+bool hasNoActivationConsumer(Value convTransposeResult) {
+  auto result = convTransposeResult.getDefiningOp<ONNXConvTransposeOp>().getY();
+  if (result.hasOneUse()) {
+    Operation *user = *(result.getUsers().begin());
+    return !mlir::isa<ONNXReluOp, ONNXLeakyReluOp>(user);
+  }
+  return true;
+}
+
 // This decomposition currently do not support all possible convtranspose
 // operations. Below are the supported usecases.
 // 1) stride[1,1] where convtranspose will decompose to one conv operation.
@@ -859,10 +869,14 @@ bool ShouldDecomposeConvTransposeOpToPhasedConvs(Value convTransposeResult,
  *                               9 conv ofms are merged                             
  */
 // clang-format on
+// If no activation op ( lrelu or relu) found in the matching, the alpha value
+// will be passed as the null, if relu is found 0 is passed, if lrelu is found
+// the alpha value is passed to this method.
 Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
     ONNXConvTransposeOp op, Value convTransposeResult, Value input,
     Value weights, Value bias, ArrayAttr dilations, IntegerAttr group,
-    ArrayAttr kernel_shape, ArrayAttr pads, ArrayAttr strides) {
+    ArrayAttr kernel_shape, ArrayAttr pads, ArrayAttr strides,
+    FloatAttr alpha) {
 
   RankedTensorType weightsType =
       mlir::cast<RankedTensorType>(weights.getType());
@@ -878,6 +892,16 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
                                 : SmallVector<int64_t>({1, 1});
 
   int numPhases = stridesShape[0] * stridesShape[1];
+  auto getActivationAppliedToConv = [&](Value conv, Type convOutputType) {
+    if (!alpha)
+      return conv;
+    return (alpha.getValueAsDouble() == 0)
+               ? rewriter.create<ONNXReluOp>(loc, convOutputType, conv)
+                     .getResult()
+               : rewriter
+                     .create<ONNXLeakyReluOp>(loc, convOutputType, conv, alpha)
+                     .getResult();
+  };
   if (numPhases == 1) {
     const std::array<int64_t, 4> convPadsShape = {
         (kernelShape[0] - 1 - padsShape[0]),
@@ -887,9 +911,11 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
 
     auto convPadsArrayAttr = rewriter.getI64ArrayAttr(convPadsShape);
 
-    return rewriter.create<ONNXConvOp>(loc, op.getY().getType(), input, weights,
-        bias, mlir::StringAttr(), dilations, group, kernel_shape,
-        convPadsArrayAttr, strides);
+    return getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, op.getY().getType(), input, weights,
+            bias, mlir::StringAttr(), dilations, group, kernel_shape,
+            convPadsArrayAttr, strides),
+        op.getY().getType());
   }
 
   auto int64Type = rewriter.getIntegerType(64);
@@ -1018,27 +1044,34 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
     };
     auto stridesArrayAttr = rewriter.getI64ArrayAttr({1, 1});
 
-    Value conv1 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[3], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr,
-        getPadsArrayAttr(kernelShape[0], 1, needWeightsPadding),
-        stridesArrayAttr);
-    Value conv2 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[0], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr,
-        getPadsArrayAttr(kernelShape[0], 2, needWeightsPadding),
-        stridesArrayAttr);
-    Value conv3 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[1], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr,
-        getPadsArrayAttr(kernelShape[0], 3, needWeightsPadding),
-        stridesArrayAttr);
-    Value conv4 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[2], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr,
-        getPadsArrayAttr(kernelShape[0], 4, needWeightsPadding),
-        stridesArrayAttr);
-
+    Value conv1 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[3],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr,
+            getPadsArrayAttr(kernelShape[0], 1, needWeightsPadding),
+            stridesArrayAttr),
+        convOutputType);
+    Value conv2 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[0],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr,
+            getPadsArrayAttr(kernelShape[0], 2, needWeightsPadding),
+            stridesArrayAttr),
+        convOutputType);
+    Value conv3 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[1],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr,
+            getPadsArrayAttr(kernelShape[0], 3, needWeightsPadding),
+            stridesArrayAttr),
+        convOutputType);
+    Value conv4 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[2],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr,
+            getPadsArrayAttr(kernelShape[0], 4, needWeightsPadding),
+            stridesArrayAttr),
+        convOutputType);
     // Need to remove excess the ofm  when weights are padded.
     if (needWeightsPadding) {
       auto startOnnxConstant = getONNXConstOpFromVector({1, 1});
@@ -1189,33 +1222,51 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
     auto padsArrayAttr = rewriter.getI64ArrayAttr({0, 0, 0, 0});
     auto stridesArrayAttr = rewriter.getI64ArrayAttr({1, 1});
 
-    auto conv1 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[8], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
-    auto conv2 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[5], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
-    auto conv3 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[6], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
-    auto conv4 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[7], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
-    auto conv5 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[4], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
-    auto conv6 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[1], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
-    auto conv7 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[2], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
-    auto conv8 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[3], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
-    auto conv9 = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        weightSlices[0], bias, mlir::StringAttr(), dilations, group,
-        convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr);
+    auto conv1 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[8],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    auto conv2 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[5],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    auto conv3 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[6],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    auto conv4 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[7],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    auto conv5 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[4],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    auto conv6 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[1],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    auto conv7 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[2],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    auto conv8 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[3],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    auto conv9 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[0],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
 
     // The nine convOutputs are adjusted to add an extra dimension at the
     // innermost level.

--- a/src/Dialect/ONNX/Transforms/Decompose.td
+++ b/src/Dialect/ONNX/Transforms/Decompose.td
@@ -51,6 +51,9 @@ def GetNullAttr : NativeCodeCall<"Attribute()">;
 
 def GetNullFloatAttr : NativeCodeCall<"FloatAttr()">;
 
+def GetZeroFloatAttr :
+	NativeCodeCall<"$_builder.getFloatAttr($_builder.getF32Type(), 0)">;
+
 def GetNullIntegerAttr : NativeCodeCall<"IntegerAttr()">;
 
 def GetNullStringAttr : NativeCodeCall<"StringAttr()">;
@@ -532,7 +535,7 @@ def getFinalOutputFromFourConvOutput: NativeCodeCall<
   "onnx_mlir::getFinalOutputFromFourConvOutput($_builder, $_loc, $0.getDefiningOp<ONNXConvOp>(),$0,$1,$2,$3)">;
 
 def decomposeIntoPhasedConvs: NativeCodeCall<
-  "onnx_mlir::decomposeIntoPhasedConvs($_builder, $_loc, $0.getDefiningOp<ONNXConvTransposeOp>(), $0,$1, $2, $3, $4, $5, $6, $7, $8)">;
+  "onnx_mlir::decomposeIntoPhasedConvs($_builder, $_loc, $0.getDefiningOp<ONNXConvTransposeOp>(), $0,$1, $2, $3, $4, $5, $6, $7, $8, $9)">;
 
 def ph1WeightForConv: NativeCodeCall<
   "onnx_mlir::ph1WeightTensor($_builder, $_loc, $0)">;
@@ -562,6 +565,11 @@ def ShouldDecomposeConvTransposeOp: Constraint<
   "X and W have static spatial dims and ConvTransposeOp decomposition is enabled"
 >;
 
+def hasNoActivationConsumer: Constraint<
+  CPred<"onnx_mlir::hasNoActivationConsumer($_self)">,
+  "Op has no activation consumer"
+>;
+
 def ShouldDecomposeConvTransposeOpToPhasedConvs: Constraint<
   CPred<"onnx_mlir::ShouldDecomposeConvTransposeOpToPhasedConvs($_self, $0, $1, $2, $3)">,
   "X and W have static spatial dims, few more specific conditions and ConvTransposeOp phased conv decomposition is enabled"  
@@ -582,16 +590,42 @@ def insertPadsConvTransposeInput: NativeCodeCall<
 
 def insertAdditionalPadsConvTranspose: NativeCodeCall<
   "onnx_mlir::insertAdditionalPadsConvTranspose($_builder, $_loc, $0.getDefiningOp<ONNXConvOp>(), $0, $1.getDefiningOp<ONNXConvTransposeOp>())">;
+
+
+def ConvTransposeOpAsConv2dWithLReluPattern1: Pattern<
+   (ONNXLeakyReluOp (ONNXConvTransposeOp:$res $x, $w, $b,
+      $auto_pad, $dilation, $group, $kernel_shape,
+      $output_padding, $output_shape, $pads, $strides), $alpha),
+   [
+    (reverseWeightConvTranspose:$reversed_w $w),
+    (decomposeIntoPhasedConvs:$output $res, $x, $reversed_w, $b, $dilation, $group, $kernel_shape, $pads, $strides, $alpha)
+   ],
+   [(HasRankAndShape:$res), (hasDefaultDilation:$res $dilation),(ShouldDecomposeConvTransposeOpToPhasedConvs:$res $kernel_shape,$pads,$strides,$output_shape)], [],
+   (addBenefit 2)
+>;
+
+def ConvTransposeOpAsConv2dWithReluPattern1: Pattern<
+   (ONNXReluOp (ONNXConvTransposeOp:$res $x, $w, $b,
+      $auto_pad, $dilation, $group, $kernel_shape,
+      $output_padding, $output_shape, $pads, $strides)),
+   [
+    (reverseWeightConvTranspose:$reversed_w $w),
+    (decomposeIntoPhasedConvs:$output $res, $x, $reversed_w, $b, $dilation, $group, $kernel_shape, $pads, $strides, (GetZeroFloatAttr))
+   ],
+   [(HasRankAndShape:$res), (hasDefaultDilation:$res $dilation),(ShouldDecomposeConvTransposeOpToPhasedConvs:$res $kernel_shape,$pads,$strides,$output_shape)], [],
+   (addBenefit 2)
+>;
+
 def ConvTransposeOpAsConv2dPattern1: Pattern<
    (ONNXConvTransposeOp:$res $x, $w, $b,
       $auto_pad, $dilation, $group, $kernel_shape,
       $output_padding, $output_shape, $pads, $strides),
    [
     (reverseWeightConvTranspose:$reversed_w $w),
-    (decomposeIntoPhasedConvs:$output $res, $x, $reversed_w, $b, $dilation, $group, $kernel_shape, $pads, $strides)
+    (decomposeIntoPhasedConvs:$output $res, $x, $reversed_w, $b, $dilation, $group, $kernel_shape, $pads, $strides,  (GetNullFloatAttr))
    ],
-   [(HasRankAndShape:$res), (hasDefaultDilation:$res $dilation),(ShouldDecomposeConvTransposeOpToPhasedConvs:$res $kernel_shape,$pads,$strides,$output_shape)], [],
-   (addBenefit 0)
+   [(HasRankAndShape:$res), (hasDefaultDilation:$res $dilation),(hasNoActivationConsumer:$res),(ShouldDecomposeConvTransposeOpToPhasedConvs:$res $kernel_shape,$pads,$strides,$output_shape)], [],
+   (addBenefit 1)
 >;
 
 def ConvTransposeOpPattern1: Pattern<

--- a/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv.mlir
@@ -562,3 +562,312 @@ func.func @test_convtrans_4phase_kernel_shape_44(%arg0: tensor<1x512x8x8xf32>, %
 // CHECK:           onnx.Return %[[VAL_39]] : tensor<1x512x16x16xf32>
 // CHECK:         }
 }
+
+// -----
+
+func.func @test_convtrans_4phase_kernel_shape_66_lrelu(%arg0: tensor<1x512x10x16xf32>, %arg1: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<256xf32>} : ()-> tensor<256xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [6, 6], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [2, 2, 2, 2], strides = [2, 2]} : (tensor<1x512x10x16xf32>, tensor<512x256x6x6xf32>, tensor<256xf32>) -> tensor<1x256x20x32xf32>
+  %2 = "onnx.LeakyRelu"(%1) {alpha = 1.000000e-01 : f32, onnx_node_name = "LeakyRelu3"} : (tensor<1x256x20x32xf32>) -> tensor<1x256x20x32xf32> 
+  onnx.Return %2 : tensor<1x256x20x32xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_66_lrelu(
+// CHECK-SAME:                                                           %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
+// CHECK-SAME:                                                           %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 256, 10, 1, 32]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 256, 10, 16, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<7> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.ReverseSequence"(%[[VAL_18]], %[[VAL_15]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Transpose"(%[[VAL_20]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_8]], %[[VAL_7]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_6]], %[[VAL_5]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_25]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.LeakyRelu"(%[[VAL_26]]) {alpha = 1.000000e-01 : f32} : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.LeakyRelu"(%[[VAL_28]]) {alpha = 1.000000e-01 : f32} : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.LeakyRelu"(%[[VAL_30]]) {alpha = 1.000000e-01 : f32} : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.LeakyRelu"(%[[VAL_32]]) {alpha = 1.000000e-01 : f32} : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Reshape"(%[[VAL_27]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Reshape"(%[[VAL_29]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Concat"(%[[VAL_34]], %[[VAL_36]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Concat"(%[[VAL_37]], %[[VAL_35]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x10x16x2xf32>, tensor<5xi64>) -> tensor<1x256x10x1x32xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.Reshape"(%[[VAL_39]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x10x16x2xf32>, tensor<5xi64>) -> tensor<1x256x10x1x32xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.Concat"(%[[VAL_40]], %[[VAL_41]]) {axis = -2 : si64} : (tensor<1x256x10x1x32xf32>, tensor<1x256x10x1x32xf32>) -> tensor<1x256x10x2x32xf32>
+// CHECK:           %[[VAL_43:.*]] = "onnx.Reshape"(%[[VAL_42]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x256x10x2x32xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
+// CHECK:           onnx.Return %[[VAL_43]] : tensor<1x256x20x32xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_4phase_kernel_shape_66_relu(%arg0: tensor<1x512x10x16xf32>, %arg1: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<256xf32>} : ()-> tensor<256xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [6, 6], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [2, 2, 2, 2], strides = [2, 2]} : (tensor<1x512x10x16xf32>, tensor<512x256x6x6xf32>, tensor<256xf32>) -> tensor<1x256x20x32xf32>
+  %2 = "onnx.Relu"(%1) {onnx_node_name = "Relu3"} : (tensor<1x256x20x32xf32>) -> tensor<1x256x20x32xf32> 
+  onnx.Return %2 : tensor<1x256x20x32xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_66_relu(
+// CHECK-SAME:                                                          %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
+// CHECK-SAME:                                                          %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 256, 10, 1, 32]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 256, 10, 16, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<7> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.ReverseSequence"(%[[VAL_18]], %[[VAL_15]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Transpose"(%[[VAL_20]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_8]], %[[VAL_7]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_6]], %[[VAL_5]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_25]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Relu"(%[[VAL_26]]) : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Relu"(%[[VAL_28]]) : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Relu"(%[[VAL_30]]) : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Relu"(%[[VAL_32]]) : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Reshape"(%[[VAL_27]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Reshape"(%[[VAL_29]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Concat"(%[[VAL_34]], %[[VAL_36]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Concat"(%[[VAL_37]], %[[VAL_35]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x10x16x2xf32>, tensor<5xi64>) -> tensor<1x256x10x1x32xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.Reshape"(%[[VAL_39]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x10x16x2xf32>, tensor<5xi64>) -> tensor<1x256x10x1x32xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.Concat"(%[[VAL_40]], %[[VAL_41]]) {axis = -2 : si64} : (tensor<1x256x10x1x32xf32>, tensor<1x256x10x1x32xf32>) -> tensor<1x256x10x2x32xf32>
+// CHECK:           %[[VAL_43:.*]] = "onnx.Reshape"(%[[VAL_42]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x256x10x2x32xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
+// CHECK:           onnx.Return %[[VAL_43]] : tensor<1x256x20x32xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_9phase_lrelu(%arg0: tensor<1x1x18x74xf32>, %arg1: tensor<1x1x3x3xf32>) -> tensor<1x1x54x222xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<1xf32>} : ()-> tensor<1xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [0, 0, 0, 0], strides = [3, 3]} : (tensor<1x1x18x74xf32>, tensor<1x1x3x3xf32>, tensor<1xf32>) -> tensor<1x1x54x222xf32>
+  %2 = "onnx.LeakyRelu"(%1) {alpha = 1.000000e-01 : f32, onnx_node_name = "LeakyRelu3"} : (tensor<1x1x54x222xf32>) -> tensor<1x1x54x222xf32> 
+  onnx.Return %2 : tensor<1x1x54x222xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_9phase_lrelu(
+// CHECK-SAME:                                           %[[VAL_0:.*]]: tensor<1x1x18x74xf32>,
+// CHECK-SAME:                                           %[[VAL_1:.*]]: tensor<1x1x3x3xf32>) -> tensor<1x1x54x222xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<5> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[3, 5]> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<2xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<[3, 4]> : tensor<2xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<[5, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<[4, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<3> : tensor<2xi64>
+// CHECK:           %[[VAL_23:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_24:.*]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK:           %[[VAL_25:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xf32>) -> tensor<3x3x1x1xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.ReverseSequence"(%[[VAL_26]], %[[VAL_24]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.ReverseSequence"(%[[VAL_27]], %[[VAL_24]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Transpose"(%[[VAL_28]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xf32>) -> tensor<1x1x3x3xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Transpose"(%[[VAL_29]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_21]], %[[VAL_22]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_20]], %[[VAL_19]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_18]], %[[VAL_17]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_16]], %[[VAL_15]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_14]], %[[VAL_13]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_12]], %[[VAL_11]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_10]], %[[VAL_9]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_8]], %[[VAL_7]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_6]], %[[VAL_5]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_39]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.LeakyRelu"(%[[VAL_40]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_36]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_43:.*]] = "onnx.LeakyRelu"(%[[VAL_42]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_44:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_37]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_45:.*]] = "onnx.LeakyRelu"(%[[VAL_44]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_46:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_38]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_47:.*]] = "onnx.LeakyRelu"(%[[VAL_46]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_48:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_35]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_49:.*]] = "onnx.LeakyRelu"(%[[VAL_48]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_50:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_32]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_51:.*]] = "onnx.LeakyRelu"(%[[VAL_50]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_52:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_33]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_53:.*]] = "onnx.LeakyRelu"(%[[VAL_52]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_54:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_34]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_55:.*]] = "onnx.LeakyRelu"(%[[VAL_54]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_56:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_31]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_57:.*]] = "onnx.LeakyRelu"(%[[VAL_56]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_58:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_59:.*]] = "onnx.Reshape"(%[[VAL_43]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_60:.*]] = "onnx.Reshape"(%[[VAL_45]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_61:.*]] = "onnx.Reshape"(%[[VAL_47]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_62:.*]] = "onnx.Reshape"(%[[VAL_49]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_63:.*]] = "onnx.Reshape"(%[[VAL_51]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_64:.*]] = "onnx.Reshape"(%[[VAL_53]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_65:.*]] = "onnx.Reshape"(%[[VAL_55]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_66:.*]] = "onnx.Reshape"(%[[VAL_57]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK:           %[[VAL_67:.*]] = "onnx.Concat"(%[[VAL_58]], %[[VAL_59]], %[[VAL_64]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK:           %[[VAL_68:.*]] = "onnx.Concat"(%[[VAL_61]], %[[VAL_62]], %[[VAL_63]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK:           %[[VAL_69:.*]] = "onnx.Concat"(%[[VAL_60]], %[[VAL_65]], %[[VAL_66]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK:           %[[VAL_70:.*]] = "onnx.Reshape"(%[[VAL_67]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           %[[VAL_71:.*]] = "onnx.Reshape"(%[[VAL_68]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           %[[VAL_72:.*]] = "onnx.Reshape"(%[[VAL_69]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           %[[VAL_73:.*]] = "onnx.Concat"(%[[VAL_70]], %[[VAL_71]], %[[VAL_72]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
+// CHECK:           %[[VAL_74:.*]] = "onnx.Reshape"(%[[VAL_73]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
+// CHECK:           onnx.Return %[[VAL_74]] : tensor<1x1x54x222xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_1phase_pads_1100_lrelu(%arg0: tensor<1x1x12x44xf32>, %arg1: tensor<1x1x4x16xf32>) -> tensor<1x1x14x58xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<1xf32>} : ()-> tensor<1xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [1, 1, 0, 0], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x14x58xf32>
+  %2 = "onnx.LeakyRelu"(%1) {alpha = 1.000000e-01 : f32, onnx_node_name = "LeakyRelu3"} : (tensor<1x1x14x58xf32>) -> tensor<1x1x14x58xf32> 
+  onnx.Return %2 : tensor<1x1x14x58xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_1phase_pads_1100_lrelu(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<1x1x12x44xf32>,
+// CHECK-SAME:                                                     %[[VAL_1:.*]]: tensor<1x1x4x16xf32>) -> tensor<1x1x14x58xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<16> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<4> : tensor<16xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK:           %[[VAL_5:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x4x16xf32>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_6:.*]] = "onnx.ReverseSequence"(%[[VAL_5]], %[[VAL_3]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x16x1x1xf32>, tensor<16xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_7:.*]] = "onnx.ReverseSequence"(%[[VAL_6]], %[[VAL_2]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<4x16x1x1xf32>, tensor<4xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_8:.*]] = "onnx.Transpose"(%[[VAL_7]]) {perm = [2, 3, 0, 1]} : (tensor<4x16x1x1xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_9:.*]] = "onnx.Transpose"(%[[VAL_8]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x4x16xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_10:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_9]], %[[VAL_4]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], pads = [2, 14, 3, 15], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x14x58xf32>
+// CHECK:           %[[VAL_11:.*]] = "onnx.LeakyRelu"(%[[VAL_10]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x14x58xf32>) -> tensor<1x1x14x58xf32>
+// CHECK:           onnx.Return %[[VAL_11]] : tensor<1x1x14x58xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_convtrans_1phase_pads_1100_lrelu_default_value(%arg0: tensor<1x1x12x44xf32>, %arg1: tensor<1x1x4x16xf32>) -> tensor<1x1x14x58xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<1xf32>} : ()-> tensor<1xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [1, 1, 0, 0], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x14x58xf32>
+  %2 = "onnx.LeakyRelu"(%1) {onnx_node_name = "LeakyRelu3"} : (tensor<1x1x14x58xf32>) -> tensor<1x1x14x58xf32> 
+  onnx.Return %2 : tensor<1x1x14x58xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_1phase_pads_1100_lrelu_default_value(
+// CHECK-SAME:                                                                   %[[VAL_0:.*]]: tensor<1x1x12x44xf32>,
+// CHECK-SAME:                                                                   %[[VAL_1:.*]]: tensor<1x1x4x16xf32>) -> tensor<1x1x14x58xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<16> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<4> : tensor<16xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK:           %[[VAL_5:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x4x16xf32>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_6:.*]] = "onnx.ReverseSequence"(%[[VAL_5]], %[[VAL_3]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x16x1x1xf32>, tensor<16xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_7:.*]] = "onnx.ReverseSequence"(%[[VAL_6]], %[[VAL_2]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<4x16x1x1xf32>, tensor<4xi64>) -> tensor<4x16x1x1xf32>
+// CHECK:           %[[VAL_8:.*]] = "onnx.Transpose"(%[[VAL_7]]) {perm = [2, 3, 0, 1]} : (tensor<4x16x1x1xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_9:.*]] = "onnx.Transpose"(%[[VAL_8]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x4x16xf32>) -> tensor<1x1x4x16xf32>
+// CHECK:           %[[VAL_10:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_9]], %[[VAL_4]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4, 16], pads = [2, 14, 3, 15], strides = [1, 1]} : (tensor<1x1x12x44xf32>, tensor<1x1x4x16xf32>, tensor<1xf32>) -> tensor<1x1x14x58xf32>
+// CHECK:           %[[VAL_11:.*]] = "onnx.LeakyRelu"(%[[VAL_10]]) {alpha = 0.00999999977 : f32} : (tensor<1x1x14x58xf32>) -> tensor<1x1x14x58xf32>
+// CHECK:           onnx.Return %[[VAL_11]] : tensor<1x1x14x58xf32>
+// CHECK:         }  
+}
+
+// -----
+
+func.func @test_convtrans_4phase_kernel_shape_66_lrelu_default_alpha(%arg0: tensor<1x512x10x16xf32>, %arg1: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<256xf32>} : ()-> tensor<256xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [6, 6], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [2, 2, 2, 2], strides = [2, 2]} : (tensor<1x512x10x16xf32>, tensor<512x256x6x6xf32>, tensor<256xf32>) -> tensor<1x256x20x32xf32>
+  %2 = "onnx.LeakyRelu"(%1) {onnx_node_name = "LeakyRelu3"} : (tensor<1x256x20x32xf32>) -> tensor<1x256x20x32xf32> 
+  onnx.Return %2 : tensor<1x256x20x32xf32>
+
+// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_66_lrelu_default_alpha(
+// CHECK-SAME:                                                           %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
+// CHECK-SAME:                                                           %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 256, 10, 1, 32]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 256, 10, 16, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<7> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.ReverseSequence"(%[[VAL_18]], %[[VAL_15]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Transpose"(%[[VAL_20]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_8]], %[[VAL_7]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Slice"(%[[VAL_21]], %[[VAL_6]], %[[VAL_5]], %[[VAL_14]], %[[VAL_13]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_25]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.LeakyRelu"(%[[VAL_26]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.LeakyRelu"(%[[VAL_28]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.LeakyRelu"(%[[VAL_30]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.LeakyRelu"(%[[VAL_32]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x10x16xf32>) -> tensor<1x256x10x16xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Reshape"(%[[VAL_27]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Reshape"(%[[VAL_29]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x256x10x16xf32>, tensor<5xi64>) -> tensor<1x256x10x16x1xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Concat"(%[[VAL_34]], %[[VAL_36]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Concat"(%[[VAL_37]], %[[VAL_35]]) {axis = -1 : si64} : (tensor<1x256x10x16x1xf32>, tensor<1x256x10x16x1xf32>) -> tensor<1x256x10x16x2xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x10x16x2xf32>, tensor<5xi64>) -> tensor<1x256x10x1x32xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.Reshape"(%[[VAL_39]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x10x16x2xf32>, tensor<5xi64>) -> tensor<1x256x10x1x32xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.Concat"(%[[VAL_40]], %[[VAL_41]]) {axis = -2 : si64} : (tensor<1x256x10x1x32xf32>, tensor<1x256x10x1x32xf32>) -> tensor<1x256x10x2x32xf32>
+// CHECK:           %[[VAL_43:.*]] = "onnx.Reshape"(%[[VAL_42]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x256x10x2x32xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
+// CHECK:           onnx.Return %[[VAL_43]] : tensor<1x256x20x32xf32>
+// CHECK:         }
+}


### PR DESCRIPTION
…_conv

convtranspose decomposition - moving the activation functions relu, lrelu close to conv
This is a backport for below PR.
https://github.com/Xilinx/onnx-mlir/pull/325