### PR TITLE
fix: disable ConvTranspose -> Conv decomposition when group > 1.

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.td
+++ b/src/Dialect/ONNX/Transforms/Decompose.td
@@ -116,6 +116,10 @@ def HasRankAndShape:
   Constraint<CPred<"::onnx_mlir::isRankedShapedType($_self.getType())">,
   "A value has rank and shape">;
 
+def IntOne : AttrConstraint<
+    CPred<"::mlir::matchPattern($_self, m_One())">,
+    "is integer one">;
+
 //===----------------------------------------------------------------------===//
 // ONNXReduceL1Op %X = ONNXReduceSumOp (ONNXAbsOp %X)
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/Transforms/DecomposeConvTranspose.td
+++ b/src/Dialect/ONNX/Transforms/DecomposeConvTranspose.td
@@ -7,6 +7,8 @@
 include "src/Dialect/ONNX/ONNX.td"
 #endif // OP_BASE
 
+include "Decompose.td"
+
 /// Note: The DRR definition used for defining patterns is shown below:
 ///
 /// class Pattern<
@@ -15,15 +17,6 @@ include "src/Dialect/ONNX/ONNX.td"
 ///    list<dag> supplementalPatterns = [],
 ///    dag benefitsAdded = (addBenefit 0)
 /// >;
-
-def GetNullStringAttr : NativeCodeCall<"StringAttr()">;
-
-def GetNullArrayAttr :  NativeCodeCall<"ArrayAttr()">;
-
-// Check if value has a type that is ranked with a shape.
-def HasRankAndShape:
-  Constraint<CPred<"::onnx_mlir::isRankedShapedType($_self.getType())">,
-  "A value has rank and shape">;
 
 //===----------------------------------------------------------------------===//
 // ONNXConvTransposeOp is rewritten into ONNXConv op and other ONNX ops to
@@ -105,7 +98,7 @@ def ShouldDecomposeConvTransposeOp: Constraint<
 
 def ConvTransposeOpPattern1: Pattern<
    (ONNXConvTransposeOp:$res $x, $w, $b,
-      $auto_pad, $dilation, $group, $kernel_shape,
+      $auto_pad, $dilation, IntOne:$group, $kernel_shape,
       $output_padding, $output_shape, $pads, $strides),
    [
     (reverseWeightConvTranspose:$reversed_w $w),
@@ -120,7 +113,7 @@ def ConvTransposeOpPattern1: Pattern<
 
 def ConvTransposeOpPattern2: Pattern<
    (ONNXConvTransposeOp:$res $x, $w, $b,
-      $auto_pad, $dilation, $group, $kernel_shape,
+      $auto_pad, $dilation, IntOne:$group, $kernel_shape,
       $output_padding, $output_shape, $pads, $strides),
    [
     (reverseWeightConvTranspose:$reversed_w $w),

--- a/src/Dialect/ONNX/Transforms/DecomposeConvTransposePhased.td
+++ b/src/Dialect/ONNX/Transforms/DecomposeConvTransposePhased.td
@@ -7,6 +7,8 @@
 include "src/Dialect/ONNX/ONNX.td"
 #endif // OP_BASE
 
+include "Decompose.td"
+
 /// Note: The DRR definition used for defining patterns is shown below:
 ///
 /// class Pattern<
@@ -15,16 +17,6 @@ include "src/Dialect/ONNX/ONNX.td"
 ///    list<dag> supplementalPatterns = [],
 ///    dag benefitsAdded = (addBenefit 0)
 /// >;
-
-def GetZeroFloatAttr :
-	NativeCodeCall<"$_builder.getFloatAttr($_builder.getF32Type(), 0)">;
-
-def GetNullFloatAttr : NativeCodeCall<"FloatAttr()">;
-
-// Check if value has a type that is ranked with a shape.
-def HasRankAndShape:
-  Constraint<CPred<"::onnx_mlir::isRankedShapedType($_self.getType())">,
-  "A value has rank and shape">;
 
 def hasNoActivationConsumer: Constraint<
   CPred<"onnx_mlir::hasNoActivationConsumer($_self)">,
@@ -67,7 +59,7 @@ def hasDefaultDilation: Constraint<
 
 def ConvTransposeOpAsConv2dWithLReluPattern1: Pattern<
    (ONNXLeakyReluOp (ONNXConvTransposeOp:$res $x, $w, $b,
-      $auto_pad, $dilation, $group, $kernel_shape,
+      $auto_pad, $dilation, IntOne:$group, $kernel_shape,
       $output_padding, $output_shape, $pads, $strides), $alpha),
    [
     (reverseWeightConvTranspose:$reversed_w $w),
@@ -79,7 +71,7 @@ def ConvTransposeOpAsConv2dWithLReluPattern1: Pattern<
 
 def ConvTransposeOpAsConv2dWithReluPattern1: Pattern<
    (ONNXReluOp (ONNXConvTransposeOp:$res $x, $w, $b,
-      $auto_pad, $dilation, $group, $kernel_shape,
+      $auto_pad, $dilation, IntOne:$group, $kernel_shape,
       $output_padding, $output_shape, $pads, $strides)),
    [
     (reverseWeightConvTranspose:$reversed_w $w),
@@ -91,7 +83,7 @@ def ConvTransposeOpAsConv2dWithReluPattern1: Pattern<
 
 def ConvTransposeOpAsConv2dPattern1: Pattern<
    (ONNXConvTransposeOp:$res $x, $w, $b,
-      $auto_pad, $dilation, $group, $kernel_shape,
+      $auto_pad, $dilation, IntOne:$group, $kernel_shape,
       $output_padding, $output_shape, $pads, $strides),
    [
     (reverseWeightConvTranspose:$reversed_w $w),

--- a/test/mlir/onnx/onnx_decompose_convtranspose.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose.mlir
@@ -220,3 +220,16 @@
 // DISABLED:           %[[VAL_3:.*]] = "onnx.ConvTranspose"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [3, 3], onnx_node_name = "test", output_padding = [1, 1], output_shape = [10, 8], strides = [3, 2]} : (tensor<?x?x3x3xf32>, tensor<?x?x3x3xf32>, none) -> tensor<?x?x10x8xf32>
 // DISABLED:           onnx.Return %[[VAL_3]] : tensor<?x?x10x8xf32>
 // DISABLED:         }
+
+// -----
+
+// Test that are is no decomposition for grouped convtransposes
+func.func @test_group_convtranspose(%arg0: tensor<1x256x16x16xf32>, %arg1: tensor<256x1x4x4xf32>) -> (tensor<1x256x32x32xf32>) {    
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 256 : si64, kernel_shape = [4, 4], onnx_node_name = "/dla_up/ida_0/up_1/ConvTranspose", pads = [1, 1, 1, 1], strides = [2, 2]} : (tensor<1x256x16x16xf32>, tensor<256x1x4x4xf32>, none) -> tensor<1x256x32x32xf32>
+    return %1 : tensor<1x256x32x32xf32>
+}
+// CHECK-LABEL:  func.func @test_group_convtranspose
+// CHECK:    "onnx.ConvTranspose
+// DISABLED-LABEL:  func.func @test_group_convtranspose
+// DISABLED:    "onnx.ConvTranspose


### PR DESCRIPTION
These decompositions don't work well for group > 1. So for now, disable them.

I know how we could support them from the upstream convtranspose decomposition, but I don't think we are interested in it just yet.