### PR TITLE
convtranspose 1d decomposition

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -46,6 +46,7 @@ bool disableKrnlOpFusion;                              // common for both
 bool disableQuantZeroPoint;                            // common for both
 bool enableKrnlBufferReuse;                            // common for both
 bool enableConvTransposeDecomposeToPhasedConv;         // common for both
+bool enableConvTranspose1dDecomposeToPhasedConv;       // common for both
 bool enableQuarkQuantizerLegalization;                 // common for both
 bool enableSafeCodeGen;                                // common for both
 bool disableMemRefPrefetch;                            // common for both
@@ -298,6 +299,15 @@ static llvm::cl::opt<bool, true> enableConvTransposeDecomposeTo4ConvOptionOpt(
                    "phased Conv."),
     llvm::cl::location(enableConvTransposeDecomposeToPhasedConv),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
+
+static llvm::cl::opt<bool, true>
+    enableConvTranspose1dDecomposeToPhasedConvOptionOpt(
+        "enable-convtranspose-1d-decompose-phased-conv",
+        llvm::cl::desc(
+            "Enable decomposition of ONNX ConvTranspose 1D operator to "
+            "phased Conv."),
+        llvm::cl::location(enableConvTranspose1dDecomposeToPhasedConv),
+        llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
 
 static llvm::cl::opt<bool, true> enableQuarkQuantizerLegalizationOptionOpt(
     "enable-quark-quantizer-legalization",

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -93,7 +93,7 @@ extern bool enableKrnlBufferReuse;                            // common for both
 extern bool enableSafeCodeGen;                                // common for both
 extern bool disableMemRefPrefetch;                            // common for both
 extern bool enableConvTransposeDecomposeToPhasedConv;         // common for both
-extern bool enableConvTranspose1dDecomposeToPhasedConv;         // common for both
+extern bool enableConvTranspose1dDecomposeToPhasedConv;       // common for both
 extern bool enableQuarkQuantizerLegalization;                 // common for both
 extern uint64_t compilationNumThreads;                        // common for both
 // AMD: Decompose unconditionally

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -93,6 +93,7 @@ extern bool enableKrnlBufferReuse;                            // common for both
 extern bool enableSafeCodeGen;                                // common for both
 extern bool disableMemRefPrefetch;                            // common for both
 extern bool enableConvTransposeDecomposeToPhasedConv;         // common for both
+extern bool enableConvTranspose1dDecomposeToPhasedConv;         // common for both
 extern bool enableQuarkQuantizerLegalization;                 // common for both
 extern uint64_t compilationNumThreads;                        // common for both
 // AMD: Decompose unconditionally

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -86,14 +86,16 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   // Decompose first. Eliminates some unsupported ops without shape inference.
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createDecomposeONNXToONNXPass(
       /*target=*/"", opts.enableConvTransposeDecompose,
-      opts.enableConvTransposeDecomposeToPhasedConv));
+      opts.enableConvTransposeDecomposeToPhasedConv,
+      opts.enableConvTranspose1dDecomposeToPhasedConv));
   if (!disableRecomposeOption)
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass());
   if (enableONNXHybridPass) {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
         !disableRecomposeOption, opts.enableQuarkQuantizedLegalization,
         opts.enableConvTransposeDecompose,
-        opts.enableConvTransposeDecomposeToPhasedConv));
+        opts.enableConvTransposeDecomposeToPhasedConv,
+        opts.enableConvTranspose1dDecomposeToPhasedConv));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
@@ -102,7 +104,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
           onnx_mlir::createONNXHybridTransformPass(!disableRecomposeOption,
               /*enableQuarkQuantizedOpsLegalization=*/false,
               opts.enableConvTransposeDecompose,
-              opts.enableConvTransposeDecomposeToPhasedConv));
+              opts.enableConvTransposeDecomposeToPhasedConv,
+              opts.enableConvTranspose1dDecomposeToPhasedConv));
     }
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
@@ -144,7 +147,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
         !disableRecomposeOption, opts.enableQuarkQuantizedLegalization,
         opts.enableConvTransposeDecompose,
-        opts.enableConvTransposeDecomposeToPhasedConv));
+        opts.enableConvTransposeDecomposeToPhasedConv,
+        opts.enableConvTranspose1dDecomposeToPhasedConv));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());
@@ -349,6 +353,8 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
     opts.enableConvTransposeDecompose = enableConvTransposeDecomposeOption;
     opts.enableConvTransposeDecomposeToPhasedConv =
         enableConvTransposeDecomposeToPhasedConv;
+    opts.enableConvTranspose1dDecomposeToPhasedConv =
+        enableConvTranspose1dDecomposeToPhasedConv;
     addONNXToMLIRPasses(pm, /*target CPU*/ false,
         /*donotScrubDisposableElementsAttr=*/false, opts);
   }

--- a/src/Compiler/CompilerPasses.hpp
+++ b/src/Compiler/CompilerPasses.hpp
@@ -29,6 +29,7 @@ struct OnnxToMlirOptions {
   bool enableQuarkQuantizedLegalization = false;
   bool enableConvTransposeDecompose = false;
   bool enableConvTransposeDecomposeToPhasedConv = false;
+  bool enableConvTranspose1dDecomposeToPhasedConv = false;
 };
 
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_onnx_mlir_rewriter(Decompose)
 add_onnx_mlir_rewriter(DecomposeConvTranspose)
 add_onnx_mlir_rewriter(DecomposeConvTransposePhased)
+add_onnx_mlir_rewriter(DecomposeConvTranspose1dPhased)
 
 add_onnx_mlir_rewriter(ConstProp)
 add_onnx_mlir_rewriter(ConvOpt)
@@ -53,6 +54,7 @@ add_onnx_mlir_library(OMONNXRewrite
   OMONNXDecomposeIncGen
   OMONNXDecomposeConvTransposeIncGen
   OMONNXDecomposeConvTransposePhasedIncGen
+  OMONNXDecomposeConvTranspose1dPhasedIncGen
   OMONNXConstPropIncGen
   OMONNXConvOptIncGen
 

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -20,6 +20,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cmath>
 #include <numeric>
 
 #include "mlir/IR/Attributes.h"
@@ -694,6 +695,83 @@ bool hasNoActivationConsumer(Value convTransposeResult) {
   return true;
 }
 
+inline bool isTwoFourOrFive(int n) { return n == 2 || n == 4 || n == 5; }
+
+// This decomposition currently do not support all possible convtranspose
+// operations. Below are the supported usecases.
+// 1) stride[2], pads [1,1], kernel 4,  where convtranspose will decompose to
+// two conv operation. with each conv having kernel divided by 2. 2) stride [4],
+// pads [2,2], kernel 8,  where it will decompose into 4 conv operations
+//  each conv with one fourth of the convtranspose kernel size.
+// 3) stride [5], pads [2,2], kernel 10 where it will decompose into 5 conv
+// operations each conv with one fifth of the convtranspose kernel size.
+
+bool ShouldDecomposeConvTransposeOp1dToPhasedConvs(Value convTransposeResult,
+    ArrayAttr kernelShapeAttr, ArrayAttr padsShapeAttr,
+    ArrayAttr stridesShapeAttr, ArrayAttr outputShapeAttr) {
+  ONNXConvTransposeOp op =
+      mlir::cast<ONNXConvTransposeOp>(convTransposeResult.getDefiningOp());
+  bool areSpatialDimsStatic = hasShapeAndRank(convTransposeResult) &&
+                              hasStaticSpatialDims(op.getX()) &&
+                              hasStaticSpatialDims(op.getW());
+  if (!areSpatialDimsStatic)
+    return false;
+  // kernel shape is required for decomposition, Not supporting the case where
+  // kernel shape can be inferred. Not supporting the case where pad values are
+  // to be inferred automatically from outputShape.
+  if (!kernelShapeAttr || outputShapeAttr) {
+    return false;
+  }
+
+  auto kernelShape = getIntVectorFromArrayAttr(kernelShapeAttr);
+  auto padsShape = (padsShapeAttr) ? getIntVectorFromArrayAttr(padsShapeAttr)
+                                   : SmallVector<int64_t>({0, 0});
+  auto stridesShape = (stridesShapeAttr)
+                          ? getIntVectorFromArrayAttr(stridesShapeAttr)
+                          : SmallVector<int64_t>({1});
+
+  RankedTensorType outputType =
+      mlir::cast<RankedTensorType>(convTransposeResult.getType());
+  auto outputShape = outputType.getShape();
+  // Checking to ensure only convtranspose with 1D spatial dims and stride 2, 4
+  // or 5 are supported.
+  if ((outputShape.size() != 3) || (stridesShape.size() != 1) ||
+      (padsShape.size() != 2) || !isTwoFourOrFive(stridesShape[0]))
+    return false;
+  // number of conv phases equals to the stride.
+  int numberOfPhases = stridesShape[0];
+  // If numberOfPhases is not 5, the ofm spatial dim should be evenly divisible
+  // by num of phases.
+  if ((numberOfPhases != 5) &&
+      !(outputShape[outputShape.size() - 1] % numberOfPhases == 0)) {
+    return false;
+  }
+  // The decomposistion creates the ofm of below dim, hence checking if the
+  // original convtranspose ofm dim is matching to the decomposition ofm.
+  // this is specific for convtranspose with stride 5.
+  auto convSpatialDim =
+      std::floor(outputShape[outputShape.size() - 1] / stridesShape[0]);
+  auto combinedSpatialDim = convSpatialDim * 5 + 1;
+  if ((numberOfPhases == 5) &&
+      (outputShape[outputShape.size() - 1] != combinedSpatialDim)) {
+    return false;
+  }
+  auto checkPadOfValue = [](llvm::ArrayRef<int64_t> pads,
+                             int checkValue) -> bool {
+    return pads[0] == checkValue && llvm::all_equal(pads);
+  };
+
+  // Currently support only below scenarios.
+  // 1. stride=2, pads=[1,1], kernel is 4.
+  // 2. stride=4, pads=[2,2], kernel is 8.
+  // 3. stride=5, pads=[2,2], kernel is 10.
+  return (numberOfPhases == 2 && checkPadOfValue(padsShape, 1) &&
+             kernelShape[0] == 4) ||
+         (numberOfPhases == 4 && checkPadOfValue(padsShape, 2) &&
+             kernelShape[0] == 8) ||
+         (numberOfPhases == 5 && checkPadOfValue(padsShape, 2) &&
+             kernelShape[0] == 10);
+}
 // This decomposition currently do not support all possible convtranspose
 // operations. Below are the supported usecases.
 // 1) stride[1,1] where convtranspose will decompose to one conv operation.
@@ -790,6 +868,420 @@ bool ShouldDecomposeConvTransposeOpToPhasedConvs(Value convTransposeResult,
     }
   }
   return false;
+}
+ONNXConstantOp getONNXConstOpFromVector(
+    PatternRewriter &rewriter, Location loc, ArrayRef<int64_t> values) {
+  auto int64Type = rewriter.getIntegerType(64);
+  SmallVector<mlir::Attribute> elements;
+  transform(values, std::back_inserter(elements),
+      [&](int64_t val) { return rewriter.getI64IntegerAttr(val); });
+  auto constType = RankedTensorType::get(values.size(), int64Type);
+  return rewriter.create<ONNXConstantOp>(loc, mlir::Attribute(),
+      DenseElementsAttr::get(constType, llvm::ArrayRef(elements)));
+}
+
+// This decomposition is targetting the convtranspose 1D operator.
+// We have another decomposition targetting convtranspose 2D operator.
+// Convtranpose can be decomposed into phased convolutions.
+// The phased convolutions are then merged to get the final output.
+// The number of phases is determined by the strides of the convtranspose op.
+// The num of phases = stride
+// The phased convolutions are weights are created by slicing the weights of the
+// convolution in the specified manner and output of convolutions are stiched
+// together to get the final output.
+// Below shows the high level view of the decomposition.
+// clang-format off
+//                                                                                             
+// +--------+     +--------+-------+--------+-------+--------+-------+                         
+// |ConvT   |     |        |       |        |       |        |       |                         
+// |        +---->| Conv1  |Conv2  | Conv1  |Conv2  | Conv1  |Conv2  |                         
+// |stride 2|     |        |       |        |       |        |       |                         
+// +--------+     +--------+-------+--------+-------+--------+-------+                         
+//                                                                                             
+// +--------+      +------+------+------+------+------+------+------+------+                   
+// |ConvT   |      |      |      |      |      |      |      |      |      |                   
+// |        +----> |conv1 |conv2 |conv3 |conv4 |conv1 |conv2 |conv3 |conv4 |                   
+// |stride4 |      +------+------+------+------+------+------+------+------+                   
+// +--------+                                                                                  
+//                                                                                             
+// +--------+                                                                                  
+// |ConvT   |   +------+------+------+------+-----+                                            
+// |        +-->|      |      |      |      |     |                                            
+// |Stride 5|   |conv1 |conv2 |conv3 |conv4 |conv5|                                            
+// +--------+   +------+------+------+------+-----+                                            
+//                                                                                             
+//                                                                                             
+//  ConvTranspose weights are sliced to generated phased conv weights                          
+//                                                                                             
+//  phased conv outputs are merged to get complete ofm                                         
+//                                                                                             
+//                                                -
+// clang-format on
+// If no activation op ( lrelu or relu) found in the matching, the alpha value
+// will be passed as the null, if relu is found 0 is passed, if lrelu is found
+// the alpha value is passed to this method.
+Value decomposeConvT1dIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
+    ONNXConvTransposeOp op, Value convTransposeResult, Value input,
+    Value weights, Value bias, ArrayAttr dilations, IntegerAttr group,
+    ArrayAttr kernel_shape, ArrayAttr pads, ArrayAttr strides,
+    FloatAttr alpha) {
+
+  RankedTensorType weightsType =
+      mlir::cast<RankedTensorType>(weights.getType());
+  assert(weightsType.hasRank() && "Weight tensor must have rank.");
+  Type elementType = getElementType(op.getType());
+  RankedTensorType outputType =
+      mlir::cast<RankedTensorType>(convTransposeResult.getType());
+  auto convTransposeOutputShape = outputType.getShape();
+  auto kernelShape = getIntVectorFromArrayAttr(kernel_shape);
+  auto padsShape =
+      (pads) ? getIntVectorFromArrayAttr(pads) : SmallVector<int64_t>({0, 0});
+  auto stridesShape = (strides) ? getIntVectorFromArrayAttr(strides)
+                                : SmallVector<int64_t>({1});
+
+  int numPhases = stridesShape[0];
+  auto getActivationAppliedToConv = [&](Value conv, Type convOutputType) {
+    if (!alpha)
+      return conv;
+    return (alpha.getValueAsDouble() == 0)
+               ? rewriter.create<ONNXReluOp>(loc, convOutputType, conv)
+                     .getResult()
+               : rewriter
+                     .create<ONNXLeakyReluOp>(loc, convOutputType, conv, alpha)
+                     .getResult();
+  };
+
+  onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(rewriter, loc);
+
+  SmallVector<mlir::Value> weightSlices;
+  int step = stridesShape[0];
+  int convKernelSize = kernelShape[0] / stridesShape[0];
+
+  auto axisOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {2});
+  auto stepOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {step});
+  auto weightsShape = weightsType.getShape();
+  auto convWeightsShapedType =
+      weightsType.get({weightsShape[0], weightsShape[1], convKernelSize},
+          weightsType.getElementType());
+  int64_t maxIndex = stridesShape[0];
+  for (int row = 0; row < maxIndex; row++) {
+    int rowEnd = (convKernelSize * step) + row;
+    llvm::SmallVector<int64_t> startVector({row});
+    llvm::SmallVector<int64_t> endVector({rowEnd});
+    auto startOnnxConstant =
+        getONNXConstOpFromVector(rewriter, loc, startVector);
+    auto endOnnxConstant = getONNXConstOpFromVector(rewriter, loc, endVector);
+    weightSlices.push_back(
+        create.onnx.slice(convWeightsShapedType, weights, startOnnxConstant,
+            endOnnxConstant, axisOnnxConstant, stepOnnxConstant));
+  }
+
+  auto convKernelShapeArrayAttr = rewriter.getI64ArrayAttr({convKernelSize});
+
+  // This is the shape of the output from each conv, which contributes to the
+  // final ofm.
+  SmallVector<int64_t> convOutputShape(convTransposeOutputShape);
+  convOutputShape[convOutputShape.size() - 1] =
+      (convOutputShape[convOutputShape.size() - 1] / stridesShape[0] + 1);
+
+  ShapedType convTransposeOutputType =
+      mlir::cast<ShapedType>(op.getY().getType());
+  auto convOutputType = RankedTensorType::get(
+      convOutputShape, convTransposeOutputType.getElementType());
+
+  // for all the usecases supported by this decomposition, conv pads is [1,1]
+  auto padsArrayAttr = rewriter.getI64ArrayAttr({1, 1});
+  auto stridesArrayAttr = rewriter.getI64ArrayAttr({1});
+  stepOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {1});
+
+  // The shape of the conv output to be consumed.
+  SmallVector<int64_t> convSliceOutputShape(convTransposeOutputShape);
+  convSliceOutputShape[convOutputShape.size() - 1] = std::floor(
+      convTransposeOutputShape[convOutputShape.size() - 1] / stridesShape[0]);
+  auto convSliceOutputType = RankedTensorType::get(
+      convSliceOutputShape, convTransposeOutputType.getElementType());
+
+  if (numPhases == 2) {
+    Value conv1 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[1],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    Value conv2 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[0],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    auto startOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {1});
+    auto endOnnxConstant = getONNXConstOpFromVector(
+        rewriter, loc, {convOutputShape[convOutputShape.size() - 1]});
+
+    // for conv1 garbage is in 1st value, for conv2 it is last value.
+    conv1 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv1,
+        startOnnxConstant, endOnnxConstant, axisOnnxConstant, stepOnnxConstant);
+
+    startOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {0});
+    endOnnxConstant = getONNXConstOpFromVector(
+        rewriter, loc, {convOutputShape[convOutputShape.size() - 1] - 1});
+    conv2 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv2,
+        startOnnxConstant, endOnnxConstant, axisOnnxConstant, stepOnnxConstant);
+    // The two convOutputs are adjusted to add an extra dimension at the
+    // innermost level.
+    SmallVector<int64_t> outputShapePlusOneDim(convSliceOutputShape);
+    outputShapePlusOneDim.push_back(1);
+    auto onnxConstForReshapeAddOneDim =
+        getONNXConstOpFromVector(rewriter, loc, outputShapePlusOneDim);
+
+    auto reshapeOutputType =
+        RankedTensorType::get(outputShapePlusOneDim, elementType);
+
+    auto reshapeOutputAddOneDimConv1 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv1, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv2 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv2, onnxConstForReshapeAddOneDim);
+    SmallVector<int64_t> outputShapeLevel1Concat(outputShapePlusOneDim);
+    outputShapeLevel1Concat[outputShapeLevel1Concat.size() - 1] = 2;
+    auto level1ConcatOutputType =
+        RankedTensorType::get(outputShapeLevel1Concat, elementType);
+
+    // Below concats result will have the innermost dim as 2.
+    auto finalConcat = rewriter.create<ONNXConcatOp>(loc,
+        level1ConcatOutputType,
+        ValueRange{reshapeOutputAddOneDimConv2, reshapeOutputAddOneDimConv1},
+        -1);
+    SmallVector<int64_t> outputShapeForResult(convSliceOutputShape);
+    auto dimValueAtLastIndex =
+        convSliceOutputShape[convSliceOutputShape.size() - 1] * 2;
+    outputShapeForResult[outputShapeForResult.size() - 1] = dimValueAtLastIndex;
+
+    auto onnxConstForLastReshape =
+        getONNXConstOpFromVector(rewriter, loc, outputShapeForResult);
+
+    auto finalOutputType =
+        RankedTensorType::get(outputShapeForResult, elementType);
+    // Result is reshaped back to match the original convtranspose output
+    // dimensions
+    auto finalOutput = rewriter.create<ONNXReshapeOp>(
+        loc, finalOutputType, finalConcat, onnxConstForLastReshape);
+    return finalOutput;
+  }
+  if (numPhases == 4) {
+    Value conv1 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[1],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    Value conv2 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[0],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    Value conv3 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[3],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    Value conv4 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[2],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    auto startOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {0});
+    auto endOnnxConstant = getONNXConstOpFromVector(
+        rewriter, loc, {convOutputShape[convOutputShape.size() - 1] - 1});
+
+    // for conv1 and conv2 garbage is at end, for conv3 and conv4 it is at
+    // start.
+    conv1 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv1,
+        startOnnxConstant, endOnnxConstant, axisOnnxConstant, stepOnnxConstant);
+
+    conv2 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv2,
+        startOnnxConstant, endOnnxConstant, axisOnnxConstant, stepOnnxConstant);
+    startOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {1});
+    endOnnxConstant = getONNXConstOpFromVector(
+        rewriter, loc, {convOutputShape[convOutputShape.size() - 1]});
+    conv3 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv3,
+        startOnnxConstant, endOnnxConstant, axisOnnxConstant, stepOnnxConstant);
+
+    conv4 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv4,
+        startOnnxConstant, endOnnxConstant, axisOnnxConstant, stepOnnxConstant);
+    // The four convOutputs are adjusted to add an extra dimension at the
+    // innermost level.
+    SmallVector<int64_t> outputShapePlusOneDim(convSliceOutputShape);
+    outputShapePlusOneDim.push_back(1);
+    auto onnxConstForReshapeAddOneDim =
+        getONNXConstOpFromVector(rewriter, loc, outputShapePlusOneDim);
+
+    auto reshapeOutputType =
+        RankedTensorType::get(outputShapePlusOneDim, elementType);
+
+    auto reshapeOutputAddOneDimConv1 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv1, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv2 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv2, onnxConstForReshapeAddOneDim);
+
+    auto reshapeOutputAddOneDimConv3 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv3, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv4 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv4, onnxConstForReshapeAddOneDim);
+
+    SmallVector<int64_t> outputShapeLevel1Concat(outputShapePlusOneDim);
+    outputShapeLevel1Concat[outputShapeLevel1Concat.size() - 1] = 4;
+    auto level1ConcatOutputType =
+        RankedTensorType::get(outputShapeLevel1Concat, elementType);
+
+    // Below concats result will have the innermost dim as 2.
+    auto finalConcat =
+        rewriter.create<ONNXConcatOp>(loc, level1ConcatOutputType,
+            ValueRange{reshapeOutputAddOneDimConv1, reshapeOutputAddOneDimConv2,
+                reshapeOutputAddOneDimConv3, reshapeOutputAddOneDimConv4},
+            -1);
+    SmallVector<int64_t> outputShapeForResult(convSliceOutputShape);
+    auto dimValueAtLastIndex =
+        convSliceOutputShape[convSliceOutputShape.size() - 1] * 4;
+    outputShapeForResult[outputShapeForResult.size() - 1] = dimValueAtLastIndex;
+
+    auto onnxConstForLastReshape =
+        getONNXConstOpFromVector(rewriter, loc, outputShapeForResult);
+
+    auto finalOutputType =
+        RankedTensorType::get(outputShapeForResult, elementType);
+    // Result is reshaped back to match the original convtranspose output
+    // dimensions
+    auto finalOutput = rewriter.create<ONNXReshapeOp>(
+        loc, finalOutputType, finalConcat, onnxConstForLastReshape);
+    return finalOutput;
+  }
+  if (numPhases == 5) {
+    Value conv1 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[2],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    Value conv2 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[1],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    Value conv3 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[0],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    Value conv4 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[4],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    Value conv5 = getActivationAppliedToConv(
+        rewriter.create<ONNXConvOp>(loc, convOutputType, input, weightSlices[3],
+            bias, mlir::StringAttr(), dilations, group,
+            convKernelShapeArrayAttr, padsArrayAttr, stridesArrayAttr),
+        convOutputType);
+    auto startOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {1});
+    auto endOnnxConstant = getONNXConstOpFromVector(
+        rewriter, loc, {convOutputShape[convOutputShape.size() - 1]});
+
+    conv4 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv4,
+        startOnnxConstant, endOnnxConstant, axisOnnxConstant, stepOnnxConstant);
+
+    conv5 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv5,
+        startOnnxConstant, endOnnxConstant, axisOnnxConstant, stepOnnxConstant);
+
+    // 1. conv1 output is taken as is, it do not have any garbge.
+    // 2. conv2, conv3 has garbage at the end, it will be taken care at the
+    // last slice operation after the concat.
+    // 3. conv4 and conv5 has garbage at the start, here we slice the start
+    // garbage, and pad at the end to match with the sizes of other conv
+    // outputs, to accomodate the concat of all the conv outputs.
+
+    std::array<int64_t, 6> convOutputPadValue = {0, 0, 0, 0, 0, 1};
+
+    auto onnxPadsValueConstant =
+        getONNXConstOpFromVector(rewriter, loc, convOutputPadValue);
+    RankedTensorType scalarTy = RankedTensorType::get({}, elementType);
+    Value onnxPaddingConstantZero = create.onnx.constant(
+        DenseElementsAttr::get(scalarTy, rewriter.getZeroAttr(elementType)));
+
+    auto onnxAxisValueConstantNone = create.onnx.none();
+    SmallVector<int64_t> paddedConvOutputShapeValue = {convSliceOutputShape[0],
+        convSliceOutputShape[1], convSliceOutputShape[2] + 1};
+    auto paddedConvOutputShapedType =
+        convOutputType.get(paddedConvOutputShapeValue, elementType);
+
+    conv4 = rewriter.create<ONNXPadOp>(loc, paddedConvOutputShapedType, conv4,
+        onnxPadsValueConstant, onnxPaddingConstantZero,
+        onnxAxisValueConstantNone, rewriter.getStringAttr("constant"));
+
+    conv5 = rewriter.create<ONNXPadOp>(loc, paddedConvOutputShapedType, conv5,
+        onnxPadsValueConstant, onnxPaddingConstantZero,
+        onnxAxisValueConstantNone, rewriter.getStringAttr("constant"));
+
+    // The five convOutputs are adjusted to add an extra dimension at the
+    // innermost level.
+    SmallVector<int64_t> outputShapePlusOneDim(paddedConvOutputShapeValue);
+    outputShapePlusOneDim.push_back(1);
+    auto onnxConstForReshapeAddOneDim =
+        getONNXConstOpFromVector(rewriter, loc, outputShapePlusOneDim);
+
+    auto reshapeOutputType =
+        RankedTensorType::get(outputShapePlusOneDim, elementType);
+
+    auto reshapeOutputAddOneDimConv1 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv1, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv2 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv2, onnxConstForReshapeAddOneDim);
+
+    auto reshapeOutputAddOneDimConv3 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv3, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv4 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv4, onnxConstForReshapeAddOneDim);
+    auto reshapeOutputAddOneDimConv5 = rewriter.create<ONNXReshapeOp>(
+        loc, reshapeOutputType, conv5, onnxConstForReshapeAddOneDim);
+
+    SmallVector<int64_t> outputShapeLevel1Concat(outputShapePlusOneDim);
+    outputShapeLevel1Concat[outputShapeLevel1Concat.size() - 1] = 5;
+    auto level1ConcatOutputType =
+        RankedTensorType::get(outputShapeLevel1Concat, elementType);
+
+    // Below concats result will have the innermost dim as 2.
+    auto convOfmConcat =
+        rewriter.create<ONNXConcatOp>(loc, level1ConcatOutputType,
+            ValueRange{reshapeOutputAddOneDimConv1, reshapeOutputAddOneDimConv2,
+                reshapeOutputAddOneDimConv3, reshapeOutputAddOneDimConv4,
+                reshapeOutputAddOneDimConv5},
+            -1);
+    SmallVector<int64_t> outputShapeForResult(paddedConvOutputShapeValue);
+    auto dimValueAtLastIndex =
+        paddedConvOutputShapeValue[paddedConvOutputShapeValue.size() - 1] * 5;
+    outputShapeForResult[outputShapeForResult.size() - 1] = dimValueAtLastIndex;
+
+    auto onnxConstForLastReshape =
+        getONNXConstOpFromVector(rewriter, loc, outputShapeForResult);
+
+    auto outputTypeBeforeSlice =
+        RankedTensorType::get(outputShapeForResult, elementType);
+    // Result is reshaped back to match the original convtranspose output
+    // dimensions
+    auto outputBeforeSlice = rewriter.create<ONNXReshapeOp>(
+        loc, outputTypeBeforeSlice, convOfmConcat, onnxConstForLastReshape);
+
+    SmallVector<int64_t> finalSliceOutputShape(convTransposeOutputShape);
+    auto finalSliceOutputType = RankedTensorType::get(
+        finalSliceOutputShape, convTransposeOutputType.getElementType());
+
+    startOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {0});
+    endOnnxConstant = getONNXConstOpFromVector(rewriter, loc,
+        {finalSliceOutputShape[finalSliceOutputShape.size() - 1]});
+
+    auto finalSlicedOutput = rewriter.create<ONNXSliceOp>(loc,
+        finalSliceOutputType, outputBeforeSlice, startOnnxConstant,
+        endOnnxConstant, axisOnnxConstant, stepOnnxConstant);
+
+    return finalSlicedOutput;
+  }
+
+  llvm_unreachable("Unsupported convtranspose decomposition");
 }
 
 // Convtranpose can be decomposed into phased convolutions.
@@ -912,16 +1404,6 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
         op.getY().getType());
   }
 
-  auto int64Type = rewriter.getIntegerType(64);
-  auto getONNXConstOpFromVector =
-      [&](ArrayRef<int64_t> values) -> ONNXConstantOp {
-    SmallVector<mlir::Attribute> elements;
-    transform(values, std::back_inserter(elements),
-        [&](int64_t val) { return rewriter.getI64IntegerAttr(val); });
-    auto constType = RankedTensorType::get(values.size(), int64Type);
-    return rewriter.create<ONNXConstantOp>(loc, mlir::Attribute(),
-        DenseElementsAttr::get(constType, llvm::ArrayRef(elements)));
-  };
   onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(rewriter, loc);
   // If the convTranspose kernel is 3x3, then the weights needs to be padded to
   // 4x4
@@ -940,7 +1422,8 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
       weightsPadValue[6] = 1;
       weightsPadValue[7] = 1;
     }
-    auto onnxPadsValueConstant = getONNXConstOpFromVector(weightsPadValue);
+    auto onnxPadsValueConstant =
+        getONNXConstOpFromVector(rewriter, loc, weightsPadValue);
     RankedTensorType scalarTy = RankedTensorType::get({}, elementType);
     Value onnxPaddingConstantZero = create.onnx.constant(
         DenseElementsAttr::get(scalarTy, rewriter.getZeroAttr(elementType)));
@@ -963,8 +1446,8 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
   int step = stridesShape[0];
   int convKernelSize = kernelShape[0] / stridesShape[0];
 
-  auto axisOnnxConstant = getONNXConstOpFromVector({2, 3});
-  auto stepOnnxConstant = getONNXConstOpFromVector({step, step});
+  auto axisOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {2, 3});
+  auto stepOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {step, step});
   auto weightsShape = weightsType.getShape();
   auto convWeightsShapedType = weightsType.get(
       {weightsShape[0], weightsShape[1], convKernelSize, convKernelSize},
@@ -976,8 +1459,9 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
       int columnEnd = (convKernelSize * step) + column;
       llvm::SmallVector<int64_t> startVector({row, column});
       llvm::SmallVector<int64_t> endVector({rowEnd, columnEnd});
-      auto startOnnxConstant = getONNXConstOpFromVector(startVector);
-      auto endOnnxConstant = getONNXConstOpFromVector(endVector);
+      auto startOnnxConstant =
+          getONNXConstOpFromVector(rewriter, loc, startVector);
+      auto endOnnxConstant = getONNXConstOpFromVector(rewriter, loc, endVector);
       weightSlices.push_back(
           create.onnx.slice(convWeightsShapedType, weights, startOnnxConstant,
               endOnnxConstant, axisOnnxConstant, stepOnnxConstant));
@@ -1068,37 +1552,37 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
         convOutputType);
     // Need to remove excess the ofm  when weights are padded.
     if (needWeightsPadding) {
-      auto startOnnxConstant = getONNXConstOpFromVector({1, 1});
-      auto endOnnxConstant = getONNXConstOpFromVector(
+      auto startOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {1, 1});
+      auto endOnnxConstant = getONNXConstOpFromVector(rewriter, loc,
           {convOutputShape[convOutputShape.size() - 2] + 2,
               convOutputShape[convOutputShape.size() - 1] + 2});
-      auto axisOnnxConstant = getONNXConstOpFromVector({2, 3});
-      auto stepOnnxConstant = getONNXConstOpFromVector({1, 1});
+      auto axisOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {2, 3});
+      auto stepOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {1, 1});
       auto convSliceOutputType = RankedTensorType::get(
           convOutputShape, convTransposeOutputType.getElementType());
       conv1 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv1,
           startOnnxConstant, endOnnxConstant, axisOnnxConstant,
           stepOnnxConstant);
 
-      startOnnxConstant = getONNXConstOpFromVector({0, 0});
-      endOnnxConstant =
-          getONNXConstOpFromVector({convOutputShape[convOutputShape.size() - 2],
+      startOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {0, 0});
+      endOnnxConstant = getONNXConstOpFromVector(rewriter, loc,
+          {convOutputShape[convOutputShape.size() - 2],
               convOutputShape[convOutputShape.size() - 1]});
       conv2 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv2,
           startOnnxConstant, endOnnxConstant, axisOnnxConstant,
           stepOnnxConstant);
 
-      startOnnxConstant = getONNXConstOpFromVector({1, 0});
-      endOnnxConstant = getONNXConstOpFromVector(
+      startOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {1, 0});
+      endOnnxConstant = getONNXConstOpFromVector(rewriter, loc,
           {convOutputShape[convOutputShape.size() - 2] + 2,
               convOutputShape[convOutputShape.size() - 1]});
       conv3 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv3,
           startOnnxConstant, endOnnxConstant, axisOnnxConstant,
           stepOnnxConstant);
 
-      startOnnxConstant = getONNXConstOpFromVector({0, 1});
-      endOnnxConstant =
-          getONNXConstOpFromVector({convOutputShape[convOutputShape.size() - 2],
+      startOnnxConstant = getONNXConstOpFromVector(rewriter, loc, {0, 1});
+      endOnnxConstant = getONNXConstOpFromVector(rewriter, loc,
+          {convOutputShape[convOutputShape.size() - 2],
               convOutputShape[convOutputShape.size() - 1] + 2});
       conv4 = rewriter.create<ONNXSliceOp>(loc, convSliceOutputType, conv4,
           startOnnxConstant, endOnnxConstant, axisOnnxConstant,
@@ -1110,7 +1594,7 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
     SmallVector<int64_t> outputShapePlusOneDim(convOutputShape);
     outputShapePlusOneDim.push_back(1);
     auto onnxConstForReshapeAddOneDim =
-        getONNXConstOpFromVector(outputShapePlusOneDim);
+        getONNXConstOpFromVector(rewriter, loc, outputShapePlusOneDim);
 
     auto reshapeOutputType =
         RankedTensorType::get(outputShapePlusOneDim, elementType);
@@ -1163,7 +1647,7 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
     outputShapeForDimAdjust.push_back(dimValueAtLastIndex);
 
     auto onnxConstForReshapeDimAdjust =
-        getONNXConstOpFromVector(outputShapeForDimAdjust);
+        getONNXConstOpFromVector(rewriter, loc, outputShapeForDimAdjust);
 
     auto reshapeOutputForDimAdjustType =
         RankedTensorType::get(outputShapeForDimAdjust, elementType);
@@ -1202,7 +1686,7 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
     outputShapeForResult[outputShapeForResult.size() - 1] = dimValueAtLastIndex;
 
     auto onnxConstForLastReshape =
-        getONNXConstOpFromVector(outputShapeForResult);
+        getONNXConstOpFromVector(rewriter, loc, outputShapeForResult);
 
     auto finalOutputType =
         RankedTensorType::get(outputShapeForResult, elementType);
@@ -1267,7 +1751,7 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
     SmallVector<int64_t> outputShapePlusOneDim(convOutputShape);
     outputShapePlusOneDim.push_back(1);
     auto onnxConstForReshapeAddOneDim =
-        getONNXConstOpFromVector(outputShapePlusOneDim);
+        getONNXConstOpFromVector(rewriter, loc, outputShapePlusOneDim);
 
     auto reshapeOutputType =
         RankedTensorType::get(outputShapePlusOneDim, elementType);
@@ -1321,7 +1805,7 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
     outputShapeForDimAdjust.push_back(dimValueAtLastIndex);
 
     auto onnxConstForReshapeDimAdjust =
-        getONNXConstOpFromVector(outputShapeForDimAdjust);
+        getONNXConstOpFromVector(rewriter, loc, outputShapeForDimAdjust);
     auto reshapeOutputForDimAdjustType =
         RankedTensorType::get(outputShapeForDimAdjust, elementType);
 
@@ -1357,7 +1841,7 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
     outputShapeForResult[outputShapeForResult.size() - 1] = dimValueAtLastIndex;
 
     auto onnxConstForLastReshape =
-        getONNXConstOpFromVector(outputShapeForResult);
+        getONNXConstOpFromVector(rewriter, loc, outputShapeForResult);
 
     auto finalOutputType =
         RankedTensorType::get(outputShapeForResult, elementType);
@@ -1521,7 +2005,9 @@ namespace convtranspose {
 namespace convtranspose_phased {
 #include "src/Dialect/ONNX/Transforms/ONNXDecomposeConvTransposePhased.inc"
 }
-
+namespace convtranspose_1d_phased {
+#include "src/Dialect/ONNX/Transforms/ONNXDecomposeConvTranspose1dPhased.inc"
+}
 RankedTensorType createReducedType(
     Type outputType, int64_t axisValue, bool keepDims) {
   RankedTensorType outputShapeType =
@@ -2814,11 +3300,14 @@ struct DecomposeONNXToONNXPass
 
   DecomposeONNXToONNXPass(const std::string &target,
       bool enableConvTransposeDecompose = false,
-      bool enableConvTransposeDecomposeToPhasedConv = false) {
+      bool enableConvTransposeDecomposeToPhasedConv = false,
+      bool enableConvTranspose1dDecomposeToPhasedConv = false) {
     this->target = target;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
     this->enableConvTransposeDecomposeToPhasedConv =
         enableConvTransposeDecomposeToPhasedConv;
+    this->enableConvTranspose1dDecomposeToPhasedConv =
+        enableConvTranspose1dDecomposeToPhasedConv;
   }
 
   DecomposeONNXToONNXPass(const DecomposeONNXToONNXPass &pass)
@@ -2851,6 +3340,13 @@ struct DecomposeONNXToONNXPass
                      "phased Conv"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableConvTranspose1dDecomposeToPhasedConv{*this,
+      "enable-convtranspose-1d-phased",
+      llvm::cl::desc(
+          "Enable decomposition of ONNX ConvTranspose 1D operator to "
+          "phased Conv"),
+      ::llvm::cl::init(false)};
+
   void runOnOperation() final;
 
   typedef PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>>
@@ -2862,7 +3358,8 @@ void DecomposeONNXToONNXPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
   onnx_mlir::getDecomposeONNXToONNXPatterns(patterns,
-      enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv);
+      enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
+      enableConvTranspose1dDecomposeToPhasedConv);
   patterns.insert<ReplaceCastLikeByCastPattern>(context);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
@@ -2879,13 +3376,16 @@ void DecomposeONNXToONNXPass::runOnOperation() {
 
 void onnx_mlir::getDecomposeONNXToONNXPatterns(
     mlir::RewritePatternSet &patterns, bool enableConvTransposeDecompose,
-    bool enableConvTransposeDecomposeToPhasedConv) {
+    bool enableConvTransposeDecomposeToPhasedConv,
+    bool enableConvTranspose1dDecomposeToPhasedConv) {
   MLIRContext *context = patterns.getContext();
   populateWithGenerated(patterns);
   if (enableConvTransposeDecompose)
     convtranspose::populateWithGenerated(patterns);
   if (enableConvTransposeDecomposeToPhasedConv)
     convtranspose_phased::populateWithGenerated(patterns);
+  if (enableConvTranspose1dDecomposeToPhasedConv)
+    convtranspose_1d_phased::populateWithGenerated(patterns);
   patterns.insert<onnx_mlir::DecomposeEinsumPattern>(context);
   patterns.insert<ConcatFusePattern>(context);
   patterns.insert<DecomposeHardSwishPattern>(context);
@@ -2924,7 +3424,9 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
  */
 std::unique_ptr<mlir::Pass> onnx_mlir::createDecomposeONNXToONNXPass(
     const std::string &target, bool enableConvTransposeDecompose,
-    bool enableConvTransposeDecomposeToPhasedConv) {
+    bool enableConvTransposeDecomposeToPhasedConv,
+    bool enableConvTranspose1dDecomposeToPhasedConv) {
   return std::make_unique<DecomposeONNXToONNXPass>(target,
-      enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv);
+      enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
+      enableConvTranspose1dDecomposeToPhasedConv);
 }

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -28,7 +28,8 @@ namespace onnx_mlir {
 // patterns that can be used with any PatternRewriter, not conversion patterns.
 void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableConvTransposeDecompose,
-    bool enableConvTransposeDecomposeToPhasedConv);
+    bool enableConvTransposeDecomposeToPhasedConv,
+    bool enableConvTranspose1dDecomposeToPhasedConv);
 
 } // namespace onnx_mlir
 #endif

--- a/src/Dialect/ONNX/Transforms/DecomposeConvTranspose1dPhased.td
+++ b/src/Dialect/ONNX/Transforms/DecomposeConvTranspose1dPhased.td
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ONNX_DECOMPOSE_CONVTRANSPOSE_1D_PHASED
+#define ONNX_DECOMPOSE_CONVTRANSPOSE_1D_PHASED
+
+#ifndef OP_BASE
+include "src/Dialect/ONNX/ONNX.td"
+#endif // OP_BASE
+
+include "Decompose.td"
+include "DecomposeConvTransposePhased.td"
+
+/// Note: The DRR definition used for defining patterns is shown below:
+///
+/// class Pattern<
+///    dag sourcePattern, list<dag> resultPatterns,
+///    list<dag> additionalConstraints = [],
+///    list<dag> supplementalPatterns = [],
+///    dag benefitsAdded = (addBenefit 0)
+/// >;
+
+//===----------------------------------------------------------------------===//
+// ONNXConvTransposeOp is rewritten into ONNXConv op and other ONNX ops to
+// convert input, weight, and pad.
+//
+// 1. Reverse elements for spatial axis in weight tensor.
+//    Emit ONNXTransposeOp and ONNXReverseSequenceOp in reverseWeightConvTranspose()
+// 2. splits the weights into phased conv weights.
+// 3. combines the conv outputs in a specific way to produce the complete ofm
+
+// TODO: Consider to write C++ code instead of using tablegen because some code
+//       are redundant. (eg. currently shapeHelper is calld multiple times.)
+//===----------------------------------------------------------------------===//
+
+def decomposeConvT1dIntoPhasedConvs: NativeCodeCall<
+  "onnx_mlir::decomposeConvT1dIntoPhasedConvs($_builder, $_loc, $0.getDefiningOp<ONNXConvTransposeOp>(), $0,$1, $2, $3, $4, $5, $6, $7, $8, $9)">;
+
+def ShouldDecomposeConvTransposeOp1dToPhasedConvs: Constraint<
+  CPred<"onnx_mlir::ShouldDecomposeConvTransposeOp1dToPhasedConvs($_self, $0, $1, $2, $3)">,
+  "X and W have static spatial dims, few more specific conditions and ConvTransposeOp phased conv decomposition is enabled"  
+>;
+
+def ConvTranspose1dOpAsConv1dWithLReluPattern1: Pattern<
+   (ONNXLeakyReluOp (ONNXConvTransposeOp:$res $x, $w, $b,
+      $auto_pad, $dilation, IntOne:$group, $kernel_shape,
+      $output_padding, $output_shape, $pads, $strides), $alpha),
+   [
+    (reverseWeightConvTranspose:$reversed_w $w),
+    (decomposeConvT1dIntoPhasedConvs:$output $res, $x, $reversed_w, $b, $dilation, $group, $kernel_shape, $pads, $strides, $alpha)
+   ],
+   [(HasRankAndShape:$res), (hasDefaultDilation:$res $dilation),(ShouldDecomposeConvTransposeOp1dToPhasedConvs:$res $kernel_shape,$pads,$strides,$output_shape)], [],
+   (addBenefit 2)
+>;
+
+def ConvTranspose1dOpAsConv1dWithReluPattern1: Pattern<
+   (ONNXReluOp (ONNXConvTransposeOp:$res $x, $w, $b,
+      $auto_pad, $dilation, IntOne:$group, $kernel_shape,
+      $output_padding, $output_shape, $pads, $strides)),
+   [
+    (reverseWeightConvTranspose:$reversed_w $w),
+    (decomposeConvT1dIntoPhasedConvs:$output $res, $x, $reversed_w, $b, $dilation, $group, $kernel_shape, $pads, $strides, (GetZeroFloatAttr))
+   ],
+   [(HasRankAndShape:$res), (hasDefaultDilation:$res $dilation),(ShouldDecomposeConvTransposeOp1dToPhasedConvs:$res $kernel_shape,$pads,$strides,$output_shape)], [],
+   (addBenefit 2)
+>;
+
+def ConvTranspose1dOpAsConv1dPattern1: Pattern<
+   (ONNXConvTransposeOp:$res $x, $w, $b,
+      $auto_pad, $dilation, IntOne:$group, $kernel_shape,
+      $output_padding, $output_shape, $pads, $strides),
+   [
+    (reverseWeightConvTranspose:$reversed_w $w),
+    (decomposeConvT1dIntoPhasedConvs:$output $res, $x, $reversed_w, $b, $dilation, $group, $kernel_shape, $pads, $strides,  (GetNullFloatAttr))
+   ],
+   [(HasRankAndShape:$res), (hasDefaultDilation:$res $dilation),(hasNoActivationConsumer:$res),(ShouldDecomposeConvTransposeOp1dToPhasedConvs:$res $kernel_shape,$pads,$strides,$output_shape)], [],
+   (addBenefit 1)
+>;
+#endif // ONNX_DECOMPOSE_CONVTRANSPOSE_1D_PHASED

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -104,17 +104,27 @@ struct ONNXHybridTransformPass
                      "phased Conv"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableConvTranspose1dDecomposeToPhasedConv{*this,
+      "enable-convtranspose-1d-phased",
+      llvm::cl::desc(
+          "Enable decomposition of ONNX ConvTranspose 1D operator to "
+          "phased Conv"),
+      ::llvm::cl::init(false)};
+
   FrozenRewritePatternSet patterns;
 
   ONNXHybridTransformPass(bool enableRecomposition,
       bool enableQuarkQuantizedOpsLegalization,
       bool enableConvTransposeDecompose,
-      bool enableConvTransposeDecomposeToPhasedConv) {
+      bool enableConvTransposeDecomposeToPhasedConv,
+      bool enableConvTranspose1dDecomposeToPhasedConv) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
     this->enableConvTransposeDecomposeToPhasedConv =
         enableConvTransposeDecomposeToPhasedConv;
+    this->enableConvTranspose1dDecomposeToPhasedConv =
+        enableConvTranspose1dDecomposeToPhasedConv;
   }
 
   ONNXHybridTransformPass(const ONNXHybridTransformPass &pass)
@@ -156,7 +166,8 @@ struct ONNXHybridTransformPass
     if (decomposition) {
       getDecomposeONNXToONNXPatterns(cumulativePatterns,
           enableConvTransposeDecompose,
-          enableConvTransposeDecomposeToPhasedConv);
+          enableConvTransposeDecomposeToPhasedConv,
+          enableConvTranspose1dDecomposeToPhasedConv);
     }
 
     if (recomposition) {
@@ -198,8 +209,10 @@ struct ONNXHybridTransformPass
 std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableRecomposition, bool enableQuarkQuantizedOpsLegalization,
     bool enableConvTransposeDecompose,
-    bool enableConvTransposeDecomposeToPhasedConv) {
+    bool enableConvTransposeDecomposeToPhasedConv,
+    bool enableConvTranspose1dDecomposeToPhasedConv) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
-      enableConvTransposeDecomposeToPhasedConv);
+      enableConvTransposeDecomposeToPhasedConv,
+      enableConvTranspose1dDecomposeToPhasedConv);
 }

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -39,7 +39,8 @@ std::unique_ptr<mlir::Pass> createONNXOpTransformPass(int threshold,
 /// Pass for rewriting inside frontend dialect.
 std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
     const std::string &target = "", bool enableConvTransposeDecompose = false,
-    bool enableConvTransposeDecomposeToPhasedConv = false);
+    bool enableConvTransposeDecomposeToPhasedConv = false,
+    bool enableConvTranspose1dDecomposeToPhasedConv = false);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "");
 
@@ -78,7 +79,7 @@ std::unique_ptr<mlir::Pass> createStandardFuncReturnPass();
 std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableRecomposition, bool enableQuarkQuantizedOpsLegalization = false,
     bool enableConvTransposeDecompose = false,
-    bool enableConvTransposeDecomposeToPhasedConv = false);
+    bool enableConvTransposeDecomposeToPhasedConv = false, bool enableConvTranspose1dDecomposeToPhasedConv = false);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -79,7 +79,8 @@ std::unique_ptr<mlir::Pass> createStandardFuncReturnPass();
 std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableRecomposition, bool enableQuarkQuantizedOpsLegalization = false,
     bool enableConvTransposeDecompose = false,
-    bool enableConvTransposeDecomposeToPhasedConv = false, bool enableConvTranspose1dDecomposeToPhasedConv = false);
+    bool enableConvTransposeDecomposeToPhasedConv = false,
+    bool enableConvTranspose1dDecomposeToPhasedConv = false);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/test/mlir/onnx/onnx_decompose_convtranspose1d_phased_conv.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose1d_phased_conv.mlir
@@ -6,9 +6,36 @@ func.func @test_convtrans_stride_2_kernel_shape_4(%arg0: tensor<1x64x200xf32>, %
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {dilations = [1], group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x200xf32>, tensor<64x24x4xf32>, tensor<24xf32>) -> tensor<1x24x400xf32>
   onnx.Return %1 : tensor<1x24x400xf32>
 }
-// CHECK-LABEL:   test_convtrans_stride_2_kernel_shape_4
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Conv
+// CHECK-LABEL:   func.func @test_convtrans_stride_2_kernel_shape_4(
+// CHECK-SAME:                                                      %[[VAL_0:.*]]: tensor<1x64x200xf32>,
+// CHECK-SAME:                                                      %[[VAL_1:.*]]: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 400]> : tensor<3xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<5> : tensor<1xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<4> : tensor<64xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK:           %[[VAL_13:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
+// CHECK:           %[[VAL_14:.*]] = "onnx.ReverseSequence"(%[[VAL_13]], %[[VAL_11]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
+// CHECK:           %[[VAL_15:.*]] = "onnx.Transpose"(%[[VAL_14]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
+// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_15]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_9]], %[[VAL_8]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_7]], %[[VAL_6]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_18]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_17]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_19]], %[[VAL_7]], %[[VAL_5]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_4]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Reshape"(%[[VAL_21]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Reshape"(%[[VAL_22]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_23]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x2xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x2xf32>, tensor<3xi64>) -> tensor<1x24x400xf32>
+// CHECK:           onnx.Return %[[VAL_26]] : tensor<1x24x400xf32>
+// CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_2_kernel_shape_4
 // DISABLED: onnx.ConvTranspose
 
@@ -19,9 +46,36 @@ func.func @test_convtrans_stride_2_kernel_shape_4_b(%arg0: tensor<1x64x400xf32>,
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {dilations = [1], group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x400xf32>, tensor<64x24x4xf32>, tensor<24xf32>) -> tensor<1x24x800xf32>
   onnx.Return %1 : tensor<1x24x800xf32>
 }
-// CHECK-LABEL:   test_convtrans_stride_2_kernel_shape_4_b
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Conv
+// CHECK-LABEL:   func.func @test_convtrans_stride_2_kernel_shape_4_b(
+// CHECK-SAME:                                                        %[[VAL_0:.*]]: tensor<1x64x400xf32>,
+// CHECK-SAME:                                                        %[[VAL_1:.*]]: tensor<64x24x4xf32>) -> tensor<1x24x800xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 400, 1]> : tensor<4xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<400> : tensor<1xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<401> : tensor<1xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<5> : tensor<1xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<4> : tensor<64xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK:           %[[VAL_13:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
+// CHECK:           %[[VAL_14:.*]] = "onnx.ReverseSequence"(%[[VAL_13]], %[[VAL_11]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
+// CHECK:           %[[VAL_15:.*]] = "onnx.Transpose"(%[[VAL_14]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
+// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_15]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_9]], %[[VAL_8]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_7]], %[[VAL_6]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_18]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x400xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x401xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_17]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x400xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x401xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_19]], %[[VAL_7]], %[[VAL_5]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x401xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x400xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_4]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x401xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x400xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Reshape"(%[[VAL_21]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x400xf32>, tensor<4xi64>) -> tensor<1x24x400x1xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Reshape"(%[[VAL_22]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x400xf32>, tensor<4xi64>) -> tensor<1x24x400x1xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_23]]) {axis = -1 : si64} : (tensor<1x24x400x1xf32>, tensor<1x24x400x1xf32>) -> tensor<1x24x400x2xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x400x2xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
+// CHECK:           onnx.Return %[[VAL_26]] : tensor<1x24x800xf32>
+// CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_2_kernel_shape_4_b
 // DISABLED: onnx.ConvTranspose
 
@@ -44,9 +98,36 @@ func.func @test_convtrans_stride_2_kernel_shape_4_nobias(%arg0: tensor<1x64x200x
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x200xf32>, tensor<64x24x4xf32>, none) -> tensor<1x24x400xf32>
   onnx.Return %1 : tensor<1x24x400xf32>
 }
-// CHECK-LABEL:   test_convtrans_stride_2_kernel_shape_4_nobias
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Conv
+// CHECK-LABEL:   func.func @test_convtrans_stride_2_kernel_shape_4_nobias(
+// CHECK-SAME:                                                             %[[VAL_0:.*]]: tensor<1x64x200xf32>,
+// CHECK-SAME:                                                             %[[VAL_1:.*]]: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 400]> : tensor<3xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<5> : tensor<1xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<4> : tensor<64xi64>
+// CHECK:           %[[VAL_12:.*]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           %[[VAL_13:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
+// CHECK:           %[[VAL_14:.*]] = "onnx.ReverseSequence"(%[[VAL_13]], %[[VAL_11]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
+// CHECK:           %[[VAL_15:.*]] = "onnx.Transpose"(%[[VAL_14]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
+// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_15]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_9]], %[[VAL_8]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_7]], %[[VAL_6]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_18]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, none) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_17]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, none) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_19]], %[[VAL_7]], %[[VAL_5]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_4]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Reshape"(%[[VAL_21]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Reshape"(%[[VAL_22]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_23]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x2xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x2xf32>, tensor<3xi64>) -> tensor<1x24x400xf32>
+// CHECK:           onnx.Return %[[VAL_26]] : tensor<1x24x400xf32>
+// CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_2_kernel_shape_4_nobias
 // DISABLED: onnx.ConvTranspose
 // -----
@@ -56,11 +137,48 @@ func.func @test_convtrans_stride_4(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [8],  pads = [2,2], strides = [4]} : (tensor<1x64x200xf32>, tensor<64x24x8xf32>, tensor<24xf32>) -> tensor<1x24x800xf32>
   onnx.Return %1 : tensor<1x24x800xf32>
 }
-// CHECK-LABEL:   test_convtrans_stride_4
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Conv
+// CHECK-LABEL:   func.func @test_convtrans_stride_4(
+// CHECK-SAME:                                       %[[VAL_0:.*]]: tensor<1x64x200xf32>,
+// CHECK-SAME:                                       %[[VAL_1:.*]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<11> : tensor<1xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<10> : tensor<1xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<9> : tensor<1xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<8> : tensor<1xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<8> : tensor<64xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_14]], %[[VAL_8]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_26]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_27]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Reshape"(%[[VAL_29]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Reshape"(%[[VAL_30]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Reshape"(%[[VAL_32]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Concat"(%[[VAL_33]], %[[VAL_34]], %[[VAL_35]], %[[VAL_36]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_37]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
+// CHECK:           onnx.Return %[[VAL_38]] : tensor<1x24x800xf32>
+// CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_4
 // DISABLED: onnx.ConvTranspose
 
@@ -71,12 +189,57 @@ func.func @test_convtrans_stride_5(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [10],  pads = [2,2], strides = [5]} : (tensor<1x64x200xf32>, tensor<64x24x10xf32>, tensor<24xf32>) -> tensor<1x24x1001xf32>
   onnx.Return %1 : tensor<1x24x1001xf32>
 }
-// CHECK-LABEL:   test_convtrans_stride_5
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Conv
+// CHECK-LABEL:   func.func @test_convtrans_stride_5(
+// CHECK-SAME:                                       %[[VAL_0:.*]]: tensor<1x64x200xf32>,
+// CHECK-SAME:                                       %[[VAL_1:.*]]: tensor<64x24x10xf32>) -> tensor<1x24x1001xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<1001> : tensor<1xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 1005]> : tensor<3xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 24, 201, 1]> : tensor<4xi64>
+// CHECK:           %[[VAL_5:.*]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<0.000000e+00> : tensor<f32>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[0, 0, 0, 0, 0, 1]> : tensor<6xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<14> : tensor<1xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<13> : tensor<1xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<12> : tensor<1xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<11> : tensor<1xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<10> : tensor<1xi64>
+// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<5> : tensor<1xi64>
+// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<10> : tensor<64xi64>
+// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x10xf32>) -> tensor<10x64x24xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.ReverseSequence"(%[[VAL_22]], %[[VAL_20]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<10x64x24xf32>, tensor<64xi64>) -> tensor<10x64x24xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Transpose"(%[[VAL_23]]) {perm = [1, 2, 0]} : (tensor<10x64x24xf32>) -> tensor<64x24x10xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Transpose"(%[[VAL_24]]) {perm = [1, 0, 2]} : (tensor<64x24x10xf32>) -> tensor<24x64x10xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_17]], %[[VAL_16]], %[[VAL_19]], %[[VAL_18]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_15]], %[[VAL_14]], %[[VAL_19]], %[[VAL_18]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_19]], %[[VAL_13]], %[[VAL_19]], %[[VAL_18]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_12]], %[[VAL_11]], %[[VAL_19]], %[[VAL_18]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_10]], %[[VAL_9]], %[[VAL_19]], %[[VAL_18]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_28]], %[[VAL_21]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_27]], %[[VAL_21]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_26]], %[[VAL_21]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_30]], %[[VAL_21]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_29]], %[[VAL_21]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_34]], %[[VAL_15]], %[[VAL_8]], %[[VAL_19]], %[[VAL_15]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Slice"(%[[VAL_35]], %[[VAL_15]], %[[VAL_8]], %[[VAL_19]], %[[VAL_15]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Pad"(%[[VAL_36]], %[[VAL_7]], %[[VAL_6]], %[[VAL_5]]) {mode = "constant"} : (tensor<1x24x200xf32>, tensor<6xi64>, tensor<f32>, none) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Pad"(%[[VAL_37]], %[[VAL_7]], %[[VAL_6]], %[[VAL_5]]) {mode = "constant"} : (tensor<1x24x200xf32>, tensor<6xi64>, tensor<f32>, none) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.Reshape"(%[[VAL_32]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
+// CHECK:           %[[VAL_43:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
+// CHECK:           %[[VAL_44:.*]] = "onnx.Reshape"(%[[VAL_39]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
+// CHECK:           %[[VAL_45:.*]] = "onnx.Concat"(%[[VAL_40]], %[[VAL_41]], %[[VAL_42]], %[[VAL_43]], %[[VAL_44]]) {axis = -1 : si64} : (tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>) -> tensor<1x24x201x5xf32>
+// CHECK:           %[[VAL_46:.*]] = "onnx.Reshape"(%[[VAL_45]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x201x5xf32>, tensor<3xi64>) -> tensor<1x24x1005xf32>
+// CHECK:           %[[VAL_47:.*]] = "onnx.Slice"(%[[VAL_46]], %[[VAL_17]], %[[VAL_2]], %[[VAL_19]], %[[VAL_15]]) : (tensor<1x24x1005xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x1001xf32>
+// CHECK:           onnx.Return %[[VAL_47]] : tensor<1x24x1001xf32>
+// CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_5
 // DISABLED: onnx.ConvTranspose
 
@@ -99,9 +262,36 @@ func.func @test_convtrans_stride_2_nodilation(%arg0: tensor<1x64x200xf32>, %arg1
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x200xf32>, tensor<64x24x4xf32>, tensor<24xf32>) -> tensor<1x24x400xf32>
   onnx.Return %1 : tensor<1x24x400xf32>
 }
-// CHECK-LABEL:   test_convtrans_stride_2_nodilation
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Conv
+// CHECK-LABEL:   func.func @test_convtrans_stride_2_nodilation(
+// CHECK-SAME:                                                  %[[VAL_0:.*]]: tensor<1x64x200xf32>,
+// CHECK-SAME:                                                  %[[VAL_1:.*]]: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 400]> : tensor<3xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<5> : tensor<1xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<4> : tensor<64xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK:           %[[VAL_13:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
+// CHECK:           %[[VAL_14:.*]] = "onnx.ReverseSequence"(%[[VAL_13]], %[[VAL_11]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
+// CHECK:           %[[VAL_15:.*]] = "onnx.Transpose"(%[[VAL_14]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
+// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_15]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_9]], %[[VAL_8]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_7]], %[[VAL_6]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_18]], %[[VAL_12]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_17]], %[[VAL_12]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_19]], %[[VAL_7]], %[[VAL_5]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_4]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Reshape"(%[[VAL_21]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Reshape"(%[[VAL_22]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_23]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x2xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x2xf32>, tensor<3xi64>) -> tensor<1x24x400xf32>
+// CHECK:           onnx.Return %[[VAL_26]] : tensor<1x24x400xf32>
+// CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_2_nodilation
 // DISABLED: onnx.ConvTranspose
 
@@ -113,15 +303,52 @@ func.func @test_convtrans_stride_4_lrelu(%arg0: tensor<1x64x200xf32>, %arg1: ten
   %2 = "onnx.LeakyRelu"(%1) {alpha = 1.000000e-01 : f32} : (tensor<1x24x800xf32>) -> tensor<1x24x800xf32> 
   onnx.Return %2 : tensor<1x24x800xf32>
 }
-// CHECK-LABEL:   test_convtrans_stride_4_lrelu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.LeakyRelu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.LeakyRelu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.LeakyRelu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.LeakyRelu
+// CHECK-LABEL:   func.func @test_convtrans_stride_4_lrelu(
+// CHECK-SAME:                                             %[[VAL_0:.*]]: tensor<1x64x200xf32>,
+// CHECK-SAME:                                             %[[VAL_1:.*]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<11> : tensor<1xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<10> : tensor<1xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<9> : tensor<1xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<8> : tensor<1xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<8> : tensor<64xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_14]], %[[VAL_8]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.LeakyRelu"(%[[VAL_25]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.LeakyRelu"(%[[VAL_27]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.LeakyRelu"(%[[VAL_29]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.LeakyRelu"(%[[VAL_31]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_26]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_32]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_34]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Reshape"(%[[VAL_35]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_36]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.Concat"(%[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
+// CHECK:           onnx.Return %[[VAL_42]] : tensor<1x24x800xf32>
+// CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_4_lrelu
 // DISABLED: onnx.ConvTranspose
 
@@ -133,15 +360,52 @@ func.func @test_convtrans_stride_4_relu(%arg0: tensor<1x64x200xf32>, %arg1: tens
   %2 = "onnx.Relu"(%1) : (tensor<1x24x800xf32>) -> tensor<1x24x800xf32> 
   onnx.Return %2 : tensor<1x24x800xf32>
 }
-// CHECK-LABEL:   test_convtrans_stride_4_relu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Relu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Relu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Relu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.Relu
+// CHECK-LABEL:   func.func @test_convtrans_stride_4_relu(
+// CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<1x64x200xf32>,
+// CHECK-SAME:                                            %[[VAL_1:.*]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<11> : tensor<1xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<10> : tensor<1xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<9> : tensor<1xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<8> : tensor<1xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<8> : tensor<64xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_14]], %[[VAL_8]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.Relu"(%[[VAL_25]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Relu"(%[[VAL_27]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Relu"(%[[VAL_29]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Relu"(%[[VAL_31]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_26]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_32]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_34]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Reshape"(%[[VAL_35]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_36]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.Concat"(%[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
+// CHECK:           onnx.Return %[[VAL_42]] : tensor<1x24x800xf32>
+// CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_4_relu
 // DISABLED: onnx.ConvTranspose
 
@@ -153,14 +417,51 @@ func.func @test_convtrans_stride_4_lrelu_default_value(%arg0: tensor<1x64x200xf3
   %2 = "onnx.LeakyRelu"(%1) : (tensor<1x24x800xf32>) -> tensor<1x24x800xf32> 
   onnx.Return %2 : tensor<1x24x800xf32>
 }
-// CHECK-LABEL:   test_convtrans_stride_4_lrelu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.LeakyRelu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.LeakyRelu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.LeakyRelu
-// CHECK:           onnx.Conv
-// CHECK:           onnx.LeakyRelu
+// CHECK-LABEL:   func.func @test_convtrans_stride_4_lrelu_default_value(
+// CHECK-SAME:                                                           %[[VAL_0:.*]]: tensor<1x64x200xf32>,
+// CHECK-SAME:                                                           %[[VAL_1:.*]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<11> : tensor<1xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<10> : tensor<1xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<9> : tensor<1xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<8> : tensor<1xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<8> : tensor<64xi64>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
+// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
+// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
+// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
+// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_14]], %[[VAL_8]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_26:.*]] = "onnx.LeakyRelu"(%[[VAL_25]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_28:.*]] = "onnx.LeakyRelu"(%[[VAL_27]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_30:.*]] = "onnx.LeakyRelu"(%[[VAL_29]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_32:.*]] = "onnx.LeakyRelu"(%[[VAL_31]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_26]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_34:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_32]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_34]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.Reshape"(%[[VAL_35]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_36]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.Concat"(%[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
+// CHECK:           onnx.Return %[[VAL_42]] : tensor<1x24x800xf32>
+// CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_4_lrelu
 // DISABLED: onnx.ConvTranspose

--- a/test/mlir/onnx/onnx_decompose_convtranspose1d_phased_conv.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose1d_phased_conv.mlir
@@ -1,0 +1,166 @@
+// RUN: onnx-mlir-opt --shape-inference --decompose-onnx=enable-convtranspose-1d-phased %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --decompose-onnx %s -split-input-file | FileCheck %s --check-prefix=DISABLED
+
+func.func @test_convtrans_stride_2_kernel_shape_4(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<24xf32>} : ()-> tensor<24xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {dilations = [1], group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x200xf32>, tensor<64x24x4xf32>, tensor<24xf32>) -> tensor<1x24x400xf32>
+  onnx.Return %1 : tensor<1x24x400xf32>
+}
+// CHECK-LABEL:   test_convtrans_stride_2_kernel_shape_4
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Conv
+// DISABLED-LABEL: test_convtrans_stride_2_kernel_shape_4
+// DISABLED: onnx.ConvTranspose
+
+// -----
+
+func.func @test_convtrans_stride_2_kernel_shape_4_b(%arg0: tensor<1x64x400xf32>, %arg1: tensor<64x24x4xf32>) -> tensor<1x24x800xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<24xf32>} : ()-> tensor<24xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {dilations = [1], group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x400xf32>, tensor<64x24x4xf32>, tensor<24xf32>) -> tensor<1x24x800xf32>
+  onnx.Return %1 : tensor<1x24x800xf32>
+}
+// CHECK-LABEL:   test_convtrans_stride_2_kernel_shape_4_b
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Conv
+// DISABLED-LABEL: test_convtrans_stride_2_kernel_shape_4_b
+// DISABLED: onnx.ConvTranspose
+
+// -----
+
+func.func @test_convtrans_stride_2_kernel_shape_8_unsupported(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64x24x8xf32>) -> tensor<1x24x404xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<24xf32>} : ()-> tensor<24xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {dilations = [1], group = 1 : si64, kernel_shape = [8],  pads = [1,1], strides = [2]} : (tensor<1x64x200xf32>, tensor<64x24x8xf32>, tensor<24xf32>) -> tensor<1x24x404xf32>
+  onnx.Return %1 : tensor<1x24x404xf32>
+}
+// CHECK-LABEL:   test_convtrans_stride_2_kernel_shape_8_unsupported
+// CHECK:           onnx.ConvTranspose
+// DISABLED-LABEL: test_convtrans_stride_2_kernel_shape_8_unsupported
+// DISABLED: onnx.ConvTranspose
+
+// -----
+
+func.func @test_convtrans_stride_2_kernel_shape_4_nobias(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {      
+  %0 = "onnx.NoValue"() { value} : () -> none
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x200xf32>, tensor<64x24x4xf32>, none) -> tensor<1x24x400xf32>
+  onnx.Return %1 : tensor<1x24x400xf32>
+}
+// CHECK-LABEL:   test_convtrans_stride_2_kernel_shape_4_nobias
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Conv
+// DISABLED-LABEL: test_convtrans_stride_2_kernel_shape_4_nobias
+// DISABLED: onnx.ConvTranspose
+// -----
+
+func.func @test_convtrans_stride_4(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<24xf32>} : ()-> tensor<24xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [8],  pads = [2,2], strides = [4]} : (tensor<1x64x200xf32>, tensor<64x24x8xf32>, tensor<24xf32>) -> tensor<1x24x800xf32>
+  onnx.Return %1 : tensor<1x24x800xf32>
+}
+// CHECK-LABEL:   test_convtrans_stride_4
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Conv
+// DISABLED-LABEL: test_convtrans_stride_4
+// DISABLED: onnx.ConvTranspose
+
+// -----
+
+func.func @test_convtrans_stride_5(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64x24x10xf32>) -> tensor<1x24x1001xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<24xf32>} : ()-> tensor<24xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [10],  pads = [2,2], strides = [5]} : (tensor<1x64x200xf32>, tensor<64x24x10xf32>, tensor<24xf32>) -> tensor<1x24x1001xf32>
+  onnx.Return %1 : tensor<1x24x1001xf32>
+}
+// CHECK-LABEL:   test_convtrans_stride_5
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Conv
+// DISABLED-LABEL: test_convtrans_stride_5
+// DISABLED: onnx.ConvTranspose
+
+// -----
+
+func.func @test_convtrans_stride_2_dilation2(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64x24x4xf32>) -> tensor<1x24x403xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<24xf32>} : ()-> tensor<24xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {dilations = [2], group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x200xf32>, tensor<64x24x4xf32>, tensor<24xf32>) -> tensor<1x24x403xf32>
+  onnx.Return %1 : tensor<1x24x403xf32>
+}
+// CHECK-LABEL:   test_convtrans_stride_2_dilation2
+// CHECK:           onnx.ConvTranspose
+// DISABLED-LABEL: test_convtrans_stride_2_dilation2
+// DISABLED: onnx.ConvTranspose
+
+// -----
+
+func.func @test_convtrans_stride_2_nodilation(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<24xf32>} : ()-> tensor<24xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x200xf32>, tensor<64x24x4xf32>, tensor<24xf32>) -> tensor<1x24x400xf32>
+  onnx.Return %1 : tensor<1x24x400xf32>
+}
+// CHECK-LABEL:   test_convtrans_stride_2_nodilation
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Conv
+// DISABLED-LABEL: test_convtrans_stride_2_nodilation
+// DISABLED: onnx.ConvTranspose
+
+// -----
+
+func.func @test_convtrans_stride_4_lrelu(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<24xf32>} : ()-> tensor<24xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [8],  pads = [2,2], strides = [4]} : (tensor<1x64x200xf32>, tensor<64x24x8xf32>, tensor<24xf32>) -> tensor<1x24x800xf32>
+  %2 = "onnx.LeakyRelu"(%1) {alpha = 1.000000e-01 : f32} : (tensor<1x24x800xf32>) -> tensor<1x24x800xf32> 
+  onnx.Return %2 : tensor<1x24x800xf32>
+}
+// CHECK-LABEL:   test_convtrans_stride_4_lrelu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.LeakyRelu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.LeakyRelu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.LeakyRelu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.LeakyRelu
+// DISABLED-LABEL: test_convtrans_stride_4_lrelu
+// DISABLED: onnx.ConvTranspose
+
+// -----
+
+func.func @test_convtrans_stride_4_relu(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<24xf32>} : ()-> tensor<24xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [8],  pads = [2,2], strides = [4]} : (tensor<1x64x200xf32>, tensor<64x24x8xf32>, tensor<24xf32>) -> tensor<1x24x800xf32>
+  %2 = "onnx.Relu"(%1) : (tensor<1x24x800xf32>) -> tensor<1x24x800xf32> 
+  onnx.Return %2 : tensor<1x24x800xf32>
+}
+// CHECK-LABEL:   test_convtrans_stride_4_relu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Relu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Relu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Relu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.Relu
+// DISABLED-LABEL: test_convtrans_stride_4_relu
+// DISABLED: onnx.ConvTranspose
+
+// -----
+
+func.func @test_convtrans_stride_4_lrelu_default_value(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {    
+  %0 = "onnx.Constant" () { value= dense<0.02> : tensor<24xf32>} : ()-> tensor<24xf32>
+  %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [8],  pads = [2,2], strides = [4]} : (tensor<1x64x200xf32>, tensor<64x24x8xf32>, tensor<24xf32>) -> tensor<1x24x800xf32>
+  %2 = "onnx.LeakyRelu"(%1) : (tensor<1x24x800xf32>) -> tensor<1x24x800xf32> 
+  onnx.Return %2 : tensor<1x24x800xf32>
+}
+// CHECK-LABEL:   test_convtrans_stride_4_lrelu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.LeakyRelu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.LeakyRelu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.LeakyRelu
+// CHECK:           onnx.Conv
+// CHECK:           onnx.LeakyRelu
+// DISABLED-LABEL: test_convtrans_stride_4_lrelu
+// DISABLED: onnx.ConvTranspose


### PR DESCRIPTION
This decomposition currently do not support all possible convtranspose operations. 
Below are the supported usecases.
1) stride[2], pads [1,1], kernel 4,  where convtranspose will decompose to two conv operation. with each conv having kernel divided by 2. 
2) stride [4], pads [2,2], kernel 8,  where it will decompose into 4 conv operations each conv with one fourth of the convtranspose kernel size.
3) stride [5], pads [2,2], kernel 10 where it will decompose into 5 conv operations each conv with one fifth of the convtranspose kernel size.

**Currently, because of the time constraint, we have the kernel shape restriction, in future we will try to generalize to support more kernel shapes.** 
