### PR TITLE
Allow lowering of (u)int4 to tosa. 

### DIFF
--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -379,6 +379,11 @@ public:
       return rewriter.notifyMatchFailure(op, "expected valid input type");
     }
     if (isa<FloatType>(inputTy.getElementType()) &&
+        resultTy.getElementType().isUnsignedInteger()) {
+      return rewriter.notifyMatchFailure(
+          op, "TOSA does not support cast from float to unsigned integer");
+    }
+    if (isa<FloatType>(inputTy.getElementType()) &&
         isa<IntegerType>(resultTy.getElementType())) {
       // ONNX.Cast has truncating behavior, and tosa.cast has rounds
       // half-to-even. We simulate truncate by floor for positive values and

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -93,7 +93,8 @@ inline bool isTOSABool(mlir::Type type) {
 
 inline bool isTOSAInt(mlir::Type type) {
   mlir::IntegerType intType = mlir::dyn_cast<mlir::IntegerType>(type);
-  std::set<unsigned> intWidth{1, 8, 16, 32, 48, 64};
+  // Int 4 is not a tosa int, but supported by tosa.mlir
+  std::set<unsigned> intWidth{1, 4, 8, 16, 32, 48, 64};
   return intType && (intType.isSignless() || intType.isUnsignedInteger()) &&
          (intWidth.find(intType.getWidth()) != intWidth.end());
 }

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Constant.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Constant.mlir
@@ -45,6 +45,24 @@ func.func @test_int_dense() -> tensor<2xi8> {
 
 // -----
 
+func.func @test_int4_dense() -> tensor<2xi4> {
+  %0 = "onnx.Constant"() {value = dense<[-1, -2]> : tensor<2xi4>} : () -> tensor<2xi4>
+  return %0 : tensor<2xi4>
+// CHECK-LABEL: @test_int4_dense() -> tensor<2xi4>
+// CHECK:       "tosa.const"() <{value = dense<[-1, -2]> : tensor<2xi4>}> : () -> tensor<2xi4>
+}
+
+// -----
+
+func.func @test_uint4_dense() -> tensor<2xui4> {
+  %0 = "onnx.Constant"() {value = dense<[1, 2]> : tensor<2xui4>} : () -> tensor<2xui4>
+  return %0 : tensor<2xui4>
+// CHECK-LABEL: @test_uint4_dense() -> tensor<2xui4>
+// CHECK:       "tosa.const"() <{value = dense<[1, 2]> : tensor<2xui4>}> : () -> tensor<2xui4>
+}
+
+// -----
+
 func.func @test_bool_single() -> tensor<i1> {
   %0 = "onnx.Constant"() {value = dense<true> : tensor<i1>} : () -> tensor<i1>
   return %0 : tensor<i1>


### PR DESCRIPTION
These types are not supported by tosa, but they are by tosa-mlir (with some AMD extensions)