### PR TITLE
Order Adds so that we can (likely) fuse with their producer

### DIFF
--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -770,6 +770,11 @@ bool isMatMulIntegerRhsZero(Value matrixValue, Value zeroPointValue) {
       matrixValue, zeroPointValue, reshapeMatMulIntegerRhsZero);
 }
 
+bool canOpLikelyBeFusedWithBias(Value opValue) {
+  return llvm::isa_and_nonnull<ONNXConvOp, ONNXMatMulOp, ONNXGemmOp>(
+      opValue.getDefiningOp());
+}
+
 ElementsAttr getMatMulIntegerMatrixElements(
     ElementsAttrBuilder &elementsBuilder, Value matrixValue,
     Value zeroPointValue,

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -113,6 +113,10 @@ def OpIsUnlikelyToBeFusedWithBias: Constraint<
   CPred<"!canOpLikelyBeFusedWithBias($_self)">,
   "Operation can unlikely be fused with the following bias">;
 
+def OpIsLikelyToBeFusedWithBias: Constraint<
+  CPred<"canOpLikelyBeFusedWithBias($_self)">,
+  "Operation can likely be fused with the following bias">;
+
 def SatisfiesExpansionBound: Constraint<
   CPred<"satisfiesExpansionBound($_self)">>;
 
@@ -368,8 +372,8 @@ def AddConstAssociative3 : NamedPat<"AddConstAssociative3",
   [(IsNotAConstant:$x), (IsNotAConstant:$y), (OpIsUnlikelyToBeFusedWithBias:$y), (HasOneUse:$rhs),
    (IsNotScalar:$y), (IsNotScalar:$c)]>;
 
-def AddConstAssociative4 : NamedPat<"AddConstAssociative4",
-  // From add(add(x, c1), add(y, c2)).
+def AddConstAssociative4NoFuse : NamedPat<"AddConstAssociative4NoFuse",
+  // From add(add(x, c1), add(y, c2)), if both x and y are not likely to be fused with bias
   (ONNXAddOp
     (ONNXAddOp:$lhs $x, (ONNXConstantOp:$c1 $_, $_, $_, $_, $_, $_, $_, $_)),
     (ONNXAddOp:$rhs $y, (ONNXConstantOp:$c2 $_, $_, $_, $_, $_, $_, $_, $_))),
@@ -377,7 +381,37 @@ def AddConstAssociative4 : NamedPat<"AddConstAssociative4",
   (ONNXAddOp
     (ONNXAddOp $x, $y),
     (ONNXAddOp $c1, $c2)),
-  [(IsNotAConstant:$x), (IsNotAConstant:$y), (HasOneUse:$lhs), (HasOneUse:$rhs)]>;
+  [(IsNotAConstant:$x), (IsNotAConstant:$y), 
+   (OpIsUnlikelyToBeFusedWithBias:$x), (OpIsUnlikelyToBeFusedWithBias:$y),
+   (HasOneUse:$lhs), (HasOneUse:$rhs)]>;
+
+def AddConstAssociative4LhsFuse : NamedPat<"AddConstAssociativeLhsFuse",
+  // From add(add(x, c1), add(y, c2)), if x is likely to be fused with bias
+  (ONNXAddOp
+    (ONNXAddOp:$lhs $x, (ONNXConstantOp:$c1 $_, $_, $_, $_, $_, $_, $_, $_)),
+    (ONNXAddOp:$rhs $y, (ONNXConstantOp:$c2 $_, $_, $_, $_, $_, $_, $_, $_))),
+  // To add(add(x, c1+c2), y).
+  (ONNXAddOp
+    (ONNXAddOp $x, (ONNXAddOp $c1, $c2)),
+     $y
+    ),
+  [(IsNotAConstant:$x), (IsNotAConstant:$y), 
+   (OpIsLikelyToBeFusedWithBias:$x),
+   (HasOneUse:$lhs), (HasOneUse:$rhs)]>;
+
+def AddConstAssociative4RhsFuse : NamedPat<"AddConstAssociativeRhsFuse",
+  // From add(add(x, c1), add(y, c2)), if y is likely to be fused with bias and x is not
+  (ONNXAddOp
+    (ONNXAddOp:$lhs $x, (ONNXConstantOp:$c1 $_, $_, $_, $_, $_, $_, $_, $_)),
+    (ONNXAddOp:$rhs $y, (ONNXConstantOp:$c2 $_, $_, $_, $_, $_, $_, $_, $_))),
+  // To add(x, add(y, c1+c2)).
+  (ONNXAddOp
+    $x,
+    (ONNXAddOp $y, (ONNXAddOp $c1, $c2))
+    ),
+  [(IsNotAConstant:$x), (IsNotAConstant:$y), 
+   (OpIsUnlikelyToBeFusedWithBias:$x), (OpIsLikelyToBeFusedWithBias:$y),
+   (HasOneUse:$lhs), (HasOneUse:$rhs)]>;
 
 // Constant Propagation for Add
 def AddConstProp : NamedPat<"AddConstProp",

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -109,6 +109,10 @@ def IsMatMulIntegerRhsZero: Constraint<
     CPred<"isMatMulIntegerRhsZero($0, $1)">,
     "MatMulInteger rhs matrix is zero for given zero point">;
 
+def OpIsUnlikelyToBeFusedWithBias: Constraint<
+  CPred<"!canOpLikelyBeFusedWithBias($_self)">,
+  "Operation can unlikely be fused with the following bias">;
+
 def SatisfiesExpansionBound: Constraint<
   CPred<"satisfiesExpansionBound($_self)">>;
 
@@ -348,7 +352,7 @@ def AddConstAssociative2 : NamedPat<"AddConstAssociative2",
   (ONNXAddOp
     (ONNXAddOp $x, $y),
     $c),
-  [(IsNotAConstant:$x), (IsNotAConstant:$y), (HasOneUse:$lhs),
+  [(IsNotAConstant:$x), (OpIsUnlikelyToBeFusedWithBias:$x), (IsNotAConstant:$y), (HasOneUse:$lhs),
    (IsNotScalar:$x), (IsNotScalar:$c)]>;
 
 // Do not apply this when both y and c are scalar since it is cheap to do.
@@ -361,7 +365,7 @@ def AddConstAssociative3 : NamedPat<"AddConstAssociative3",
   (ONNXAddOp
     (ONNXAddOp $x, $y),
     $c),
-  [(IsNotAConstant:$x), (IsNotAConstant:$y), (HasOneUse:$rhs),
+  [(IsNotAConstant:$x), (IsNotAConstant:$y), (OpIsUnlikelyToBeFusedWithBias:$y), (HasOneUse:$rhs),
    (IsNotScalar:$y), (IsNotScalar:$c)]>;
 
 def AddConstAssociative4 : NamedPat<"AddConstAssociative4",

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -2797,3 +2797,62 @@ func.func @test_matmul_add_rhs(%arg0: tensor<1x4x2xi32>, %arg1: tensor<1x2x4xi32
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[PARAM_2_]], [[VAR_2_]]) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
 // CHECK:           onnx.Return [[VAR_3_]] : tensor<1x4x4xi32>
 }
+
+// -----
+
+func.func @test_two_matmuls_with_bias(%arg0: tensor<1x4x2xi32>, %arg1: tensor<1x2x4xi32>, %arg3: tensor<1x4x2xi32>, %arg4: tensor<1x2x4xi32>) -> tensor<1x4x4xi32> {
+  %cst_0 = onnx.Constant dense<1> : tensor<1x4x4xi32>
+  %cst_1 = onnx.Constant dense<2> : tensor<1x4x4xi32>
+  %matmul_0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+  %matmul_1 = "onnx.MatMul"(%arg3, %arg4) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+  %add_0 = "onnx.Add"(%matmul_0, %cst_0) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  %add_1 = "onnx.Add"(%matmul_1, %cst_1) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  %add_2 = "onnx.Add"(%add_0, %add_1) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  "onnx.Return"(%add_2) : (tensor<1x4x4xi32>) -> ()
+// CHECK-LABEL:  func.func @test_two_matmuls_with_bias
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x2xi32>, [[PARAM_1_:%.+]]: tensor<1x2x4xi32>, [[PARAM_2_:%.+]]: tensor<1x4x2xi32>, [[PARAM_3_:%.+]]: tensor<1x2x4xi32>) -> tensor<1x4x4xi32> {
+// CHECK-DAG:       [[CST:%.+]] = onnx.Constant dense<3> : tensor<1x4x4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.MatMul"([[PARAM_2_]], [[PARAM_3_]]) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[VAR_1_]], [[CST]]) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Add"([[VAR_3_]], [[VAR_2_]]) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<1x4x4xi32>
+}
+
+// -----
+
+func.func @test_one_matmul_with_bias_lhs(%arg0: tensor<1x4x2xi32>, %arg1: tensor<1x2x4xi32>, %arg3: tensor<1x4x4xi32>) -> tensor<1x4x4xi32> {
+  %cst_0 = onnx.Constant dense<1> : tensor<1x4x4xi32>
+  %cst_1 = onnx.Constant dense<2> : tensor<1x4x4xi32>
+  %matmul_0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+  %add_0 = "onnx.Add"(%matmul_0, %cst_0) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  %add_1 = "onnx.Add"(%arg3, %cst_1) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  %add_2 = "onnx.Add"(%add_0, %add_1) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  "onnx.Return"(%add_2) : (tensor<1x4x4xi32>) -> ()
+// CHECK-LABEL:  func.func @test_one_matmul_with_bias_lhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x2xi32>, [[PARAM_1_:%.+]]: tensor<1x2x4xi32>, [[PARAM_2_:%.+]]: tensor<1x4x4xi32>) -> tensor<1x4x4xi32> {
+// CHECK-DAG:       [[CST:%.+]] = onnx.Constant dense<3> : tensor<1x4x4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Add"([[VAR_1_]], [[CST]]) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[VAR_2_]], [[PARAM_2_]]) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<1x4x4xi32>
+}
+
+// -----
+
+func.func @test_one_matmul_with_bias_rhs(%arg0: tensor<1x4x2xi32>, %arg1: tensor<1x2x4xi32>, %arg3: tensor<1x4x4xi32>) -> tensor<1x4x4xi32> {
+  %cst_0 = onnx.Constant dense<1> : tensor<1x4x4xi32>
+  %cst_1 = onnx.Constant dense<2> : tensor<1x4x4xi32>
+  %matmul_0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+  %add_0 = "onnx.Add"(%matmul_0, %cst_0) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  %add_1 = "onnx.Add"(%arg3, %cst_1) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  %add_2 = "onnx.Add"(%add_1, %add_0) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  "onnx.Return"(%add_2) : (tensor<1x4x4xi32>) -> ()
+// CHECK-LABEL:  func.func @test_one_matmul_with_bias_rhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x2xi32>, [[PARAM_1_:%.+]]: tensor<1x2x4xi32>, [[PARAM_2_:%.+]]: tensor<1x4x4xi32>) -> tensor<1x4x4xi32> {
+// CHECK-DAG:       [[CST:%.+]] = onnx.Constant dense<3> : tensor<1x4x4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Add"([[VAR_1_]], [[CST]]) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[PARAM_2_]], [[VAR_2_]]) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<1x4x4xi32>
+}

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -2761,3 +2761,39 @@ func.func @test_round() -> tensor<5xf32> {
   // CHECK: {{.*}} = onnx.Constant dense<[1.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00, -4.000000e+00]> : tensor<5xf32>
   // CHECK-NOT: {{.*}} = "onnx.Round"{{.*}}
 }
+
+
+//===----------------------------------------------------------------------===//
+/// Test for Ops that can likely be fused with a (const) bias
+
+func.func @test_matmul_add_lhs(%arg0: tensor<1x4x2xi32>, %arg1: tensor<1x2x4xi32>, %arg3: tensor<1x4x4xi32>) -> tensor<1x4x4xi32> {
+  %0 = onnx.Constant dense<1> : tensor<1x4x4xi32>
+  %1 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+  %2 = "onnx.Add"(%1, %0) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  %3 = "onnx.Add"(%2, %arg3) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  "onnx.Return"(%3) : (tensor<1x4x4xi32>) -> ()
+// CHECK-LABEL:  func.func @test_matmul_add_lhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x2xi32>, [[PARAM_1_:%.+]]: tensor<1x2x4xi32>, [[PARAM_2_:%.+]]: tensor<1x4x4xi32>) -> tensor<1x4x4xi32> {
+// CHECK-DAG:       [[CST:%.+]] = onnx.Constant dense<1> : tensor<1x4x4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Add"([[VAR_1_]], [[CST]]) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[VAR_2_]], [[PARAM_2_]]) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<1x4x4xi32>
+}
+
+// -----
+
+func.func @test_matmul_add_rhs(%arg0: tensor<1x4x2xi32>, %arg1: tensor<1x2x4xi32>, %arg3: tensor<1x4x4xi32>) -> tensor<1x4x4xi32> {
+  %0 = onnx.Constant dense<1> : tensor<1x4x4xi32>
+  %1 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+  %2 = "onnx.Add"(%1, %0) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  %3 = "onnx.Add"(%arg3, %2) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+  "onnx.Return"(%3) : (tensor<1x4x4xi32>) -> ()
+// CHECK-LABEL:  func.func @test_matmul_add_rhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x2xi32>, [[PARAM_1_:%.+]]: tensor<1x2x4xi32>, [[PARAM_2_:%.+]]: tensor<1x4x4xi32>) -> tensor<1x4x4xi32> {
+// CHECK-DAG:       [[CST:%.+]] = onnx.Constant dense<1> : tensor<1x4x4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<1x4x2xi32>, tensor<1x2x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Add"([[VAR_1_]], [[CST]]) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[PARAM_2_]], [[VAR_2_]]) : (tensor<1x4x4xi32>, tensor<1x4x4xi32>) -> tensor<1x4x4xi32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<1x4x4xi32>
+}


### PR DESCRIPTION
Some ops like Matmul, Conv have support for fusing with a following (const) bias.
This PR changes the canonicalization/constprop so that adds with a constant are kept close to operations that likely support fusing in later compile stages