### PR TITLE
Do not build test binaries by default when ONNX_MLIR_BUILD_TESTS=OFF

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,10 @@ if (NOT ${ONNX_MLIR_TEST_OPTLEVEL} IN_LIST OPTLEVELS)
 endif()
 message(STATUS "Tests optimization level : ${ONNX_MLIR_TEST_OPTLEVEL}")
 
+if (NOT ONNX_MLIR_BUILD_TESTS)
+  set(EXCLUDE_FROM_ALL ON)
+endif()
+
 # Create one target for all the backend and numerical tests that we
 # want to run in parallel. The reason we have to do this follows.
 #


### PR DESCRIPTION
The targets are still created but not added to the ALL target. This was already done for a few binaries, and this PR adds the remaining test binaries. It saves ~ 1 GB of disk space and bit of build time.