### PR TITLE
ci: Don't use sccache

### DIFF
--- a/.github/workflows/ubuntu-build-intree.yml
+++ b/.github/workflows/ubuntu-build-intree.yml
@@ -32,8 +32,7 @@ jobs:
         # A full build seems to take ~ 250 MB. Leave a bit more room
         # so we don't run out of cache space in the future.
         max-size: 400M
-        key: sccache-intree
-        variant: sccache
+        key: ccache-intree
         create-symlink: true
 
     - name: install dependencies
@@ -64,8 +63,8 @@ jobs:
           -DLLVM_USE_LINKER=lld \
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
         cmake --build build --target onnx-mlir
 

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -37,8 +37,7 @@ jobs:
         # enough cache space for all the tests to run at once and still
         # fit under the 10 GB limit.
         max-size: 500M
-        key: sccache
-        variant: sccache
+        key: ccache
         create-symlink: true
 
     - name: install dependencies
@@ -49,14 +48,14 @@ jobs:
     - name: clone & build MLIR
       run: |
         cd ..
-        export EXTRA_CMAKE_ARGS="-DLLVM_USE_LINKER=lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+        export EXTRA_CMAKE_ARGS="-DLLVM_USE_LINKER=lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
         sh onnx-mlir/utils/clone-mlir.sh
         sh onnx-mlir/utils/build-mlir.sh
 
     - name: build onnx-mlir
       run: |
         cd ..
-        export EXTRA_CMAKE_ARGS="-DONNX_MLIR_ENABLE_STABLEHLO=OFF -DLLVM_USE_LINKER=lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+        export EXTRA_CMAKE_ARGS="-DONNX_MLIR_ENABLE_STABLEHLO=OFF -DLLVM_USE_LINKER=lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
         bash onnx-mlir/utils/install-onnx-mlir.sh
 
     - name: build and run docs/doc_example tests


### PR DESCRIPTION
The action uses an very old version of sccache that sometimes fails with https://github.com/mozilla/sccache/issues/2092