### PR TITLE
fix: ensure using the right float type when create float attr

### DIFF
--- a/src/Conversion/ONNXToTOSA/Tensor/PaddingOp.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/PaddingOp.cpp
@@ -21,6 +21,7 @@
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
@@ -119,8 +120,9 @@ public:
       auto constType = RankedTensorType::get({}, elementDtype);
 
       DenseElementsAttr constAttr;
-      if (isa<FloatType>(elementDtype)) {
-        constAttr = DenseElementsAttr::get(constType, 0.0F);
+      if (auto floatType = dyn_cast<FloatType>(elementDtype)) {
+        constAttr = DenseElementsAttr::get(
+            constType, APFloat::getZero(floatType.getFloatSemantics()));
       } else {
         assert(isTOSAInt(elementDtype) && "Already validated");
         auto tyAsInt = cast<IntegerType>(elementDtype);

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Padding.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Padding.mlir
@@ -135,3 +135,15 @@ func.func @test_pad_bf16(%arg0: tensor<20x16x44x32xbf16>) ->  tensor<24x22x52x42
 // CHECK: %[[VAR2:.*]] = tosa.pad %arg0, %[[VAR0]], %[[VAR1]]
 }
 
+// -----
+func.func @test_pad_f16_constant_none(%arg0: tensor<256x1x1x5x1xf16>) -> tensor<256x1x1x5x2xf16> {
+    %noval = "onnx.NoValue"() {value} : () -> none
+    %0 = "onnx.Constant"() {value = dense<[0, 0, 0, 0, 0, 0, 0, 0, 0, 1]> : tensor<10xi64>} : () -> tensor<10xi64>
+    %1 = "onnx.Pad"(%arg0, %0, %noval, %noval) {mode = "constant"} : (tensor<256x1x1x5x1xf16>, tensor<10xi64>, none, none) -> tensor<256x1x1x5x2xf16>
+    return %1 :   tensor<256x1x1x5x2xf16>
+// CHECK-LABEL: test_pad_f16_constant_none
+// CHECK: %[[VAR0:.*]] = "tosa.const"() <{value = dense<[{{\[}}0, 0], [0, 0], [0, 0], [0, 0], [0, 1]]> : tensor<5x2xi64>}> : () -> tensor<5x2xi64>
+// CHECK: %[[VAR1:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f16>}> : () -> tensor<f16>
+// CHECK: %[[VAR2:.*]] = tosa.pad %arg0, %[[VAR0]], %[[VAR1]] : (tensor<256x1x1x5x1xf16>, tensor<5x2xi64>, tensor<f16>) -> tensor<256x1x1x5x2xf16>
+// CHECK: return %[[VAR2]] : tensor<256x1x1x5x2xf16>
+}


### PR DESCRIPTION
There is a small bug in the ONNXToTosa conversion for ONNXPad operation.
The bug happen with f16 tensor and when the `constant_value` is `None`.

When that happen the conversion creates a float `DenseElementsAttr`, but the initial value given to create the attribute was always a `float32`.
This triggered the assertion ` Assertion `::isValidIntOrFloat(type.getElementType(), dataEltSize, isInt, isSigned)` in the function `mlir::DenseIntOrFPElementsAttr::getRawIntOrFloat`.

The PR make sure to use the right type of float to create the Attribute.