### PR TITLE
LLVM Bump to c27444ab4976dd9ff131212f87463f9945ab28d7

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -15,7 +15,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 776b07b472a12db1a451fb4bfc737e05c0ee0b1c && cd ..
+cd llvm-project && git checkout c27444ab4976dd9ff131212f87463f9945ab28d7 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -52,7 +52,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 776b07b472a12db1a451fb4bfc737e05c0ee0b1c && cd ..
+cd llvm-project && git checkout c27444ab4976dd9ff131212f87463f9945ab28d7 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/src/Conversion/KrnlToLLVM/KrnlVectorTypeCast.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlVectorTypeCast.cpp
@@ -62,7 +62,7 @@ public:
 
     // Get memRefDescriptor, the new memref descriptor.
     MemRefDescriptor memRefDescriptor =
-        MemRefDescriptor::undef(rewriter, loc, targetStructType);
+        MemRefDescriptor::poison(rewriter, loc, targetStructType);
     auto targetElementPtrType = memRefDescriptor.getElementPtrType();
 
     // Set the new memref to the same buffer as the source memref.

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -15,6 +15,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 
+#include "mlir/Dialect/Tosa/Utils/ConversionUtils.h"
 #include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
@@ -177,14 +178,16 @@ Value TosaBuilder::transpose(Value &value, llvm::ArrayRef<int32_t> perm) {
 
 Value TosaBuilder::slice(Value &inputConst, llvm::ArrayRef<int64_t> size,
     llvm::ArrayRef<int64_t> start) {
-  DenseI64ArrayAttr sizeAttr = rewriter().getDenseI64ArrayAttr(size);
-  DenseI64ArrayAttr startAttr = rewriter().getDenseI64ArrayAttr(start);
+  auto startVal =
+      mlir::tosa::getTosaConstShape(rewriter(), loc(), llvm::to_vector(start));
+  auto sizeVal =
+      mlir::tosa::getTosaConstShape(rewriter(), loc(), llvm::to_vector(size));
   Value newSliceInput =
       tosa::CreateOpAndInfer<mlir::tosa::SliceOp>(rewriter(), loc(),
           RankedTensorType::get(
               llvm::SmallVector<int64_t, 4>(size.size(), ShapedType::kDynamic),
               mlir::cast<ShapedType>(inputConst.getType()).getElementType()),
-          inputConst, startAttr, sizeAttr);
+          inputConst, startVal, sizeVal);
   return newSliceInput;
 }
 
@@ -200,11 +203,12 @@ Value TosaBuilder::reshape(Value value, llvm::ArrayRef<int64_t> shape) {
   Type newValueType = RankedTensorType::get(
       llvm::SmallVector<int64_t, 4>(shape.size(), ShapedType::kDynamic),
       valueType.getElementType());
-  return tosa::CreateOpAndInfer<mlir::tosa::ReshapeOp>(
-      rewriter(), loc(), newValueType, value, shapeAttr);
+  return tosa::CreateOpAndInfer<mlir::tosa::ReshapeOp>(rewriter(), loc(),
+      newValueType, value,
+      mlir::tosa::getTosaConstShape(rewriter(), loc(), shapeAttr));
 }
 
-Value TosaBuilder::mul(Value &lhs, Value &rhs, int32_t shift) {
+Value TosaBuilder::mul(Value &lhs, Value &rhs, int8_t shift) {
   if (needsRankBroadcast({lhs, rhs})) {
     llvm::SmallVector<Value, 4> valueVec = equalizeRanks({lhs, rhs});
     lhs = valueVec[0];
@@ -217,8 +221,12 @@ Value TosaBuilder::mul(Value &lhs, Value &rhs, int32_t shift) {
           : RankedTensorType::get(llvm::SmallVector<int64_t, 4>(
                                       lhsType.getRank(), ShapedType::kDynamic),
                 lhsType.getElementType());
+
+  auto int8Type = rewriter().getI8Type();
+  auto shiftValue =
+      TosaBuilder::createConst(ArrayRef<int8_t>{shift}, {1}, int8Type);
   return tosa::CreateOpAndInfer<mlir::tosa::MulOp>(
-      rewriter(), loc(), newValueType, lhs, rhs, shift);
+      rewriter(), loc(), newValueType, lhs, rhs, shiftValue);
 }
 
 Value TosaBuilder::intdiv(Value &lhs, Value &rhs) {

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -209,6 +209,13 @@ Value TosaBuilder::reshape(Value value, llvm::ArrayRef<int64_t> shape) {
 }
 
 Value TosaBuilder::mul(Value &lhs, Value &rhs, int8_t shift) {
+  auto int8Type = rewriter().getI8Type();
+  auto shiftValue =
+      TosaBuilder::createConst(ArrayRef<int8_t>{shift}, {1}, int8Type);
+  return TosaBuilder::mul(lhs, rhs, shiftValue);
+}
+
+Value TosaBuilder::mul(Value &lhs, Value &rhs, Value shift) {
   if (needsRankBroadcast({lhs, rhs})) {
     llvm::SmallVector<Value, 4> valueVec = equalizeRanks({lhs, rhs});
     lhs = valueVec[0];
@@ -222,11 +229,8 @@ Value TosaBuilder::mul(Value &lhs, Value &rhs, int8_t shift) {
                                       lhsType.getRank(), ShapedType::kDynamic),
                 lhsType.getElementType());
 
-  auto int8Type = rewriter().getI8Type();
-  auto shiftValue =
-      TosaBuilder::createConst(ArrayRef<int8_t>{shift}, {1}, int8Type);
   return tosa::CreateOpAndInfer<mlir::tosa::MulOp>(
-      rewriter(), loc(), newValueType, lhs, rhs, shiftValue);
+      rewriter(), loc(), newValueType, lhs, rhs, shift);
 }
 
 Value TosaBuilder::intdiv(Value &lhs, Value &rhs) {

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -44,6 +44,7 @@ struct TosaBuilder : DialectBuilder {
   template <typename T>
   mlir::Value binaryOp(mlir::Value &lhs, mlir::Value &rhs);
   mlir::Value mul(mlir::Value &lhs, mlir::Value &rhs, int8_t shift = 0);
+  mlir::Value mul(mlir::Value &lhs, mlir::Value &rhs, mlir::Value shift);
   mlir::Value intdiv(mlir::Value &lhs, mlir::Value &rhs);
 
   mlir::Value transpose(mlir::Value &value, llvm::ArrayRef<int32_t> perm);

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -43,7 +43,7 @@ struct TosaBuilder : DialectBuilder {
       int32_t axis);
   template <typename T>
   mlir::Value binaryOp(mlir::Value &lhs, mlir::Value &rhs);
-  mlir::Value mul(mlir::Value &lhs, mlir::Value &rhs, int32_t shift = 0);
+  mlir::Value mul(mlir::Value &lhs, mlir::Value &rhs, int8_t shift = 0);
   mlir::Value intdiv(mlir::Value &lhs, mlir::Value &rhs);
 
   mlir::Value transpose(mlir::Value &value, llvm::ArrayRef<int32_t> perm);

--- a/src/Conversion/ONNXToTOSA/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Gemm.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/Dialect/Tosa/Utils/ConversionUtils.h"
 #include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
@@ -71,13 +72,14 @@ public:
 
     llvm::SmallVector<int64_t> dynamicTensorShape = {
         ShapedType::kDynamic, ShapedType::kDynamic, ShapedType::kDynamic};
+
     A = tosa::CreateOpAndInfer<mlir::tosa::ReshapeOp>(rewriter, op->getLoc(),
         RankedTensorType::get(dynamicTensorShape, AType.getElementType()), A,
-        rewriter.getDenseI64ArrayAttr(newShapeA))
+        mlir::tosa::getTosaConstShape(rewriter, op.getLoc(), newShapeA))
             .getResult();
     B = tosa::CreateOpAndInfer<mlir::tosa::ReshapeOp>(rewriter, op->getLoc(),
         RankedTensorType::get(dynamicTensorShape, BType.getElementType()), B,
-        rewriter.getDenseI64ArrayAttr(newShapeB))
+        mlir::tosa::getTosaConstShape(rewriter, op.getLoc(), newShapeB))
             .getResult();
 
     // If transA or transB are present, create Transpose operators.

--- a/src/Conversion/ONNXToTOSA/NN/DequantizeLinear.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/DequantizeLinear.cpp
@@ -95,9 +95,8 @@ public:
         rewriter, loc, adaptor.getXScale(), axis, resultType.getRank());
     Value scaleFactorCast =
         tosaBuilder.castToNewTensorElementType(scaleFactorConst, arithType);
-    Value mulOp = tosa::CreateOpAndInfer<mlir::tosa::MulOp>(
-        rewriter, loc, casted.getType(), casted, scaleFactorCast, 0)
-                      .getResult();
+
+    Value mulOp = tosaBuilder.mul(casted, scaleFactorCast);
     Value castOp = tosaBuilder.castToNewTensorElementType(
         mulOp, resultType.getElementType());
 

--- a/src/Conversion/ONNXToTOSA/NN/QuantizeLinear.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/QuantizeLinear.cpp
@@ -35,6 +35,7 @@ public:
   LogicalResult matchAndRewrite(ONNXQuantizeLinearOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
+    TosaBuilder tosaBuilder(rewriter, op->getLoc());
     auto resultType = dyn_cast_if_present<ShapedType>(
         getTypeConverter()->convertType(op.getResult().getType()));
     if (!resultType || !resultType.hasStaticShape()) {
@@ -91,9 +92,7 @@ public:
     Value recOp = tosa::CreateOpAndInfer<mlir::tosa::ReciprocalOp>(rewriter,
         loc, expandedScaleFactorConst.getType(), expandedScaleFactorConst)
                       .getResult();
-    Value scaledResult = tosa::CreateOpAndInfer<mlir::tosa::MulOp>(
-        rewriter, loc, xType, x, recOp, 0)
-                             .getResult();
+    Value scaledResult = tosaBuilder.mul(x, recOp);
 
     // Quantization to i4/i8/16/ is particular since the intermediate result of
     // (x / y_scale) must round to the nearest even. This is particularly

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
@@ -75,7 +75,7 @@ std::optional<mlir::Value> convertReduceOpCommon(mlir::PatternRewriter &rewriter
     if (!keepDims) {
       auto reshapeOp =
           CreateOpAndInfer<mlir::tosa::ReshapeOp>(rewriter, op->getLoc(),
-              outputType, val, rewriter.getDenseI64ArrayAttr(outputShape));
+              outputType, val,  mlir::tosa::getTosaConstShape(rewriter, op->getLoc(), outputShape));
       val = reshapeOp.getResult();
     }
   }

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
@@ -139,14 +139,14 @@ mlir::Value expandShape(mlir::PatternRewriter &rewriter, mlir::Location loc,
     llvm::SmallVector<int64_t> newShape;
     return rewriter.createOrFold<mlir::tosa::ReshapeOp>(loc,
         RankedTensorType::get(newShape, inTy.getElementType()), tensor,
-        newShape);
+        mlir::tosa::getTosaConstShape(rewriter, loc, newShape));
   }
   llvm::SmallVector<int64_t> newShape(rank, 1);
   newShape[axis] = inTy.getNumElements();
   auto resultTy = RankedTensorType::get(newShape, inTy.getElementType());
 
-  return rewriter.createOrFold<mlir::tosa::ReshapeOp>(
-      loc, resultTy, tensor, newShape);
+  return rewriter.createOrFold<mlir::tosa::ReshapeOp>(loc, resultTy, tensor,
+      mlir::tosa::getTosaConstShape(rewriter, loc, newShape));
 }
 
 } // namespace tosa

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -4,18 +4,20 @@
 func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x256x256xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<5x2x15x15xf32> {
   %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<5x3x256x256xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) ->  tensor<5x2x15x15xf32>
   return %0 : tensor<5x2x15x15xf32>
-// CHECK-LABEL:   func.func @test_onnx_conv2d_stride_13(
-// CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<5x3x256x256xf32>,
-// CHECK-SAME:                                          %[[VAL_1:.*]]: tensor<2x3x64x64xf32>,
-// CHECK-SAME:                                          %[[VAL_2:.*]]: tensor<2xf32>) -> tensor<5x2x15x15xf32> {
-// CHECK:           %[[VAL_3:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK-DAG:       %[[VAL_4:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_3]] : (tensor<5x3x256x256xf32>, tensor<4xi32>) -> tensor<5x256x256x3xf32>
-// CHECK-DAG:       %[[VAL_5:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_3]] : (tensor<2x3x64x64xf32>, tensor<4xi32>) -> tensor<2x64x64x3xf32>
-// CHECK:           %[[VAL_6:.*]] = tosa.slice %[[VAL_4]] {size = array<i64: 5, 245, 245, 3>, start = array<i64: 0, 0, 0, 0>} : (tensor<5x256x256x3xf32>) -> tensor<5x245x245x3xf32>
-// CHECK-DAG:       %[[VAL_7:.*]] = tosa.conv2d %[[VAL_6]], %[[VAL_5]], %[[VAL_2]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 0, 1, 0>, stride = array<i64: 13, 13>} : (tensor<5x245x245x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x15x15x2xf32>
-// CHECK-DAG:       %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_7]], %[[VAL_8]] : (tensor<5x15x15x2xf32>, tensor<4xi32>) -> tensor<5x2x15x15xf32>
-// CHECK:           return %[[VAL_9]] : tensor<5x2x15x15xf32>
+// CHECK-LABEL:  func.func @test_onnx_conv2d_stride_13
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x256x256xf32>, [[PARAM_1_:%.+]]: tensor<2x3x64x64xf32>, [[PARAM_2_:%.+]]: tensor<2xf32>) -> tensor<5x2x15x15xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<5x3x256x256xf32>, tensor<4xi32>) -> tensor<5x256x256x3xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_0_]] : (tensor<2x3x64x64xf32>, tensor<4xi32>) -> tensor<2x64x64x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[5, 245, 245, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.slice [[VAR_1_]], [[VAR_3_]], [[VAR_4_]] : (tensor<5x256x256x3xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<5x245x245x3xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.conv2d [[VAR_5_]], [[VAR_2_]], [[PARAM_2_]], [[VAR_6_]], [[VAR_6_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 0, 1, 0>, stride = array<i64: 13, 13>} : (tensor<5x245x245x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<5x15x15x2xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_9_:%.+]] = tosa.transpose [[VAR_7_]], [[VAR_8_]] : (tensor<5x15x15x2xf32>, tensor<4xi32>) -> tensor<5x2x15x15xf32>
+// CHECK:           return [[VAR_9_]] : tensor<5x2x15x15xf32>
+// CHECK:         }
 }
 
 // -----
@@ -23,17 +25,18 @@ func.func @test_onnx_conv2d_novalue(%arg0: tensor<5x3x256x256xf32>, %arg1 : tens
   %none = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %none) {pads = [1, 2, 3, 4], dilations = [1, 1]} : (tensor<5x3x256x256xf32>, tensor<2x3x64x64xf32>, none) ->  tensor<5x2x197x199xf32>
   return %0 : tensor<5x2x197x199xf32>
-// CHECK-LABEL:   func.func @test_onnx_conv2d_novalue(
-// CHECK-SAME:                                        %[[VAL_0:.*]]: tensor<5x3x256x256xf32>,
-// CHECK-SAME:                                        %[[VAL_1:.*]]: tensor<2x3x64x64xf32>) -> tensor<5x2x197x199xf32> {
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           %[[VAL_3:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_2]] : (tensor<5x3x256x256xf32>, tensor<4xi32>) -> tensor<5x256x256x3xf32>
-// CHECK:           %[[VAL_4:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_2]] : (tensor<2x3x64x64xf32>, tensor<4xi32>) -> tensor<2x64x64x3xf32>
-// CHECK:           %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<2xf32>}> : () -> tensor<2xf32>
-// CHECK:           %[[VAL_6:.*]] = tosa.conv2d %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 3, 2, 4>, stride = array<i64: 1, 1>} : (tensor<5x256x256x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x197x199x2xf32>
-// CHECK:           %[[VAL_7:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           %[[VAL_8:.*]] = tosa.transpose %[[VAL_6]], %[[VAL_7]] : (tensor<5x197x199x2xf32>, tensor<4xi32>) -> tensor<5x2x197x199xf32>
-// CHECK:           return %[[VAL_8]] : tensor<5x2x197x199xf32>
+// CHECK-LABEL:  func.func @test_onnx_conv2d_novalue
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x256x256xf32>, [[PARAM_1_:%.+]]: tensor<2x3x64x64xf32>) -> tensor<5x2x197x199xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<5x3x256x256xf32>, tensor<4xi32>) -> tensor<5x256x256x3xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_0_]] : (tensor<2x3x64x64xf32>, tensor<4xi32>) -> tensor<2x64x64x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<2xf32>}> : () -> tensor<2xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.conv2d [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_4_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 3, 2, 4>, stride = array<i64: 1, 1>} : (tensor<5x256x256x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<5x197x199x2xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_7_:%.+]] = tosa.transpose [[VAR_5_]], [[VAR_6_]] : (tensor<5x197x199x2xf32>, tensor<4xi32>) -> tensor<5x2x197x199xf32>
+// CHECK:           return [[VAR_7_]] : tensor<5x2x197x199xf32>
+// CHECK:         }
 }
 
 // -----
@@ -41,18 +44,20 @@ func.func @test_onnx_conv2d_no_dilation_pad(%arg0: tensor<5x3x256x256xf32>, %arg
   %none = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %none) {strides = [13, 13]} : (tensor<5x3x256x256xf32>, tensor<7x3x64x64xf32>, none) ->  tensor<5x7x15x15xf32>
   return %0 :  tensor<5x7x15x15xf32>
-// CHECK-LABEL:   func.func @test_onnx_conv2d_no_dilation_pad(
-// CHECK-SAME:                                                %[[VAL_0:.*]]: tensor<5x3x256x256xf32>,
-// CHECK-SAME:                                                %[[VAL_1:.*]]: tensor<7x3x64x64xf32>) -> tensor<5x7x15x15xf32> {
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK-DAG:       %[[VAL_3:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_2]] : (tensor<5x3x256x256xf32>, tensor<4xi32>) -> tensor<5x256x256x3xf32>
-// CHECK-DAG:       %[[VAL_4:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_2]] : (tensor<7x3x64x64xf32>, tensor<4xi32>) -> tensor<7x64x64x3xf32>
-// CHECK-DAG:       %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<7xf32>}> : () -> tensor<7xf32>
-// CHECK:           %[[VAL_6:.*]] = tosa.slice %[[VAL_3]] {size = array<i64: 5, 246, 246, 3>, start = array<i64: 0, 0, 0, 0>} : (tensor<5x256x256x3xf32>) -> tensor<5x246x246x3xf32>
-// CHECK:           %[[VAL_7:.*]] = tosa.conv2d %[[VAL_6]], %[[VAL_4]], %[[VAL_5]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 13, 13>} : (tensor<5x246x246x3xf32>, tensor<7x64x64x3xf32>, tensor<7xf32>) -> tensor<5x15x15x7xf32>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_7]], %[[VAL_8]] : (tensor<5x15x15x7xf32>, tensor<4xi32>) -> tensor<5x7x15x15xf32>
-// CHECK:           return %[[VAL_9]] : tensor<5x7x15x15xf32>
+// CHECK-LABEL:  func.func @test_onnx_conv2d_no_dilation_pad
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x256x256xf32>, [[PARAM_1_:%.+]]: tensor<7x3x64x64xf32>) -> tensor<5x7x15x15xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<5x3x256x256xf32>, tensor<4xi32>) -> tensor<5x256x256x3xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_0_]] : (tensor<7x3x64x64xf32>, tensor<4xi32>) -> tensor<7x64x64x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<7xf32>}> : () -> tensor<7xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.const_shape  {value = dense<[5, 246, 246, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.slice [[VAR_1_]], [[VAR_4_]], [[VAR_5_]] : (tensor<5x256x256x3xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<5x246x246x3xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.conv2d [[VAR_6_]], [[VAR_2_]], [[VAR_3_]], [[VAR_7_]], [[VAR_7_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 13, 13>} : (tensor<5x246x246x3xf32>, tensor<7x64x64x3xf32>, tensor<7xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<5x15x15x7xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_10_:%.+]] = tosa.transpose [[VAR_8_]], [[VAR_9_]] : (tensor<5x15x15x7xf32>, tensor<4xi32>) -> tensor<5x7x15x15xf32>
+// CHECK:           return [[VAR_10_]] : tensor<5x7x15x15xf32>
 }
 
 // -----
@@ -60,18 +65,20 @@ func.func @test_onnx_conv2d_bf16_no_bias(%arg0: tensor<5x3x256x256xbf16>, %arg1 
   %none = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %none) {strides = [13, 13]} : (tensor<5x3x256x256xbf16>, tensor<7x3x64x64xbf16>, none) ->  tensor<5x7x15x15xbf16>
   return %0 :  tensor<5x7x15x15xbf16>
-// CHECK-LABEL:   func.func @test_onnx_conv2d_bf16_no_bias(
-// CHECK-SAME:                                                %[[VAL_0:.*]]: tensor<5x3x256x256xbf16>,
-// CHECK-SAME:                                                %[[VAL_1:.*]]: tensor<7x3x64x64xbf16>) -> tensor<5x7x15x15xbf16> {
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK-DAG:       %[[VAL_3:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_2]] : (tensor<5x3x256x256xbf16>, tensor<4xi32>) -> tensor<5x256x256x3xbf16>
-// CHECK-DAG:       %[[VAL_4:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_2]] : (tensor<7x3x64x64xbf16>, tensor<4xi32>) -> tensor<7x64x64x3xbf16>
-// CHECK-DAG:       %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<7xbf16>}> : () -> tensor<7xbf16>
-// CHECK:           %[[VAL_6:.*]] = tosa.slice %[[VAL_3]] {size = array<i64: 5, 246, 246, 3>, start = array<i64: 0, 0, 0, 0>} : (tensor<5x256x256x3xbf16>) -> tensor<5x246x246x3xbf16>
-// CHECK:           %[[VAL_7:.*]] = tosa.conv2d %[[VAL_6]], %[[VAL_4]], %[[VAL_5]] {acc_type = f32, dilation  = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 13, 13>} : (tensor<5x246x246x3xbf16>, tensor<7x64x64x3xbf16>, tensor<7xbf16>) -> tensor<5x15x15x7xbf16>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_7]], %[[VAL_8]] : (tensor<5x15x15x7xbf16>, tensor<4xi32>) -> tensor<5x7x15x15xbf16>
-// CHECK:           return %[[VAL_9]] : tensor<5x7x15x15xbf16>
+// CHECK-LABEL:  func.func @test_onnx_conv2d_bf16_no_bias
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x256x256xbf16>, [[PARAM_1_:%.+]]: tensor<7x3x64x64xbf16>) -> tensor<5x7x15x15xbf16> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<5x3x256x256xbf16>, tensor<4xi32>) -> tensor<5x256x256x3xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_0_]] : (tensor<7x3x64x64xbf16>, tensor<4xi32>) -> tensor<7x64x64x3xbf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<7xbf16>}> : () -> tensor<7xbf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.const_shape  {value = dense<[5, 246, 246, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.slice [[VAR_1_]], [[VAR_4_]], [[VAR_5_]] : (tensor<5x256x256x3xbf16>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<5x246x246x3xbf16>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xbf16>}> : () -> tensor<1xbf16>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.conv2d [[VAR_6_]], [[VAR_2_]], [[VAR_3_]], [[VAR_7_]], [[VAR_7_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 13, 13>} : (tensor<5x246x246x3xbf16>, tensor<7x64x64x3xbf16>, tensor<7xbf16>, tensor<1xbf16>, tensor<1xbf16>) -> tensor<5x15x15x7xbf16>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_10_:%.+]] = tosa.transpose [[VAR_8_]], [[VAR_9_]] : (tensor<5x15x15x7xbf16>, tensor<4xi32>) -> tensor<5x7x15x15xbf16>
+// CHECK:           return [[VAR_10_]] : tensor<5x7x15x15xbf16>
 }
 
 // -----
@@ -79,18 +86,20 @@ func.func @test_onnx_conv2d_f16_no_bias(%arg0: tensor<5x3x256x256xf16>, %arg1 : 
   %none = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %none) {strides = [13, 13]} : (tensor<5x3x256x256xf16>, tensor<7x3x64x64xf16>, none) ->  tensor<5x7x15x15xf16>
   return %0 :  tensor<5x7x15x15xf16>
-// CHECK-LABEL:   func.func @test_onnx_conv2d_f16_no_bias(
-// CHECK-SAME:                                                %[[VAL_0:.*]]: tensor<5x3x256x256xf16>,
-// CHECK-SAME:                                                %[[VAL_1:.*]]: tensor<7x3x64x64xf16>) -> tensor<5x7x15x15xf16> {
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK-DAG:       %[[VAL_3:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_2]] : (tensor<5x3x256x256xf16>, tensor<4xi32>) -> tensor<5x256x256x3xf16>
-// CHECK-DAG:       %[[VAL_4:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_2]] : (tensor<7x3x64x64xf16>, tensor<4xi32>) -> tensor<7x64x64x3xf16>
-// CHECK-DAG:       %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<7xf16>}> : () -> tensor<7xf16>
-// CHECK:           %[[VAL_6:.*]] = tosa.slice %[[VAL_3]] {size = array<i64: 5, 246, 246, 3>, start = array<i64: 0, 0, 0, 0>} : (tensor<5x256x256x3xf16>) -> tensor<5x246x246x3xf16>
-// CHECK:           %[[VAL_7:.*]] = tosa.conv2d %[[VAL_6]], %[[VAL_4]], %[[VAL_5]] {acc_type = f32, dilation  = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 13, 13>} : (tensor<5x246x246x3xf16>, tensor<7x64x64x3xf16>, tensor<7xf16>) -> tensor<5x15x15x7xf16>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_7]], %[[VAL_8]] : (tensor<5x15x15x7xf16>, tensor<4xi32>) -> tensor<5x7x15x15xf16>
-// CHECK:           return %[[VAL_9]] : tensor<5x7x15x15xf16>
+// CHECK-LABEL:  func.func @test_onnx_conv2d_f16_no_bias
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x256x256xf16>, [[PARAM_1_:%.+]]: tensor<7x3x64x64xf16>) -> tensor<5x7x15x15xf16> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<5x3x256x256xf16>, tensor<4xi32>) -> tensor<5x256x256x3xf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_0_]] : (tensor<7x3x64x64xf16>, tensor<4xi32>) -> tensor<7x64x64x3xf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<7xf16>}> : () -> tensor<7xf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.const_shape  {value = dense<[5, 246, 246, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.slice [[VAR_1_]], [[VAR_4_]], [[VAR_5_]] : (tensor<5x256x256x3xf16>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<5x246x246x3xf16>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf16>}> : () -> tensor<1xf16>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.conv2d [[VAR_6_]], [[VAR_2_]], [[VAR_3_]], [[VAR_7_]], [[VAR_7_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 13, 13>} : (tensor<5x246x246x3xf16>, tensor<7x64x64x3xf16>, tensor<7xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<5x15x15x7xf16>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_10_:%.+]] = tosa.transpose [[VAR_8_]], [[VAR_9_]] : (tensor<5x15x15x7xf16>, tensor<4xi32>) -> tensor<5x7x15x15xf16>
+// CHECK:           return [[VAR_10_]] : tensor<5x7x15x15xf16>
 }
 
 // -----
@@ -98,71 +107,82 @@ func.func @test_onnx_conv2d_no_dilation_pad_stride(%arg0: tensor<5x3x256x260xf32
   %none = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %none) : (tensor<5x3x256x260xf32>, tensor<2x3x60x64xf32>, none) ->  tensor<5x2x197x197xf32>
   return %0 : tensor<5x2x197x197xf32>
-// CHECK-LABEL:   func.func @test_onnx_conv2d_no_dilation_pad_stride(
-// CHECK-SAME:                                                       %[[VAL_0:.*]]: tensor<5x3x256x260xf32>,
-// CHECK-SAME:                                                       %[[VAL_1:.*]]: tensor<2x3x60x64xf32>) -> tensor<5x2x197x197xf32> {
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           %[[VAL_3:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_2]] : (tensor<5x3x256x260xf32>, tensor<4xi32>) -> tensor<5x256x260x3xf32>
-// CHECK:           %[[VAL_4:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_2]] : (tensor<2x3x60x64xf32>, tensor<4xi32>) -> tensor<2x60x64x3xf32>
-// CHECK:           %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<2xf32>}> : () -> tensor<2xf32>
-// CHECK:           %[[VAL_6:.*]] = tosa.conv2d %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<5x256x260x3xf32>, tensor<2x60x64x3xf32>, tensor<2xf32>) -> tensor<5x197x197x2xf32>
-// CHECK:           %[[VAL_7:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           %[[VAL_8:.*]] = tosa.transpose %[[VAL_6]], %[[VAL_7]] : (tensor<5x197x197x2xf32>, tensor<4xi32>) -> tensor<5x2x197x197xf32>
-// CHECK:           return %[[VAL_8]] : tensor<5x2x197x197xf32>
+// CHECK-LABEL:  func.func @test_onnx_conv2d_no_dilation_pad_stride
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x256x260xf32>, [[PARAM_1_:%.+]]: tensor<2x3x60x64xf32>) -> tensor<5x2x197x197xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<5x3x256x260xf32>, tensor<4xi32>) -> tensor<5x256x260x3xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_0_]] : (tensor<2x3x60x64xf32>, tensor<4xi32>) -> tensor<2x60x64x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<2xf32>}> : () -> tensor<2xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.conv2d [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_4_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<5x256x260x3xf32>, tensor<2x60x64x3xf32>, tensor<2xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<5x197x197x2xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_7_:%.+]] = tosa.transpose [[VAR_5_]], [[VAR_6_]] : (tensor<5x197x197x2xf32>, tensor<4xi32>) -> tensor<5x2x197x197xf32>
+// CHECK:           return [[VAR_7_]] : tensor<5x2x197x197xf32>
+// CHECK:         }
 }
 
 // -----
 func.func @test_onnx_conv2d_group(%arg0: tensor<5x64x256x256xf32>, %arg1 : tensor<12x16x45x45xf32>, %arg2: tensor<12xf32>) ->  tensor<5x12x17x17xf32> {
   %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {pads = [1, 1, 1, 1], strides = [13, 13], group = 4 : si64} : (tensor<5x64x256x256xf32>, tensor<12x16x45x45xf32>, tensor<12xf32>) ->  tensor<5x12x17x17xf32>
   return %0 : tensor<5x12x17x17xf32>
-// CHECK-LABEL:   func.func @test_onnx_conv2d_group(
-// CHECK-SAME:                                      %[[VAL_0:.*]]: tensor<5x64x256x256xf32>,
-// CHECK-SAME:                                      %[[VAL_1:.*]]: tensor<12x16x45x45xf32>,
-// CHECK-SAME:                                      %[[VAL_2:.*]]: tensor<12xf32>) -> tensor<5x12x17x17xf32> {
-// CHECK:           %[[VAL_3:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK-DAG:       %[[VAL_4:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_3]] : (tensor<5x64x256x256xf32>, tensor<4xi32>) -> tensor<5x256x256x64xf32>
-// CHECK-DAG:       %[[VAL_5:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_3]] : (tensor<12x16x45x45xf32>, tensor<4xi32>) -> tensor<12x45x45x16xf32>
-// CHECK:           %[[VAL_6:.*]] = tosa.slice %[[VAL_4]] {size = array<i64: 5, 252, 252, 64>, start = array<i64: 0, 0, 0, 0>} : (tensor<5x256x256x64xf32>) -> tensor<5x252x252x64xf32>
-// CHECK:           %[[VAL_7:.*]] = tosa.slice %[[VAL_6]] {size = array<i64: 5, 252, 252, 16>, start = array<i64: 0, 0, 0, 0>} : (tensor<5x252x252x64xf32>) -> tensor<5x252x252x16xf32>
-// CHECK-DAG:       %[[VAL_8:.*]] = tosa.slice %[[VAL_5]] {size = array<i64: 3, 45, 45, 16>, start = array<i64: 0, 0, 0, 0>} : (tensor<12x45x45x16xf32>) -> tensor<3x45x45x16xf32>
-// CHECK-DAG:       %[[VAL_9:.*]] = tosa.slice %[[VAL_2]] {size = array<i64: 3>, start = array<i64: 0>} : (tensor<12xf32>) -> tensor<3xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       %[[VAL_10:.*]] = tosa.conv2d %[[VAL_7]], %[[VAL_8]], %[[VAL_9]] {acc_type = f32, dilation  = array<i64: 1, 1>, pad = array<i64: 1, 0, 1, 0>, stride = array<i64: 13, 13>} : (tensor<5x252x252x16xf32>, tensor<3x45x45x16xf32>, tensor<3xf32>) -> tensor<5x17x17x3xf32>
-// CHECK-DAG:       %[[VAL_11:.*]] = tosa.slice %[[VAL_6]] {size = array<i64: 5, 252, 252, 16>, start = array<i64: 0, 0, 0, 16>} : (tensor<5x252x252x64xf32>) -> tensor<5x252x252x16xf32>
-// CHECK-DAG:       %[[VAL_12:.*]] = tosa.slice %[[VAL_5]] {size = array<i64: 3, 45, 45, 16>, start = array<i64: 3, 0, 0, 0>} : (tensor<12x45x45x16xf32>) -> tensor<3x45x45x16xf32>
-// CHECK-DAG:       %[[VAL_13:.*]] = tosa.slice %[[VAL_2]] {size = array<i64: 3>, start = array<i64: 3>} : (tensor<12xf32>) -> tensor<3xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       %[[VAL_14:.*]] = tosa.conv2d %[[VAL_11]], %[[VAL_12]], %[[VAL_13]] {acc_type = f32, dilation  = array<i64: 1, 1>, pad = array<i64: 1, 0, 1, 0>, stride = array<i64: 13, 13>} : (tensor<5x252x252x16xf32>, tensor<3x45x45x16xf32>, tensor<3xf32>) -> tensor<5x17x17x3xf32>
-// CHECK-DAG:       %[[VAL_15:.*]] = tosa.slice %[[VAL_6]] {size = array<i64: 5, 252, 252, 16>, start = array<i64: 0, 0, 0, 32>} : (tensor<5x252x252x64xf32>) -> tensor<5x252x252x16xf32>
-// CHECK-DAG:       %[[VAL_16:.*]] = tosa.slice %[[VAL_5]] {size = array<i64: 3, 45, 45, 16>, start = array<i64: 6, 0, 0, 0>} : (tensor<12x45x45x16xf32>) -> tensor<3x45x45x16xf32>
-// CHECK-DAG:       %[[VAL_17:.*]] = tosa.slice %[[VAL_2]] {size = array<i64: 3>, start = array<i64: 6>} : (tensor<12xf32>) -> tensor<3xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       %[[VAL_18:.*]] = tosa.conv2d %[[VAL_15]], %[[VAL_16]], %[[VAL_17]] {acc_type = f32, dilation  = array<i64: 1, 1>, pad = array<i64: 1, 0, 1, 0>, stride = array<i64: 13, 13>} : (tensor<5x252x252x16xf32>, tensor<3x45x45x16xf32>, tensor<3xf32>) -> tensor<5x17x17x3xf32>
-// CHECK-DAG:       %[[VAL_19:.*]] = tosa.slice %[[VAL_6]] {size = array<i64: 5, 252, 252, 16>, start = array<i64: 0, 0, 0, 48>} : (tensor<5x252x252x64xf32>) -> tensor<5x252x252x16xf32>
-// CHECK-DAG:       %[[VAL_20:.*]] = tosa.slice %[[VAL_5]] {size = array<i64: 3, 45, 45, 16>, start = array<i64: 9, 0, 0, 0>} : (tensor<12x45x45x16xf32>) -> tensor<3x45x45x16xf32>
-// CHECK-DAG:       %[[VAL_21:.*]] = tosa.slice %[[VAL_2]] {size = array<i64: 3>, start = array<i64: 9>} : (tensor<12xf32>) -> tensor<3xf32>
-// CHECK:           %[[VAL_22:.*]] = tosa.conv2d %[[VAL_19]], %[[VAL_20]], %[[VAL_21]] {acc_type = f32, dilation  = array<i64: 1, 1>, pad = array<i64: 1, 0, 1, 0>, stride = array<i64: 13, 13>} : (tensor<5x252x252x16xf32>, tensor<3x45x45x16xf32>, tensor<3xf32>) -> tensor<5x17x17x3xf32>
-// CHECK-DAG:       %[[VAL_23:.*]] = tosa.concat %[[VAL_10]], %[[VAL_14]], %[[VAL_18]], %[[VAL_22]] {axis = 3 : i32} : (tensor<5x17x17x3xf32>, tensor<5x17x17x3xf32>, tensor<5x17x17x3xf32>, tensor<5x17x17x3xf32>) -> tensor<5x17x17x12xf32>
-// CHECK-DAG:       %[[VAL_24:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           %[[VAL_25:.*]] = tosa.transpose %[[VAL_23]], %[[VAL_24]] : (tensor<5x17x17x12xf32>, tensor<4xi32>) -> tensor<5x12x17x17xf32>
-// CHECK:           return %[[VAL_25]] : tensor<5x12x17x17xf32>
+// CHECK-LABEL:  func.func @test_onnx_conv2d_group
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x64x256x256xf32>, [[PARAM_1_:%.+]]: tensor<12x16x45x45xf32>, [[PARAM_2_:%.+]]: tensor<12xf32>) -> tensor<5x12x17x17xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<5x64x256x256xf32>, tensor<4xi32>) -> tensor<5x256x256x64xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_0_]] : (tensor<12x16x45x45xf32>, tensor<4xi32>) -> tensor<12x45x45x16xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[5, 252, 252, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.slice [[VAR_1_]], [[VAR_3_]], [[VAR_4_]] : (tensor<5x256x256x64xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<5x252x252x64xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.const_shape  {value = dense<[5, 252, 252, 16]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.slice [[VAR_5_]], [[VAR_3_]], [[VAR_6_]] : (tensor<5x252x252x64xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<5x252x252x16xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.const_shape  {value = dense<[3, 45, 45, 16]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.slice [[VAR_2_]], [[VAR_3_]], [[VAR_8_]] : (tensor<12x45x45x16xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<3x45x45x16xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.const_shape  {value = dense<3> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK-DAG:       [[VAR_12_:%.+]] = tosa.slice [[PARAM_2_]], [[VAR_10_]], [[VAR_11_]] : (tensor<12xf32>, !tosa.shape<1>, !tosa.shape<1>) -> tensor<3xf32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = tosa.conv2d [[VAR_7_]], [[VAR_9_]], [[VAR_12_]], [[VAR_13_]], [[VAR_13_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 0, 1, 0>, stride = array<i64: 13, 13>} : (tensor<5x252x252x16xf32>, tensor<3x45x45x16xf32>, tensor<3xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<5x17x17x3xf32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = tosa.const_shape  {value = dense<[0, 0, 0, 16]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_16_:%.+]] = tosa.slice [[VAR_5_]], [[VAR_15_]], [[VAR_6_]] : (tensor<5x252x252x64xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<5x252x252x16xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = tosa.const_shape  {value = dense<[3, 0, 0, 0]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_18_:%.+]] = tosa.slice [[VAR_2_]], [[VAR_17_]], [[VAR_8_]] : (tensor<12x45x45x16xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<3x45x45x16xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = tosa.slice [[PARAM_2_]], [[VAR_11_]], [[VAR_11_]] : (tensor<12xf32>, !tosa.shape<1>, !tosa.shape<1>) -> tensor<3xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = tosa.conv2d [[VAR_16_]], [[VAR_18_]], [[VAR_19_]], [[VAR_13_]], [[VAR_13_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 0, 1, 0>, stride = array<i64: 13, 13>} : (tensor<5x252x252x16xf32>, tensor<3x45x45x16xf32>, tensor<3xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<5x17x17x3xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = tosa.const_shape  {value = dense<[0, 0, 0, 32]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_22_:%.+]] = tosa.slice [[VAR_5_]], [[VAR_21_]], [[VAR_6_]] : (tensor<5x252x252x64xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<5x252x252x16xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = tosa.const_shape  {value = dense<[6, 0, 0, 0]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_24_:%.+]] = tosa.slice [[VAR_2_]], [[VAR_2_]]3, [[VAR_8_]] : (tensor<12x45x45x16xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<3x45x45x16xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = tosa.const_shape  {value = dense<6> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK:           [[VAR_26_:%.+]] = tosa.slice [[PARAM_2_]], [[VAR_25_]], [[VAR_11_]] : (tensor<12xf32>, !tosa.shape<1>, !tosa.shape<1>) -> tensor<3xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = tosa.conv2d [[VAR_22_]], [[VAR_24_]], [[VAR_26_]], [[VAR_13_]], [[VAR_13_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 0, 1, 0>, stride = array<i64: 13, 13>} : (tensor<5x252x252x16xf32>, tensor<3x45x45x16xf32>, tensor<3xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<5x17x17x3xf32>
+// CHECK-DAG:       [[VAR_28_:%.+]] = tosa.const_shape  {value = dense<[0, 0, 0, 48]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_29_:%.+]] = tosa.slice [[VAR_5_]], [[VAR_28_]], [[VAR_6_]] : (tensor<5x252x252x64xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<5x252x252x16xf32>
+// CHECK-DAG:       [[VAR_30_:%.+]] = tosa.const_shape  {value = dense<[9, 0, 0, 0]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_31_:%.+]] = tosa.slice [[VAR_2_]], [[VAR_30_]], [[VAR_8_]] : (tensor<12x45x45x16xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<3x45x45x16xf32>
+// CHECK-DAG:       [[VAR_32_:%.+]] = tosa.const_shape  {value = dense<9> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK:           [[VAR_33_:%.+]] = tosa.slice [[PARAM_2_]], [[VAR_32_]], [[VAR_11_]] : (tensor<12xf32>, !tosa.shape<1>, !tosa.shape<1>) -> tensor<3xf32>
+// CHECK:           [[VAR_34_:%.+]] = tosa.conv2d [[VAR_29_]], [[VAR_31_]], [[VAR_33_]], [[VAR_13_]], [[VAR_13_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 0, 1, 0>, stride = array<i64: 13, 13>} : (tensor<5x252x252x16xf32>, tensor<3x45x45x16xf32>, tensor<3xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<5x17x17x3xf32>
+// CHECK-DAG:       [[VAR_35_:%.+]] = tosa.concat [[VAR_14_]], [[VAR_20_]], [[VAR_27_]], [[VAR_34_]] {axis = 3 : i32} : (tensor<5x17x17x3xf32>, tensor<5x17x17x3xf32>, tensor<5x17x17x3xf32>, tensor<5x17x17x3xf32>) -> tensor<5x17x17x12xf32>
+// CHECK-DAG:       [[VAR_36_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_37_:%.+]] = tosa.transpose [[VAR_35_]], [[VAR_36_]] : (tensor<5x17x17x12xf32>, tensor<4xi32>) -> tensor<5x12x17x17xf32>
+// CHECK:           return [[VAR_37_]] : tensor<5x12x17x17xf32>
 }
 
 // -----
 func.func @test_onnx_conv2d_autopad(%arg0: tensor<5x3x125x256xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<5x2x125x256xf32> {
   %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "SAME_LOWER"} : (tensor<5x3x125x256xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) ->  tensor<5x2x125x256xf32>
   return %0 : tensor<5x2x125x256xf32>
-// CHECK-LABEL:   func.func @test_onnx_conv2d_autopad(
-// CHECK-SAME:                                        %[[VAL_0:.*]]: tensor<5x3x125x256xf32>,
-// CHECK-SAME:                                        %[[VAL_1:.*]]: tensor<2x3x64x64xf32>,
-// CHECK-SAME:                                        %[[VAL_2:.*]]: tensor<2xf32>) -> tensor<5x2x125x256xf32> {
-// CHECK:           %[[VAL_3:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           %[[VAL_4:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_3]] : (tensor<5x3x125x256xf32>, tensor<4xi32>) -> tensor<5x125x256x3xf32>
-// CHECK:           %[[VAL_5:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_3]] : (tensor<2x3x64x64xf32>, tensor<4xi32>) -> tensor<2x64x64x3xf32>
-// CHECK:           %[[VAL_6:.*]] = tosa.conv2d %[[VAL_4]], %[[VAL_5]], %[[VAL_2]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 32, 31, 32, 31>, stride = array<i64: 1, 1>} : (tensor<5x125x256x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x125x256x2xf32>
-// CHECK:           %[[VAL_7:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           %[[VAL_8:.*]] = tosa.transpose %[[VAL_6]], %[[VAL_7]] : (tensor<5x125x256x2xf32>, tensor<4xi32>) -> tensor<5x2x125x256xf32>
-// CHECK:           return %[[VAL_8]] : tensor<5x2x125x256xf32>
+// CHECK-LABEL:  func.func @test_onnx_conv2d_autopad
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x125x256xf32>, [[PARAM_1_:%.+]]: tensor<2x3x64x64xf32>, [[PARAM_2_:%.+]]: tensor<2xf32>) -> tensor<5x2x125x256xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<5x3x125x256xf32>, tensor<4xi32>) -> tensor<5x125x256x3xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_0_]] : (tensor<2x3x64x64xf32>, tensor<4xi32>) -> tensor<2x64x64x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.conv2d [[VAR_1_]], [[VAR_2_]], [[PARAM_2_]], [[VAR_3_]], [[VAR_3_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 32, 31, 32, 31>, stride = array<i64: 1, 1>} : (tensor<5x125x256x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<5x125x256x2xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_6_:%.+]] = tosa.transpose [[VAR_4_]], [[VAR_5_]] : (tensor<5x125x256x2xf32>, tensor<4xi32>) -> tensor<5x2x125x256xf32>
+// CHECK:           return [[VAR_6_]] : tensor<5x2x125x256xf32>
+// CHECK:         }
 }
 
 // -----
@@ -184,12 +204,15 @@ func.func @test_onnx_conv2d_group_to_depthwise(%arg0: tensor<32x48x112x112xf32>,
 // CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<32x48x112x112xf32>, tensor<4xi32>) -> tensor<32x112x112x48xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[2, 3, 0, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           [[VAR_3_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_2_]] : (tensor<48x1x3x3xf32>, tensor<4xi32>) -> tensor<3x3x48x1xf32>
-// CHECK:           [[VAR_4_:%.+]] = tosa.reshape [[VAR_3_]] {new_shape = array<i64: 3, 3, 48, 1>} : (tensor<3x3x48x1xf32>) -> tensor<3x3x48x1xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.depthwise_conv2d [[VAR_1_]], [[VAR_4_]], [[PARAM_2_]] {acc_type = f32, dilation  = array<i64: 1, 1>, pad = array<i64: 1, 1, 1, 1>, stride = array<i64: 1, 1>} : (tensor<32x112x112x48xf32>, tensor<3x3x48x1xf32>, tensor<48xf32>) -> tensor<32x112x112x48xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           [[VAR_7_:%.+]] = tosa.transpose [[VAR_5_]], [[VAR_6_]] : (tensor<32x112x112x48xf32>, tensor<4xi32>) -> tensor<32x48x112x112xf32>
-// CHECK:           return [[VAR_7_]] : tensor<32x48x112x112xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_2_]] : (tensor<48x1x3x3xf32>, tensor<4xi32>) -> tensor<3x3x48x1xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[3, 3, 48, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_3_]], [[VAR_4_]] : (tensor<3x3x48x1xf32>, !tosa.shape<4>) -> tensor<3x3x48x1xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.depthwise_conv2d [[VAR_1_]], [[VAR_5_]], [[PARAM_2_]], [[VAR_6_]], [[VAR_6_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 1, 1, 1>, stride = array<i64: 1, 1>} : (tensor<32x112x112x48xf32>, tensor<3x3x48x1xf32>, tensor<48xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<32x112x112x48xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_9_:%.+]] = tosa.transpose [[VAR_7_]], [[VAR_8_]] : (tensor<32x112x112x48xf32>, tensor<4xi32>) -> tensor<32x48x112x112xf32>
+// CHECK:           return [[VAR_9_]] : tensor<32x48x112x112xf32>
+// CHECK:         }
 }
 
 // -----
@@ -202,12 +225,14 @@ func.func @test_onnx_conv2d_group_to_depthwise_integer_multiple(%arg0: tensor<32
 // CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<32x24x112x112xf32>, tensor<4xi32>) -> tensor<32x112x112x24xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[2, 3, 0, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           [[VAR_3_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_2_]] : (tensor<48x1x3x3xf32>, tensor<4xi32>) -> tensor<3x3x48x1xf32>
-// CHECK:           [[VAR_4_:%.+]] = tosa.reshape [[VAR_3_]] {new_shape = array<i64: 3, 3, 24, 2>} : (tensor<3x3x48x1xf32>) -> tensor<3x3x24x2xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.depthwise_conv2d [[VAR_1_]], [[VAR_4_]], [[PARAM_2_]] {acc_type = f32, dilation  = array<i64: 1, 1>, pad = array<i64: 1, 1, 1, 1>, stride = array<i64: 1, 1>} : (tensor<32x112x112x24xf32>, tensor<3x3x24x2xf32>, tensor<48xf32>) -> tensor<32x112x112x48xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           [[VAR_7_:%.+]] = tosa.transpose [[VAR_5_]], [[VAR_6_]] : (tensor<32x112x112x48xf32>, tensor<4xi32>) -> tensor<32x48x112x112xf32>
-// CHECK:           return [[VAR_7_]] : tensor<32x48x112x112xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_2_]] : (tensor<48x1x3x3xf32>, tensor<4xi32>) -> tensor<3x3x48x1xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[3, 3, 24, 2]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_3_]], [[VAR_4_]] : (tensor<3x3x48x1xf32>, !tosa.shape<4>) -> tensor<3x3x24x2xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.depthwise_conv2d [[VAR_1_]], [[VAR_5_]], [[PARAM_2_]], [[VAR_6_]], [[VAR_6_]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 1, 1, 1>, stride = array<i64: 1, 1>} : (tensor<32x112x112x24xf32>, tensor<3x3x24x2xf32>, tensor<48xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<32x112x112x48xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_9_:%.+]] = tosa.transpose [[VAR_7_]], [[VAR_8_]] : (tensor<32x112x112x48xf32>, tensor<4xi32>) -> tensor<32x48x112x112xf32>
+// CHECK:           return [[VAR_9_]] : tensor<32x48x112x112xf32>
 }
 
 // -----

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -266,7 +266,7 @@ func.func @test_mul_rank_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<21x
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
 // CHECK-LABEL:  func.func @test_mul_rank_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<21x1xf32>) -> tensor<13x21x1xf32> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 21, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 21, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
 // CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<21x1xf32>, !tosa.shape<3>) -> tensor<1x21x1xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
 // CHECK:           [[VAR_3_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_1_]], [[VAR_2_]] : (tensor<13x21x1xf32>, tensor<1x21x1xf32>, tensor<1xi8>) -> tensor<13x21x1xf32>
@@ -280,7 +280,7 @@ func.func @test_mul_rank_broadcast2(%arg0: tensor<21x1xf32>, %arg1: tensor<13x21
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
 // CHECK-LABEL:  func.func @test_mul_rank_broadcast2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<21x1xf32>, [[PARAM_1_:%.+]]: tensor<13x21x1xf32>) -> tensor<13x21x1xf32> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 21, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 21, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
 // CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<21x1xf32>, !tosa.shape<3>) -> tensor<1x21x1xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
 // CHECK:           [[VAR_3_:%.+]] = tosa.mul [[VAR_1_]], [[PARAM_1_]], [[VAR_2_]] : (tensor<1x21x1xf32>, tensor<13x21x1xf32>, tensor<1xi8>) -> tensor<13x21x1xf32>
@@ -731,9 +731,9 @@ func.func @test_div_decomposed_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tens
 // CHECK-LABEL:  func @test_div_decomposed_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xf32> {
 // CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.reciprocal [[PARAM_1_]] : (tensor<1xf32>) -> tensor<1xf32>
-// CHECK-NEXT:      [[SHAPE:%.+]] = tosa.const_shape {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
-// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]], [[SHAPE]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
-// CHECK-NEXT:      [[ZERO:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:       [[SHAPE:%.+]] = tosa.const_shape {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]], [[SHAPE]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
+// CHECK-DAG:       [[ZERO:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
 // CHECK-NEXT:      [[VAR_2_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_1_]], [[ZERO]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>, tensor<1xi8>) -> tensor<13x21x1xf32>
 }
 

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -158,7 +158,8 @@ func.func @test_add_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1xf32>) 
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
 // CHECK-LABEL:  func.func @test_add_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xf32> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
+// CHECK:           [[SHAPE:%.+]] = tosa.const_shape {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
 // CHECK:           [[VAR_1_:%.+]] = tosa.add [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xf32>
 // CHECK:           return [[VAR_1_]] : tensor<13x21x1xf32>
 }
@@ -190,12 +191,13 @@ func.func @test_add_dyn_shape_and_const(%arg0: tensor<?x1xi64>) -> tensor<?x1xi6
   %0 = onnx.Constant dense<8400> : tensor<1xi64>
   %1 = "onnx.Add"(%arg0, %0) : (tensor<?x1xi64>, tensor<1xi64>) -> tensor<?x1xi64>
   "func.return"(%1) : (tensor<?x1xi64>) -> ()
-// CHECK-LABEL:  test_add_dyn_shape_and_const
-// CHECK:   ([[PARAM_0_:%.+]]: tensor<?x1xi64>) -> tensor<?x1xi64> {
-// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<8400> : tensor<1xi64>}> : () -> tensor<1xi64>
-// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 1, 1>} : (tensor<1xi64>) -> tensor<1x1xi64>
-// CHECK:           [[VAR_2_:%.+]] = tosa.add [[PARAM_0_]], [[VAR_1_]] : (tensor<?x1xi64>, tensor<1x1xi64>) -> tensor<?x1xi64>
-// CHECK:           return [[VAR_2_]] : tensor<?x1xi64>
+// CHECK-LABEL:  func.func @test_add_dyn_shape_and_const
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x1xi64>) -> tensor<?x1xi64> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<8400> : tensor<1xi64>}> : () -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[VAR_0_]], [[VAR_2_]] : (tensor<1xi64>, !tosa.shape<2>) -> tensor<1x1xi64>
+// CHECK:           [[VAR_4_:%.+]] = tosa.add [[PARAM_0_]], [[VAR_3_]] : (tensor<?x1xi64>, tensor<1x1xi64>) -> tensor<?x1xi64>
+// CHECK:           return [[VAR_4_]] : tensor<?x1xi64>
 }
 
 // -----
@@ -227,7 +229,8 @@ func.func @test_sub_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1xf32>) 
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
 // CHECK-LABEL:  func.func @test_sub_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xf32> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
+// CHECK:           [[SHAPE:%.+]] = tosa.const_shape {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
 // CHECK:           [[VAR_1_:%.+]] = tosa.sub [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xf32>
 // CHECK:           return [[VAR_1_]] : tensor<13x21x1xf32>
 }
@@ -237,9 +240,11 @@ func.func @test_sub_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1xf32>) 
 func.func @test_mul(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x1xf32>) -> tensor<13x21x1xf32> {
   %0 = "onnx.Mul"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
-// CHECK-LABEL:  func @test_mul
+// CHECK-LABEL:  func.func @test_mul
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<13x21x1xf32>) -> tensor<13x21x1xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.mul [[PARAM_0_]], [[PARAM_1_]] {shift = 0 : i8} : (tensor<13x21x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_1_:%.+]] = tosa.mul [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]] : (tensor<13x21x1xf32>, tensor<13x21x1xf32>, tensor<1xi8>) -> tensor<13x21x1xf32>
+// CHECK:           return [[VAR_1_]] : tensor<13x21x1xf32>
 }
 
 // -----
@@ -247,9 +252,11 @@ func.func @test_mul(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x1xf32>) -> t
 func.func @test_mul_dynamic(%arg0: tensor<?x?x?xf32>, %arg1: tensor<13x?x?xf32>) -> tensor<13x?x?xf32> {
   %0 = "onnx.Mul"(%arg0, %arg1) : (tensor<?x?x?xf32>, tensor<13x?x?xf32>) -> tensor<13x?x?xf32>
   "func.return"(%0) : (tensor<13x?x?xf32>) -> ()
-// CHECK-LABEL:  func @test_mul_dynamic
+// CHECK-LABEL:  func.func @test_mul_dynamic
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x?xf32>, [[PARAM_1_:%.+]]: tensor<13x?x?xf32>) -> tensor<13x?x?xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.mul [[PARAM_0_]], [[PARAM_1_]] {shift = 0 : i8} : (tensor<?x?x?xf32>, tensor<13x?x?xf32>) -> tensor<13x?x?xf32>
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_1_:%.+]] = tosa.mul [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]] : (tensor<?x?x?xf32>, tensor<13x?x?xf32>, tensor<1xi8>) -> tensor<13x?x?xf32>
+// CHECK:           return [[VAR_1_]] : tensor<13x?x?xf32>
 }
 
 // -----
@@ -257,10 +264,13 @@ func.func @test_mul_dynamic(%arg0: tensor<?x?x?xf32>, %arg1: tensor<13x?x?xf32>)
 func.func @test_mul_rank_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<21x1xf32>) -> tensor<13x21x1xf32> {
   %0 = "onnx.Mul"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<21x1xf32>) -> tensor<13x21x1xf32>
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
-// CHECK-LABEL:  func @test_mul_rank_broadcast
+// CHECK-LABEL:  func.func @test_mul_rank_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<21x1xf32>) -> tensor<13x21x1xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 21, 1>} : (tensor<21x1xf32>) -> tensor<1x21x1xf32>
-// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<13x21x1xf32>, tensor<1x21x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 21, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<21x1xf32>, !tosa.shape<3>) -> tensor<1x21x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_3_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_1_]], [[VAR_2_]] : (tensor<13x21x1xf32>, tensor<1x21x1xf32>, tensor<1xi8>) -> tensor<13x21x1xf32>
+// CHECK:           return [[VAR_3_]] : tensor<13x21x1xf32>
 }
 
 // -----
@@ -268,10 +278,13 @@ func.func @test_mul_rank_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<21x
 func.func @test_mul_rank_broadcast2(%arg0: tensor<21x1xf32>, %arg1: tensor<13x21x1xf32>) -> tensor<13x21x1xf32> {
   %0 = "onnx.Mul"(%arg0, %arg1) : (tensor<21x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
-// CHECK-LABEL:  func @test_mul_rank_broadcast2
+// CHECK-LABEL:  func.func @test_mul_rank_broadcast2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<21x1xf32>, [[PARAM_1_:%.+]]: tensor<13x21x1xf32>) -> tensor<13x21x1xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 21, 1>} : (tensor<21x1xf32>) -> tensor<1x21x1xf32>
-// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.mul [[VAR_0_]], [[PARAM_1_]] {shift = 0 : i8} : (tensor<1x21x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 21, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<21x1xf32>, !tosa.shape<3>) -> tensor<1x21x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_3_:%.+]] = tosa.mul [[VAR_1_]], [[PARAM_1_]], [[VAR_2_]] : (tensor<1x21x1xf32>, tensor<13x21x1xf32>, tensor<1xi8>) -> tensor<13x21x1xf32>
+// CHECK:           return [[VAR_3_]] : tensor<13x21x1xf32>
 }
 
 // -----
@@ -301,10 +314,10 @@ func.func @test_div_dynamic_float(%arg0: tensor<?x?x?xf32>, %arg1: tensor<13x?x?
   "func.return"(%0) : (tensor<13x?x?xf32>) -> ()
 // CHECK-LABEL:  func.func @test_div_dynamic_float
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x?xf32>, [[PARAM_1_:%.+]]: tensor<13x?x?xf32>) -> tensor<13x?x?xf32> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reciprocal [[PARAM_1_]] : (tensor<13x?x?xf32>) -> tensor<13x?x?xf32>
-// CHECK:           [[VAR_1_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<?x?x?xf32>, tensor<13x?x?xf32>) -> tensor<13x?x?xf32>
-// CHECK:           return [[VAR_1_]] : tensor<13x?x?xf32>
-// CHECK:         }
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reciprocal [[PARAM_1_]] : (tensor<13x?x?xf32>) -> tensor<13x?x?xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_2_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<?x?x?xf32>, tensor<13x?x?xf32>, tensor<1xi8>) -> tensor<13x?x?xf32>
+// CHECK:           return [[VAR_2_]] : tensor<13x?x?xf32>
 }
 
 // -----
@@ -324,7 +337,8 @@ func.func @test_div_broadcast(%arg0: tensor<13x21x1xi32>, %arg1: tensor<1xi32>) 
   "func.return"(%0) : (tensor<13x21x1xi32>) -> ()
 // CHECK-LABEL:  func @test_div_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xi32>, [[PARAM_1_:%.+]]: tensor<1xi32>) -> tensor<13x21x1xi32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xi32>) -> tensor<1x1x1xi32>
+// CHECK-NEXT:      [[SHAPE:%.+]] = tosa.const_shape {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE]] : (tensor<1xi32>, !tosa.shape<3>) -> tensor<1x1x1xi32>
 // CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.int_div [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xi32>, tensor<1x1x1xi32>) -> tensor<13x21x1xi32>
 }
 
@@ -336,7 +350,8 @@ func.func @test_div_decomposed(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x1
 // CHECK-LABEL:  func @test_div_decomposed
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<13x21x1xf32>) -> tensor<13x21x1xf32> {
 // CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.reciprocal [[PARAM_1_]] : (tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
-// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<13x21x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
+// CHECK-NEXT:      [[ZERO:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_0_]], [[ZERO]] : (tensor<13x21x1xf32>, tensor<13x21x1xf32>, tensor<1xi8>) -> tensor<13x21x1xf32>
 }
 
 // -----
@@ -344,23 +359,29 @@ func.func @test_div_decomposed(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x1
 func.func @test_leaky_relu(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   %0 = "onnx.LeakyRelu"(%arg0) {alpha = 0.707330704  : f32} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   func.return %0 : tensor<13x21x3xf32>
-// CHECK-LABEL: test_leaky_relu
-// CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xf32>}>
-// CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<0.707330704> : tensor<1x1x1xf32>}>
-// CHECK-DAG: %[[VAR2:.*]] = tosa.mul %arg0, %[[VAR1]] {shift = 0 : i8}
-// CHECK-DAG: %[[VAR3:.*]] = tosa.greater_equal %arg0, %[[VAR0]]
-// CHECK: %[[VAR6:.*]] = tosa.select %[[VAR3]], %arg0, %[[VAR2]]
+// CHECK-LABEL:  func.func @test_leaky_relu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<0.707330704> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_0_]], [[VAR_2_]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>, tensor<1xi8>) -> tensor<13x21x3xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.greater_equal [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>) -> tensor<13x21x3xi1>
+// CHECK:           [[VAR_5_:%.+]] = tosa.select [[VAR_4_]], [[PARAM_0_]], [[VAR_3_]] : (tensor<13x21x3xi1>, tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK:           return [[VAR_5_]] : tensor<13x21x3xf32>
 }
 
 func.func @test_leaky_relu_bf16(%arg0: tensor<13x21x3xbf16>) -> tensor<13x21x3xbf16> {
   %0 = "onnx.LeakyRelu"(%arg0) {alpha = 0.707330704  : f32} : (tensor<13x21x3xbf16>) -> tensor<13x21x3xbf16>
   func.return %0 : tensor<13x21x3xbf16>
-// CHECK-LABEL: test_leaky_relu_bf16
-// CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xbf16>}>
-// CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<7.070310e-01> : tensor<1x1x1xbf16>}>
-// CHECK-DAG: %[[VAR2:.*]] = tosa.mul %arg0, %[[VAR1]] {shift = 0 : i8}
-// CHECK-DAG: %[[VAR3:.*]] = tosa.greater_equal %arg0, %[[VAR0]]
-// CHECK: %[[VAR6:.*]] = tosa.select %[[VAR3]], %arg0, %[[VAR2]]
+// CHECK-LABEL:  func.func @test_leaky_relu_bf16
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x3xbf16>) -> tensor<13x21x3xbf16> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<7.070310e-01> : tensor<1x1x1xbf16>}> : () -> tensor<1x1x1xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xbf16>}> : () -> tensor<1x1x1xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_0_]], [[VAR_2_]] : (tensor<13x21x3xbf16>, tensor<1x1x1xbf16>, tensor<1xi8>) -> tensor<13x21x3xbf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.greater_equal [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x3xbf16>, tensor<1x1x1xbf16>) -> tensor<13x21x3xi1>
+// CHECK:           [[VAR_5_:%.+]] = tosa.select [[VAR_4_]], [[PARAM_0_]], [[VAR_3_]] : (tensor<13x21x3xi1>, tensor<13x21x3xbf16>, tensor<13x21x3xbf16>) -> tensor<13x21x3xbf16>
+// CHECK:           return [[VAR_5_]] : tensor<13x21x3xbf16>
 }
 
 // -----
@@ -368,21 +389,27 @@ func.func @test_leaky_relu_bf16(%arg0: tensor<13x21x3xbf16>) -> tensor<13x21x3xb
 func.func @test_prelu(%arg0: tensor<13x21x3xf32>, %arg1: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   func.return %0 : tensor<13x21x3xf32>
-// CHECK-LABEL: test_prelu
-// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xf32>}>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.mul %arg0, %arg1 {shift = 0 : i8}
-// CHECK:           [[VAR_2_:%.+]] = tosa.greater_equal %arg0, [[VAR_0_]]
-// CHECK:           [[VAR_3_:%.+]] = tosa.select [[VAR_2_]], %arg0, [[VAR_1_]]
+// CHECK-LABEL:  func.func @test_prelu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x3xf32>, [[PARAM_1_:%.+]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.mul [[PARAM_0_]], [[PARAM_1_]], [[VAR_1_]] : (tensor<13x21x3xf32>, tensor<13x21x3xf32>, tensor<1xi8>) -> tensor<13x21x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.greater_equal [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>) -> tensor<13x21x3xi1>
+// CHECK:           [[VAR_4_:%.+]] = tosa.select [[VAR_3_]], [[PARAM_0_]], [[VAR_2_]] : (tensor<13x21x3xi1>, tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK:           return [[VAR_4_]] : tensor<13x21x3xf32>
 }
 
 func.func @test_prelu_bf16(%arg0: tensor<13x21x3xbf16>, %arg1: tensor<13x21x3xbf16>) -> tensor<13x21x3xbf16> {
   %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<13x21x3xbf16>, tensor<13x21x3xbf16>) -> tensor<13x21x3xbf16>
   func.return %0 : tensor<13x21x3xbf16>
-// CHECK-LABEL: test_prelu_bf16
+// CHECK-LABEL:  func.func @test_prelu_bf16
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x3xbf16>, [[PARAM_1_:%.+]]: tensor<13x21x3xbf16>) -> tensor<13x21x3xbf16> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xbf16>}> : () -> tensor<1x1x1xbf16>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.mul %arg0, %arg1 {shift = 0 : i8}
-// CHECK:           [[VAR_2_:%.+]] = tosa.greater_equal %arg0, [[VAR_0_]]
-// CHECK:           [[VAR_3_:%.+]] = tosa.select [[VAR_2_]], %arg0, [[VAR_1_]]
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.mul [[PARAM_0_]], [[PARAM_1_]], [[VAR_1_]] : (tensor<13x21x3xbf16>, tensor<13x21x3xbf16>, tensor<1xi8>) -> tensor<13x21x3xbf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.greater_equal [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x3xbf16>, tensor<1x1x1xbf16>) -> tensor<13x21x3xi1>
+// CHECK:           [[VAR_4_:%.+]] = tosa.select [[VAR_3_]], [[PARAM_0_]], [[VAR_2_]] : (tensor<13x21x3xi1>, tensor<13x21x3xbf16>, tensor<13x21x3xbf16>) -> tensor<13x21x3xbf16>
+// CHECK:           return [[VAR_4_]] : tensor<13x21x3xbf16>
 }
 
 // -----
@@ -390,33 +417,37 @@ func.func @test_prelu_bf16(%arg0: tensor<13x21x3xbf16>, %arg1: tensor<13x21x3xbf
 func.func @test_selu_default_value(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   %0 = "onnx.Selu"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   func.return %0 : tensor<13x21x3xf32>
-// CHECK-LABEL: test_selu_default_value
+// CHECK-LABEL:  func.func @test_selu_default_value
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<1.673260e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<1.050700e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.exp %arg0
-// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_0_]] {shift = 0 : i8}
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.sub [[VAR_4_]], [[VAR_0_]]
-// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.greater %arg0, [[VAR_2_]]
-// CHECK:           [[VAR_7_:%.+]] = tosa.select [[VAR_6_]], %arg0, [[VAR_5_]]
-// CHECK:           [[VAR_8_:%.+]] = tosa.mul [[VAR_7_]], [[VAR_1_]] {shift = 0 : i8}
-// CHECK:           return [[VAR_8_]] : tensor<13x21x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.exp [[PARAM_0_]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_0_]], [[VAR_4_]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>, tensor<1xi8>) -> tensor<13x21x3xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.sub [[VAR_5_]], [[VAR_0_]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>) -> tensor<13x21x3xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.greater [[PARAM_0_]], [[VAR_2_]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>) -> tensor<13x21x3xi1>
+// CHECK:           [[VAR_8_:%.+]] = tosa.select [[VAR_7_]], [[PARAM_0_]], [[VAR_6_]] : (tensor<13x21x3xi1>, tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK:           [[VAR_9_:%.+]] = tosa.mul [[VAR_8_]], [[VAR_1_]], [[VAR_4_]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>, tensor<1xi8>) -> tensor<13x21x3xf32>
+// CHECK:           return [[VAR_9_]] : tensor<13x21x3xf32>
 }
 
 func.func @test_selu(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   %0 = "onnx.Selu"(%arg0) {alpha = 1.5 : f32, gamma = 2.0 : f32} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   func.return %0 : tensor<13x21x3xf32>
-// CHECK-LABEL: test_selu
+// CHECK-LABEL:  func.func @test_selu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<1.500000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<2.000000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.exp %arg0 : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
-// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_0_]] {shift = 0 : i8}
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.sub [[VAR_4_]], [[VAR_0_]]
-// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.greater %arg0, [[VAR_2_]]
-// CHECK:           [[VAR_7_:%.+]] = tosa.select [[VAR_6_]], %arg0, [[VAR_5_]]
-// CHECK:           [[VAR_8_:%.+]] = tosa.mul [[VAR_7_]], [[VAR_1_]] {shift = 0 : i8}
-// CHECK:           return [[VAR_8_]] : tensor<13x21x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.exp [[PARAM_0_]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_0_]], [[VAR_4_]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>, tensor<1xi8>) -> tensor<13x21x3xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.sub [[VAR_5_]], [[VAR_0_]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>) -> tensor<13x21x3xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.greater [[PARAM_0_]], [[VAR_2_]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>) -> tensor<13x21x3xi1>
+// CHECK:           [[VAR_8_:%.+]] = tosa.select [[VAR_7_]], [[PARAM_0_]], [[VAR_6_]] : (tensor<13x21x3xi1>, tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK:           [[VAR_9_:%.+]] = tosa.mul [[VAR_8_]], [[VAR_1_]], [[VAR_4_]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>, tensor<1xi8>) -> tensor<13x21x3xf32>
+// CHECK:           return [[VAR_9_]] : tensor<13x21x3xf32>
 }
 
 // -----
@@ -442,12 +473,13 @@ func.func @test_selu_dynamic(%arg0: tensor<?x4x?xf32>) -> tensor<?x4x?xf32> {
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<2.000000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = tosa.exp [[PARAM_0_]] : (tensor<?x4x?xf32>) -> tensor<?x4x?xf32>
-// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<?x4x?xf32>, tensor<1x1x1xf32>) -> tensor<?x4x?xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.sub [[VAR_4_]], [[VAR_0_]] : (tensor<?x4x?xf32>, tensor<1x1x1xf32>) -> tensor<?x4x?xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.greater [[PARAM_0_]], [[VAR_2_]] : (tensor<?x4x?xf32>, tensor<1x1x1xf32>) -> tensor<?x4x?xi1>
-// CHECK:           [[VAR_7_:%.+]] = tosa.select [[VAR_6_]], [[PARAM_0_]], [[VAR_5_]] : (tensor<?x4x?xi1>, tensor<?x4x?xf32>, tensor<?x4x?xf32>) -> tensor<?x4x?xf32>
-// CHECK:           [[VAR_8_:%.+]] = tosa.mul [[VAR_7_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<?x4x?xf32>, tensor<1x1x1xf32>) -> tensor<?x4x?xf32>
-// CHECK:           return [[VAR_8_]] : tensor<?x4x?xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_0_]], [[VAR_4_]] : (tensor<?x4x?xf32>, tensor<1x1x1xf32>, tensor<1xi8>) -> tensor<?x4x?xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.sub [[VAR_5_]], [[VAR_0_]] : (tensor<?x4x?xf32>, tensor<1x1x1xf32>) -> tensor<?x4x?xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.greater [[PARAM_0_]], [[VAR_2_]] : (tensor<?x4x?xf32>, tensor<1x1x1xf32>) -> tensor<?x4x?xi1>
+// CHECK:           [[VAR_8_:%.+]] = tosa.select [[VAR_7_]], [[PARAM_0_]], [[VAR_6_]] : (tensor<?x4x?xi1>, tensor<?x4x?xf32>, tensor<?x4x?xf32>) -> tensor<?x4x?xf32>
+// CHECK:           [[VAR_9_:%.+]] = tosa.mul [[VAR_8_]], [[VAR_1_]], [[VAR_4_]] : (tensor<?x4x?xf32>, tensor<1x1x1xf32>, tensor<1xi8>) -> tensor<?x4x?xf32>
+// CHECK:           return [[VAR_9_]] : tensor<?x4x?xf32>
 }
 
 // -----
@@ -619,11 +651,12 @@ func.func @test_clip(%arg0: tensor<3xi32>, %arg1: tensor<i32>, %arg2: tensor<i32
   return %0 : tensor<3xi32>
 // CHECK-LABEL:  func.func @test_clip
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xi32>, [[PARAM_1_:%.+]]: tensor<i32>, [[PARAM_2_:%.+]]: tensor<i32>) -> tensor<3xi32> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1>} : (tensor<i32>) -> tensor<1xi32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.maximum [[PARAM_0_]], [[VAR_0_]] : (tensor<3xi32>, tensor<1xi32>) -> tensor<3xi32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1>} : (tensor<i32>) -> tensor<1xi32>
-// CHECK:           [[VAR_3_:%.+]] = tosa.minimum [[VAR_1_]], [[VAR_2_]] : (tensor<3xi32>, tensor<1xi32>) -> tensor<3xi32>
-// CHECK:           return [[VAR_3_]] : tensor<3xi32>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<i32>, !tosa.shape<1>) -> tensor<1xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.maximum [[PARAM_0_]], [[VAR_1_]] : (tensor<3xi32>, tensor<1xi32>) -> tensor<3xi32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.reshape [[PARAM_2_]], [[VAR_0_]] : (tensor<i32>, !tosa.shape<1>) -> tensor<1xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.minimum [[VAR_2_]], [[VAR_3_]] : (tensor<3xi32>, tensor<1xi32>) -> tensor<3xi32>
+// CHECK:           return [[VAR_4_]] : tensor<3xi32>
 // CHECK:         }
 }
 
@@ -636,9 +669,10 @@ func.func @test_clip_default_min_f32(%arg0: tensor<3xf32>, %arg1: tensor<f32>) -
   return %0 : tensor<3xf32>
 // CHECK-LABEL:  func.func @test_clip_default_min_f32
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf32>, [[PARAM_1_:%.+]]: tensor<f32>) -> tensor<3xf32> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1>} : (tensor<f32>) -> tensor<1xf32>
-// CHECK:           [[VAR_1_:%.+]] = tosa.minimum [[PARAM_0_]], [[VAR_0_]] : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
-// CHECK:           return [[VAR_1_]] : tensor<3xf32>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<f32>, !tosa.shape<1>) -> tensor<1xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.minimum [[PARAM_0_]], [[VAR_1_]] : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
+// CHECK:           return [[VAR_2_]] : tensor<3xf32>
 // CHECK:         }
 }
 
@@ -651,9 +685,10 @@ func.func @test_clip_default_max_bf16(%arg0: tensor<3xbf16>, %arg1: tensor<bf16>
   return %0 : tensor<3xbf16>
 // CHECK-LABEL:  func.func @test_clip_default_max_bf16
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xbf16>, [[PARAM_1_:%.+]]: tensor<bf16>) -> tensor<3xbf16> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1>} : (tensor<bf16>) -> tensor<1xbf16>
-// CHECK:           [[VAR_1_:%.+]] = tosa.maximum [[PARAM_0_]], [[VAR_0_]] : (tensor<3xbf16>, tensor<1xbf16>) -> tensor<3xbf16>
-// CHECK:           return [[VAR_1_]] : tensor<3xbf16>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<bf16>, !tosa.shape<1>) -> tensor<1xbf16>
+// CHECK:           [[VAR_2_:%.+]] = tosa.maximum [[PARAM_0_]], [[VAR_1_]] : (tensor<3xbf16>, tensor<1xbf16>) -> tensor<3xbf16>
+// CHECK:           return [[VAR_2_]] : tensor<3xbf16>
 // CHECK:         }
 }
 
@@ -696,8 +731,10 @@ func.func @test_div_decomposed_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tens
 // CHECK-LABEL:  func @test_div_decomposed_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xf32> {
 // CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.reciprocal [[PARAM_1_]] : (tensor<1xf32>) -> tensor<1xf32>
-// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
-// CHECK-NEXT:      [[VAR_2_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xf32>
+// CHECK-NEXT:      [[SHAPE:%.+]] = tosa.const_shape {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]], [[SHAPE]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
+// CHECK-NEXT:      [[ZERO:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-NEXT:      [[VAR_2_:%.+]] = tosa.mul [[PARAM_0_]], [[VAR_1_]], [[ZERO]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>, tensor<1xi8>) -> tensor<13x21x1xf32>
 }
 
 // -----
@@ -713,10 +750,12 @@ func.func @test_pow(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x1xf32>) -> t
 func.func @test_pow_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1xf32>) -> tensor<13x21x1xf32> {
   %0 = "onnx.Pow"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<1xf32>) -> tensor<13x21x1xf32>
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
-// CHECK-LABEL:  func @test_pow_broadcast
+// CHECK-LABEL:  func.func @test_pow_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
-// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.pow [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.pow [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xf32>
 }
 
 func.func @test_pow_f64(%arg0: tensor<13x21x1xf64>, %arg1: tensor<13x21x1xf64>) -> tensor<13x21x1xf64> {
@@ -845,49 +884,53 @@ func.func @test_hardsigmoid_default_values_f32(%arg0: tensor<3xf32>) -> tensor<3
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<2.500000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<2.000000e-01> : tensor<1xf32>}> : () -> tensor<1xf32>
 // CHECK:           [[VAR_2_:%.+]] = tosa.add [[PARAM_0_]], [[VAR_0_]] : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
-// CHECK:           [[VAR_3_:%.+]] = tosa.clamp [[VAR_2_]] {max_fp = 5.000000e+00 : f32, max_int = 5 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<3xf32>) -> tensor<3xf32>
-// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
-// CHECK:           return [[VAR_4_]] : tensor<3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.clamp [[VAR_2_]] {max_fp = 5.000000e+00 : f32, max_int = 5 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<3xf32>) -> tensor<3xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]], [[VAR_4_]] : (tensor<3xf32>, tensor<1xf32>, tensor<1xi8>) -> tensor<3xf32>
+// CHECK:           return [[VAR_5_]] : tensor<3xf32>
 }
 
 func.func @test_hardsigmoid_default_values_f16(%arg0: tensor<3xf16>) -> tensor<3xf16> {
   %0 = "onnx.HardSigmoid"(%arg0) : (tensor<3xf16>) -> tensor<3xf16>
   return %0 : tensor<3xf16>
-// CHECK-LABEL:  func @test_hardsigmoid_default_values_f16
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf16>) -> tensor<3xf16>
+// CHECK-LABEL:  func.func @test_hardsigmoid_default_values_f16
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf16>) -> tensor<3xf16> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<2.500000e+00> : tensor<1xf16>}> : () -> tensor<1xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<1.999510e-01> : tensor<1xf16>}> : () -> tensor<1xf16>
 // CHECK:           [[VAR_2_:%.+]] = tosa.add [[PARAM_0_]], [[VAR_0_]] : (tensor<3xf16>, tensor<1xf16>) -> tensor<3xf16>
-// CHECK:           [[VAR_3_:%.+]] = tosa.clamp [[VAR_2_]] {max_fp = 5.000000e+00 : f32, max_int = 5 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<3xf16>) -> tensor<3xf16>
-// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<3xf16>, tensor<1xf16>) -> tensor<3xf16>
-// CHECK:           return [[VAR_4_]] : tensor<3xf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.clamp [[VAR_2_]] {max_fp = 5.000000e+00 : f32, max_int = 5 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<3xf16>) -> tensor<3xf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]], [[VAR_4_]] : (tensor<3xf16>, tensor<1xf16>, tensor<1xi8>) -> tensor<3xf16>
+// CHECK:           return [[VAR_5_]] : tensor<3xf16>
 }
 
 // alpha = 0.166666672, beta = 5.000000e-01
 func.func @test_hardsigmoid_f32(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %0 = "onnx.HardSigmoid"(%arg0) {alpha = 0.166666672 : f32, beta = 5.000000e-01 : f32} : (tensor<3xf32>) -> tensor<3xf32>
   return %0 : tensor<3xf32>
-// CHECK-LABEL:  func @test_hardsigmoid_f32
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf32>) -> tensor<3xf32>
+// CHECK-LABEL:  func.func @test_hardsigmoid_f32
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf32>) -> tensor<3xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0.166666672> : tensor<1xf32>}> : () -> tensor<1xf32>
 // CHECK:           [[VAR_2_:%.+]] = tosa.add [[PARAM_0_]], [[VAR_0_]] : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
-// CHECK:           [[VAR_3_:%.+]] = tosa.clamp [[VAR_2_]] {max_fp = 6.000000e+00 : f32, max_int = 6 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<3xf32>) -> tensor<3xf32>
-// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
-// CHECK:           return [[VAR_4_]] : tensor<3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.clamp [[VAR_2_]] {max_fp = 6.000000e+00 : f32, max_int = 6 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<3xf32>) -> tensor<3xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]], [[VAR_4_]] : (tensor<3xf32>, tensor<1xf32>, tensor<1xi8>) -> tensor<3xf32>
+// CHECK:           return [[VAR_5_]] : tensor<3xf32>
 }
 
 func.func @test_hardsigmoid_f16(%arg0: tensor<3xf16>) -> tensor<3xf16> {
   %0 = "onnx.HardSigmoid"(%arg0) {alpha = 0.166666672 : f32, beta = 5.000000e-01 : f32} : (tensor<3xf16>) -> tensor<3xf16>
   return %0 : tensor<3xf16>
-// CHECK-LABEL:  func @test_hardsigmoid_f16
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf16>) -> tensor<3xf16>
+// CHECK-LABEL:  func.func @test_hardsigmoid_f16
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf16>) -> tensor<3xf16> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3.000000e+00> : tensor<1xf16>}> : () -> tensor<1xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<1.666260e-01> : tensor<1xf16>}> : () -> tensor<1xf16>
 // CHECK:           [[VAR_2_:%.+]] = tosa.add [[PARAM_0_]], [[VAR_0_]] : (tensor<3xf16>, tensor<1xf16>) -> tensor<3xf16>
-// CHECK:           [[VAR_3_:%.+]] = tosa.clamp [[VAR_2_]] {max_fp = 6.000000e+00 : f32, max_int = 6 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<3xf16>) -> tensor<3xf16>
-// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<3xf16>, tensor<1xf16>) -> tensor<3xf16>
-// CHECK:           return [[VAR_4_]] : tensor<3xf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.clamp [[VAR_2_]] {max_fp = 6.000000e+00 : f32, max_int = 6 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<3xf16>) -> tensor<3xf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]], [[VAR_4_]] : (tensor<3xf16>, tensor<1xf16>, tensor<1xi8>) -> tensor<3xf16>
+// CHECK:           return [[VAR_5_]] : tensor<3xf16>
 }
 
 // -----
@@ -900,9 +943,10 @@ func.func @test_hardsigmoid_dynamic(%arg0: tensor<?x3x?xf16>) -> tensor<?x3x?xf1
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3.000000e+00> : tensor<1x1x1xf16>}> : () -> tensor<1x1x1xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<1.666260e-01> : tensor<1x1x1xf16>}> : () -> tensor<1x1x1xf16>
 // CHECK:           [[VAR_2_:%.+]] = tosa.add [[PARAM_0_]], [[VAR_0_]] : (tensor<?x3x?xf16>, tensor<1x1x1xf16>) -> tensor<?x3x?xf16>
-// CHECK:           [[VAR_3_:%.+]] = tosa.clamp [[VAR_2_]] {max_fp = 6.000000e+00 : f32, max_int = 6 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<?x3x?xf16>) -> tensor<?x3x?xf16>
-// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<?x3x?xf16>, tensor<1x1x1xf16>) -> tensor<?x3x?xf16>
-// CHECK:           return [[VAR_4_]] : tensor<?x3x?xf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.clamp [[VAR_2_]] {max_fp = 6.000000e+00 : f32, max_int = 6 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<?x3x?xf16>) -> tensor<?x3x?xf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]], [[VAR_4_]] : (tensor<?x3x?xf16>, tensor<1x1x1xf16>, tensor<1xi8>) -> tensor<?x3x?xf16>
+// CHECK:           return [[VAR_5_]] : tensor<?x3x?xf16>
 }
 
 // -----
@@ -927,11 +971,12 @@ func.func @test_elu_f32(%arg0: tensor<3xf32>) -> tensor<3xf32> {
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0.166666672> : tensor<1xf32>}> : () -> tensor<1xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = tosa.exp [[PARAM_0_]] : (tensor<3xf32>) -> tensor<3xf32>
-// CHECK:           [[VAR_4_:%.+]] = tosa.sub [[VAR_3_]], [[VAR_0_]] : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.mul [[VAR_4_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.greater_equal [[PARAM_0_]], [[VAR_2_]] : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xi1>
-// CHECK:           [[VAR_7_:%.+]] = tosa.select [[VAR_6_]], [[PARAM_0_]], [[VAR_5_]] : (tensor<3xi1>, tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
-// CHECK:           return [[VAR_7_]]
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.sub [[VAR_3_]], [[VAR_0_]] : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.mul [[VAR_4_]], [[VAR_1_]], [[VAR_5_]] : (tensor<3xf32>, tensor<1xf32>, tensor<1xi8>) -> tensor<3xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.greater_equal [[PARAM_0_]], [[VAR_2_]] : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xi1>
+// CHECK:           [[VAR_8_:%.+]] = tosa.select [[VAR_7_]], [[PARAM_0_]], [[VAR_6_]] : (tensor<3xi1>, tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+// CHECK:           return [[VAR_8_]] : tensor<3xf32>
 }
 
 func.func @test_elu_f16(%arg0: tensor<3xf16>) -> tensor<3xf16> {
@@ -943,11 +988,12 @@ func.func @test_elu_f16(%arg0: tensor<3xf16>) -> tensor<3xf16> {
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<1.666260e-01> : tensor<1xf16>}> : () -> tensor<1xf16>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf16>}> : () -> tensor<1xf16>
 // CHECK-DAG:       [[VAR_3_:%.+]] = tosa.exp [[PARAM_0_]] : (tensor<3xf16>) -> tensor<3xf16>
-// CHECK:           [[VAR_4_:%.+]] = tosa.sub [[VAR_3_]], [[VAR_0_]] : (tensor<3xf16>, tensor<1xf16>) -> tensor<3xf16>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.mul [[VAR_4_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<3xf16>, tensor<1xf16>) -> tensor<3xf16>
-// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.greater_equal [[PARAM_0_]], [[VAR_2_]] : (tensor<3xf16>, tensor<1xf16>) -> tensor<3xi1>
-// CHECK:           [[VAR_7_:%.+]] = tosa.select [[VAR_6_]], [[PARAM_0_]], [[VAR_5_]] : (tensor<3xi1>, tensor<3xf16>, tensor<3xf16>) -> tensor<3xf16>
-// CHECK:           return [[VAR_7_]]
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.sub [[VAR_3_]], [[VAR_0_]] : (tensor<3xf16>, tensor<1xf16>) -> tensor<3xf16>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.mul [[VAR_4_]], [[VAR_1_]], [[VAR_5_]] : (tensor<3xf16>, tensor<1xf16>, tensor<1xi8>) -> tensor<3xf16>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.greater_equal [[PARAM_0_]], [[VAR_2_]] : (tensor<3xf16>, tensor<1xf16>) -> tensor<3xi1>
+// CHECK:           [[VAR_8_:%.+]] = tosa.select [[VAR_7_]], [[PARAM_0_]], [[VAR_6_]] : (tensor<3xi1>, tensor<3xf16>, tensor<3xf16>) -> tensor<3xf16>
+// CHECK:           return [[VAR_8_]] : tensor<3xf16>
 }
 
 // -----
@@ -961,12 +1007,12 @@ func.func @test_elu_unranked(%arg0: tensor<*xf32>) -> tensor<3xf32> {
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0.166666672> : tensor<1xf32>}> : () -> tensor<1xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = tosa.exp [[PARAM_0_]] : (tensor<*xf32>) -> tensor<3xf32>
-// CHECK:           [[VAR_4_:%.+]] = tosa.sub [[VAR_3_]], [[VAR_0_]] : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.mul [[VAR_4_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.greater_equal [[PARAM_0_]], [[VAR_2_]] : (tensor<*xf32>, tensor<1xf32>) -> tensor<*xi1>
-// CHECK:           [[VAR_7_:%.+]] = tosa.select [[VAR_6_]], [[PARAM_0_]], [[VAR_5_]] : (tensor<*xi1>, tensor<*xf32>, tensor<3xf32>) -> tensor<3xf32>
-// CHECK:           return [[VAR_7_]] : tensor<3xf32>
-// CHECK:         }
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.sub [[VAR_3_]], [[VAR_0_]] : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.mul [[VAR_4_]], [[VAR_1_]], [[VAR_5_]] : (tensor<3xf32>, tensor<1xf32>, tensor<1xi8>) -> tensor<3xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.greater_equal [[PARAM_0_]], [[VAR_2_]] : (tensor<*xf32>, tensor<1xf32>) -> tensor<*xi1>
+// CHECK:           [[VAR_8_:%.+]] = tosa.select [[VAR_7_]], [[PARAM_0_]], [[VAR_6_]] : (tensor<*xi1>, tensor<*xf32>, tensor<3xf32>) -> tensor<3xf32>
+// CHECK:           return [[VAR_8_]] : tensor<3xf32>
 }
 
 
@@ -987,9 +1033,10 @@ func.func @test_and_broadcast(%arg0: tensor<13x21x1xi1>, %arg1: tensor<1xi1>) ->
   "func.return"(%0) : (tensor<13x21x1xi1>) -> ()
 // CHECK-LABEL:  func.func @test_and_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xi1>, [[PARAM_1_:%.+]]: tensor<1xi1>) -> tensor<13x21x1xi1> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xi1>) -> tensor<1x1x1xi1>
-// CHECK:           [[VAR_1_:%.+]] = tosa.logical_and [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xi1>, tensor<1x1x1xi1>) -> tensor<13x21x1xi1>
-// CHECK:           return [[VAR_1_]] : tensor<13x21x1xi1>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xi1>, !tosa.shape<3>) -> tensor<1x1x1xi1>
+// CHECK:           [[VAR_2_:%.+]] = tosa.logical_and [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xi1>, tensor<1x1x1xi1>) -> tensor<13x21x1xi1>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xi1>
 }
 // -----
 
@@ -1007,9 +1054,10 @@ func.func @test_bitwise_and_broadcast(%arg0: tensor<13x21x1xi64>, %arg1: tensor<
   "func.return"(%0) : (tensor<13x21x1xi64>) -> ()
 // CHECK-LABEL:  func.func @test_bitwise_and_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xi64>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<13x21x1xi64> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xi64>) -> tensor<1x1x1xi64>
-// CHECK:           [[VAR_1_:%.+]] = tosa.bitwise_and [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xi64>, tensor<1x1x1xi64>) -> tensor<13x21x1xi64>
-// CHECK:           return [[VAR_1_]] : tensor<13x21x1xi64>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xi64>, !tosa.shape<3>) -> tensor<1x1x1xi64>
+// CHECK:           [[VAR_2_:%.+]] = tosa.bitwise_and [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xi64>, tensor<1x1x1xi64>) -> tensor<13x21x1xi64>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xi64>
 }
 // -----
 
@@ -1027,9 +1075,10 @@ func.func @test_or_broadcast(%arg0: tensor<13x21x1xi1>, %arg1: tensor<1xi1>) -> 
   "func.return"(%0) : (tensor<13x21x1xi1>) -> ()
 // CHECK-LABEL:  func.func @test_or_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xi1>, [[PARAM_1_:%.+]]: tensor<1xi1>) -> tensor<13x21x1xi1> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xi1>) -> tensor<1x1x1xi1>
-// CHECK:           [[VAR_1_:%.+]] = tosa.logical_or [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xi1>, tensor<1x1x1xi1>) -> tensor<13x21x1xi1>
-// CHECK:           return [[VAR_1_]] : tensor<13x21x1xi1>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xi1>, !tosa.shape<3>) -> tensor<1x1x1xi1>
+// CHECK:           [[VAR_2_:%.+]] = tosa.logical_or [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xi1>, tensor<1x1x1xi1>) -> tensor<13x21x1xi1>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xi1>
 }
 // -----
 
@@ -1047,9 +1096,10 @@ func.func @test_bitwise_or_broadcast(%arg0: tensor<13x21x1xi64>, %arg1: tensor<1
   "func.return"(%0) : (tensor<13x21x1xi64>) -> ()
 // CHECK-LABEL:  func.func @test_bitwise_or_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xi64>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<13x21x1xi64> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xi64>) -> tensor<1x1x1xi64>
-// CHECK:           [[VAR_1_:%.+]] = tosa.bitwise_or [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xi64>, tensor<1x1x1xi64>) -> tensor<13x21x1xi64>
-// CHECK:           return [[VAR_1_]] : tensor<13x21x1xi64>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xi64>, !tosa.shape<3>) -> tensor<1x1x1xi64>
+// CHECK:           [[VAR_2_:%.+]] = tosa.bitwise_or [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xi64>, tensor<1x1x1xi64>) -> tensor<13x21x1xi64>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xi64>
 }
 
 // -----
@@ -1069,9 +1119,10 @@ func.func @test_xor_broadcast(%arg0: tensor<13x21x1xi1>, %arg1: tensor<1xi1>) ->
   "func.return"(%0) : (tensor<13x21x1xi1>) -> ()
 // CHECK-LABEL:  func.func @test_xor_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xi1>, [[PARAM_1_:%.+]]: tensor<1xi1>) -> tensor<13x21x1xi1> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xi1>) -> tensor<1x1x1xi1>
-// CHECK:           [[VAR_1_:%.+]] = tosa.logical_xor [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xi1>, tensor<1x1x1xi1>) -> tensor<13x21x1xi1>
-// CHECK:           return [[VAR_1_]] : tensor<13x21x1xi1>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xi1>, !tosa.shape<3>) -> tensor<1x1x1xi1>
+// CHECK:           [[VAR_2_:%.+]] = tosa.logical_xor [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xi1>, tensor<1x1x1xi1>) -> tensor<13x21x1xi1>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xi1>
 }
 // -----
 
@@ -1089,9 +1140,10 @@ func.func @test_bitwise_xor_broadcast(%arg0: tensor<13x21x1xi64>, %arg1: tensor<
   "func.return"(%0) : (tensor<13x21x1xi64>) -> ()
 // CHECK-LABEL:  func.func @test_bitwise_xor_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xi64>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<13x21x1xi64> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xi64>) -> tensor<1x1x1xi64>
-// CHECK:           [[VAR_1_:%.+]] = tosa.bitwise_xor [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xi64>, tensor<1x1x1xi64>) -> tensor<13x21x1xi64>
-// CHECK:           return [[VAR_1_]] : tensor<13x21x1xi64>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xi64>, !tosa.shape<3>) -> tensor<1x1x1xi64>
+// CHECK:           [[VAR_2_:%.+]] = tosa.bitwise_xor [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xi64>, tensor<1x1x1xi64>) -> tensor<13x21x1xi64>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xi64>
 }
 
 // -----
@@ -1109,10 +1161,12 @@ func.func @test_min(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x1xf32>) -> t
 func.func @test_min_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1xf32>) -> tensor<13x21x1xf32> {
   %0 = "onnx.Min"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<1xf32>) -> tensor<13x21x1xf32>
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
-// CHECK-LABEL:  func @test_min_broadcast
+// CHECK-LABEL:  func.func @test_min_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
-// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.minimum [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.minimum [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xf32>
 }
 // -----
 
@@ -1129,10 +1183,12 @@ func.func @test_max(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x1xf32>) -> t
 func.func @test_max_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1xf32>) -> tensor<13x21x1xf32> {
   %0 = "onnx.Max"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<1xf32>) -> tensor<13x21x1xf32>
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
-// CHECK-LABEL:  func @test_max_broadcast
+// CHECK-LABEL:  func.func @test_max_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
-// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.maximum [[PARAM_0_]], [[VAR_0_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.maximum [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xf32>
 }
 
 // -----
@@ -1197,9 +1253,11 @@ func.func @test_equal_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1xf32>
   %0 = "onnx.Equal"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<1xf32>) -> tensor<13x21x1xi1>
   "func.return"(%0) : (tensor<13x21x1xi1>) -> ()
 // CHECK-LABEL:  func.func @test_equal_broadcast
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape %arg1 {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
-// CHECK:           [[VAR_1_:%.+]] = tosa.equal %arg0, [[VAR_0_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xi1>
-// CHECK:           return [[VAR_1_]] : tensor<13x21x1xi1>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xi1> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.equal [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xi1>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xi1>
 }
 
 // -----
@@ -1216,9 +1274,11 @@ func.func @test_greaterequal_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor
   %0 = "onnx.GreaterOrEqual"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<1xf32>) -> tensor<13x21x1xi1>
   "func.return"(%0) : (tensor<13x21x1xi1>) -> ()
 // CHECK-LABEL:  func.func @test_greaterequal_broadcast
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape %arg1 {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
-// CHECK:           [[VAR_1_:%.+]] = tosa.greater_equal %arg0, [[VAR_0_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xi1>
-// CHECK:           return [[VAR_1_]] : tensor<13x21x1xi1>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xi1> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.greater_equal [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xi1>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xi1>
 }
 
 // -----
@@ -1235,9 +1295,11 @@ func.func @test_greater_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1xf3
   %0 = "onnx.Greater"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<1xf32>) -> tensor<13x21x1xi1>
   "func.return"(%0) : (tensor<13x21x1xi1>) -> ()
 // CHECK-LABEL:  func.func @test_greater_broadcast
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape %arg1 {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
-// CHECK:           [[VAR_1_:%.+]] = tosa.greater %arg0, [[VAR_0_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xi1>
-// CHECK:           return [[VAR_1_]] : tensor<13x21x1xi1>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xi1> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.greater [[PARAM_0_]], [[VAR_1_]] : (tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xi1>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xi1>
 }
 
 // -----
@@ -1254,9 +1316,11 @@ func.func @test_lessequal_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1x
   %0 = "onnx.LessOrEqual"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<1xf32>) -> tensor<13x21x1xi1>
   "func.return"(%0) : (tensor<13x21x1xi1>) -> ()
 // CHECK-LABEL:  func.func @test_lessequal_broadcast
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape %arg1 {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
-// CHECK:           [[VAR_1_:%.+]] = tosa.greater_equal [[VAR_0_]], %arg0 : (tensor<1x1x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xi1>
-// CHECK:           return [[VAR_1_]] : tensor<13x21x1xi1>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xi1> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.greater_equal [[VAR_1_]], [[PARAM_0_]] : (tensor<1x1x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xi1>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xi1>
 }
 
 // -----
@@ -1273,7 +1337,9 @@ func.func @test_less_broadcast(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1xf32>)
   %0 = "onnx.Less"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<1xf32>) -> tensor<13x21x1xi1>
   "func.return"(%0) : (tensor<13x21x1xi1>) -> ()
 // CHECK-LABEL:  func.func @test_less_broadcast
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape %arg1 {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
-// CHECK:           [[VAR_1_:%.+]] = tosa.greater [[VAR_0_]], %arg0 : (tensor<1x1x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xi1>
-// CHECK:           return [[VAR_1_]] : tensor<13x21x1xi1>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xi1> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.greater [[VAR_1_]], [[PARAM_0_]] : (tensor<1x1x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xi1>
+// CHECK:           return [[VAR_2_]] : tensor<13x21x1xi1>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Math/Gemm_to_linear.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Gemm_to_linear.mlir
@@ -21,9 +21,10 @@ func.func @gemm_to_fc_broadcast(%arg0: tensor<2x5xf32>, %arg1: tensor<4x5xf32>, 
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x5xf32>, [[PARAM_1_:%.+]]: tensor<4x5xf32>, [[PARAM_2_:%.+]]: tensor<1xf32>) -> tensor<2x4xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<4xf32>}> : () -> tensor<4xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = tosa.fully_connected [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]] : (tensor<2x5xf32>, tensor<4x5xf32>, tensor<4xf32>) -> tensor<2x4xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1, 1>} : (tensor<1xf32>) -> tensor<1x1xf32>
-// CHECK:           [[VAR_3_:%.+]] = tosa.add [[VAR_1_]], [[VAR_2_]] : (tensor<2x4xf32>, tensor<1x1xf32>) -> tensor<2x4xf32>
-// CHECK:           return [[VAR_3_]] : tensor<2x4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[PARAM_2_]], [[VAR_2_]] : (tensor<1xf32>, !tosa.shape<2>) -> tensor<1x1xf32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.add [[VAR_1_]], [[VAR_3_]] : (tensor<2x4xf32>, tensor<1x1xf32>) -> tensor<2x4xf32>
+// CHECK:           return [[VAR_4_]] : tensor<2x4xf32>
 // CHECK:         }
 }
 

--- a/test/mlir/conversion/onnx_to_tosa/Math/Gemm_to_matmul.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Gemm_to_matmul.mlir
@@ -5,13 +5,17 @@ func.func @test_gemm_to_matmul(%arg0: tensor<3x5xf32>, %arg1: tensor<5x4xf32>, %
   return %0 : tensor<3x4xf32>
 // CHECK-LABEL:  func.func @test_gemm_to_matmul
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x5xf32>, [[PARAM_1_:%.+]]: tensor<5x4xf32>, [[PARAM_2_:%.+]]: tensor<3x4xf32>) -> tensor<3x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 3, 5>} : (tensor<3x5xf32>) -> tensor<1x3x5xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 5, 4>} : (tensor<5x4xf32>) -> tensor<1x5x4xf32>
+// CHECK-DAG:       [[SHAPE_0:%.+]] = tosa.const_shape {value = dense<[1, 3, 5]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]], [[SHAPE_0]] : (tensor<3x5xf32>, !tosa.shape<3>) -> tensor<1x3x5xf32>
+// CHECK-DAG:       [[SHAPE_1:%.+]] = tosa.const_shape {value = dense<[1, 5, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE_1]] : (tensor<5x4xf32>, !tosa.shape<3>) -> tensor<1x5x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.matmul [[VAR_0_]], [[VAR_1_]] : (tensor<1x3x5xf32>, tensor<1x5x4xf32>) -> tensor<1x3x4xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1, 3, 4>} : (tensor<3x4xf32>) -> tensor<1x3x4xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.matmul [[VAR_0_]], [[VAR_1_]] : (tensor<1x3x5xf32>, tensor<1x5x4xf32>) -> tensor<1x3x4xf32>
+// CHECK-DAG:       [[SHAPE_2:%.+]] = tosa.const_shape {value = dense<[1, 3, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[PARAM_2_]], [[SHAPE_2]] : (tensor<3x4xf32>, !tosa.shape<3>) -> tensor<1x3x4xf32>
 // CHECK:           [[VAR_4_:%.+]] = tosa.add [[VAR_2_]], [[VAR_3_]] : (tensor<1x3x4xf32>, tensor<1x3x4xf32>) -> tensor<1x3x4xf32>
-// CHECK:           [[VAR_5_:%.+]] = tosa.reshape [[VAR_4_]] {new_shape = array<i64: 3, 4>} : (tensor<1x3x4xf32>) -> tensor<3x4xf32>
+// CHECK-DAG:       [[SHAPE_3:%.+]] = tosa.const_shape {value = dense<[3, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_5_:%.+]] = tosa.reshape [[VAR_4_]], [[SHAPE_3]] : (tensor<1x3x4xf32>, !tosa.shape<2>) -> tensor<3x4xf32>
 // CHECK:           return [[VAR_5_]] : tensor<3x4xf32>
 // CHECK:         }
 }
@@ -23,14 +27,19 @@ func.func @test_alpha(%arg0: tensor<3x6xf32>, %arg1: tensor<6x4xf32>, %arg2: ten
   return %0 : tensor<3x4xf32>
 // CHECK-LABEL:  func.func @test_alpha
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x6xf32>, [[PARAM_1_:%.+]]: tensor<6x4xf32>, [[PARAM_2_:%.+]]: tensor<3x4xf32>) -> tensor<3x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 3, 6>} : (tensor<3x6xf32>) -> tensor<1x3x6xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 6, 4>} : (tensor<6x4xf32>) -> tensor<1x6x4xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<1.618000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
-// CHECK:           [[VAR_3_:%.+]] = tosa.mul [[VAR_2_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<1x1x1xf32>, tensor<1x3x6xf32>) -> tensor<1x3x6xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.matmul [[VAR_3_]], [[VAR_1_]] : (tensor<1x3x6xf32>, tensor<1x6x4xf32>) -> tensor<1x3x4xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1, 3, 4>} : (tensor<3x4xf32>) -> tensor<1x3x4xf32>
+// CHECK-DAG:       [[SHAPE_0:%.+]] = tosa.const_shape {value = dense<[1, 3, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]], [[SHAPE_0]] : (tensor<3x6xf32>, !tosa.shape<3>) -> tensor<1x3x6xf32>
+// CHECK-DAG:       [[SHAPE_1:%.+]] = tosa.const_shape {value = dense<[1, 6, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE_1]] : (tensor<6x4xf32>, !tosa.shape<3>) -> tensor<1x6x4xf32>
+// CHECK:           [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<1.618000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+// CHECK:           [[ZERO:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>  
+// CHECK:           [[VAR_3_:%.+]] = tosa.mul [[VAR_2_]], [[VAR_0_]], [[ZERO]] : (tensor<1x1x1xf32>, tensor<1x3x6xf32>, tensor<1xi8>) -> tensor<1x3x6xf32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.matmul [[VAR_3_]], [[VAR_1_]] : (tensor<1x3x6xf32>, tensor<1x6x4xf32>) -> tensor<1x3x4xf32>
+// CHECK-DAG:       [[SHAPE_2:%.+]] = tosa.const_shape {value = dense<[1, 3, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_5_:%.+]] = tosa.reshape [[PARAM_2_]], [[SHAPE_2]] : (tensor<3x4xf32>, !tosa.shape<3>) -> tensor<1x3x4xf32>
 // CHECK:           [[VAR_6_:%.+]] = tosa.add [[VAR_4_]], [[VAR_5_]] : (tensor<1x3x4xf32>, tensor<1x3x4xf32>) -> tensor<1x3x4xf32>
-// CHECK:           [[VAR_7_:%.+]] = tosa.reshape [[VAR_6_]] {new_shape = array<i64: 3, 4>} : (tensor<1x3x4xf32>) -> tensor<3x4xf32>
+// CHECK-DAG:       [[SHAPE_3:%.+]] = tosa.const_shape {value = dense<[3, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_7_:%.+]] = tosa.reshape [[VAR_6_]], [[SHAPE_3]] : (tensor<1x3x4xf32>, !tosa.shape<2>) -> tensor<3x4xf32>
 // CHECK:           return [[VAR_7_]] : tensor<3x4xf32>
 // CHECK:         }
 }
@@ -42,15 +51,20 @@ func.func @test_beta(%arg0: tensor<3x6xf32>, %arg1: tensor<6x6xf32>, %arg2: tens
   return %0 : tensor<3x6xf32>
 // CHECK-LABEL:  func.func @test_beta
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x6xf32>, [[PARAM_1_:%.+]]: tensor<6x6xf32>, [[PARAM_2_:%.+]]: tensor<3x6xf32>) -> tensor<3x6xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 3, 6>} : (tensor<3x6xf32>) -> tensor<1x3x6xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 6, 6>} : (tensor<6x6xf32>) -> tensor<1x6x6xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<1.349000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1, 3, 6>} : (tensor<3x6xf32>) -> tensor<1x3x6xf32>
+// CHECK-DAG:       [[SHAPE_0:%.+]] = tosa.const_shape {value = dense<[1, 3, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]], [[SHAPE_0]] : (tensor<3x6xf32>, !tosa.shape<3>) -> tensor<1x3x6xf32>
+// CHECK-DAG:       [[SHAPE_1:%.+]] = tosa.const_shape {value = dense<[1, 6, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE_1]] : (tensor<6x6xf32>, !tosa.shape<3>) -> tensor<1x6x6xf32>
+// CHECK:           [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<1.349000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+// CHECK-DAG:       [[SHAPE_2:%.+]] = tosa.const_shape {value = dense<[1, 3, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[PARAM_2_]], [[SHAPE_2]] : (tensor<3x6xf32>, !tosa.shape<3>) -> tensor<1x3x6xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.mul [[VAR_2_]], [[VAR_3_]] {shift = 0 : i8} : (tensor<1x1x1xf32>, tensor<1x3x6xf32>) -> tensor<1x3x6xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.matmul [[VAR_0_]], [[VAR_1_]] : (tensor<1x3x6xf32>, tensor<1x6x6xf32>) -> tensor<1x3x6xf32>
+// CHECK:           [[ZERO:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_2_]], [[VAR_3_]], [[ZERO]] : (tensor<1x1x1xf32>, tensor<1x3x6xf32>, tensor<1xi8>) -> tensor<1x3x6xf32>
+// CHECK:           [[VAR_5_:%.+]] = tosa.matmul [[VAR_0_]], [[VAR_1_]] : (tensor<1x3x6xf32>, tensor<1x6x6xf32>) -> tensor<1x3x6xf32>
 // CHECK:           [[VAR_6_:%.+]] = tosa.add [[VAR_5_]], [[VAR_4_]] : (tensor<1x3x6xf32>, tensor<1x3x6xf32>) -> tensor<1x3x6xf32>
-// CHECK:           [[VAR_7_:%.+]] = tosa.reshape [[VAR_6_]] {new_shape = array<i64: 3, 6>} : (tensor<1x3x6xf32>) -> tensor<3x6xf32>
+// CHECK-DAG:       [[SHAPE_3:%.+]] = tosa.const_shape {value = dense<[3, 6]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_7_:%.+]] = tosa.reshape [[VAR_6_]], [[SHAPE_3]] : (tensor<1x3x6xf32>, !tosa.shape<2>) -> tensor<3x6xf32>
 // CHECK:           return [[VAR_7_]] : tensor<3x6xf32>
 // CHECK:         }
 }
@@ -62,14 +76,18 @@ func.func @test_transa(%arg0: tensor<6x3xf32>, %arg1: tensor<6x4xf32>, %arg2: te
   return %0 : tensor<3x4xf32>
 // CHECK-LABEL:  func.func @test_transa
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<6x3xf32>, [[PARAM_1_:%.+]]: tensor<6x4xf32>, [[PARAM_2_:%.+]]: tensor<3x4xf32>) -> tensor<3x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 6, 3>} : (tensor<6x3xf32>) -> tensor<1x6x3xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 6, 4>} : (tensor<6x4xf32>) -> tensor<1x6x4xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK-DAG:       [[SHAPE_0:%.+]] = tosa.const_shape {value = dense<[1, 6, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]], [[SHAPE_0]] : (tensor<6x3xf32>, !tosa.shape<3>) -> tensor<1x6x3xf32>
+// CHECK-DAG:       [[SHAPE_1:%.+]] = tosa.const_shape {value = dense<[1, 6, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE_1]] : (tensor<6x4xf32>, !tosa.shape<3>) -> tensor<1x6x4xf32>
+// CHECK:           [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
 // CHECK:           [[VAR_3_:%.+]] = tosa.transpose [[VAR_0_]], [[VAR_2_]] : (tensor<1x6x3xf32>, tensor<3xi32>) -> tensor<1x3x6xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.matmul [[VAR_3_]], [[VAR_1_]] : (tensor<1x3x6xf32>, tensor<1x6x4xf32>) -> tensor<1x3x4xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1, 3, 4>} : (tensor<3x4xf32>) -> tensor<1x3x4xf32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.matmul [[VAR_3_]], [[VAR_1_]] : (tensor<1x3x6xf32>, tensor<1x6x4xf32>) -> tensor<1x3x4xf32>
+// CHECK-DAG:       [[SHAPE_2:%.+]] = tosa.const_shape {value = dense<[1, 3, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_5_:%.+]] = tosa.reshape [[PARAM_2_]], [[SHAPE_2]] : (tensor<3x4xf32>, !tosa.shape<3>) -> tensor<1x3x4xf32>
 // CHECK:           [[VAR_6_:%.+]] = tosa.add [[VAR_4_]], [[VAR_5_]] : (tensor<1x3x4xf32>, tensor<1x3x4xf32>) -> tensor<1x3x4xf32>
-// CHECK:           [[VAR_7_:%.+]] = tosa.reshape [[VAR_6_]] {new_shape = array<i64: 3, 4>} : (tensor<1x3x4xf32>) -> tensor<3x4xf32>
+// CHECK-DAG:       [[SHAPE_3:%.+]] = tosa.const_shape {value = dense<[3, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_7_:%.+]] = tosa.reshape [[VAR_6_]], [[SHAPE_3]] : (tensor<1x3x4xf32>, !tosa.shape<2>) -> tensor<3x4xf32>
 // CHECK:           return [[VAR_7_]] : tensor<3x4xf32>
 // CHECK:         }
 }
@@ -81,17 +99,22 @@ func.func @test_transb(%arg0: tensor<3x6xf32>, %arg1: tensor<4x6xf32>, %arg2: te
   return %0 : tensor<3x4xf32>
 // CHECK-LABEL:  func.func @test_transb
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x6xf32>, [[PARAM_1_:%.+]]: tensor<4x6xf32>, [[PARAM_2_:%.+]]: tensor<3x4xf32>) -> tensor<3x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 3, 6>} : (tensor<3x6xf32>) -> tensor<1x3x6xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 4, 6>} : (tensor<4x6xf32>) -> tensor<1x4x6xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK:           [[SHAPE_0:%.+]] = tosa.const_shape {value = dense<[1, 3, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]], [[SHAPE_0]] : (tensor<3x6xf32>, !tosa.shape<3>) -> tensor<1x3x6xf32>
+// CHECK:           [[SHAPE_1:%.+]] = tosa.const_shape {value = dense<[1, 4, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE_1]] : (tensor<4x6xf32>, !tosa.shape<3>) -> tensor<1x4x6xf32>
+// CHECK:           [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.transpose [[VAR_1_]], [[VAR_2_]] : (tensor<1x4x6xf32>, tensor<3xi32>) -> tensor<1x6x4xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<1.184000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
-// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_4_]], [[VAR_0_]] {shift = 0 : i8} : (tensor<1x1x1xf32>, tensor<1x3x6xf32>) -> tensor<1x3x6xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.matmul [[VAR_5_]], [[VAR_3_]] : (tensor<1x3x6xf32>, tensor<1x6x4xf32>) -> tensor<1x3x4xf32>
-// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1, 3, 4>} : (tensor<3x4xf32>) -> tensor<1x3x4xf32>
+// CHECK:           [[VAR_3_:%.+]] = tosa.transpose [[VAR_1_]], [[VAR_2_]] : (tensor<1x4x6xf32>, tensor<3xi32>) -> tensor<1x6x4xf32>
+// CHECK:           [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<1.184000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+// CHECK:           [[ZERO:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_4_]], [[VAR_0_]], [[ZERO]] : (tensor<1x1x1xf32>, tensor<1x3x6xf32>, tensor<1xi8>) -> tensor<1x3x6xf32>
+// CHECK:           [[VAR_6_:%.+]] = tosa.matmul [[VAR_5_]], [[VAR_3_]] : (tensor<1x3x6xf32>, tensor<1x6x4xf32>) -> tensor<1x3x4xf32>
+// CHECK:           [[SHAPE_2:%.+]] = tosa.const_shape {value = dense<[1, 3, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_7_:%.+]] = tosa.reshape [[PARAM_2_]], [[SHAPE_2]] : (tensor<3x4xf32>, !tosa.shape<3>) -> tensor<1x3x4xf32>
 // CHECK:           [[VAR_8_:%.+]] = tosa.add [[VAR_6_]], [[VAR_7_]] : (tensor<1x3x4xf32>, tensor<1x3x4xf32>) -> tensor<1x3x4xf32>
-// CHECK:           [[VAR_9_:%.+]] = tosa.reshape [[VAR_8_]] {new_shape = array<i64: 3, 4>} : (tensor<1x3x4xf32>) -> tensor<3x4xf32>
+// CHECK:           [[SHAPE_3:%.+]] = tosa.const_shape {value = dense<[3, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_9_:%.+]] = tosa.reshape [[VAR_8_]], [[SHAPE_3]] : (tensor<1x3x4xf32>, !tosa.shape<2>) -> tensor<3x4xf32>
 // CHECK:           return [[VAR_9_]] : tensor<3x4xf32>
 // CHECK:         }
 }
@@ -105,12 +128,15 @@ func.func @test_no_c(%arg0: tensor<1x5xf32>, %arg1: tensor<5x5xf32>) -> tensor<1
 // CHECK-LABEL:  func.func @test_no_c
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x5xf32>, [[PARAM_1_:%.+]]: tensor<5x5xf32>) -> tensor<1x5xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 1, 5>} : (tensor<1x5xf32>) -> tensor<1x1x5xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 5, 5>} : (tensor<5x5xf32>) -> tensor<1x5x5xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK:           [[SHAPE_0:%.+]] = tosa.const_shape {value = dense<[1, 1, 5]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[SHAPE_0]] : (tensor<1x5xf32>, !tosa.shape<3>) -> tensor<1x1x5xf32>
+// CHECK-DAG:       [[SHAPE_1:%.+]] = tosa.const_shape {value = dense<[1, 5, 5]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE_1]] : (tensor<5x5xf32>, !tosa.shape<3>) -> tensor<1x5x5xf32>
+// CHECK:           [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
 // CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x5x5xf32>, tensor<3xi32>) -> tensor<1x5x5xf32>
 // CHECK:           [[VAR_5_:%.+]] = tosa.matmul [[VAR_1_]], [[VAR_4_]] : (tensor<1x1x5xf32>, tensor<1x5x5xf32>) -> tensor<1x1x5xf32>
-// CHECK:           [[VAR_6_:%.+]] = tosa.reshape [[VAR_5_]] {new_shape = array<i64: 1, 5>} : (tensor<1x1x5xf32>) -> tensor<1x5xf32>
+// CHECK-DAG:       [[SHAPE_2:%.+]] = tosa.const_shape {value = dense<[1, 5]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_6_:%.+]] = tosa.reshape [[VAR_5_]], [[SHAPE_2]] : (tensor<1x1x5xf32>, !tosa.shape<2>) -> tensor<1x5xf32>
 // CHECK:           return [[VAR_6_]] : tensor<1x5xf32>
 // CHECK:         }
 }
@@ -124,12 +150,16 @@ func.func @test_no_c_no_trans(%arg0: tensor<1x5xf32>, %arg1: tensor<5x6xf32>) ->
 // CHECK-LABEL:  func.func @test_no_c_no_trans
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x5xf32>, [[PARAM_1_:%.+]]: tensor<5x6xf32>) -> tensor<1x6xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 1, 5>} : (tensor<1x5xf32>) -> tensor<1x1x5xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 5, 6>} : (tensor<5x6xf32>) -> tensor<1x5x6xf32>
+// CHECK-DAG:       [[SHAPE_0:%.+]] = tosa.const_shape {value = dense<[1, 1, 5]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[SHAPE_0]] : (tensor<1x5xf32>, !tosa.shape<3>) -> tensor<1x1x5xf32>
+// CHECK-DAG:       [[SHAPE_1:%.+]] = tosa.const_shape {value = dense<[1, 5, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE_1]] : (tensor<5x6xf32>, !tosa.shape<3>) -> tensor<1x5x6xf32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<1.349000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
-// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]] {shift = 0 : i8} : (tensor<1x1x1xf32>, tensor<1x1x5xf32>) -> tensor<1x1x5xf32>
+// CHECK-DAG:       [[ZERO:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_1_]], [[ZERO]] : (tensor<1x1x1xf32>, tensor<1x1x5xf32>, tensor<1xi8>) -> tensor<1x1x5xf32>
 // CHECK:           [[VAR_5_:%.+]] = tosa.matmul [[VAR_4_]], [[VAR_2_]] : (tensor<1x1x5xf32>, tensor<1x5x6xf32>) -> tensor<1x1x6xf32>
-// CHECK:           [[VAR_6_:%.+]] = tosa.reshape [[VAR_5_]] {new_shape = array<i64: 1, 6>} : (tensor<1x1x6xf32>) -> tensor<1x6xf32>
+// CHECK-DAG:       [[SHAPE_2:%.+]] = tosa.const_shape {value = dense<[1, 6]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_6_:%.+]] = tosa.reshape [[VAR_5_]], [[SHAPE_2]] : (tensor<1x1x6xf32>, !tosa.shape<2>) -> tensor<1x6xf32>
 // CHECK:           return [[VAR_6_]] : tensor<1x6xf32>
 // CHECK:         }
 }
@@ -141,24 +171,30 @@ func.func @test_mixed(%arg0: tensor<11x5xf32>, %arg1: tensor<3x11xf32>, %arg2: t
   return %0 : tensor<5x3xf32>
 // CHECK-LABEL:  func.func @test_mixed
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<11x5xf32>, [[PARAM_1_:%.+]]: tensor<3x11xf32>, [[PARAM_2_:%.+]]: tensor<5x3xf32>) -> tensor<5x3xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 11, 5>} : (tensor<11x5xf32>) -> tensor<1x11x5xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 3, 11>} : (tensor<3x11xf32>) -> tensor<1x3x11xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK-DAG:       [[SHAPE_0:%.+]] = tosa.const_shape {value = dense<[1, 11, 5]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]], [[SHAPE_0]] : (tensor<11x5xf32>, !tosa.shape<3>) -> tensor<1x11x5xf32>
+// CHECK:           [[SHAPE_1:%.+]] = tosa.const_shape {value = dense<[1, 3, 11]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE_1]] : (tensor<3x11xf32>, !tosa.shape<3>) -> tensor<1x3x11xf32>
+// CHECK:           [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.transpose [[VAR_0_]], [[VAR_2_]] : (tensor<1x11x5xf32>, tensor<3xi32>) -> tensor<1x5x11xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK:           [[VAR_3_:%.+]] = tosa.transpose [[VAR_0_]], [[VAR_2_]] : (tensor<1x11x5xf32>, tensor<3xi32>) -> tensor<1x5x11xf32>
+// CHECK:           [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.transpose [[VAR_1_]], [[VAR_4_]] : (tensor<1x3x11xf32>, tensor<3xi32>) -> tensor<1x11x3xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<1.402000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+// CHECK:           [[VAR_5_:%.+]] = tosa.transpose [[VAR_1_]], [[VAR_4_]] : (tensor<1x3x11xf32>, tensor<3xi32>) -> tensor<1x11x3xf32>
+// CHECK:           [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<1.402000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+// CHECK-DAG:       [[ZERO_0:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.mul [[VAR_6_]], [[VAR_3_]] {shift = 0 : i8} : (tensor<1x1x1xf32>, tensor<1x5x11xf32>) -> tensor<1x5x11xf32>
-// CHECK-DAG:       [[VAR_8_:%.+]] = "tosa.const"() <{value = dense<1.998000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1, 5, 3>} : (tensor<5x3xf32>) -> tensor<1x5x3xf32>
+// CHECK:           [[VAR_7_:%.+]] = tosa.mul [[VAR_6_]], [[VAR_3_]], [[ZERO_0]] : (tensor<1x1x1xf32>, tensor<1x5x11xf32>, tensor<1xi8>) -> tensor<1x5x11xf32>
+// CHECK:           [[VAR_8_:%.+]] = "tosa.const"() <{value = dense<1.998000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+// CHECK:           [[SHAPE_2:%.+]] = tosa.const_shape {value = dense<[1, 5, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_9_:%.+]] = tosa.reshape [[PARAM_2_]], [[SHAPE_2]] : (tensor<5x3xf32>, !tosa.shape<3>) -> tensor<1x5x3xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.mul [[VAR_8_]], [[VAR_9_]] {shift = 0 : i8} : (tensor<1x1x1xf32>, tensor<1x5x3xf32>) -> tensor<1x5x3xf32>
-// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.matmul [[VAR_7_]], [[VAR_5_]] : (tensor<1x5x11xf32>, tensor<1x11x3xf32>) -> tensor<1x5x3xf32>
+// CHECK:           [[ZERO_1:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_10_:%.+]] = tosa.mul [[VAR_8_]], [[VAR_9_]], [[ZERO_1]] : (tensor<1x1x1xf32>, tensor<1x5x3xf32>, tensor<1xi8>) -> tensor<1x5x3xf32>
+// CHECK:           [[VAR_11_:%.+]] = tosa.matmul [[VAR_7_]], [[VAR_5_]] : (tensor<1x5x11xf32>, tensor<1x11x3xf32>) -> tensor<1x5x3xf32>
 // CHECK:           [[VAR_12_:%.+]] = tosa.add [[VAR_11_]], [[VAR_10_]] : (tensor<1x5x3xf32>, tensor<1x5x3xf32>) -> tensor<1x5x3xf32>
-// CHECK:           [[VAR_13_:%.+]] = tosa.reshape [[VAR_12_]] {new_shape = array<i64: 5, 3>} : (tensor<1x5x3xf32>) -> tensor<5x3xf32>
+// CHECK:           [[SHAPE_3:%.+]] = tosa.const_shape {value = dense<[5, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_13_:%.+]] = tosa.reshape [[VAR_12_]], [[SHAPE_3]] : (tensor<1x5x3xf32>, !tosa.shape<2>) -> tensor<5x3xf32>
 // CHECK:           return [[VAR_13_]] : tensor<5x3xf32>
 // CHECK:         }
 }

--- a/test/mlir/conversion/onnx_to_tosa/Math/Gemm_to_matmul.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Gemm_to_matmul.mlir
@@ -55,11 +55,10 @@ func.func @test_beta(%arg0: tensor<3x6xf32>, %arg1: tensor<6x6xf32>, %arg2: tens
 // CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]], [[SHAPE_0]] : (tensor<3x6xf32>, !tosa.shape<3>) -> tensor<1x3x6xf32>
 // CHECK-DAG:       [[SHAPE_1:%.+]] = tosa.const_shape {value = dense<[1, 6, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
 // CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[SHAPE_1]] : (tensor<6x6xf32>, !tosa.shape<3>) -> tensor<1x6x6xf32>
-// CHECK:           [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<1.349000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<1.349000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
 // CHECK-DAG:       [[SHAPE_2:%.+]] = tosa.const_shape {value = dense<[1, 3, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
-// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[PARAM_2_]], [[SHAPE_2]] : (tensor<3x6xf32>, !tosa.shape<3>) -> tensor<1x3x6xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK:           [[ZERO:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.reshape [[PARAM_2_]], [[SHAPE_2]] : (tensor<3x6xf32>, !tosa.shape<3>) -> tensor<1x3x6xf32>
+// CHECK-DAG:       [[ZERO:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
 // CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_2_]], [[VAR_3_]], [[ZERO]] : (tensor<1x1x1xf32>, tensor<1x3x6xf32>, tensor<1xi8>) -> tensor<1x3x6xf32>
 // CHECK:           [[VAR_5_:%.+]] = tosa.matmul [[VAR_0_]], [[VAR_1_]] : (tensor<1x3x6xf32>, tensor<1x6x6xf32>) -> tensor<1x3x6xf32>
 // CHECK:           [[VAR_6_:%.+]] = tosa.add [[VAR_5_]], [[VAR_4_]] : (tensor<1x3x6xf32>, tensor<1x3x6xf32>) -> tensor<1x3x6xf32>
@@ -185,11 +184,10 @@ func.func @test_mixed(%arg0: tensor<11x5xf32>, %arg1: tensor<3x11xf32>, %arg2: t
 // CHECK-DAG:       [[ZERO_0:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK:           [[VAR_7_:%.+]] = tosa.mul [[VAR_6_]], [[VAR_3_]], [[ZERO_0]] : (tensor<1x1x1xf32>, tensor<1x5x11xf32>, tensor<1xi8>) -> tensor<1x5x11xf32>
-// CHECK:           [[VAR_8_:%.+]] = "tosa.const"() <{value = dense<1.998000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
-// CHECK:           [[SHAPE_2:%.+]] = tosa.const_shape {value = dense<[1, 5, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
-// CHECK:           [[VAR_9_:%.+]] = tosa.reshape [[PARAM_2_]], [[SHAPE_2]] : (tensor<5x3xf32>, !tosa.shape<3>) -> tensor<1x5x3xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK:           [[ZERO_1:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:       [[VAR_8_:%.+]] = "tosa.const"() <{value = dense<1.998000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+// CHECK-DAG:       [[SHAPE_2:%.+]] = tosa.const_shape {value = dense<[1, 5, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.reshape [[PARAM_2_]], [[SHAPE_2]] : (tensor<5x3xf32>, !tosa.shape<3>) -> tensor<1x5x3xf32>
+// CHECK-DAG:       [[ZERO_1:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
 // CHECK:           [[VAR_10_:%.+]] = tosa.mul [[VAR_8_]], [[VAR_9_]], [[ZERO_1]] : (tensor<1x1x1xf32>, tensor<1x5x3xf32>, tensor<1xi8>) -> tensor<1x5x3xf32>
 // CHECK:           [[VAR_11_:%.+]] = tosa.matmul [[VAR_7_]], [[VAR_5_]] : (tensor<1x5x11xf32>, tensor<1x11x3xf32>) -> tensor<1x5x3xf32>
 // CHECK:           [[VAR_12_:%.+]] = tosa.add [[VAR_11_]], [[VAR_10_]] : (tensor<1x5x3xf32>, tensor<1x5x3xf32>) -> tensor<1x5x3xf32>

--- a/test/mlir/conversion/onnx_to_tosa/Math/ReduceMax.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/ReduceMax.mlir
@@ -36,8 +36,9 @@ return %1 : tensor<2x5xf32>
 // CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<2x5x9x11xf32>) -> tensor<2x5xf32> {
 // CHECK:           %[[VAL_1:.*]] = tosa.reduce_max %[[VAL_0]] {axis = 2 : i32} : (tensor<2x5x9x11xf32>) -> tensor<2x5x1x11xf32>
 // CHECK:           %[[VAL_2:.*]] = tosa.reduce_max %[[VAL_1]] {axis = 3 : i32} : (tensor<2x5x1x11xf32>) -> tensor<2x5x1x1xf32>
-// CHECK:           %[[VAL_3:.*]] = tosa.reshape %[[VAL_2]] {new_shape = array<i64: 2, 5>} : (tensor<2x5x1x1xf32>) -> tensor<2x5xf32>
-// CHECK:           return %[[VAL_3]] : tensor<2x5xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[2, 5]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape %[[VAL_2]], [[VAR_2_]] : (tensor<2x5x1x1xf32>, !tosa.shape<2>) -> tensor<2x5xf32>
+// CHECK:           return [[VAR_3_]] : tensor<2x5xf32>
 }
 
 // -----
@@ -84,6 +85,7 @@ func.func @test_reducemaxV13_keep_dims_0(%arg0: tensor<1x32x112x112xf32>) -> ten
 // CHECK-LABEL:  func.func @test_reducemaxV13_keep_dims_0
 // CHECK:           [[VAR_0_:%.+]] = tosa.reduce_max %arg0 {axis = 2 : i32}
 // CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reduce_max [[VAR_0_]] {axis = 3 : i32}
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 1, 32>}
-// CHECK:           return [[VAR_2_]] : tensor<1x32xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 32]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_2_]] : (tensor<1x32x1x1xf32>, !tosa.shape<2>) -> tensor<1x32xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x32xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Math/ReduceMean.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/ReduceMean.mlir
@@ -4,13 +4,14 @@ func.func @reduce_mean(%arg0: tensor<2x5x9x11xf32>) -> tensor<2x5x1x1xf32> {
 %0 = "onnx.Constant"() {value = dense<[2, 3]> : tensor<2xi64>} : () -> tensor<2xi64>
 %1 = "onnx.ReduceMean"(%arg0, %0) : (tensor<2x5x9x11xf32>, tensor<2xi64>) -> tensor<2x5x1x1xf32>
 return %1 : tensor<2x5x1x1xf32>
-// CHECK-LABEL:   func.func @reduce_mean(
-// CHECK-SAME:                           %[[VAL_0:.*]]: tensor<2x5x9x11xf32>) -> tensor<2x5x1x1xf32> {
-// CHECK:           %[[VAL_1:.*]] = tosa.reduce_sum %[[VAL_0]] {axis = 2 : i32} : (tensor<2x5x9x11xf32>) -> tensor<2x5x1x11xf32>
-// CHECK:           %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 3 : i32} : (tensor<2x5x1x11xf32>) -> tensor<2x5x1x1xf32>
-// CHECK:           %[[VAL_3:.*]] = "tosa.const"() <{value = dense<0.0101010101> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_4:.*]] = tosa.mul %[[VAL_2]], %[[VAL_3]] {shift = 0 : i8} : (tensor<2x5x1x1xf32>, tensor<1x1x1x1xf32>) -> tensor<2x5x1x1xf32>
-// CHECK:           return %[[VAL_4]] : tensor<2x5x1x1xf32>
+// CHECK-LABEL:  func.func @reduce_mean
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x5x9x11xf32>) -> tensor<2x5x1x1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reduce_sum [[PARAM_0_]] {axis = 2 : i32} : (tensor<2x5x9x11xf32>) -> tensor<2x5x1x11xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reduce_sum [[VAR_0_]] {axis = 3 : i32} : (tensor<2x5x1x11xf32>) -> tensor<2x5x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0.0101010101> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_1_]], [[VAR_2_]], [[VAR_3_]] : (tensor<2x5x1x1xf32>, tensor<1x1x1x1xf32>, tensor<1xi8>) -> tensor<2x5x1x1xf32>
+// CHECK:           return [[VAR_4_]] : tensor<2x5x1x1xf32>
 }
 
 // -----
@@ -19,15 +20,16 @@ func.func @reduce_mean_no_axes_attr(%arg0: tensor<2x5x9x11xf32>) -> tensor<1x1x1
 %none = "onnx.NoValue"() {value} : () -> none
 %0 = "onnx.ReduceMean"(%arg0, %none) : (tensor<2x5x9x11xf32>, none) -> tensor<1x1x1x1xf32>
 return %0 : tensor<1x1x1x1xf32>
-// CHECK-LABEL:   func.func @reduce_mean_no_axes_attr(
-// CHECK-SAME:                                        %[[VAL_0:.*]]: tensor<2x5x9x11xf32>) -> tensor<1x1x1x1xf32> {
-// CHECK:           %[[VAL_1:.*]] = tosa.reduce_sum %[[VAL_0]] {axis = 0 : i32} : (tensor<2x5x9x11xf32>) -> tensor<1x5x9x11xf32>
-// CHECK:           %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 1 : i32} : (tensor<1x5x9x11xf32>) -> tensor<1x1x9x11xf32>
-// CHECK:           %[[VAL_3:.*]] = tosa.reduce_sum %[[VAL_2]] {axis = 2 : i32} : (tensor<1x1x9x11xf32>) -> tensor<1x1x1x11xf32>
-// CHECK:           %[[VAL_4:.*]] = tosa.reduce_sum %[[VAL_3]] {axis = 3 : i32} : (tensor<1x1x1x11xf32>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0.00101010106> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_6:.*]] = tosa.mul %[[VAL_4]], %[[VAL_5]] {shift = 0 : i8} : (tensor<1x1x1x1xf32>, tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
-// CHECK:           return %[[VAL_6]] : tensor<1x1x1x1xf32>
+// CHECK-LABEL:  func.func @reduce_mean_no_axes_attr
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x5x9x11xf32>) -> tensor<1x1x1x1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reduce_sum [[PARAM_0_]] {axis = 0 : i32} : (tensor<2x5x9x11xf32>) -> tensor<1x5x9x11xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reduce_sum [[VAR_0_]] {axis = 1 : i32} : (tensor<1x5x9x11xf32>) -> tensor<1x1x9x11xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reduce_sum [[VAR_1_]] {axis = 2 : i32} : (tensor<1x1x9x11xf32>) -> tensor<1x1x1x11xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.reduce_sum [[VAR_2_]] {axis = 3 : i32} : (tensor<1x1x1x11xf32>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0.00101010106> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_6_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_4_]], [[VAR_5_]] : (tensor<1x1x1x1xf32>, tensor<1x1x1x1xf32>, tensor<1xi8>) -> tensor<1x1x1x1xf32>
+// CHECK:           return [[VAR_6_]] : tensor<1x1x1x1xf32>
 }
 
 // -----
@@ -36,14 +38,16 @@ func.func @reduce_mean_keepdims_false(%arg0: tensor<2x5x9x11xf32>) -> tensor<2x5
 %0 = "onnx.Constant"() {value = dense<[2, 3]> : tensor<2xi64>} : () -> tensor<2xi64>
 %1 = "onnx.ReduceMean"(%arg0, %0) {keepdims = 0 : si64} : (tensor<2x5x9x11xf32>, tensor<2xi64>) -> tensor<2x5xf32>
 return %1 : tensor<2x5xf32>
-// CHECK-LABEL:   func.func @reduce_mean_keepdims_false(
-// CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<2x5x9x11xf32>) -> tensor<2x5xf32> {
-// CHECK:           %[[VAL_1:.*]] = tosa.reduce_sum %[[VAL_0]] {axis = 2 : i32} : (tensor<2x5x9x11xf32>) -> tensor<2x5x1x11xf32>
-// CHECK:           %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 3 : i32} : (tensor<2x5x1x11xf32>) -> tensor<2x5x1x1xf32>
-// CHECK:           %[[VAL_3:.*]] = tosa.reshape %[[VAL_2]] {new_shape = array<i64: 2, 5>} : (tensor<2x5x1x1xf32>) -> tensor<2x5xf32>
-// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{value = dense<0.0101010101> : tensor<1x1xf32>}> : () -> tensor<1x1xf32>
-// CHECK:           %[[VAL_5:.*]] = tosa.mul %[[VAL_3]], %[[VAL_4]] {shift = 0 : i8} : (tensor<2x5xf32>, tensor<1x1xf32>) -> tensor<2x5xf32>
-// CHECK:           return %[[VAL_5]] : tensor<2x5xf32>
+// CHECK-LABEL:  func.func @reduce_mean_keepdims_false
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x5x9x11xf32>) -> tensor<2x5xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reduce_sum [[PARAM_0_]] {axis = 2 : i32} : (tensor<2x5x9x11xf32>) -> tensor<2x5x1x11xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reduce_sum [[VAR_0_]] {axis = 3 : i32} : (tensor<2x5x1x11xf32>) -> tensor<2x5x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[2, 5]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_2_]] : (tensor<2x5x1x1xf32>, !tosa.shape<2>) -> tensor<2x5xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<0.0101010101> : tensor<1x1xf32>}> : () -> tensor<1x1xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_6_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_4_]], [[VAR_5_]] : (tensor<2x5xf32>, tensor<1x1xf32>, tensor<1xi8>) -> tensor<2x5xf32>
+// CHECK:           return [[VAR_6_]] : tensor<2x5xf32>
 }
 
 // -----
@@ -52,13 +56,14 @@ func.func @reduce_mean_noop_with_emtpy_axes_one(%arg0: tensor<2x5x9x11xf32>) -> 
 %0 = "onnx.Constant"() {value = dense<[2, 3]> : tensor<2xi64>} : () -> tensor<2xi64>
 %1 = "onnx.ReduceMean"(%arg0, %0) {noop_with_empty_axes = 1 : si64} : (tensor<2x5x9x11xf32>, tensor<2xi64>) -> tensor<2x5x1x1xf32>
 return %1 : tensor<2x5x1x1xf32>
-// CHECK-LABEL:   func.func @reduce_mean_noop_with_emtpy_axes_one(
-// CHECK-SAME:                                                    %[[VAL_0:.*]]: tensor<2x5x9x11xf32>) -> tensor<2x5x1x1xf32> {
-// CHECK:           %[[VAL_1:.*]] = tosa.reduce_sum %[[VAL_0]] {axis = 2 : i32} : (tensor<2x5x9x11xf32>) -> tensor<2x5x1x11xf32>
-// CHECK:           %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 3 : i32} : (tensor<2x5x1x11xf32>) -> tensor<2x5x1x1xf32>
-// CHECK:           %[[VAL_3:.*]] = "tosa.const"() <{value = dense<0.0101010101> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_4:.*]] = tosa.mul %[[VAL_2]], %[[VAL_3]] {shift = 0 : i8} : (tensor<2x5x1x1xf32>, tensor<1x1x1x1xf32>) -> tensor<2x5x1x1xf32>
-// CHECK:           return %[[VAL_4]] : tensor<2x5x1x1xf32>
+// CHECK-LABEL:  func.func @reduce_mean_noop_with_emtpy_axes_one
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x5x9x11xf32>) -> tensor<2x5x1x1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reduce_sum [[PARAM_0_]] {axis = 2 : i32} : (tensor<2x5x9x11xf32>) -> tensor<2x5x1x11xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reduce_sum [[VAR_0_]] {axis = 3 : i32} : (tensor<2x5x1x11xf32>) -> tensor<2x5x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0.0101010101> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_1_]], [[VAR_2_]], [[VAR_3_]] : (tensor<2x5x1x1xf32>, tensor<1x1x1x1xf32>, tensor<1xi8>) -> tensor<2x5x1x1xf32>
+// CHECK:           return [[VAR_4_]] : tensor<2x5x1x1xf32>
 }
 
 // -----
@@ -78,11 +83,13 @@ func.func @test_reducemeanV13(%arg0: tensor<1x32x112x112xf32>) -> tensor<1x32x1x
   %0 = "onnx.ReduceMeanV13"(%arg0) {axes = [2, 3], keepdims = 1 : si64} : (tensor<1x32x112x112xf32>) -> tensor<1x32x1x1xf32>
   return %0 : tensor<1x32x1x1xf32>
 // CHECK-LABEL:  func.func @test_reducemeanV13
-// CHECK:           [[VAR_0_:%.+]] = tosa.reduce_sum %arg0 {axis = 2 : i32}
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reduce_sum [[VAR_0_]] {axis = 3 : i32}
-// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<7.97193861E-5> : tensor<1x1x1x1xf32>}>
-// CHECK:           [[VAR_3_:%.+]] = tosa.mul [[VAR_1_]], [[VAR_2_]] {shift = 0 : i8} : (tensor<1x32x1x1xf32>, tensor<1x1x1x1xf32>)
-// CHECK:           return [[VAR_3_]] : tensor<1x32x1x1xf32>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x32x112x112xf32>) -> tensor<1x32x1x1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reduce_sum [[PARAM_0_]] {axis = 2 : i32} : (tensor<1x32x112x112xf32>) -> tensor<1x32x1x112xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reduce_sum [[VAR_0_]] {axis = 3 : i32} : (tensor<1x32x1x112xf32>) -> tensor<1x32x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<7.97193861E-5> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_1_]], [[VAR_2_]], [[VAR_3_]] : (tensor<1x32x1x1xf32>, tensor<1x1x1x1xf32>, tensor<1xi8>) -> tensor<1x32x1x1xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x32x1x1xf32>
 }
 
 // -----

--- a/test/mlir/conversion/onnx_to_tosa/Math/ReduceMin.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/ReduceMin.mlir
@@ -36,8 +36,9 @@ return %1 : tensor<2x5xf32>
 // CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<2x5x9x11xf32>) -> tensor<2x5xf32> {
 // CHECK:           %[[VAL_1:.*]] = tosa.reduce_min %[[VAL_0]] {axis = 2 : i32} : (tensor<2x5x9x11xf32>) -> tensor<2x5x1x11xf32>
 // CHECK:           %[[VAL_2:.*]] = tosa.reduce_min %[[VAL_1]] {axis = 3 : i32} : (tensor<2x5x1x11xf32>) -> tensor<2x5x1x1xf32>
-// CHECK:           %[[VAL_3:.*]] = tosa.reshape %[[VAL_2]] {new_shape = array<i64: 2, 5>} : (tensor<2x5x1x1xf32>) -> tensor<2x5xf32>
-// CHECK:           return %[[VAL_3]] : tensor<2x5xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[2, 5]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape %[[VAL_2]], [[VAR_2_]] : (tensor<2x5x1x1xf32>, !tosa.shape<2>) -> tensor<2x5xf32>
+// CHECK:           return [[VAR_3_]] : tensor<2x5xf32>
 }
 
 // -----
@@ -84,6 +85,7 @@ func.func @test_reduceminV13_keep_dims_0(%arg0: tensor<1x32x112x112xf32>) -> ten
 // CHECK-LABEL:  func.func @test_reduceminV13_keep_dims_0
 // CHECK:           [[VAR_0_:%.+]] = tosa.reduce_min %arg0 {axis = 2 : i32}
 // CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reduce_min [[VAR_0_]] {axis = 3 : i32}
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 1, 32>}
-// CHECK:           return [[VAR_2_]] : tensor<1x32xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 32]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_2_]] : (tensor<1x32x1x1xf32>, !tosa.shape<2>) -> tensor<1x32xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x32xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Math/ReduceProd.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/ReduceProd.mlir
@@ -36,8 +36,9 @@ return %1 : tensor<2x5xf32>
 // CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<2x5x9x11xf32>) -> tensor<2x5xf32> {
 // CHECK:           %[[VAL_1:.*]] = tosa.reduce_prod %[[VAL_0]] {axis = 2 : i32} : (tensor<2x5x9x11xf32>) -> tensor<2x5x1x11xf32>
 // CHECK:           %[[VAL_2:.*]] = tosa.reduce_prod %[[VAL_1]] {axis = 3 : i32} : (tensor<2x5x1x11xf32>) -> tensor<2x5x1x1xf32>
-// CHECK:           %[[VAL_3:.*]] = tosa.reshape %[[VAL_2]] {new_shape = array<i64: 2, 5>} : (tensor<2x5x1x1xf32>) -> tensor<2x5xf32>
-// CHECK:           return %[[VAL_3]] : tensor<2x5xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[2, 5]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape %[[VAL_2]], [[VAR_2_]] : (tensor<2x5x1x1xf32>, !tosa.shape<2>) -> tensor<2x5xf32>
+// CHECK:           return [[VAR_3_]] : tensor<2x5xf32>
 }
 
 // -----
@@ -84,7 +85,8 @@ func.func @test_reduceprodV13_keep_dims_false(%arg0: tensor<1x32x112x112xf32>) -
 // CHECK-LABEL:  func.func @test_reduceprodV13_keep_dims_false
 // CHECK:           [[VAR_0_:%.+]] = tosa.reduce_prod %arg0 {axis = 2 : i32}
 // CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reduce_prod [[VAR_0_]] {axis = 3 : i32}
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 1, 32>}
-// CHECK:           return [[VAR_2_]] : tensor<1x32xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 32]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_2_]] : (tensor<1x32x1x1xf32>, !tosa.shape<2>) -> tensor<1x32xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x32xf32>
 }
 

--- a/test/mlir/conversion/onnx_to_tosa/Math/ReduceSum.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/ReduceSum.mlir
@@ -36,8 +36,9 @@ return %1 : tensor<2x5xf32>
 // CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<2x5x9x11xf32>) -> tensor<2x5xf32> {
 // CHECK:           %[[VAL_1:.*]] = tosa.reduce_sum %[[VAL_0]] {axis = 2 : i32} : (tensor<2x5x9x11xf32>) -> tensor<2x5x1x11xf32>
 // CHECK:           %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 3 : i32} : (tensor<2x5x1x11xf32>) -> tensor<2x5x1x1xf32>
-// CHECK:           %[[VAL_3:.*]] = tosa.reshape %[[VAL_2]] {new_shape = array<i64: 2, 5>} : (tensor<2x5x1x1xf32>) -> tensor<2x5xf32>
-// CHECK:           return %[[VAL_3]] : tensor<2x5xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[2, 5]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape %[[VAL_2]], [[VAR_2_]] : (tensor<2x5x1x1xf32>, !tosa.shape<2>) -> tensor<2x5xf32>
+// CHECK:           return [[VAR_3_]] : tensor<2x5xf32>
 }
 
 // -----
@@ -84,6 +85,7 @@ func.func @test_reducesumV11_keep_dims_false(%arg0: tensor<1x32x112x112xf32>) ->
 // CHECK-LABEL:  func.func @test_reducesumV11_keep_dims_false
 // CHECK:           [[VAR_0_:%.+]] = tosa.reduce_sum %arg0 {axis = 2 : i32}
 // CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reduce_sum [[VAR_0_]] {axis = 3 : i32}
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 1, 32>}
-// CHECK:           return [[VAR_2_]] : tensor<1x32xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 32]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_2_]] : (tensor<1x32x1x1xf32>, !tosa.shape<2>) -> tensor<1x32xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x32xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Math/Softmax.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Softmax.mlir
@@ -9,7 +9,8 @@ func.func @test_softmax_v13(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 // CHECK: %[[VAL_1:.*]] = tosa.exp %[[SUB]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
 // CHECK: %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 2 : i32} : (tensor<13x21x3xf32>) -> tensor<13x21x1xf32>
 // CHECK: %[[VAL_3:.*]] = tosa.reciprocal %[[VAL_2]] : (tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
-// CHECK: %[[VAL_4:.*]] = tosa.mul %[[VAL_1]], %[[VAL_3]] {shift = 0 : i8} : (tensor<13x21x3xf32>, tensor<13x21x1xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[ZERO:.*]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK: %[[VAL_4:.*]] = tosa.mul %[[VAL_1]], %[[VAL_3]], %[[ZERO]] : (tensor<13x21x3xf32>, tensor<13x21x1xf32>, tensor<1xi8>) -> tensor<13x21x3xf32>
 }
 
 // -----
@@ -23,7 +24,8 @@ func.func @test_softmax_v13_axis_one(%arg0: tensor<13x21x3xf32>) -> tensor<13x21
 // CHECK: %[[VAL_1:.*]] = tosa.exp %[[SUB]] : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
 // CHECK: %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 1 : i32} : (tensor<13x21x3xf32>) -> tensor<13x1x3xf32>
 // CHECK: %[[VAL_3:.*]] = tosa.reciprocal %[[VAL_2]] : (tensor<13x1x3xf32>) -> tensor<13x1x3xf32>
-// CHECK: %[[VAL_4:.*]] = tosa.mul %[[VAL_1]], %[[VAL_3]] {shift = 0 : i8} : (tensor<13x21x3xf32>, tensor<13x1x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[ZERO:.*]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK: %[[VAL_4:.*]] = tosa.mul %[[VAL_1]], %[[VAL_3]], %[[ZERO]] : (tensor<13x21x3xf32>, tensor<13x1x3xf32>, tensor<1xi8>) -> tensor<13x21x3xf32>
 }
 
 // -----
@@ -39,7 +41,8 @@ func.func @test_softmax_before_v13(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3
 // CHECK: %[[VAL_2:.*]] = tosa.reduce_sum %[[VAL_1]] {axis = 1 : i32} : (tensor<13x21x3xf32>) -> tensor<13x1x3xf32>
 // CHECK: %[[VAL_3:.*]] = tosa.reduce_sum %[[VAL_2]] {axis = 2 : i32} : (tensor<13x1x3xf32>) -> tensor<13x1x1xf32>
 // CHECK: %[[VAL_4:.*]] = tosa.reciprocal %[[VAL_3]] : (tensor<13x1x1xf32>) -> tensor<13x1x1xf32>
-// CHECK: %[[VAL_5:.*]] = tosa.mul %[[VAL_1]], %[[VAL_4]] {shift = 0 : i8} : (tensor<13x21x3xf32>, tensor<13x1x1xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[ZERO:.*]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK: %[[VAL_5:.*]] = tosa.mul %[[VAL_1]], %[[VAL_4]], %[[ZERO]] : (tensor<13x21x3xf32>, tensor<13x1x1xf32>, tensor<1xi8>) -> tensor<13x21x3xf32>
 }
 
 // -----
@@ -57,5 +60,6 @@ func.func @test_softmax_before_v13_axis_zero(%arg0: tensor<13x21x3xf32>) -> tens
 // CHECK: %[[VAL_3:.*]] = tosa.reduce_sum %[[VAL_2]] {axis = 1 : i32} : (tensor<1x21x3xf32>) -> tensor<1x1x3xf32>
 // CHECK: %[[VAL_4:.*]] = tosa.reduce_sum %[[VAL_3]] {axis = 2 : i32} : (tensor<1x1x3xf32>) -> tensor<1x1x1xf32>
 // CHECK: %[[VAL_5:.*]] = tosa.reciprocal %[[VAL_4]] : (tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
-// CHECK: %[[VAL_6:.*]] = tosa.mul %[[VAL_1]], %[[VAL_5]] {shift = 0 : i8} : (tensor<13x21x3xf32>, tensor<1x1x1xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[ZERO:.*]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK: %[[VAL_6:.*]] = tosa.mul %[[VAL_1]], %[[VAL_5]], %[[ZERO]] : (tensor<13x21x3xf32>, tensor<1x1x1xf32>, tensor<1xi8>) -> tensor<13x21x3xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/NN/AveragePool.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/AveragePool.mlir
@@ -75,12 +75,14 @@ func.func @test_default_averagepool_strides_nonunifpad(%arg0 : tensor<5x5x30x32x
 // CHECK-LABEL:  func.func @test_default_averagepool_strides_nonunifpad
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x5x30x32xf32>) -> tensor<5x5x15x16xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<5x5x30x32xf32>, tensor<4xi32>) -> tensor<5x30x32x5xf32>
-// CHECK:           [[SLICE:%.+]] = tosa.slice [[VAR_1_]] {size = array<i64: 5, 29, 32, 5>, start = array<i64: 0, 0, 0, 0>} : (tensor<5x30x32x5xf32>) -> tensor<5x29x32x5xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.avg_pool2d [[SLICE]] {acc_type = f32, kernel = array<i64: 2, 2>, pad = array<i64: 1, 0, 0, 0>, stride = array<i64: 2, 2>} : (tensor<5x29x32x5xf32>) -> tensor<5x15x16x5xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<5x15x16x5xf32>, tensor<4xi32>) -> tensor<5x5x15x16xf32>
-// CHECK:           return [[VAR_4_]] : tensor<5x5x15x16xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<5x5x30x32xf32>, tensor<4xi32>) -> tensor<5x30x32x5xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[5, 29, 32, 5]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           [[VAR_4_:%.+]] = tosa.slice [[VAR_1_]], [[VAR_2_]], [[VAR_3_]] : (tensor<5x30x32x5xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<5x29x32x5xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.avg_pool2d [[VAR_4_]] {acc_type = f32, kernel = array<i64: 2, 2>, pad = array<i64: 1, 0, 0, 0>, stride = array<i64: 2, 2>} : (tensor<5x29x32x5xf32>) -> tensor<5x15x16x5xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_7_:%.+]] = tosa.transpose [[VAR_5_]], [[VAR_6_]] : (tensor<5x15x16x5xf32>, tensor<4xi32>) -> tensor<5x5x15x16xf32>
+// CHECK:           return [[VAR_7_]] : tensor<5x5x15x16xf32>
 // CHECK:         }
 
 // -----

--- a/test/mlir/conversion/onnx_to_tosa/NN/BatchNorm.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/BatchNorm.mlir
@@ -7,24 +7,26 @@ func.func @test_batchnorm_f32(%arg0: tensor<100x3x10x10xf32>) -> tensor<100x3x10
     %3 = "onnx.Constant"() {value = dense<[4.0, 5.0, 6.0]> : tensor<3xf32>} : () -> tensor<3xf32>
     %4 = "onnx.BatchNormalizationInferenceMode"(%arg0, %0, %1, %2, %3) {epsilon = 1.00000007E-5 : f32, momentum = 1.00000007E-3 : f32} : (tensor<100x3x10x10xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<100x3x10x10xf32>
     return %4 : tensor<100x3x10x10xf32>
-// CHECK-LABEL: func @test_batchnorm_f32
-// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<100x3x10x10xf32>) -> tensor<100x3x10x10xf32>
+// CHECK-LABEL:  func.func @test_batchnorm_f32
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<100x3x10x10xf32>) -> tensor<100x3x10x10xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>}> : () -> tensor<3xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<[2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<3xf32>}> : () -> tensor<3xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[3.000000e+00, 4.000000e+00, 5.000000e+00]> : tensor<3xf32>}> : () -> tensor<3xf32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[4.000000e+00, 5.000000e+00, 6.000000e+00]> : tensor<3xf32>}> : () -> tensor<3xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.reshape [[VAR_2_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf32>) -> tensor<1x3x1x1xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf32>) -> tensor<1x3x1x1xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf32>) -> tensor<1x3x1x1xf32>
-// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.reshape [[VAR_3_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf32>) -> tensor<1x3x1x1xf32>
-// CHECK-DAG:       [[VAR_8_:%.+]] = "tosa.const"() <{value = dense<1.00000007E-5> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.sub [[PARAM_0_]], [[VAR_4_]] : (tensor<100x3x10x10xf32>, tensor<1x3x1x1xf32>) -> tensor<100x3x10x10xf32>
-// CHECK:           [[VAR_10_:%.+]] = tosa.add [[VAR_7_]], [[VAR_8_]] : (tensor<1x3x1x1xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x1x1xf32>
-// CHECK:           [[VAR_11_:%.+]] = tosa.rsqrt [[VAR_10_]] : (tensor<1x3x1x1xf32>) -> tensor<1x3x1x1xf32>
-// CHECK:           [[VAR_12_:%.+]] = tosa.mul [[VAR_9_]], [[VAR_11_]] {shift = 0 : i8} : (tensor<100x3x10x10xf32>, tensor<1x3x1x1xf32>) -> tensor<100x3x10x10xf32>
-// CHECK:           [[VAR_13_:%.+]] = tosa.mul [[VAR_12_]], [[VAR_5_]] {shift = 0 : i8} : (tensor<100x3x10x10xf32>, tensor<1x3x1x1xf32>) -> tensor<100x3x10x10xf32>
-// CHECK:           [[VAR_14_:%.+]] = tosa.add [[VAR_13_]], [[VAR_6_]] : (tensor<100x3x10x10xf32>, tensor<1x3x1x1xf32>) -> tensor<100x3x10x10xf32>
-// CHECK:           return [[VAR_14_]] : tensor<100x3x10x10xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[1, 3, 1, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_2_]], [[VAR_4_]] : (tensor<3xf32>, !tosa.shape<4>) -> tensor<1x3x1x1xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.reshape [[VAR_0_]], [[VAR_4_]] : (tensor<3xf32>, !tosa.shape<4>) -> tensor<1x3x1x1xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_4_]] : (tensor<3xf32>, !tosa.shape<4>) -> tensor<1x3x1x1xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.reshape [[VAR_3_]], [[VAR_4_]] : (tensor<3xf32>, !tosa.shape<4>) -> tensor<1x3x1x1xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "tosa.const"() <{value = dense<1.00000007E-5> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.sub [[PARAM_0_]], [[VAR_5_]] : (tensor<100x3x10x10xf32>, tensor<1x3x1x1xf32>) -> tensor<100x3x10x10xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.add [[VAR_8_]], [[VAR_9_]] : (tensor<1x3x1x1xf32>, tensor<1x1x1x1xf32>) -> tensor<1x3x1x1xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = tosa.rsqrt [[VAR_11_]] : (tensor<1x3x1x1xf32>) -> tensor<1x3x1x1xf32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_14_:%.+]] = tosa.mul [[VAR_10_]], [[VAR_12_]], [[VAR_13_]] : (tensor<100x3x10x10xf32>, tensor<1x3x1x1xf32>, tensor<1xi8>) -> tensor<100x3x10x10xf32>
+// CHECK:           [[VAR_15_:%.+]] = tosa.mul [[VAR_14_]], [[VAR_6_]], [[VAR_13_]] : (tensor<100x3x10x10xf32>, tensor<1x3x1x1xf32>, tensor<1xi8>) -> tensor<100x3x10x10xf32>
+// CHECK:           [[VAR_16_:%.+]] = tosa.add [[VAR_15_]], [[VAR_7_]] : (tensor<100x3x10x10xf32>, tensor<1x3x1x1xf32>) -> tensor<100x3x10x10xf32>
+// CHECK:           return [[VAR_16_]] : tensor<100x3x10x10xf32>
 }
 
 // -----
@@ -35,24 +37,26 @@ func.func @test_batchnorm_f16_dynamic(%arg0: tensor<100x3x?x?xf16>) -> tensor<*x
     %3 = "onnx.Constant"() {value = dense<[4.0, 5.0, 6.0]> : tensor<3xf16>} : () -> tensor<3xf16>
     %4 = "onnx.BatchNormalizationInferenceMode"(%arg0, %0, %1, %2, %3) {epsilon = 1.00000007E-5 : f32, momentum = 1.00000007E-3 : f32} : (tensor<100x3x?x?xf16>, tensor<3xf16>, tensor<3xf16>, tensor<3xf16>, tensor<3xf16>) -> tensor<*xf16>
     return %4 : tensor<*xf16>
-// CHECK-LABEL: func @test_batchnorm_f16_dynamic
-// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<100x3x?x?xf16>) -> tensor<100x3x?x?xf16>
+// CHECK-LABEL:  func.func @test_batchnorm_f16_dynamic
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<100x3x?x?xf16>) -> tensor<100x3x?x?xf16> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf16>}> : () -> tensor<3xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<[2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<3xf16>}> : () -> tensor<3xf16>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[3.000000e+00, 4.000000e+00, 5.000000e+00]> : tensor<3xf16>}> : () -> tensor<3xf16>
 // CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[4.000000e+00, 5.000000e+00, 6.000000e+00]> : tensor<3xf16>}> : () -> tensor<3xf16>
-// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.reshape [[VAR_2_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf16>) -> tensor<1x3x1x1xf16>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf16>) -> tensor<1x3x1x1xf16>
-// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf16>) -> tensor<1x3x1x1xf16>
-// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.reshape [[VAR_3_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf16>) -> tensor<1x3x1x1xf16>
-// CHECK-DAG:       [[VAR_8_:%.+]] = "tosa.const"() <{value = dense<1.001360e-05> : tensor<1x1x1x1xf16>}> : () -> tensor<1x1x1x1xf16>
-// CHECK:           [[VAR_9_:%.+]] = tosa.sub [[PARAM_0_]], [[VAR_4_]] : (tensor<100x3x?x?xf16>, tensor<1x3x1x1xf16>) -> tensor<100x3x?x?xf16>
-// CHECK:           [[VAR_10_:%.+]] = tosa.add [[VAR_7_]], [[VAR_8_]] : (tensor<1x3x1x1xf16>, tensor<1x1x1x1xf16>) -> tensor<1x3x1x1xf16>
-// CHECK:           [[VAR_11_:%.+]] = tosa.rsqrt [[VAR_10_]] : (tensor<1x3x1x1xf16>) -> tensor<1x3x1x1xf16>
-// CHECK:           [[VAR_12_:%.+]] = tosa.mul [[VAR_9_]], [[VAR_11_]] {shift = 0 : i8} : (tensor<100x3x?x?xf16>, tensor<1x3x1x1xf16>) -> tensor<100x3x?x?xf16>
-// CHECK:           [[VAR_13_:%.+]] = tosa.mul [[VAR_12_]], [[VAR_5_]] {shift = 0 : i8} : (tensor<100x3x?x?xf16>, tensor<1x3x1x1xf16>) -> tensor<100x3x?x?xf16>
-// CHECK:           [[VAR_14_:%.+]] = tosa.add [[VAR_13_]], [[VAR_6_]] : (tensor<100x3x?x?xf16>, tensor<1x3x1x1xf16>) -> tensor<100x3x?x?xf16>
-// CHECK:           return [[VAR_14_]] : tensor<100x3x?x?xf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[1, 3, 1, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_2_]], [[VAR_4_]] : (tensor<3xf16>, !tosa.shape<4>) -> tensor<1x3x1x1xf16>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.reshape [[VAR_0_]], [[VAR_4_]] : (tensor<3xf16>, !tosa.shape<4>) -> tensor<1x3x1x1xf16>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_4_]] : (tensor<3xf16>, !tosa.shape<4>) -> tensor<1x3x1x1xf16>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.reshape [[VAR_3_]], [[VAR_4_]] : (tensor<3xf16>, !tosa.shape<4>) -> tensor<1x3x1x1xf16>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "tosa.const"() <{value = dense<1.001360e-05> : tensor<1x1x1x1xf16>}> : () -> tensor<1x1x1x1xf16>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.sub [[PARAM_0_]], [[VAR_5_]] : (tensor<100x3x?x?xf16>, tensor<1x3x1x1xf16>) -> tensor<100x3x?x?xf16>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.add [[VAR_8_]], [[VAR_9_]] : (tensor<1x3x1x1xf16>, tensor<1x1x1x1xf16>) -> tensor<1x3x1x1xf16>
+// CHECK-DAG:       [[VAR_12_:%.+]] = tosa.rsqrt [[VAR_11_]] : (tensor<1x3x1x1xf16>) -> tensor<1x3x1x1xf16>
+// CHECK-DAG:       [[VAR_13_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_14_:%.+]] = tosa.mul [[VAR_10_]], [[VAR_12_]], [[VAR_13_]] : (tensor<100x3x?x?xf16>, tensor<1x3x1x1xf16>, tensor<1xi8>) -> tensor<100x3x?x?xf16>
+// CHECK:           [[VAR_15_:%.+]] = tosa.mul [[VAR_14_]], [[VAR_6_]], [[VAR_13_]] : (tensor<100x3x?x?xf16>, tensor<1x3x1x1xf16>, tensor<1xi8>) -> tensor<100x3x?x?xf16>
+// CHECK:           [[VAR_16_:%.+]] = tosa.add [[VAR_15_]], [[VAR_7_]] : (tensor<100x3x?x?xf16>, tensor<1x3x1x1xf16>) -> tensor<100x3x?x?xf16>
+// CHECK:           return [[VAR_16_]] : tensor<100x3x?x?xf16>
 }
 
 // -----
@@ -64,24 +68,26 @@ func.func @test_batchnorm_bf16_dynamic(%arg0: tensor<100x3x?x?xbf16>) -> tensor<
     %3 = "onnx.Constant"() {value = dense<[4.0, 5.0, 6.0]> : tensor<3xbf16>} : () -> tensor<3xbf16>
     %4 = "onnx.BatchNormalizationInferenceMode"(%arg0, %0, %1, %2, %3) {epsilon = 1.00000007E-5 : f32, momentum = 1.00000007E-3 : f32} : (tensor<100x3x?x?xbf16>, tensor<3xbf16>, tensor<3xbf16>, tensor<3xbf16>, tensor<3xbf16>) -> tensor<*xbf16>
     return %4 : tensor<*xbf16>
-// CHECK-LABEL: func @test_batchnorm_bf16_dynamic
-// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<100x3x?x?xbf16>) -> tensor<100x3x?x?xbf16>
+// CHECK-LABEL:  func.func @test_batchnorm_bf16_dynamic
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<100x3x?x?xbf16>) -> tensor<100x3x?x?xbf16> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xbf16>}> : () -> tensor<3xbf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<[2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<3xbf16>}> : () -> tensor<3xbf16>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[3.000000e+00, 4.000000e+00, 5.000000e+00]> : tensor<3xbf16>}> : () -> tensor<3xbf16>
 // CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[4.000000e+00, 5.000000e+00, 6.000000e+00]> : tensor<3xbf16>}> : () -> tensor<3xbf16>
-// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.reshape [[VAR_2_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xbf16>) -> tensor<1x3x1x1xbf16>
-// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xbf16>) -> tensor<1x3x1x1xbf16>
-// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xbf16>) -> tensor<1x3x1x1xbf16>
-// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.reshape [[VAR_3_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xbf16>) -> tensor<1x3x1x1xbf16>
-// CHECK-DAG:       [[VAR_8_:%.+]] = "tosa.const"() <{value = dense<1.001360e-05> : tensor<1x1x1x1xbf16>}> : () -> tensor<1x1x1x1xbf16>
-// CHECK:           [[VAR_9_:%.+]] = tosa.sub [[PARAM_0_]], [[VAR_4_]] : (tensor<100x3x?x?xbf16>, tensor<1x3x1x1xbf16>) -> tensor<100x3x?x?xbf16>
-// CHECK:           [[VAR_10_:%.+]] = tosa.add [[VAR_7_]], [[VAR_8_]] : (tensor<1x3x1x1xbf16>, tensor<1x1x1x1xbf16>) -> tensor<1x3x1x1xbf16>
-// CHECK:           [[VAR_11_:%.+]] = tosa.rsqrt [[VAR_10_]] : (tensor<1x3x1x1xbf16>) -> tensor<1x3x1x1xbf16>
-// CHECK:           [[VAR_12_:%.+]] = tosa.mul [[VAR_9_]], [[VAR_11_]] {shift = 0 : i8} : (tensor<100x3x?x?xbf16>, tensor<1x3x1x1xbf16>) -> tensor<100x3x?x?xbf16>
-// CHECK:           [[VAR_13_:%.+]] = tosa.mul [[VAR_12_]], [[VAR_5_]] {shift = 0 : i8} : (tensor<100x3x?x?xbf16>, tensor<1x3x1x1xbf16>) -> tensor<100x3x?x?xbf16>
-// CHECK:           [[VAR_14_:%.+]] = tosa.add [[VAR_13_]], [[VAR_6_]] : (tensor<100x3x?x?xbf16>, tensor<1x3x1x1xbf16>) -> tensor<100x3x?x?xbf16>
-// CHECK:           return [[VAR_14_]] : tensor<100x3x?x?xbf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[1, 3, 1, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_2_]], [[VAR_4_]] : (tensor<3xbf16>, !tosa.shape<4>) -> tensor<1x3x1x1xbf16>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.reshape [[VAR_0_]], [[VAR_4_]] : (tensor<3xbf16>, !tosa.shape<4>) -> tensor<1x3x1x1xbf16>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_4_]] : (tensor<3xbf16>, !tosa.shape<4>) -> tensor<1x3x1x1xbf16>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.reshape [[VAR_3_]], [[VAR_4_]] : (tensor<3xbf16>, !tosa.shape<4>) -> tensor<1x3x1x1xbf16>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "tosa.const"() <{value = dense<1.001360e-05> : tensor<1x1x1x1xbf16>}> : () -> tensor<1x1x1x1xbf16>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.sub [[PARAM_0_]], [[VAR_5_]] : (tensor<100x3x?x?xbf16>, tensor<1x3x1x1xbf16>) -> tensor<100x3x?x?xbf16>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.add [[VAR_8_]], [[VAR_9_]] : (tensor<1x3x1x1xbf16>, tensor<1x1x1x1xbf16>) -> tensor<1x3x1x1xbf16>
+// CHECK-DAG:       [[VAR_12_:%.+]] = tosa.rsqrt [[VAR_11_]] : (tensor<1x3x1x1xbf16>) -> tensor<1x3x1x1xbf16>
+// CHECK-DAG:       [[VAR_13_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_14_:%.+]] = tosa.mul [[VAR_10_]], [[VAR_12_]], [[VAR_13_]] : (tensor<100x3x?x?xbf16>, tensor<1x3x1x1xbf16>, tensor<1xi8>) -> tensor<100x3x?x?xbf16>
+// CHECK:           [[VAR_15_:%.+]] = tosa.mul [[VAR_14_]], [[VAR_6_]], [[VAR_13_]] : (tensor<100x3x?x?xbf16>, tensor<1x3x1x1xbf16>, tensor<1xi8>) -> tensor<100x3x?x?xbf16>
+// CHECK:           [[VAR_16_:%.+]] = tosa.add [[VAR_15_]], [[VAR_7_]] : (tensor<100x3x?x?xbf16>, tensor<1x3x1x1xbf16>) -> tensor<100x3x?x?xbf16>
+// CHECK:           return [[VAR_16_]] : tensor<100x3x?x?xbf16>
 }
 
 // -----
@@ -93,22 +99,24 @@ func.func @test_batchnorm_f64(%arg0: tensor<100x3x10x10xf64>) -> tensor<100x3x10
     %3 = "onnx.Constant"() {value = dense<[4.0, 5.0, 6.0]> : tensor<3xf64>} : () -> tensor<3xf64>
     %4 = "onnx.BatchNormalizationInferenceMode"(%arg0, %0, %1, %2, %3) {epsilon = 1.00000007E-5 : f32} : (tensor<100x3x10x10xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>) -> tensor<100x3x10x10xf64>
     return %4 : tensor<100x3x10x10xf64>
-// CHECK-LABEL: @test_batchnorm_f64
-// CHECK-SAME: ([[PARAM_0:%.*]]: tensor<100x3x10x10xf64>) -> tensor<100x3x10x10xf64> {
-// CHECK-NEXT: [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf64>}> : () -> tensor<3xf64>
-// CHECK-NEXT: [[VAR_1_:%.+]]  = "tosa.const"() <{value = dense<[2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<3xf64>}> : () -> tensor<3xf64>
-// CHECK-NEXT: [[VAR_2_:%.+]]  = "tosa.const"() <{value = dense<[3.000000e+00, 4.000000e+00, 5.000000e+00]> : tensor<3xf64>}> : () -> tensor<3xf64>
-// CHECK-NEXT: [[VAR_3_:%.+]]  = "tosa.const"() <{value = dense<[4.000000e+00, 5.000000e+00, 6.000000e+00]> : tensor<3xf64>}> : () -> tensor<3xf64>
-// CHECK-NEXT: [[VAR_4_:%.+]]  = tosa.reshape [[VAR_2_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf64>) -> tensor<1x3x1x1xf64>
-// CHECK-NEXT: [[VAR_5_:%.+]]  = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf64>) -> tensor<1x3x1x1xf64>
-// CHECK-NEXT: [[VAR_6_:%.+]]  = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf64>) -> tensor<1x3x1x1xf64>
-// CHECK-NEXT: [[VAR_7_:%.+]]  = tosa.reshape [[VAR_3_]] {new_shape = array<i64: 1, 3, 1, 1>} : (tensor<3xf64>) -> tensor<1x3x1x1xf64>
-// CHECK-NEXT: [[VAR_8_:%.+]]  = "tosa.const"() <{value = dense<1.0000000656873453E-5> : tensor<1x1x1x1xf64>}> : () -> tensor<1x1x1x1xf64>
-// CHECK-NEXT: [[VAR_9_:%.+]]  = tosa.sub %arg0, [[VAR_4_]] : (tensor<100x3x10x10xf64>, tensor<1x3x1x1xf64>) -> tensor<100x3x10x10xf64>
-// CHECK-NEXT: [[VAR_10_:%.+]]  = tosa.add %7, [[VAR_8_]] : (tensor<1x3x1x1xf64>, tensor<1x1x1x1xf64>) -> tensor<1x3x1x1xf64>
-// CHECK-NEXT: [[VAR_11_:%.+]]  = tosa.rsqrt [[VAR_10_]] : (tensor<1x3x1x1xf64>) -> tensor<1x3x1x1xf64>
-// CHECK-NEXT: [[VAR_12_:%.+]]  = tosa.mul [[VAR_9_]], %11 {shift = 0 : i8} : (tensor<100x3x10x10xf64>, tensor<1x3x1x1xf64>) -> tensor<100x3x10x10xf64>
-// CHECK-NEXT: [[VAR_13_:%.+]]  = tosa.mul [[VAR_12_]], %5 {shift = 0 : i8} : (tensor<100x3x10x10xf64>, tensor<1x3x1x1xf64>) -> tensor<100x3x10x10xf64>
-// CHECK-NEXT: [[VAR_14_:%.+]]  = tosa.add [[VAR_13_]], [[VAR_6_]] : (tensor<100x3x10x10xf64>, tensor<1x3x1x1xf64>) -> tensor<100x3x10x10xf64>
-// CHECK-NEXT: return [[VAR_14_]] : tensor<100x3x10x10xf64>
+// CHECK-LABEL:  func.func @test_batchnorm_f64
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<100x3x10x10xf64>) -> tensor<100x3x10x10xf64> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf64>}> : () -> tensor<3xf64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<[2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<3xf64>}> : () -> tensor<3xf64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[3.000000e+00, 4.000000e+00, 5.000000e+00]> : tensor<3xf64>}> : () -> tensor<3xf64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[4.000000e+00, 5.000000e+00, 6.000000e+00]> : tensor<3xf64>}> : () -> tensor<3xf64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[1, 3, 1, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_2_]], [[VAR_4_]] : (tensor<3xf64>, !tosa.shape<4>) -> tensor<1x3x1x1xf64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.reshape [[VAR_0_]], [[VAR_4_]] : (tensor<3xf64>, !tosa.shape<4>) -> tensor<1x3x1x1xf64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_4_]] : (tensor<3xf64>, !tosa.shape<4>) -> tensor<1x3x1x1xf64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.reshape [[VAR_3_]], [[VAR_4_]] : (tensor<3xf64>, !tosa.shape<4>) -> tensor<1x3x1x1xf64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "tosa.const"() <{value = dense<1.0000000656873453E-5> : tensor<1x1x1x1xf64>}> : () -> tensor<1x1x1x1xf64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.sub [[PARAM_0_]], [[VAR_5_]] : (tensor<100x3x10x10xf64>, tensor<1x3x1x1xf64>) -> tensor<100x3x10x10xf64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.add [[VAR_8_]], [[VAR_9_]] : (tensor<1x3x1x1xf64>, tensor<1x1x1x1xf64>) -> tensor<1x3x1x1xf64>
+// CHECK-DAG:       [[VAR_12_:%.+]] = tosa.rsqrt [[VAR_11_]] : (tensor<1x3x1x1xf64>) -> tensor<1x3x1x1xf64>
+// CHECK-DAG:       [[VAR_13_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_14_:%.+]] = tosa.mul [[VAR_10_]], [[VAR_12_]], [[VAR_13_]] : (tensor<100x3x10x10xf64>, tensor<1x3x1x1xf64>, tensor<1xi8>) -> tensor<100x3x10x10xf64>
+// CHECK:           [[VAR_15_:%.+]] = tosa.mul [[VAR_14_]], [[VAR_6_]], [[VAR_13_]] : (tensor<100x3x10x10xf64>, tensor<1x3x1x1xf64>, tensor<1xi8>) -> tensor<100x3x10x10xf64>
+// CHECK:           [[VAR_16_:%.+]] = tosa.add [[VAR_15_]], [[VAR_7_]] : (tensor<100x3x10x10xf64>, tensor<1x3x1x1xf64>) -> tensor<100x3x10x10xf64>
+// CHECK:           return [[VAR_16_]] : tensor<100x3x10x10xf64>
 }

--- a/test/mlir/conversion/onnx_to_tosa/NN/DequantizeLinear.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/DequantizeLinear.mlir
@@ -13,7 +13,8 @@ func.func @test_dequantizeLinear(%arg0 : tensor<32x3x224x224xi8>) -> tensor<32x3
 // CHECK-DAG:    %[[CAST_0:.*]] = tosa.cast %[[ARG_0]] : (tensor<32x3x224x224xi8>) -> tensor<32x3x224x224xf32>
 // CHECK-DAG:    %[[CASTZP:.*]] = tosa.cast %[[ZP]] : (tensor<1x1x1x1xi8>) -> tensor<1x1x1x1xf32>
 // CHECK-DAG:    %[[SUB:.*]] = tosa.sub %[[CAST_0]], %[[CASTZP]] : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
-// CHECK-DAG:    %[[MUL:.*]] = tosa.mul %[[SUB]], %[[SCALE]] {shift = 0 : i8} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
+// CHECK-DAG:     [[VAR_5_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:    %[[MUL:.*]] = tosa.mul %[[SUB]], %[[SCALE]], [[VAR_5_]] : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>, tensor<1xi8>) -> tensor<32x3x224x224xf32>
 // CHECK-DAG:    return %[[MUL]] : tensor<32x3x224x224xf32>
 
 // -----
@@ -33,7 +34,8 @@ func.func @test_dequantizeLinear_f16(%arg0 : tensor<32x3x224x224xi8>) -> tensor<
 // CHECK-DAG:    %[[CASTZP:.*]] = tosa.cast %[[ZP]] : (tensor<1x1x1x1xi8>) -> tensor<1x1x1x1xf32>
 // CHECK-DAG:    %[[SUB:.*]] = tosa.sub %[[CAST_0]], %[[CASTZP]] : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
 // CHECK-DAG:    %[[CASTSCALE:.*]] = tosa.cast %[[SCALE]] : (tensor<1x1x1x1xf16>) -> tensor<1x1x1x1xf32>
-// CHECK-DAG:    %[[MUL:.*]] = tosa.mul %[[SUB]], %[[CASTSCALE]] {shift = 0 : i8} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
+// CHECK-DAG:     [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:    %[[MUL:.*]] = tosa.mul %[[SUB]], %[[CASTSCALE]], [[VAR_6_]] : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>, tensor<1xi8>) -> tensor<32x3x224x224xf32>
 // CHECK-DAG:    %[[CAST:.*]] = tosa.cast %[[MUL]] : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xf16>
 // CHECK-DAG:    return %[[CAST]] : tensor<32x3x224x224xf16>
 
@@ -46,6 +48,16 @@ func.func @per_axis(%arg0: tensor<8x2xi8>) -> tensor<8x2xf32> {
     {axis = 1 : si64,
      saturate = 1 : si64} : (tensor<8x2xi8>, tensor<2xf32>, tensor<2xi8>) -> tensor<8x2xf32>
   return %2 : tensor<8x2xf32>
+  // CHECK-LABEL:  func.func @per_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<8x2xi8>) -> tensor<8x2xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.cast [[PARAM_0_]] : (tensor<8x2xi8>) -> tensor<8x2xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<{{.}}[0, 1]{{.}}> : tensor<1x2xi8>}> : () -> tensor<1x2xi8>
+// CHECK:           [[VAR_2_:%.+]] = tosa.cast [[VAR_1_]] : (tensor<1x2xi8>) -> tensor<1x2xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.sub [[VAR_0_]], [[VAR_2_]] : (tensor<8x2xf32>, tensor<1x2xf32>) -> tensor<8x2xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<{{.}}[1.000000e+00, 2.000000e+00]{{.}}> : tensor<1x2xf32>}> : () -> tensor<1x2xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_6_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_4_]], [[VAR_5_]] : (tensor<8x2xf32>, tensor<1x2xf32>, tensor<1xi8>) -> tensor<8x2xf32>
+// CHECK:           return [[VAR_6_]] : tensor<8x2xf32>
 }
 
 // -----
@@ -71,13 +83,14 @@ func.func @no_zeropoint(%arg0: tensor<5xi8>, %arg1: tensor<f32>) -> tensor<5xf32
   return %1 : tensor<5xf32>
 }
 
-// CHECK-LABEL: @no_zeropoint(
-// CHECK-SAME:                            %[[VAL_0:.*]]: tensor<5xi8>,
-// CHECK-SAME:                            %[[VAL_1:.*]]: tensor<f32>) -> tensor<5xf32> {
-// CHECK:           %[[VAL_2:.*]] = tosa.cast %[[VAL_0]] : (tensor<5xi8>) -> tensor<5xf32>
-// CHECK:           %[[VAL_3:.*]] = tosa.reshape %[[VAL_1]] {new_shape = array<i64: 1>} : (tensor<f32>) -> tensor<1xf32>
-// CHECK:           %[[VAL_4:.*]] = tosa.mul %[[VAL_2]], %[[VAL_3]] {shift = 0 : i8} : (tensor<5xf32>, tensor<1xf32>) -> tensor<5xf32>
-// CHECK:           return %[[VAL_4]] : tensor<5xf32>
+// CHECK-LABEL:  func.func @no_zeropoint
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5xi8>, [[PARAM_1_:%.+]]: tensor<f32>) -> tensor<5xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.cast [[PARAM_0_]] : (tensor<5xi8>) -> tensor<5xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_1_]] : (tensor<f32>, !tosa.shape<1>) -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_0_]], [[VAR_2_]], [[VAR_3_]] : (tensor<5xf32>, tensor<1xf32>, tensor<1xi8>) -> tensor<5xf32>
+// CHECK:           return [[VAR_4_]] : tensor<5xf32>
 
 // -----
 
@@ -87,13 +100,14 @@ func.func @f8E4M3FN(%arg0: tensor<5xf8E4M3FN>, %arg1: tensor<f32>) -> tensor<5xf
   return %1 : tensor<5xf32>
 }
 
-// CHECK-LABEL: @f8E4M3FN
-// CHECK-SAME:                        %[[VAL_0:.*]]: tensor<5xf8E4M3FN>,
-// CHECK-SAME:                        %[[VAL_1:.*]]: tensor<f32>) -> tensor<5xf32> {
-// CHECK:           %[[VAL_2:.*]] = tosa.cast %[[VAL_0]] : (tensor<5xf8E4M3FN>) -> tensor<5xf32>
-// CHECK:           %[[VAL_3:.*]] = tosa.reshape %[[VAL_1]] {new_shape = array<i64: 1>} : (tensor<f32>) -> tensor<1xf32>
-// CHECK:           %[[VAL_4:.*]] = tosa.mul %[[VAL_2]], %[[VAL_3]] {shift = 0 : i8} : (tensor<5xf32>, tensor<1xf32>) -> tensor<5xf32>
-// CHECK:           return %[[VAL_4]] : tensor<5xf32>
+// CHECK-LABEL:  func.func @f8E4M3FN
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5xf8E4M3FN>, [[PARAM_1_:%.+]]: tensor<f32>) -> tensor<5xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.cast [[PARAM_0_]] : (tensor<5xf8E4M3FN>) -> tensor<5xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_1_]] : (tensor<f32>, !tosa.shape<1>) -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           [[VAR_4_:%.+]] = tosa.mul [[VAR_0_]], [[VAR_2_]], [[VAR_3_]] : (tensor<5xf32>, tensor<1xf32>, tensor<1xi8>) -> tensor<5xf32>
+// CHECK:           return [[VAR_4_]] : tensor<5xf32>
 
 // -----
 

--- a/test/mlir/conversion/onnx_to_tosa/NN/MatMul.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/MatMul.mlir
@@ -3,12 +3,16 @@
 func.func @test_onnx_to_matmul2d(%arg0 : tensor<4x8xf32>, %arg1 : tensor<8x16xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<4x8xf32>, tensor<8x16xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
-  // CHECK: func.func @test_onnx_to_matmul2d(%arg0: tensor<4x8xf32>, %arg1: tensor<8x16xf32>) -> tensor<4x16xf32>
-  // CHECK:  %0 = tosa.reshape %arg0 {new_shape = array<i64: 1, 4, 8>} : (tensor<4x8xf32>) -> tensor<1x4x8xf32>
-  // CHECK:  %1 = tosa.reshape %arg1 {new_shape = array<i64: 1, 8, 16>} : (tensor<8x16xf32>) -> tensor<1x8x16xf32>
-  // CHECK:  %2 = tosa.matmul %0, %1 : (tensor<1x4x8xf32>, tensor<1x8x16xf32>) -> tensor<1x4x16xf32>
-  // CHECK:  %3 = tosa.reshape %2 {new_shape = array<i64: 4, 16>} : (tensor<1x4x16xf32>) -> tensor<4x16xf32>
-  // CHECK:  return %3 : tensor<4x16xf32>
+// CHECK-LABEL:  func.func @test_onnx_to_matmul2d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x8xf32>, [[PARAM_1_:%.+]]: tensor<8x16xf32>) -> tensor<4x16xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 4, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<4x8xf32>, !tosa.shape<3>) -> tensor<1x4x8xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 8, 16]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_2_]] : (tensor<8x16xf32>, !tosa.shape<3>) -> tensor<1x8x16xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.matmul [[VAR_1_]], [[VAR_3_]] : (tensor<1x4x8xf32>, tensor<1x8x16xf32>) -> tensor<1x4x16xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.const_shape  {value = dense<[4, 16]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_6_:%.+]] = tosa.reshape [[VAR_4_]], [[VAR_5_]] : (tensor<1x4x16xf32>, !tosa.shape<2>) -> tensor<4x16xf32>
+// CHECK:           return [[VAR_6_]] : tensor<4x16xf32>
 }
 
 // -----
@@ -16,15 +20,19 @@ func.func @test_onnx_to_matmul2d(%arg0 : tensor<4x8xf32>, %arg1 : tensor<8x16xf3
 func.func @test_onnx_to_matmul3dbcast(%arg0 : tensor<100x4x8xf32>, %arg1 : tensor<8x16xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<100x4x8xf32>, tensor<8x16xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
-  // CHECK: func.func @test_onnx_to_matmul3dbcast(%arg0: tensor<100x4x8xf32>, %arg1: tensor<8x16xf32>) -> tensor<100x4x16xf32> {
-  // CHECK:   %0 = tosa.reshape %arg1 {new_shape = array<i64: 1, 8, 16>} : (tensor<8x16xf32>) -> tensor<1x8x16xf32>
-  // CHECK:   %1 = tosa.reshape %arg0 {new_shape = array<i64: 1, 400, 8>} : (tensor<100x4x8xf32>) -> tensor<1x400x8xf32>
-  // CHECK:   %2 = "tosa.const"() <{value = dense<[1, 0, 2]> : tensor<3xi32>}> : () -> tensor<3xi32>
-  // CHECK:   %3 = tosa.transpose %0, %2 : (tensor<1x8x16xf32>, tensor<3xi32>) -> tensor<8x1x16xf32>
-  // CHECK:   %4 = tosa.reshape %3 {new_shape = array<i64: 1, 8, 16>} : (tensor<8x1x16xf32>) -> tensor<1x8x16xf32>
-  // CHECK:   %5 = tosa.matmul %1, %4 : (tensor<1x400x8xf32>, tensor<1x8x16xf32>) -> tensor<1x400x16xf32>
-  // CHECK:   %6 = tosa.reshape %5 {new_shape = array<i64: 100, 4, 16>} : (tensor<1x400x16xf32>) -> tensor<100x4x16xf32>
-  // CHECK:   return %6 : tensor<100x4x16xf32>
+// CHECK-LABEL:  func.func @test_onnx_to_matmul3dbcast
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<100x4x8xf32>, [[PARAM_1_:%.+]]: tensor<8x16xf32>) -> tensor<100x4x16xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 8, 16]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<8x16xf32>, !tosa.shape<3>) -> tensor<1x8x16xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 400, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_2_]] : (tensor<100x4x8xf32>, !tosa.shape<3>) -> tensor<1x400x8xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<[1, 0, 2]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK:           [[VAR_5_:%.+]] = tosa.transpose [[VAR_1_]], [[VAR_4_]] : (tensor<1x8x16xf32>, tensor<3xi32>) -> tensor<8x1x16xf32>
+// CHECK:           [[VAR_6_:%.+]] = tosa.reshape [[VAR_5_]], [[VAR_0_]] : (tensor<8x1x16xf32>, !tosa.shape<3>) -> tensor<1x8x16xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.matmul [[VAR_3_]], [[VAR_6_]] : (tensor<1x400x8xf32>, tensor<1x8x16xf32>) -> tensor<1x400x16xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.const_shape  {value = dense<[100, 4, 16]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_9_:%.+]] = tosa.reshape [[VAR_7_]], [[VAR_8_]] : (tensor<1x400x16xf32>, !tosa.shape<3>) -> tensor<100x4x16xf32>
+// CHECK:           return [[VAR_9_]] : tensor<100x4x16xf32>
 }
 
 // -----
@@ -32,14 +40,20 @@ func.func @test_onnx_to_matmul3dbcast(%arg0 : tensor<100x4x8xf32>, %arg1 : tenso
 func.func @test_onnx_1d(%arg0 : tensor<6xf32>, %arg1 : tensor<6xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<6xf32>, tensor<6xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
-  // CHECK: func.func @test_onnx_1d(%arg0: tensor<6xf32>, %arg1: tensor<6xf32>) -> tensor<f32> {
-  // CHECK:   %0 = tosa.reshape %arg0 {new_shape = array<i64: 1, 6>} : (tensor<6xf32>) -> tensor<1x6xf32>
-  // CHECK:   %1 = tosa.reshape %arg1 {new_shape = array<i64: 6, 1>} : (tensor<6xf32>) -> tensor<6x1xf32>
-  // CHECK:   %2 = tosa.reshape %0 {new_shape = array<i64: 1, 1, 6>} : (tensor<1x6xf32>) -> tensor<1x1x6xf32>
-  // CHECK:   %3 = tosa.reshape %1 {new_shape = array<i64: 1, 6, 1>} : (tensor<6x1xf32>) -> tensor<1x6x1xf32>
-  // CHECK:   %4 = tosa.matmul %2, %3 : (tensor<1x1x6xf32>, tensor<1x6x1xf32>) -> tensor<1x1x1xf32>
-  // CHECK:   %5 = tosa.reshape %4 {new_shape = array<i64>} : (tensor<1x1x1xf32>) -> tensor<f32>
-  // CHECK:   return %5 : tensor<f32>
+// CHECK-LABEL:  func.func @test_onnx_1d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<6xf32>, [[PARAM_1_:%.+]]: tensor<6xf32>) -> tensor<f32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 6]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<6xf32>, !tosa.shape<2>) -> tensor<1x6xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[6, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_2_]] : (tensor<6xf32>, !tosa.shape<2>) -> tensor<6x1xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[1, 1, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_4_]] : (tensor<1x6xf32>, !tosa.shape<3>) -> tensor<1x1x6xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.const_shape  {value = dense<[1, 6, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_7_:%.+]] = tosa.reshape [[VAR_3_]], [[VAR_6_]] : (tensor<6x1xf32>, !tosa.shape<3>) -> tensor<1x6x1xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.matmul [[VAR_5_]], [[VAR_7_]] : (tensor<1x1x6xf32>, tensor<1x6x1xf32>) -> tensor<1x1x1xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.const_shape  {value = dense<> : tensor<0xindex>} : () -> !tosa.shape<0>
+// CHECK:           [[VAR_10_:%.+]] = tosa.reshape [[VAR_8_]], [[VAR_9_]] : (tensor<1x1x1xf32>, !tosa.shape<0>) -> tensor<f32>
+// CHECK:           return [[VAR_10_]] : tensor<f32>
 }
 
 // -----
@@ -47,13 +61,18 @@ func.func @test_onnx_1d(%arg0 : tensor<6xf32>, %arg1 : tensor<6xf32>) -> tensor<
 func.func @test_onnx_12d(%arg0 : tensor<6xf32>, %arg1 : tensor<6x1xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<6xf32>, tensor<6x1xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
-  // CHECK: func.func @test_onnx_12d(%arg0: tensor<6xf32>, %arg1: tensor<6x1xf32>) -> tensor<1xf32> {
-  // CHECK:   %0 = tosa.reshape %arg0 {new_shape = array<i64: 1, 6>} : (tensor<6xf32>) -> tensor<1x6xf32>
-  // CHECK:   %1 = tosa.reshape %0 {new_shape = array<i64: 1, 1, 6>} : (tensor<1x6xf32>) -> tensor<1x1x6xf32>
-  // CHECK:   %2 = tosa.reshape %arg1 {new_shape = array<i64: 1, 6, 1>} : (tensor<6x1xf32>) -> tensor<1x6x1xf32>
-  // CHECK:   %3 = tosa.matmul %1, %2 : (tensor<1x1x6xf32>, tensor<1x6x1xf32>) -> tensor<1x1x1xf32>
-  // CHECK:   %4 = tosa.reshape %3 {new_shape = array<i64: 1>} : (tensor<1x1x1xf32>) -> tensor<1xf32>
-  // CHECK:   return %4 : tensor<1xf32>
+// CHECK-LABEL:  func.func @test_onnx_12d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<6xf32>, [[PARAM_1_:%.+]]: tensor<6x1xf32>) -> tensor<1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 6]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<6xf32>, !tosa.shape<2>) -> tensor<1x6xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 1, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_2_]] : (tensor<1x6xf32>, !tosa.shape<3>) -> tensor<1x1x6xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[1, 6, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_5_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_4_]] : (tensor<6x1xf32>, !tosa.shape<3>) -> tensor<1x6x1xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.matmul [[VAR_3_]], [[VAR_5_]] : (tensor<1x1x6xf32>, tensor<1x6x1xf32>) -> tensor<1x1x1xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK:           [[VAR_8_:%.+]] = tosa.reshape [[VAR_6_]], [[VAR_7_]] : (tensor<1x1x1xf32>, !tosa.shape<1>) -> tensor<1xf32>
+// CHECK:           return [[VAR_8_]] : tensor<1xf32>
 }
 
 // -----
@@ -61,13 +80,18 @@ func.func @test_onnx_12d(%arg0 : tensor<6xf32>, %arg1 : tensor<6x1xf32>) -> tens
 func.func @test_onnx_21d(%arg0 : tensor<2x6xf32>, %arg1 : tensor<6xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<2x6xf32>, tensor<6xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
-  // CHECK: func.func @test_onnx_21d(%arg0: tensor<2x6xf32>, %arg1: tensor<6xf32>) -> tensor<2xf32> {
-  // CHECK:   %0 = tosa.reshape %arg1 {new_shape = array<i64: 6, 1>} : (tensor<6xf32>) -> tensor<6x1xf32>
-  // CHECK:   %1 = tosa.reshape %arg0 {new_shape = array<i64: 1, 2, 6>} : (tensor<2x6xf32>) -> tensor<1x2x6xf32>
-  // CHECK:   %2 = tosa.reshape %0 {new_shape = array<i64: 1, 6, 1>} : (tensor<6x1xf32>) -> tensor<1x6x1xf32>
-  // CHECK:   %3 = tosa.matmul %1, %2 : (tensor<1x2x6xf32>, tensor<1x6x1xf32>) -> tensor<1x2x1xf32>
-  // CHECK:   %4 = tosa.reshape %3 {new_shape = array<i64: 2>} : (tensor<1x2x1xf32>) -> tensor<2xf32>
-  // CHECK:   return %4 : tensor<2xf32>
+// CHECK-LABEL:  func.func @test_onnx_21d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x6xf32>, [[PARAM_1_:%.+]]: tensor<6xf32>) -> tensor<2xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[6, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<6xf32>, !tosa.shape<2>) -> tensor<6x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 2, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_2_]] : (tensor<2x6xf32>, !tosa.shape<3>) -> tensor<1x2x6xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[1, 6, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_5_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_4_]] : (tensor<6x1xf32>, !tosa.shape<3>) -> tensor<1x6x1xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.matmul [[VAR_3_]], [[VAR_5_]] : (tensor<1x2x6xf32>, tensor<1x6x1xf32>) -> tensor<1x2x1xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.const_shape  {value = dense<2> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK:           [[VAR_8_:%.+]] = tosa.reshape [[VAR_6_]], [[VAR_7_]] : (tensor<1x2x1xf32>, !tosa.shape<1>) -> tensor<2xf32>
+// CHECK:           return [[VAR_8_]] : tensor<2xf32>
 }
 
 // -----
@@ -75,12 +99,16 @@ func.func @test_onnx_21d(%arg0 : tensor<2x6xf32>, %arg1 : tensor<6xf32>) -> tens
 func.func @test_onnx_4d(%arg0 : tensor<10x10x6x2xf32>, %arg1 : tensor<10x10x2x6xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<10x10x6x2xf32>, tensor<10x10x2x6xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
-  // CHECK: func.func @test_onnx_4d(%arg0: tensor<10x10x6x2xf32>, %arg1: tensor<10x10x2x6xf32>) -> tensor<10x10x6x6xf32> {
-  // CHECK:   %0 = tosa.reshape %arg0 {new_shape = array<i64: 100, 6, 2>} : (tensor<10x10x6x2xf32>) -> tensor<100x6x2xf32>
-  // CHECK:   %1 = tosa.reshape %arg1 {new_shape = array<i64: 100, 2, 6>} : (tensor<10x10x2x6xf32>) -> tensor<100x2x6xf32>
-  // CHECK:   %2 = tosa.matmul %0, %1 : (tensor<100x6x2xf32>, tensor<100x2x6xf32>) -> tensor<100x6x6xf32>
-  // CHECK:   %3 = tosa.reshape %2 {new_shape = array<i64: 10, 10, 6, 6>} : (tensor<100x6x6xf32>) -> tensor<10x10x6x6xf32>
-  // CHECK:   return %3 : tensor<10x10x6x6xf32>
+// CHECK-LABEL:  func.func @test_onnx_4d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x10x6x2xf32>, [[PARAM_1_:%.+]]: tensor<10x10x2x6xf32>) -> tensor<10x10x6x6xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[100, 6, 2]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<10x10x6x2xf32>, !tosa.shape<3>) -> tensor<100x6x2xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[100, 2, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_2_]] : (tensor<10x10x2x6xf32>, !tosa.shape<3>) -> tensor<100x2x6xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.matmul [[VAR_1_]], [[VAR_3_]] : (tensor<100x6x2xf32>, tensor<100x2x6xf32>) -> tensor<100x6x6xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.const_shape  {value = dense<[10, 10, 6, 6]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           [[VAR_6_:%.+]] = tosa.reshape [[VAR_4_]], [[VAR_5_]] : (tensor<100x6x6xf32>, !tosa.shape<4>) -> tensor<10x10x6x6xf32>
+// CHECK:           return [[VAR_6_]] : tensor<10x10x6x6xf32>
 }
 
 // -----
@@ -88,19 +116,24 @@ func.func @test_onnx_4d(%arg0 : tensor<10x10x6x2xf32>, %arg1 : tensor<10x10x2x6x
 func.func @test_onnx_4d_mixed(%arg0 : tensor<10x6x2xf32>, %arg1 : tensor<10x10x2x6xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<10x6x2xf32>, tensor<10x10x2x6xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
-  // CHECK: func.func @test_onnx_4d_mixed(%arg0: tensor<10x6x2xf32>, %arg1: tensor<10x10x2x6xf32>) -> tensor<10x10x6x6xf32> {
-  // CHECK:   %0 = tosa.reshape %arg0 {new_shape = array<i64: 1, 10, 6, 2>} : (tensor<10x6x2xf32>) -> tensor<1x10x6x2xf32>
-  // CHECK:   %1 = "tosa.const"() <{value = dense<[1, 0, 2, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
-  // CHECK:   %2 = tosa.transpose %0, %1 : (tensor<1x10x6x2xf32>, tensor<4xi32>) -> tensor<10x1x6x2xf32>
-  // CHECK:   %3 = tosa.reshape %2 {new_shape = array<i64: 10, 6, 2>} : (tensor<10x1x6x2xf32>) -> tensor<10x6x2xf32>
-  // CHECK:   %4 = "tosa.const"() <{value = dense<[1, 2, 0, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
-  // CHECK:   %5 = tosa.transpose %arg1, %4 : (tensor<10x10x2x6xf32>, tensor<4xi32>) -> tensor<10x2x10x6xf32>
-  // CHECK:   %6 = tosa.reshape %5 {new_shape = array<i64: 10, 2, 60>} : (tensor<10x2x10x6xf32>) -> tensor<10x2x60xf32>
-  // CHECK:   %7 = tosa.matmul %3, %6 : (tensor<10x6x2xf32>, tensor<10x2x60xf32>) -> tensor<10x6x60xf32>
-  // CHECK:   %8 = tosa.reshape %7 {new_shape = array<i64: 10, 6, 10, 6>} : (tensor<10x6x60xf32>) -> tensor<10x6x10x6xf32>
-  // CHECK:   %9 = "tosa.const"() <{value = dense<[2, 0, 1, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
-  // CHECK:   %10 = tosa.transpose %8, %9 : (tensor<10x6x10x6xf32>, tensor<4xi32>) -> tensor<10x10x6x6xf32>
-  // CHECK:   return %10 : tensor<10x10x6x6xf32>
+// CHECK-LABEL:  func.func @test_onnx_4d_mixed
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x6x2xf32>, [[PARAM_1_:%.+]]: tensor<10x10x2x6xf32>) -> tensor<10x10x6x6xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 10, 6, 2]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<10x6x2xf32>, !tosa.shape<4>) -> tensor<1x10x6x2xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[1, 0, 2, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.transpose [[VAR_1_]], [[VAR_2_]] : (tensor<1x10x6x2xf32>, tensor<4xi32>) -> tensor<10x1x6x2xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[10, 6, 2]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_3_]], [[VAR_4_]] : (tensor<10x1x6x2xf32>, !tosa.shape<3>) -> tensor<10x6x2xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<[1, 2, 0, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_6_]] : (tensor<10x10x2x6xf32>, tensor<4xi32>) -> tensor<10x2x10x6xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.const_shape  {value = dense<[10, 2, 60]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_9_:%.+]] = tosa.reshape [[VAR_7_]], [[VAR_8_]] : (tensor<10x2x10x6xf32>, !tosa.shape<3>) -> tensor<10x2x60xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.matmul [[VAR_5_]], [[VAR_9_]] : (tensor<10x6x2xf32>, tensor<10x2x60xf32>) -> tensor<10x6x60xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.const_shape  {value = dense<[10, 6, 10, 6]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_12_:%.+]] = tosa.reshape [[VAR_10_]], [[VAR_11_]] : (tensor<10x6x60xf32>, !tosa.shape<4>) -> tensor<10x6x10x6xf32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = "tosa.const"() <{value = dense<[2, 0, 1, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_14_:%.+]] = tosa.transpose [[VAR_12_]], [[VAR_13_]] : (tensor<10x6x10x6xf32>, tensor<4xi32>) -> tensor<10x10x6x6xf32>
+// CHECK:           return [[VAR_14_]] : tensor<10x10x6x6xf32>
 }
 
 // -----
@@ -108,16 +141,20 @@ func.func @test_onnx_4d_mixed(%arg0 : tensor<10x6x2xf32>, %arg1 : tensor<10x10x2
 func.func @test_onnx_to_matmul4d_non_broadcastable(%arg0 : tensor<4x1x5x6xf32>, %arg1 : tensor<1x3x6x7xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<4x1x5x6xf32>, tensor<1x3x6x7xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
-  // CHECK: func.func @test_onnx_to_matmul4d_non_broadcastable(%arg0: tensor<4x1x5x6xf32>, %arg1: tensor<1x3x6x7xf32>) -> tensor<4x3x5x7xf32> {
-  // CHECK:   %0 = tosa.reshape %arg0 {new_shape = array<i64: 1, 20, 6>} : (tensor<4x1x5x6xf32>) -> tensor<1x20x6xf32>
-  // CHECK:   %1 = "tosa.const"() <{value = dense<[2, 0, 1, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
-  // CHECK:   %2 = tosa.transpose %arg1, %1 : (tensor<1x3x6x7xf32>, tensor<4xi32>) -> tensor<6x1x3x7xf32>
-  // CHECK:   %3 = tosa.reshape %2 {new_shape = array<i64: 1, 6, 21>} : (tensor<6x1x3x7xf32>) -> tensor<1x6x21xf32>
-  // CHECK:   %4 = tosa.matmul %0, %3 : (tensor<1x20x6xf32>, tensor<1x6x21xf32>) -> tensor<1x20x21xf32>
-  // CHECK:   %5 = tosa.reshape %4 {new_shape = array<i64: 4, 5, 3, 7>} : (tensor<1x20x21xf32>) -> tensor<4x5x3x7xf32>
-  // CHECK:   %6 = "tosa.const"() <{value = dense<[0, 2, 1, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
-  // CHECK:   %7 = tosa.transpose %5, %6 : (tensor<4x5x3x7xf32>, tensor<4xi32>) -> tensor<4x3x5x7xf32>
-  // CHECK:   return %7 : tensor<4x3x5x7xf32>
+// CHECK-LABEL:  func.func @test_onnx_to_matmul4d_non_broadcastable
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x1x5x6xf32>, [[PARAM_1_:%.+]]: tensor<1x3x6x7xf32>) -> tensor<4x3x5x7xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 20, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<4x1x5x6xf32>, !tosa.shape<3>) -> tensor<1x20x6xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[2, 0, 1, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_2_]] : (tensor<1x3x6x7xf32>, tensor<4xi32>) -> tensor<6x1x3x7xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[1, 6, 21]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_5_:%.+]] = tosa.reshape [[VAR_3_]], [[VAR_4_]] : (tensor<6x1x3x7xf32>, !tosa.shape<3>) -> tensor<1x6x21xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.matmul [[VAR_1_]], [[VAR_5_]] : (tensor<1x20x6xf32>, tensor<1x6x21xf32>) -> tensor<1x20x21xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.const_shape  {value = dense<[4, 5, 3, 7]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.reshape [[VAR_6_]], [[VAR_7_]] : (tensor<1x20x21xf32>, !tosa.shape<4>) -> tensor<4x5x3x7xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 1, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_10_:%.+]] = tosa.transpose [[VAR_8_]], [[VAR_9_]] : (tensor<4x5x3x7xf32>, tensor<4xi32>) -> tensor<4x3x5x7xf32>
+// CHECK:           return [[VAR_10_]] : tensor<4x3x5x7xf32>
 }
 
 // -----
@@ -125,18 +162,22 @@ func.func @test_onnx_to_matmul4d_non_broadcastable(%arg0 : tensor<4x1x5x6xf32>, 
 func.func @test_onnx_to_matmul_7d_6d_broadcastable(%arg0: tensor<1x1x6x1x4x4xf32>, %arg1: tensor<4x2x6x2500x4x1xf32>) -> (tensor<*xf32>) {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1x6x1x4x4xf32>, tensor<4x2x6x2500x4x1xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
-// CHECK: func.func @test_onnx_to_matmul_7d_6d_broadcastable(%arg0: tensor<1x1x6x1x4x4xf32>, %arg1: tensor<4x2x6x2500x4x1xf32>) -> tensor<4x2x6x2500x4x1xf32> {
-// CHECK:   %[[VAL_2:.*]] = "tosa.const"() <{value = dense<[2, 0, 1, 3, 4, 5]> : tensor<6xi32>}> : () -> tensor<6xi32>
-// CHECK:   %[[VAL_3:.*]] = tosa.transpose %arg0, %[[VAL_2]] : (tensor<1x1x6x1x4x4xf32>, tensor<6xi32>) -> tensor<6x1x1x1x4x4xf32>
-// CHECK:   %[[VAL_4:.*]] = tosa.reshape %[[VAL_3]] {new_shape = array<i64: 6, 4, 4>} : (tensor<6x1x1x1x4x4xf32>) -> tensor<6x4x4xf32>
-// CHECK:   %[[VAL_5:.*]] = "tosa.const"() <{value = dense<[2, 4, 0, 1, 3, 5]> : tensor<6xi32>}> : () -> tensor<6xi32>
-// CHECK:   %[[VAL_6:.*]] = tosa.transpose %arg1, %[[VAL_5]] : (tensor<4x2x6x2500x4x1xf32>, tensor<6xi32>) -> tensor<6x4x4x2x2500x1xf32>
-// CHECK:   %[[VAL_7:.*]] = tosa.reshape %[[VAL_6]] {new_shape = array<i64: 6, 4, 20000>} : (tensor<6x4x4x2x2500x1xf32>) -> tensor<6x4x20000xf32>
-// CHECK:   %[[VAL_8:.*]] = tosa.matmul %[[VAL_4]], %[[VAL_7]] : (tensor<6x4x4xf32>, tensor<6x4x20000xf32>) -> tensor<6x4x20000xf32>
-// CHECK:   %[[VAL_9:.*]] = tosa.reshape %[[VAL_8]] {new_shape = array<i64: 6, 4, 4, 2, 2500, 1>} : (tensor<6x4x20000xf32>) -> tensor<6x4x4x2x2500x1xf32>
-// CHECK:   %[[VAL_10:.*]] = "tosa.const"() <{value = dense<[2, 3, 0, 4, 1, 5]> : tensor<6xi32>}> : () -> tensor<6xi32>
-// CHECK:   %[[VAL_11:.*]] = tosa.transpose %[[VAL_9]], %[[VAL_10]] : (tensor<6x4x4x2x2500x1xf32>, tensor<6xi32>) -> tensor<4x2x6x2500x4x1xf32>
-// CHECK:   return %[[VAL_11]] : tensor<4x2x6x2500x4x1xf32>
+// CHECK-LABEL:  func.func @test_onnx_to_matmul_7d_6d_broadcastable
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x6x1x4x4xf32>, [[PARAM_1_:%.+]]: tensor<4x2x6x2500x4x1xf32>) -> tensor<4x2x6x2500x4x1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[2, 0, 1, 3, 4, 5]> : tensor<6xi32>}> : () -> tensor<6xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x6x1x4x4xf32>, tensor<6xi32>) -> tensor<6x1x1x1x4x4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[6, 4, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.reshape [[VAR_1_]], [[VAR_2_]] : (tensor<6x1x1x1x4x4xf32>, !tosa.shape<3>) -> tensor<6x4x4xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tosa.const"() <{value = dense<[2, 4, 0, 1, 3, 5]> : tensor<6xi32>}> : () -> tensor<6xi32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.transpose [[PARAM_1_]], [[VAR_4_]] : (tensor<4x2x6x2500x4x1xf32>, tensor<6xi32>) -> tensor<6x4x4x2x2500x1xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.const_shape  {value = dense<[6, 4, 20000]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_7_:%.+]] = tosa.reshape [[VAR_5_]], [[VAR_6_]] : (tensor<6x4x4x2x2500x1xf32>, !tosa.shape<3>) -> tensor<6x4x20000xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.matmul [[VAR_3_]], [[VAR_7_]] : (tensor<6x4x4xf32>, tensor<6x4x20000xf32>) -> tensor<6x4x20000xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.const_shape  {value = dense<[6, 4, 4, 2, 2500, 1]> : tensor<6xindex>} : () -> !tosa.shape<6>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.reshape [[VAR_8_]], [[VAR_9_]] : (tensor<6x4x20000xf32>, !tosa.shape<6>) -> tensor<6x4x4x2x2500x1xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "tosa.const"() <{value = dense<[2, 3, 0, 4, 1, 5]> : tensor<6xi32>}> : () -> tensor<6xi32>
+// CHECK:           [[VAR_12_:%.+]] = tosa.transpose [[VAR_10_]], [[VAR_11_]] : (tensor<6x4x4x2x2500x1xf32>, tensor<6xi32>) -> tensor<4x2x6x2500x4x1xf32>
+// CHECK:           return [[VAR_12_]] : tensor<4x2x6x2500x4x1xf32>
 }
 
 // -----
@@ -144,19 +185,24 @@ func.func @test_onnx_to_matmul_7d_6d_broadcastable(%arg0: tensor<1x1x6x1x4x4xf32
 func.func @test_onnx_to_matmul_8d_7d_broadcastable(%arg0: tensor<4x3x2x1x5x4x7x6xf32>, %arg1: tensor<2x9x1x1x6x8xf32>) -> (tensor<*xf32>) {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<4x3x2x1x5x4x7x6xf32>, tensor<2x9x1x1x6x8xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
-// CHECK: func.func @test_onnx_to_matmul_8d_7d_broadcastable(%arg0: tensor<4x3x2x1x5x4x7x6xf32>, %arg1: tensor<2x9x1x1x6x8xf32>)
-// CHECK:   %[[VAL_2:.*]] = tosa.reshape %arg1 {new_shape = array<i64: 1, 1, 2, 9, 1, 1, 6, 8>} : (tensor<2x9x1x1x6x8xf32>) -> tensor<1x1x2x9x1x1x6x8xf32>
-// CHECK:   %[[VAL_3:.*]] = "tosa.const"() <{value = dense<[2, 0, 1, 3, 4, 5, 6, 7]> : tensor<8xi32>}> : () -> tensor<8xi32>
-// CHECK:   %[[VAL_4:.*]] = tosa.transpose %arg0, %[[VAL_3]] : (tensor<4x3x2x1x5x4x7x6xf32>, tensor<8xi32>) -> tensor<2x4x3x1x5x4x7x6xf32>
-// CHECK:   %[[VAL_5:.*]] = tosa.reshape %[[VAL_4]] {new_shape = array<i64: 2, 1680, 6>} : (tensor<2x4x3x1x5x4x7x6xf32>) -> tensor<2x1680x6xf32>
-// CHECK:   %[[VAL_6:.*]] = "tosa.const"() <{value = dense<[2, 6, 0, 1, 3, 4, 5, 7]> : tensor<8xi32>}> : () -> tensor<8xi32>
-// CHECK:   %[[VAL_7:.*]] = tosa.transpose %[[VAL_2]], %[[VAL_6]] : (tensor<1x1x2x9x1x1x6x8xf32>, tensor<8xi32>) -> tensor<2x6x1x1x9x1x1x8xf32>
-// CHECK:   %[[VAL_8:.*]] = tosa.reshape %[[VAL_7]] {new_shape = array<i64: 2, 6, 72>} : (tensor<2x6x1x1x9x1x1x8xf32>) -> tensor<2x6x72xf32>
-// CHECK:   %[[VAL_9:.*]] = tosa.matmul %[[VAL_5]], %[[VAL_8]] : (tensor<2x1680x6xf32>, tensor<2x6x72xf32>) -> tensor<2x1680x72xf32>
-// CHECK:   %[[VAL_10:.*]] = tosa.reshape %[[VAL_9]] {new_shape = array<i64: 2, 4, 3, 5, 4, 7, 9, 8>} : (tensor<2x1680x72xf32>) -> tensor<2x4x3x5x4x7x9x8xf32>
-// CHECK:   %[[VAL_11:.*]] = "tosa.const"() <{value = dense<[1, 2, 0, 6, 3, 4, 5, 7]> : tensor<8xi32>}> : () -> tensor<8xi32>
-// CHECK:   %[[VAL_12:.*]] = tosa.transpose %[[VAL_10]], %[[VAL_11]] : (tensor<2x4x3x5x4x7x9x8xf32>, tensor<8xi32>) -> tensor<4x3x2x9x5x4x7x8xf32>
-// CHECK:   return %[[VAL_12]] : tensor<4x3x2x9x5x4x7x8xf32>
+// CHECK-LABEL:  func.func @test_onnx_to_matmul_8d_7d_broadcastable
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x3x2x1x5x4x7x6xf32>, [[PARAM_1_:%.+]]: tensor<2x9x1x1x6x8xf32>) -> tensor<4x3x2x9x5x4x7x8xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 1, 2, 9, 1, 1, 6, 8]> : tensor<8xindex>} : () -> !tosa.shape<8>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]], [[VAR_0_]] : (tensor<2x9x1x1x6x8xf32>, !tosa.shape<8>) -> tensor<1x1x2x9x1x1x6x8xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<[2, 0, 1, 3, 4, 5, 6, 7]> : tensor<8xi32>}> : () -> tensor<8xi32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_2_]] : (tensor<4x3x2x1x5x4x7x6xf32>, tensor<8xi32>) -> tensor<2x4x3x1x5x4x7x6xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[2, 1680, 6]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.reshape [[VAR_3_]], [[VAR_4_]] : (tensor<2x4x3x1x5x4x7x6xf32>, !tosa.shape<3>) -> tensor<2x1680x6xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<[2, 6, 0, 1, 3, 4, 5, 7]> : tensor<8xi32>}> : () -> tensor<8xi32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.transpose [[VAR_1_]], [[VAR_6_]] : (tensor<1x1x2x9x1x1x6x8xf32>, tensor<8xi32>) -> tensor<2x6x1x1x9x1x1x8xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.const_shape  {value = dense<[2, 6, 72]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_9_:%.+]] = tosa.reshape [[VAR_7_]], [[VAR_8_]] : (tensor<2x6x1x1x9x1x1x8xf32>, !tosa.shape<3>) -> tensor<2x6x72xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.matmul [[VAR_5_]], [[VAR_9_]] : (tensor<2x1680x6xf32>, tensor<2x6x72xf32>) -> tensor<2x1680x72xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.const_shape  {value = dense<[2, 4, 3, 5, 4, 7, 9, 8]> : tensor<8xindex>} : () -> !tosa.shape<8>
+// CHECK-DAG:       [[VAR_12_:%.+]] = tosa.reshape [[VAR_10_]], [[VAR_11_]] : (tensor<2x1680x72xf32>, !tosa.shape<8>) -> tensor<2x4x3x5x4x7x9x8xf32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = "tosa.const"() <{value = dense<[1, 2, 0, 6, 3, 4, 5, 7]> : tensor<8xi32>}> : () -> tensor<8xi32>
+// CHECK:           [[VAR_14_:%.+]] = tosa.transpose [[VAR_12_]], [[VAR_13_]] : (tensor<2x4x3x5x4x7x9x8xf32>, tensor<8xi32>) -> tensor<4x3x2x9x5x4x7x8xf32>
+// CHECK:           return [[VAR_14_]] : tensor<4x3x2x9x5x4x7x8xf32>
 }
 
 // -----

--- a/test/mlir/conversion/onnx_to_tosa/NN/MaxPoolSingleOut.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/MaxPoolSingleOut.mlir
@@ -67,7 +67,9 @@ func.func @test_default_maxpoolsingleout_strides_nonunifpad(%arg0 : tensor<5x5x3
 // CHECK-LABEL:   func.func @test_default_maxpoolsingleout_strides_nonunifpad(%arg0: tensor<5x5x30x32xf32>) -> tensor<5x5x15x16xf32> {
 // CHECK-DAG:     %[[TRANS_CONST_1:.*]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
 // CHECK-DAG:     %[[TRANS_ARG:.*]] = tosa.transpose %arg0, %[[TRANS_CONST_1]] : (tensor<5x5x30x32xf32>, tensor<4xi32>) -> tensor<5x30x32x5xf32>
-// CHECK-DAG:     %[[SLICE:.+]] = tosa.slice %[[TRANS_ARG]] {size = array<i64: 5, 29, 32, 5>, start = array<i64: 0, 0, 0, 0>} : (tensor<5x30x32x5xf32>) -> tensor<5x29x32x5xf32>
+// CHECK-DAG:      [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:      [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[5, 29, 32, 5]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:     %[[SLICE:.+]] = tosa.slice %[[TRANS_ARG]], [[VAR_2_]], [[VAR_3_]] : (tensor<5x30x32x5xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<5x29x32x5xf32>
 // CHECK-DAG:     %[[MPOOL_RES:.*]] = tosa.max_pool2d %[[SLICE]] {kernel = array<i64: 2, 2>, pad = array<i64: 1, 0, 0, 0>, stride = array<i64: 2, 2>} : (tensor<5x29x32x5xf32>) -> tensor<5x15x16x5xf32>
 // CHECK-DAG:     %[[TRANS_CONST_2:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
 // CHECK-DAG:     %[[TRANS_MPOOL_RES:.*]] = tosa.transpose %[[MPOOL_RES]], %[[TRANS_CONST_2]] : (tensor<5x15x16x5xf32>, tensor<4xi32>) -> tensor<5x5x15x16xf32>

--- a/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
@@ -11,7 +11,8 @@ func.func @test_quantizeLinear(%arg0 : tensor<32x3x224x224xf32>) -> tensor<32x3x
 // CHECK-DAG:    %[[ZP:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1x1x1xi8>}> : () -> tensor<1x1x1x1xi8>
 // CHECK-DAG:    %[[SCALE:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
 // CHECK-DAG:    %[[REC:.*]] = tosa.reciprocal %[[SCALE]] : (tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
-// CHECK-DAG:    %[[MUL:.*]] = tosa.mul %[[ARG_0]], %[[REC]] {shift = 0 : i8} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
+// CHECK-DAG:    [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:    %[[MUL:.*]] = tosa.mul %[[ARG_0]], %[[REC]], [[VAR_2_]] : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>, tensor<1xi8>) -> tensor<32x3x224x224xf32>
 // CHECK-DAG:    %[[MUL_CAST:.*]] = tosa.cast %[[MUL]] : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi32>
 // CHECK-DAG:    %[[ZPCAST:.*]] = tosa.cast %[[ZP]] : (tensor<1x1x1x1xi8>) -> tensor<1x1x1x1xi32>
 // CHECK-DAG:    %[[ADD:.*]] = tosa.add %[[MUL_CAST]], %[[ZPCAST]] : (tensor<32x3x224x224xi32>, tensor<1x1x1x1xi32>) -> tensor<32x3x224x224xi32>
@@ -32,7 +33,8 @@ func.func @test_quantizeLinear_none(%arg0 : tensor<32x3x224x224xf32>) -> tensor<
 // CHECK-SAME:    (%[[ARG_0:.*]]: tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xui8>
 // CHECK-DAG:   %[[SCALE:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
 // CHECK-DAG:   %[[REC:.*]] = tosa.reciprocal %[[SCALE]] : (tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
-// CHECK-DAG:   %[[MUL:.*]] = tosa.mul %[[ARG_0]], %[[REC]] {shift = 0 : i8} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
+// CHECK-DAG:    [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:   %[[MUL:.*]] = tosa.mul %[[ARG_0]], %[[REC]], [[VAR_2_]] : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>, tensor<1xi8>) -> tensor<32x3x224x224xf32>
 // CHECK-DAG:   %[[MUL_CAST:.*]] = tosa.cast %[[MUL]] : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi32>
 // CHECK-DAG:   %[[CAST:.*]] = tosa.cast %[[MUL_CAST]] : (tensor<32x3x224x224xi32>) -> tensor<32x3x224x224xui8>
 // CHECK-DAG:   return %[[CAST]] : tensor<32x3x224x224xui8>
@@ -51,7 +53,8 @@ func.func @test_quantizeLinear_per_axis(%arg0: tensor<8x2xf32>) -> tensor<8x2xi8
 // CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<8x2xf32>) -> tensor<8x2xi8> {
 // CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<{{\[\[}}1.000000e+00, 2.000000e+00]]> : tensor<1x2xf32>}> : () -> tensor<1x2xf32>
 // CHECK:           %[[REC:.*]] = tosa.reciprocal %[[VAL_2]] : (tensor<1x2xf32>) -> tensor<1x2xf32>
-// CHECK:           %[[MUL:.*]] = tosa.mul %[[VAL_0]], %[[REC]] {shift = 0 : i8} : (tensor<8x2xf32>, tensor<1x2xf32>) -> tensor<8x2xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           %[[MUL:.*]] = tosa.mul %[[VAL_0]], %[[REC]], [[VAR_2_]] : (tensor<8x2xf32>, tensor<1x2xf32>, tensor<1xi8>) -> tensor<8x2xf32>
 // CHECK:           %[[MUL_CAST:.*]] = tosa.cast %[[MUL]] : (tensor<8x2xf32>) -> tensor<8x2xi32>
 // CHECK:           %[[ZP:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 1]]> : tensor<1x2xi8>}> : () -> tensor<1x2xi8>
 // CHECK:           %[[ZPCAST:.*]] = tosa.cast %[[ZP]] : (tensor<1x2xi8>) -> tensor<1x2xi32>
@@ -87,7 +90,8 @@ func.func @test_quantizeLinear_ui8(%arg0 : tensor<32x3x224x224xf32>) -> tensor<3
 // CHECK-DAG:    %[[ZP:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1x1x1xui8>}> : () -> tensor<1x1x1x1xui8>
 // CHECK-DAG:    %[[SCALE:.*]] = "tosa.const"() <{value = dense<3.125000e-02> : tensor<1x1x1x1xf32>}> : () -> tensor<1x1x1x1xf32>
 // CHECK-DAG:    %[[REC:.*]] = tosa.reciprocal %[[SCALE]] : (tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
-// CHECK-DAG:    %[[MUL:.*]] = tosa.mul %[[ARG_0]], %[[REC]] {shift = 0 : i8} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
+// CHECK-DAG:    [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK-DAG:    %[[MUL:.*]] = tosa.mul %[[ARG_0]], %[[REC]], [[VAR_2_]] : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>, tensor<1xi8>) -> tensor<32x3x224x224xf32>
 // CHECK-DAG:    %[[MUL_CAST:.*]] = tosa.cast %[[MUL]] : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi32>
 // CHECK-DAG:    %[[ZPCAST:.*]] = tosa.cast %[[ZP]] : (tensor<1x1x1x1xui8>) -> tensor<1x1x1x1xi32>
 // CHECK-DAG:    %[[ADD:.*]] = tosa.add %[[MUL_CAST]], %[[ZPCAST]] : (tensor<32x3x224x224xi32>, tensor<1x1x1x1xi32>) -> tensor<32x3x224x224xi32>

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Expand.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Expand.mlir
@@ -39,10 +39,11 @@ func.func @test_expand_new_dims_out(%arg0: tensor<1x64x1xf32>) -> tensor<64x64x6
 // CHECK-LABEL:  func.func @test_expand_new_dims_out
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x1xf32>) -> tensor<64x64x64x64xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<64> : tensor<4xi64>}> : () -> tensor<4xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 64, 1, 1>} : (tensor<1x64x1xf32>) -> tensor<1x64x1x1xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[64, 1, 64, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
-// CHECK:           [[VAR_3_:%.+]] = tosa.tile [[VAR_1_]], [[VAR_2_]] : (tensor<1x64x1x1xf32>, !tosa.shape<4>) -> tensor<64x64x64x64xf32>
-// CHECK:           return [[VAR_3_]] : tensor<64x64x64x64xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 64, 1, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_1_]] : (tensor<1x64x1xf32>, !tosa.shape<4>) -> tensor<1x64x1x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[64, 1, 64, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           [[VAR_4_:%.+]] = tosa.tile [[VAR_2_]], [[VAR_3_]] : (tensor<1x64x1x1xf32>, !tosa.shape<4>) -> tensor<64x64x64x64xf32>
+// CHECK:           return [[VAR_4_]] : tensor<64x64x64x64xf32>
 
 // -----
 
@@ -55,10 +56,11 @@ func.func @test_expand_new_dims_start(%arg0: tensor<256x256x16xf32>) -> tensor<1
 // CHECK-LABEL:  func.func @test_expand_new_dims_start
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<256x256x16xf32>) -> tensor<1x512x256x16xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1, 512, 256, 16]> : tensor<4xi64>}> : () -> tensor<4xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 256, 256, 16>} : (tensor<256x256x16xf32>) -> tensor<1x256x256x16xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 2, 1, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
-// CHECK:           [[VAR_3_:%.+]] = tosa.tile [[VAR_1_]], [[VAR_2_]] : (tensor<1x256x256x16xf32>, !tosa.shape<4>) -> tensor<1x512x256x16xf32>
-// CHECK:           return [[VAR_3_]] : tensor<1x512x256x16xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 256, 256, 16]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_1_]] : (tensor<256x256x16xf32>, !tosa.shape<4>) -> tensor<1x256x256x16xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[1, 2, 1, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           [[VAR_4_:%.+]] = tosa.tile [[VAR_2_]], [[VAR_3_]] : (tensor<1x256x256x16xf32>, !tosa.shape<4>) -> tensor<1x512x256x16xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x512x256x16xf32>
 
 // -----
 
@@ -71,10 +73,11 @@ func.func @test_expand_new_dims_mix(%arg0: tensor<128x64xf32>) -> tensor<1x128x1
 // CHECK-LABEL:  func.func @test_expand_new_dims_mix
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x64xf32>) -> tensor<1x128x16x128x16xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1, 128, 16, 128, 16]> : tensor<5xi64>}> : () -> tensor<5xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 128, 1, 64, 1>} : (tensor<128x64xf32>) -> tensor<1x128x1x64x1xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 1, 16, 2, 16]> : tensor<5xindex>} : () -> !tosa.shape<5>
-// CHECK:           [[VAR_3_:%.+]] = tosa.tile [[VAR_1_]], [[VAR_2_]] : (tensor<1x128x1x64x1xf32>, !tosa.shape<5>) -> tensor<1x128x16x128x16xf32>
-// CHECK:           return [[VAR_3_]] : tensor<1x128x16x128x16xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 128, 1, 64, 1]> : tensor<5xindex>} : () -> !tosa.shape<5>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_1_]] : (tensor<128x64xf32>, !tosa.shape<5>) -> tensor<1x128x1x64x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[1, 1, 16, 2, 16]> : tensor<5xindex>} : () -> !tosa.shape<5>
+// CHECK:           [[VAR_4_:%.+]] = tosa.tile [[VAR_2_]], [[VAR_3_]] : (tensor<1x128x1x64x1xf32>, !tosa.shape<5>) -> tensor<1x128x16x128x16xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x128x16x128x16xf32>
 
 // -----
 
@@ -87,10 +90,11 @@ func.func @test_expand_no_tile(%arg0: tensor<128x16xf32>) -> tensor<1x1x128x16xf
 // CHECK-LABEL:  func.func @test_expand_no_tile
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x16xf32>) -> tensor<1x1x128x16xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1, 1, 128, 16]> : tensor<4xi64>}> : () -> tensor<4xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 1, 128, 16>} : (tensor<128x16xf32>) -> tensor<1x1x128x16xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<4xindex>} : () -> !tosa.shape<4>
-// CHECK:           [[VAR_3_:%.+]] = tosa.tile [[VAR_1_]], [[VAR_2_]] : (tensor<1x1x128x16xf32>, !tosa.shape<4>) -> tensor<1x1x128x16xf32>
-// CHECK:           return [[VAR_3_]] : tensor<1x1x128x16xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 1, 128, 16]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_1_]] : (tensor<128x16xf32>, !tosa.shape<4>) -> tensor<1x1x128x16xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           [[VAR_4_:%.+]] = tosa.tile [[VAR_2_]], [[VAR_3_]] : (tensor<1x1x128x16xf32>, !tosa.shape<4>) -> tensor<1x1x128x16xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x128x16xf32>
 
 // -----
 func.func @test_expand_tile_one_dim_big(%arg0: tensor<1x6x1x1xf32>) -> tensor<1x6x576x672xf32> {
@@ -116,10 +120,11 @@ func.func @test_expand_smaller_dims(%arg0: tensor<128x64x1x1xf32>) -> tensor<1x1
 // CHECK-LABEL:  func.func @test_expand_smaller_dims
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x64x1x1xf32>) -> tensor<1x128x64x64x128xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1, 64, 128]> : tensor<3xi64>}> : () -> tensor<3xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 128, 64, 1, 1>} : (tensor<128x64x1x1xf32>) -> tensor<1x128x64x1x1xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 1, 1, 64, 128]> : tensor<5xindex>} : () -> !tosa.shape<5>
-// CHECK:           [[VAR_3_:%.+]] = tosa.tile [[VAR_1_]], [[VAR_2_]] : (tensor<1x128x64x1x1xf32>, !tosa.shape<5>) -> tensor<1x128x64x64x128xf32>
-// CHECK:           return [[VAR_3_]] : tensor<1x128x64x64x128xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 128, 64, 1, 1]> : tensor<5xindex>} : () -> !tosa.shape<5>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_1_]] : (tensor<128x64x1x1xf32>, !tosa.shape<5>) -> tensor<1x128x64x1x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[1, 1, 1, 64, 128]> : tensor<5xindex>} : () -> !tosa.shape<5>
+// CHECK:           [[VAR_4_:%.+]] = tosa.tile [[VAR_2_]], [[VAR_3_]] : (tensor<1x128x64x1x1xf32>, !tosa.shape<5>) -> tensor<1x128x64x64x128xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x128x64x64x128xf32>
 
 // -----
 
@@ -132,10 +137,11 @@ func.func @test_expand_mixed_smaller(%arg0 : tensor<2x1x6x1xbf16>) -> tensor<2x7
 // CHECK-LABEL:  func.func @test_expand_mixed_smaller
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x1x6x1xbf16>) -> tensor<2x7x6x5xbf16> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[7, 1, 5]> : tensor<3xi64>}> : () -> tensor<3xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 2, 1, 6, 1>} : (tensor<2x1x6x1xbf16>) -> tensor<2x1x6x1xbf16>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 7, 1, 5]> : tensor<4xindex>} : () -> !tosa.shape<4>
-// CHECK:           [[VAR_3_:%.+]] = tosa.tile [[VAR_1_]], [[VAR_2_]] : (tensor<2x1x6x1xbf16>, !tosa.shape<4>) -> tensor<2x7x6x5xbf16>
-// CHECK:           return [[VAR_3_]] : tensor<2x7x6x5xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[2, 1, 6, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_1_]] : (tensor<2x1x6x1xbf16>, !tosa.shape<4>) -> tensor<2x1x6x1xbf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[1, 7, 1, 5]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           [[VAR_4_:%.+]] = tosa.tile [[VAR_2_]], [[VAR_3_]] : (tensor<2x1x6x1xbf16>, !tosa.shape<4>) -> tensor<2x7x6x5xbf16>
+// CHECK:           return [[VAR_4_]] : tensor<2x7x6x5xbf16>
 
 // -----
 

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Flatten.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Flatten.mlir
@@ -3,35 +3,55 @@
 func.func @test_static_flatten(%arg0: tensor<32x512x1x1xf32>) -> tensor<32x512xf32> {
   %0 = "onnx.Flatten"(%arg0) {axis = 1 : si64} : (tensor<32x512x1x1xf32>) -> tensor<32x512xf32>
   return %0 : tensor<32x512xf32>
-  //CHECK: {{%.+}} =  tosa.reshape %arg0 {new_shape = array<i64: 32, 512>} : (tensor<32x512x1x1xf32>) -> tensor<32x512xf32>
+// CHECK-LABEL:  func.func @test_static_flatten
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<32x512x1x1xf32>) -> tensor<32x512xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[32, 512]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<32x512x1x1xf32>, !tosa.shape<2>) -> tensor<32x512xf32>
+// CHECK:           return [[VAR_1_]] : tensor<32x512xf32>
 }
 
 // -----
 func.func @test_static_flatten_mult(%arg0: tensor<32x51x5x3xf32>) -> tensor<1632x15xf32> {
   %0 = "onnx.Flatten"(%arg0) {axis = 2 : si64} : (tensor<32x51x5x3xf32>) -> tensor<1632x15xf32>
   return %0 : tensor<1632x15xf32>
-  //CHECK:  {{%.+}} = tosa.reshape %arg0 {new_shape = array<i64: 1632, 15>} : (tensor<32x51x5x3xf32>) -> tensor<1632x15xf32>
+// CHECK-LABEL:  func.func @test_static_flatten_mult
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<32x51x5x3xf32>) -> tensor<1632x15xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1632, 15]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<32x51x5x3xf32>, !tosa.shape<2>) -> tensor<1632x15xf32>
+// CHECK:           return [[VAR_1_]] : tensor<1632x15xf32>
 }
 
 // -----
 func.func @test_flatten_axes_0(%arg0: tensor<32x51x1x1xf32>) -> tensor<1x1632xf32> {
   %0 = "onnx.Flatten"(%arg0) {axis = 0 : si64} : (tensor<32x51x1x1xf32>) -> tensor<1x1632xf32>
   return %0 : tensor<1x1632xf32>
-  //CHECK:  {{%.+}} = tosa.reshape %arg0 {new_shape = array<i64: 1, 1632>} : (tensor<32x51x1x1xf32>) -> tensor<1x1632xf32>
+// CHECK-LABEL:  func.func @test_flatten_axes_0
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<32x51x1x1xf32>) -> tensor<1x1632xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 1632]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<32x51x1x1xf32>, !tosa.shape<2>) -> tensor<1x1632xf32>
+// CHECK:           return [[VAR_1_]] : tensor<1x1632xf32>
 }
 
 // -----
 func.func @test_flatten_axes_last(%arg0: tensor<32x51x1x3xf32>) -> tensor<1632x3xf32> {
   %0 = "onnx.Flatten"(%arg0) {axis = 3 : si64} : (tensor<32x51x1x3xf32>) -> tensor<1632x3xf32>
   return %0 : tensor<1632x3xf32>
-  //CHECK:  {{%.+}} = tosa.reshape %arg0 {new_shape = array<i64: 1632, 3>} : (tensor<32x51x1x3xf32>) -> tensor<1632x3xf32>
+// CHECK-LABEL:  func.func @test_flatten_axes_last
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<32x51x1x3xf32>) -> tensor<1632x3xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1632, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<32x51x1x3xf32>, !tosa.shape<2>) -> tensor<1632x3xf32>
+// CHECK:           return [[VAR_1_]] : tensor<1632x3xf32>
 }
 
 // -----
 func.func @test_flatten_axes_equals_rank(%arg0: tensor<32x51x1x3xf32>) -> tensor<4896x1xf32> {
   %0 = "onnx.Flatten"(%arg0) {axis = 4 : si64} : (tensor<32x51x1x3xf32>) -> tensor<4896x1xf32>
   return %0 : tensor<4896x1xf32>
-  //CHECK:  {{%.+}} = tosa.reshape %arg0 {new_shape = array<i64: 4896, 1>} : (tensor<32x51x1x3xf32>) -> tensor<4896x1xf32>
+  // CHECK-LABEL:  func.func @test_flatten_axes_equals_rank
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<32x51x1x3xf32>) -> tensor<4896x1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[4896, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<32x51x1x3xf32>, !tosa.shape<2>) -> tensor<4896x1xf32>
+// CHECK:           return [[VAR_1_]] : tensor<4896x1xf32>
 }
 
 // -----

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
@@ -4,24 +4,27 @@ func.func @test_gather_axis0(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
   %indices = "onnx.Constant"() {value = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>} : () -> tensor<2x2xi64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<2x2xi64>) -> tensor<2x2x2xf32>
   "func.return"(%0) : (tensor<2x2x2xf32>) -> ()
-// CHECK-LABEL:   func.func @test_gather_axis0(
-// CHECK-SAME:                                 %[[VAL_0:.*]]: tensor<3x2xf32>) -> tensor<2x2x2xf32> {
-// CHECK:           %[[VAL_1:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 1], [1, 2]]> : tensor<2x2xi64>}> : () -> tensor<2x2xi64>
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_3:.*]] = tosa.add %[[VAL_1]], %[[VAL_2]] : (tensor<2x2xi64>, tensor<1x1xi64>) -> tensor<2x2xi64>
-// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_5:.*]] = tosa.greater_equal %[[VAL_1]], %[[VAL_4]] : (tensor<2x2xi64>, tensor<1x1xi64>) -> tensor<2x2xi1>
-// CHECK:           %[[VAL_6:.*]] = tosa.select %[[VAL_5]], %[[VAL_1]], %[[VAL_3]] : (tensor<2x2xi1>, tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi64>
-// CHECK:           %[[VAL_7:.*]] = tosa.cast %[[VAL_6]] : (tensor<2x2xi64>) -> tensor<2x2xi32>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[0, 1]> : tensor<2xi32>}> : () -> tensor<2xi32>
-// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_8]] : (tensor<3x2xf32>, tensor<2xi32>) -> tensor<3x2xf32>
-// CHECK:           %[[VAL_10:.*]] = tosa.reshape %[[VAL_9]] {new_shape = array<i64: 1, 3, 2>} : (tensor<3x2xf32>) -> tensor<1x3x2xf32>
-// CHECK:           %[[VAL_11:.*]] = tosa.reshape %[[VAL_7]] {new_shape = array<i64: 1, 4>} : (tensor<2x2xi32>) -> tensor<1x4xi32>
-// CHECK:           %[[VAL_12:.*]] = tosa.gather %[[VAL_10]], %[[VAL_11]] : (tensor<1x3x2xf32>, tensor<1x4xi32>) -> tensor<1x4x2xf32>
-// CHECK:           %[[VAL_13:.*]] = tosa.reshape %[[VAL_12]] {new_shape = array<i64: 2, 2, 2>} : (tensor<1x4x2xf32>) -> tensor<2x2x2xf32>
-// CHECK:           %[[VAL_14:.*]] = "tosa.const"() <{value = dense<[0, 1, 2]> : tensor<3xi32>}> : () -> tensor<3xi32>
-// CHECK:           %[[VAL_15:.*]] = tosa.transpose %[[VAL_13]], %[[VAL_14]] : (tensor<2x2x2xf32>, tensor<3xi32>) -> tensor<2x2x2xf32>
-// CHECK:           return %[[VAL_15]] : tensor<2x2x2xf32>
+// CHECK-LABEL:  func.func @test_gather_axis0
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2xf32>) -> tensor<2x2x2xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<{{.}}[0, 1], [1, 2]{{.}}> : tensor<2x2xi64>}> : () -> tensor<2x2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.add [[VAR_0_]], [[VAR_1_]] : (tensor<2x2xi64>, tensor<1x1xi64>) -> tensor<2x2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK:           [[VAR_4_:%.+]] = tosa.greater_equal [[VAR_0_]], [[VAR_3_]] : (tensor<2x2xi64>, tensor<1x1xi64>) -> tensor<2x2xi1>
+// CHECK:           [[VAR_5_:%.+]] = tosa.select [[VAR_4_]], [[VAR_0_]], [[VAR_2_]] : (tensor<2x2xi1>, tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.cast [[VAR_5_]] : (tensor<2x2xi64>) -> tensor<2x2xi32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "tosa.const"() <{value = dense<[0, 1]> : tensor<2xi32>}> : () -> tensor<2xi32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_7_]] : (tensor<3x2xf32>, tensor<2xi32>) -> tensor<3x2xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.const_shape  {value = dense<[1, 3, 2]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.reshape [[VAR_8_]], [[VAR_9_]] : (tensor<3x2xf32>, !tosa.shape<3>) -> tensor<1x3x2xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.const_shape  {value = dense<[1, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_12_:%.+]] = tosa.reshape [[VAR_6_]], [[VAR_11_]] : (tensor<2x2xi32>, !tosa.shape<2>) -> tensor<1x4xi32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = tosa.gather [[VAR_10_]], [[VAR_12_]] : (tensor<1x3x2xf32>, tensor<1x4xi32>) -> tensor<1x4x2xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = tosa.const_shape  {value = dense<2> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_15_:%.+]] = tosa.reshape [[VAR_13_]], [[VAR_14_]] : (tensor<1x4x2xf32>, !tosa.shape<3>) -> tensor<2x2x2xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "tosa.const"() <{value = dense<[0, 1, 2]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK:           [[VAR_17_:%.+]] = tosa.transpose [[VAR_15_]], [[VAR_16_]] : (tensor<2x2x2xf32>, tensor<3xi32>) -> tensor<2x2x2xf32>
+// CHECK:           return [[VAR_17_]] : tensor<2x2x2xf32>
 }
 
 // -----
@@ -31,24 +34,27 @@ func.func @test_gather_axis0_neg_idx(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf3
   %indices = "onnx.Constant"() {value = dense<[[0, -1], [1, 2]]> : tensor<2x2xi64>} : () -> tensor<2x2xi64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<2x2xi64>) -> tensor<2x2x2xf32>
   "func.return"(%0) : (tensor<2x2x2xf32>) -> ()
-// CHECK-LABEL:   func.func @test_gather_axis0_neg_idx(
-// CHECK-SAME:                                         %[[VAL_0:.*]]: tensor<3x2xf32>) -> tensor<2x2x2xf32> {
-// CHECK:           %[[VAL_1:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, -1], [1, 2]]> : tensor<2x2xi64>}> : () -> tensor<2x2xi64>
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_3:.*]] = tosa.add %[[VAL_1]], %[[VAL_2]] : (tensor<2x2xi64>, tensor<1x1xi64>) -> tensor<2x2xi64>
-// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_5:.*]] = tosa.greater_equal %[[VAL_1]], %[[VAL_4]] : (tensor<2x2xi64>, tensor<1x1xi64>) -> tensor<2x2xi1>
-// CHECK:           %[[VAL_6:.*]] = tosa.select %[[VAL_5]], %[[VAL_1]], %[[VAL_3]] : (tensor<2x2xi1>, tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi64>
-// CHECK:           %[[VAL_7:.*]] = tosa.cast %[[VAL_6]] : (tensor<2x2xi64>) -> tensor<2x2xi32>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[0, 1]> : tensor<2xi32>}> : () -> tensor<2xi32>
-// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_8]] : (tensor<3x2xf32>, tensor<2xi32>) -> tensor<3x2xf32>
-// CHECK:           %[[VAL_10:.*]] = tosa.reshape %[[VAL_9]] {new_shape = array<i64: 1, 3, 2>} : (tensor<3x2xf32>) -> tensor<1x3x2xf32>
-// CHECK:           %[[VAL_11:.*]] = tosa.reshape %[[VAL_7]] {new_shape = array<i64: 1, 4>} : (tensor<2x2xi32>) -> tensor<1x4xi32>
-// CHECK:           %[[VAL_12:.*]] = tosa.gather %[[VAL_10]], %[[VAL_11]] : (tensor<1x3x2xf32>, tensor<1x4xi32>) -> tensor<1x4x2xf32>
-// CHECK:           %[[VAL_13:.*]] = tosa.reshape %[[VAL_12]] {new_shape = array<i64: 2, 2, 2>} : (tensor<1x4x2xf32>) -> tensor<2x2x2xf32>
-// CHECK:           %[[VAL_14:.*]] = "tosa.const"() <{value = dense<[0, 1, 2]> : tensor<3xi32>}> : () -> tensor<3xi32>
-// CHECK:           %[[VAL_15:.*]] = tosa.transpose %[[VAL_13]], %[[VAL_14]] : (tensor<2x2x2xf32>, tensor<3xi32>) -> tensor<2x2x2xf32>
-// CHECK:           return %[[VAL_15]] : tensor<2x2x2xf32>
+// CHECK-LABEL:  func.func @test_gather_axis0_neg_idx
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2xf32>) -> tensor<2x2x2xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<{{.}}[0, -1], [1, 2]{{.}}> : tensor<2x2xi64>}> : () -> tensor<2x2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.add [[VAR_0_]], [[VAR_1_]] : (tensor<2x2xi64>, tensor<1x1xi64>) -> tensor<2x2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK:           [[VAR_4_:%.+]] = tosa.greater_equal [[VAR_0_]], [[VAR_3_]] : (tensor<2x2xi64>, tensor<1x1xi64>) -> tensor<2x2xi1>
+// CHECK:           [[VAR_5_:%.+]] = tosa.select [[VAR_4_]], [[VAR_0_]], [[VAR_2_]] : (tensor<2x2xi1>, tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.cast [[VAR_5_]] : (tensor<2x2xi64>) -> tensor<2x2xi32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "tosa.const"() <{value = dense<[0, 1]> : tensor<2xi32>}> : () -> tensor<2xi32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_7_]] : (tensor<3x2xf32>, tensor<2xi32>) -> tensor<3x2xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.const_shape  {value = dense<[1, 3, 2]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.reshape [[VAR_8_]], [[VAR_9_]] : (tensor<3x2xf32>, !tosa.shape<3>) -> tensor<1x3x2xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.const_shape  {value = dense<[1, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_12_:%.+]] = tosa.reshape [[VAR_6_]], [[VAR_11_]] : (tensor<2x2xi32>, !tosa.shape<2>) -> tensor<1x4xi32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = tosa.gather [[VAR_10_]], [[VAR_12_]] : (tensor<1x3x2xf32>, tensor<1x4xi32>) -> tensor<1x4x2xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = tosa.const_shape  {value = dense<2> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_15_:%.+]] = tosa.reshape [[VAR_13_]], [[VAR_14_]] : (tensor<1x4x2xf32>, !tosa.shape<3>) -> tensor<2x2x2xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "tosa.const"() <{value = dense<[0, 1, 2]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK:           [[VAR_17_:%.+]] = tosa.transpose [[VAR_15_]], [[VAR_16_]] : (tensor<2x2x2xf32>, tensor<3xi32>) -> tensor<2x2x2xf32>
+// CHECK:           return [[VAR_17_]] : tensor<2x2x2xf32>
 }
 
 // -----
@@ -58,25 +64,27 @@ func.func @test_gather_axis1(%arg0 : tensor<3x3xf32>) -> tensor<3x1x2xf32> {
   %indices = "onnx.Constant"() {value = dense<[[0, 2]]> : tensor<1x2xi64>} : () -> tensor<1x2xi64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<3x1x2xf32>
   "func.return"(%0) : (tensor<3x1x2xf32>) -> ()
-// CHECK-LABEL:   func.func @test_gather_axis1(
-// CHECK-SAME:                                 %[[VAL_0:.*]]: tensor<3x3xf32>) -> tensor<3x1x2xf32> {
-// CHECK:           %[[VAL_1:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 2]]> : tensor<1x2xi64>}> : () -> tensor<1x2xi64>
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_3:.*]] = tosa.add %[[VAL_1]], %[[VAL_2]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi64>
-// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_5:.*]] = tosa.greater_equal %[[VAL_1]], %[[VAL_4]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi1>
-// CHECK:           %[[VAL_6:.*]] = tosa.select %[[VAL_5]], %[[VAL_1]], %[[VAL_3]] : (tensor<1x2xi1>, tensor<1x2xi64>, tensor<1x2xi64>) -> tensor<1x2xi64>
-// CHECK:           %[[VAL_7:.*]] = tosa.cast %[[VAL_6]] : (tensor<1x2xi64>) -> tensor<1x2xi32>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}> : () -> tensor<2xi32>
-// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_8]] : (tensor<3x3xf32>, tensor<2xi32>) -> tensor<3x3xf32>
-// CHECK:           %[[VAL_10:.*]] = tosa.reshape %[[VAL_9]] {new_shape = array<i64: 1, 3, 3>} : (tensor<3x3xf32>) -> tensor<1x3x3xf32>
-// CHECK:           %[[VAL_11:.*]] = tosa.reshape %[[VAL_7]] {new_shape = array<i64: 1, 2>} : (tensor<1x2xi32>) -> tensor<1x2xi32>
-// CHECK:           %[[VAL_12:.*]] = tosa.gather %[[VAL_10]], %[[VAL_11]] : (tensor<1x3x3xf32>, tensor<1x2xi32>) -> tensor<1x2x3xf32>
-// CHECK:           %[[VAL_13:.*]] = tosa.reshape %[[VAL_12]] {new_shape = array<i64: 1, 2, 3>} : (tensor<1x2x3xf32>) -> tensor<1x2x3xf32>
-// CHECK:           %[[VAL_14:.*]] = "tosa.const"() <{value = dense<[2, 0, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
-// CHECK:           %[[VAL_15:.*]] = tosa.transpose %[[VAL_13]], %[[VAL_14]] : (tensor<1x2x3xf32>, tensor<3xi32>) -> tensor<3x1x2xf32>
-// CHECK:           return %[[VAL_15]] : tensor<3x1x2xf32>
-// CHECK:         }
+// CHECK-LABEL:  func.func @test_gather_axis1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x3xf32>) -> tensor<3x1x2xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<{{.}}[0, 2]{{.}}> : tensor<1x2xi64>}> : () -> tensor<1x2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.add [[VAR_0_]], [[VAR_1_]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK:           [[VAR_4_:%.+]] = tosa.greater_equal [[VAR_0_]], [[VAR_3_]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi1>
+// CHECK:           [[VAR_5_:%.+]] = tosa.select [[VAR_4_]], [[VAR_0_]], [[VAR_2_]] : (tensor<1x2xi1>, tensor<1x2xi64>, tensor<1x2xi64>) -> tensor<1x2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.cast [[VAR_5_]] : (tensor<1x2xi64>) -> tensor<1x2xi32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}> : () -> tensor<2xi32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_7_]] : (tensor<3x3xf32>, tensor<2xi32>) -> tensor<3x3xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.const_shape  {value = dense<[1, 3, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.reshape [[VAR_8_]], [[VAR_9_]] : (tensor<3x3xf32>, !tosa.shape<3>) -> tensor<1x3x3xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.const_shape  {value = dense<[1, 2]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_12_:%.+]] = tosa.reshape [[VAR_6_]], [[VAR_11_]] : (tensor<1x2xi32>, !tosa.shape<2>) -> tensor<1x2xi32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = tosa.gather [[VAR_10_]], [[VAR_12_]] : (tensor<1x3x3xf32>, tensor<1x2xi32>) -> tensor<1x2x3xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = tosa.const_shape  {value = dense<[1, 2, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_15_:%.+]] = tosa.reshape [[VAR_13_]], [[VAR_14_]] : (tensor<1x2x3xf32>, !tosa.shape<3>) -> tensor<1x2x3xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "tosa.const"() <{value = dense<[2, 0, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK:           [[VAR_17_:%.+]] = tosa.transpose [[VAR_15_]], [[VAR_16_]] : (tensor<1x2x3xf32>, tensor<3xi32>) -> tensor<3x1x2xf32>
+// CHECK:           return [[VAR_17_]] : tensor<3x1x2xf32>
 }
 
 // -----
@@ -84,24 +92,26 @@ func.func @test_gather_axis1(%arg0 : tensor<3x3xf32>) -> tensor<3x1x2xf32> {
 func.func @test_gather_dynamic_indices(%arg0 : tensor<3x3xf32>, %indices: tensor<1x2xi64>) -> tensor<3x1x2xf32> {
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<3x1x2xf32>
   "func.return"(%0) : (tensor<3x1x2xf32>) -> ()
-// CHECK-LABEL:   func.func @test_gather_dynamic_indices(
-// CHECK-SAME:                                           %[[VAL_0:.*]]: tensor<3x3xf32>,
-// CHECK-SAME:                                           %[[VAL_1:.*]]: tensor<1x2xi64>) -> tensor<3x1x2xf32> {
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_3:.*]] = tosa.add %[[VAL_1]], %[[VAL_2]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi64>
-// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK:           %[[VAL_5:.*]] = tosa.greater_equal %[[VAL_1]], %[[VAL_4]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi1>
-// CHECK:           %[[VAL_6:.*]] = tosa.select %[[VAL_5]], %[[VAL_1]], %[[VAL_3]] : (tensor<1x2xi1>, tensor<1x2xi64>, tensor<1x2xi64>) -> tensor<1x2xi64>
-// CHECK:           %[[VAL_7:.*]] = tosa.cast %[[VAL_6]] : (tensor<1x2xi64>) -> tensor<1x2xi32>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}> : () -> tensor<2xi32>
-// CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_8]] : (tensor<3x3xf32>, tensor<2xi32>) -> tensor<3x3xf32>
-// CHECK:           %[[VAL_10:.*]] = tosa.reshape %[[VAL_9]] {new_shape = array<i64: 1, 3, 3>} : (tensor<3x3xf32>) -> tensor<1x3x3xf32>
-// CHECK:           %[[VAL_11:.*]] = tosa.reshape %[[VAL_7]] {new_shape = array<i64: 1, 2>} : (tensor<1x2xi32>) -> tensor<1x2xi32>
-// CHECK:           %[[VAL_12:.*]] = tosa.gather %[[VAL_10]], %[[VAL_11]] : (tensor<1x3x3xf32>, tensor<1x2xi32>) -> tensor<1x2x3xf32>
-// CHECK:           %[[VAL_13:.*]] = tosa.reshape %[[VAL_12]] {new_shape = array<i64: 1, 2, 3>} : (tensor<1x2x3xf32>) -> tensor<1x2x3xf32>
-// CHECK:           %[[VAL_14:.*]] = "tosa.const"() <{value = dense<[2, 0, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
-// CHECK:           %[[VAL_15:.*]] = tosa.transpose %[[VAL_13]], %[[VAL_14]] : (tensor<1x2x3xf32>, tensor<3xi32>) -> tensor<3x1x2xf32>
-// CHECK:           return %[[VAL_15]] : tensor<3x1x2xf32>
+// CHECK-LABEL:  func.func @test_gather_dynamic_indices
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x3xf32>, [[PARAM_1_:%.+]]: tensor<1x2xi64>) -> tensor<3x1x2xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.add [[PARAM_1_]], [[VAR_0_]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK:           [[VAR_3_:%.+]] = tosa.greater_equal [[PARAM_1_]], [[VAR_2_]] : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi1>
+// CHECK:           [[VAR_4_:%.+]] = tosa.select [[VAR_3_]], [[PARAM_1_]], [[VAR_1_]] : (tensor<1x2xi1>, tensor<1x2xi64>, tensor<1x2xi64>) -> tensor<1x2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.cast [[VAR_4_]] : (tensor<1x2xi64>) -> tensor<1x2xi32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}> : () -> tensor<2xi32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_6_]] : (tensor<3x3xf32>, tensor<2xi32>) -> tensor<3x3xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.const_shape  {value = dense<[1, 3, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.reshape [[VAR_7_]], [[VAR_8_]] : (tensor<3x3xf32>, !tosa.shape<3>) -> tensor<1x3x3xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.const_shape  {value = dense<[1, 2]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_11_:%.+]] = tosa.reshape [[VAR_5_]], [[VAR_10_]] : (tensor<1x2xi32>, !tosa.shape<2>) -> tensor<1x2xi32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = tosa.gather [[VAR_9_]], [[VAR_11_]] : (tensor<1x3x3xf32>, tensor<1x2xi32>) -> tensor<1x2x3xf32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = tosa.const_shape  {value = dense<[1, 2, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_14_:%.+]] = tosa.reshape [[VAR_12_]], [[VAR_13_]] : (tensor<1x2x3xf32>, !tosa.shape<3>) -> tensor<1x2x3xf32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = "tosa.const"() <{value = dense<[2, 0, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK:           [[VAR_16_:%.+]] = tosa.transpose [[VAR_14_]], [[VAR_15_]] : (tensor<1x2x3xf32>, tensor<3xi32>) -> tensor<3x1x2xf32>
+// CHECK:           return [[VAR_16_]] : tensor<3x1x2xf32>
 }
 
 // -----
@@ -109,23 +119,25 @@ func.func @test_gather_dynamic_indices(%arg0 : tensor<3x3xf32>, %indices: tensor
 func.func @test_gather_dynamic_indices_i32(%arg0 : tensor<3x3xf32>, %indices: tensor<1x2xi32>) -> tensor<3x1x2xf32> {
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<1x2xi32>) -> tensor<3x1x2xf32>
   "func.return"(%0) : (tensor<3x1x2xf32>) -> ()
-// CHECK-LABEL:   func.func @test_gather_dynamic_indices_i32(
-// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<3x3xf32>,
-// CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<1x2xi32>) -> tensor<3x1x2xf32> {
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK:           %[[VAL_4:.*]] = tosa.add %[[VAL_1]], %[[VAL_2]] : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
-// CHECK:           %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK:           %[[VAL_7:.*]] = tosa.greater_equal %[[VAL_1]], %[[VAL_5]] : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi1>
-// CHECK:           %[[VAL_8:.*]] = tosa.select %[[VAL_7]], %[[VAL_1]], %[[VAL_4]] : (tensor<1x2xi1>, tensor<1x2xi32>, tensor<1x2xi32>) -> tensor<1x2xi32>
-// CHECK:           %[[VAL_9:.*]] = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}> : () -> tensor<2xi32>
-// CHECK:           %[[VAL_10:.*]] = tosa.transpose %[[VAL_0]], %[[VAL_9]] : (tensor<3x3xf32>, tensor<2xi32>) -> tensor<3x3xf32>
-// CHECK:           %[[VAL_11:.*]] = tosa.reshape %[[VAL_10]] {new_shape = array<i64: 1, 3, 3>} : (tensor<3x3xf32>) -> tensor<1x3x3xf32>
-// CHECK:           %[[VAL_12:.*]] = tosa.reshape %[[VAL_8]] {new_shape = array<i64: 1, 2>} : (tensor<1x2xi32>) -> tensor<1x2xi32>
-// CHECK:           %[[VAL_13:.*]] = tosa.gather %[[VAL_11]], %[[VAL_12]] : (tensor<1x3x3xf32>, tensor<1x2xi32>) -> tensor<1x2x3xf32>
-// CHECK:           %[[VAL_14:.*]] = tosa.reshape %[[VAL_13]] {new_shape = array<i64: 1, 2, 3>} : (tensor<1x2x3xf32>) -> tensor<1x2x3xf32>
-// CHECK:           %[[VAL_15:.*]] = "tosa.const"() <{value = dense<[2, 0, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
-// CHECK:           %[[VAL_16:.*]] = tosa.transpose %[[VAL_14]], %[[VAL_15]] : (tensor<1x2x3xf32>, tensor<3xi32>) -> tensor<3x1x2xf32>
-// CHECK:           return %[[VAL_16]] : tensor<3x1x2xf32>
+// CHECK-LABEL:  func.func @test_gather_dynamic_indices_i32
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x3xf32>, [[PARAM_1_:%.+]]: tensor<1x2xi32>) -> tensor<3x1x2xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<3> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.add [[PARAM_1_]], [[VAR_0_]] : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tosa.const"() <{value = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK:           [[VAR_3_:%.+]] = tosa.greater_equal [[PARAM_1_]], [[VAR_2_]] : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi1>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.select [[VAR_3_]], [[PARAM_1_]], [[VAR_1_]] : (tensor<1x2xi1>, tensor<1x2xi32>, tensor<1x2xi32>) -> tensor<1x2xi32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}> : () -> tensor<2xi32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_5_]] : (tensor<3x3xf32>, tensor<2xi32>) -> tensor<3x3xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.const_shape  {value = dense<[1, 3, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.reshape [[VAR_6_]], [[VAR_7_]] : (tensor<3x3xf32>, !tosa.shape<3>) -> tensor<1x3x3xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.const_shape  {value = dense<[1, 2]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_10_:%.+]] = tosa.reshape [[VAR_4_]], [[VAR_9_]] : (tensor<1x2xi32>, !tosa.shape<2>) -> tensor<1x2xi32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.gather [[VAR_8_]], [[VAR_10_]] : (tensor<1x3x3xf32>, tensor<1x2xi32>) -> tensor<1x2x3xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = tosa.const_shape  {value = dense<[1, 2, 3]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_13_:%.+]] = tosa.reshape [[VAR_11_]], [[VAR_12_]] : (tensor<1x2x3xf32>, !tosa.shape<3>) -> tensor<1x2x3xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = "tosa.const"() <{value = dense<[2, 0, 1]> : tensor<3xi32>}> : () -> tensor<3xi32>
+// CHECK:           [[VAR_15_:%.+]] = tosa.transpose [[VAR_13_]], [[VAR_14_]] : (tensor<1x2x3xf32>, tensor<3xi32>) -> tensor<3x1x2xf32>
+// CHECK:           return [[VAR_15_]] : tensor<3x1x2xf32>
 }
 
 // -----
@@ -134,11 +146,14 @@ func.func @test_gather_like_slice(%arg0 : tensor<3x3xf32>) -> tensor<3xf32> {
   %indices = onnx.Constant dense<0> : tensor<i64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
   "func.return"(%0) : (tensor<3xf32>) -> ()
-// CHECK-LABEL:   test_gather_like_slice
-// CHECK-SAME:    (%[[ARG:.*]]: tensor<3x3xf32>)
-// CHECK:         %[[VAL_1:.*]] = tosa.slice %[[ARG]] {size = array<i64: 3, 1>, start = array<i64: 0, 0>} : (tensor<3x3xf32>) -> tensor<3x1xf32>
-// CHECK:         %[[VAL_2:.*]] = tosa.reshape %[[VAL_1]] {{.*}} -> tensor<3xf32>
-// CHECK:         return %[[VAL_2]]
+// CHECK-LABEL:  func.func @test_gather_like_slice
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x3xf32>) -> tensor<3xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[3, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<3x3xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<3x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<3> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK:           [[VAR_4_:%.+]] = tosa.reshape [[VAR_2_]], [[VAR_3_]] : (tensor<3x1xf32>, !tosa.shape<1>) -> tensor<3xf32>
+// CHECK:           return [[VAR_4_]] : tensor<3xf32>
 }
 
 // -----
@@ -147,11 +162,14 @@ func.func @test_gather_like_slice_positive_integer(%arg0 : tensor<3x3xf32>) -> t
   %indices = onnx.Constant dense<2> : tensor<i64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
   "func.return"(%0) : (tensor<3xf32>) -> ()
-// CHECK-LABEL:   test_gather_like_slice
-// CHECK-SAME:    (%[[ARG:.*]]: tensor<3x3xf32>)
-// CHECK:         %[[VAL_1:.*]] = tosa.slice %[[ARG]] {size = array<i64: 1, 3>, start = array<i64: 2, 0>} : (tensor<3x3xf32>) -> tensor<1x3xf32>
-// CHECK:         %[[VAL_2:.*]] = tosa.reshape %[[VAL_1]] {{.*}} -> tensor<3xf32>
-// CHECK:         return %[[VAL_2]]
+// CHECK-LABEL:  func.func @test_gather_like_slice_positive_integer
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x3xf32>) -> tensor<3xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[2, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<3x3xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<1x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<3> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK:           [[VAR_4_:%.+]] = tosa.reshape [[VAR_2_]], [[VAR_3_]] : (tensor<1x3xf32>, !tosa.shape<1>) -> tensor<3xf32>
+// CHECK:           return [[VAR_4_]] : tensor<3xf32>
 }
 
 // -----
@@ -160,11 +178,14 @@ func.func @test_gather_like_slice_negative_integer(%arg0 : tensor<3x3xf32>) -> t
   %indices = onnx.Constant dense<-1> : tensor<i64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
   "func.return"(%0) : (tensor<3xf32>) -> ()
-// CHECK-LABEL:   test_gather_like_slice
-// CHECK-SAME:    (%[[ARG:.*]]: tensor<3x3xf32>)
-// CHECK:         %[[VAL_1:.*]] = tosa.slice %[[ARG]] {size = array<i64: 1, 3>, start = array<i64: 2, 0>} : (tensor<3x3xf32>) -> tensor<1x3xf32>
-// CHECK:         %[[VAL_2:.*]] = tosa.reshape %[[VAL_1]] {{.*}} -> tensor<3xf32>
-// CHECK:         return %[[VAL_2]]
+// CHECK-LABEL:  func.func @test_gather_like_slice_negative_integer
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x3xf32>) -> tensor<3xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[2, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<3x3xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<1x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<3> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK:           [[VAR_4_:%.+]] = tosa.reshape [[VAR_2_]], [[VAR_3_]] : (tensor<1x3xf32>, !tosa.shape<1>) -> tensor<3xf32>
+// CHECK:           return [[VAR_4_]] : tensor<3xf32>
 }
 
 // -----

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Reshape.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Reshape.mlir
@@ -6,7 +6,8 @@ func.func @test_reshape(%arg0 : tensor<128x1024xf32>) -> tensor<1x128x16x64xf32>
   "func.return"(%1) : (tensor<1x128x16x64xf32>) -> ()
 // CHECK-LABEL:  func @test_reshape
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x1024xf32>) -> tensor<1x128x16x64xf32> {
-// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 128, 16, 64>} : (tensor<128x1024xf32>) -> tensor<1x128x16x64xf32>
+// CHECK:           [[SHAPE:%.+]] = tosa.const_shape {value = dense<[1, 128, 16, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[SHAPE]] : (tensor<128x1024xf32>, !tosa.shape<4>) -> tensor<1x128x16x64xf32>
 // CHECK-NEXT:      return [[VAR_1_]] : tensor<1x128x16x64xf32>
 }
 
@@ -16,7 +17,8 @@ func.func @test_reshape_allowzero(%arg0 : tensor<12x128x1024xf32>) -> tensor<12x
   "func.return"(%1) : (tensor<12x128x16x64xf32>) -> ()
 // CHECK-LABEL:  func @test_reshape
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<12x128x1024xf32>) -> tensor<12x128x16x64xf32> {
-// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 12, 128, 16, 64>} : (tensor<12x128x1024xf32>) -> tensor<12x128x16x64xf32>
+// CHECK:           [[SHAPE:%.+]] = tosa.const_shape {value = dense<[12, 128, 16, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-NEXT:      [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[SHAPE]] : (tensor<12x128x1024xf32>, !tosa.shape<4>) -> tensor<12x128x16x64xf32>
 // CHECK-NEXT:      return [[VAR_1_]] : tensor<12x128x16x64xf32>
 }
 
@@ -24,8 +26,10 @@ func.func @test_reshape_fp8(%arg0 : tensor<128x1024xf8E5M2FNUZ>) -> tensor<1x128
   %0 = "onnx.Constant"() {value = dense<[-1, 128, 16, 64]> : tensor<4xi64>} : () -> tensor<4xi64>
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<128x1024xf8E5M2FNUZ>, tensor<4xi64>) -> tensor<1x128x16x64xf8E5M2FNUZ>
   "func.return"(%1) : (tensor<1x128x16x64xf8E5M2FNUZ>) -> ()
-// CHECK-LABEL: @test_reshape_fp8
-// CHECK-SAME: ([[PARAM_0_:%.+]] tensor<128x1024xf8E5M2FNUZ>) -> tensor<1x128x16x64xf8E5M2FNUZ> {
-// CHECK: [[VAR_1_:%.+]] = tosa.reshape %arg0 {new_shape = array<i64: 1, 128, 16, 64>} : (tensor<128x1024xf8E5M2FNUZ>) -> tensor<1x128x16x64xf8E5M2FNUZ>
-// CHECK-NEXT: return [[VAR_1_]] : tensor<1x128x16x64xf8E5M2FNUZ>
+// CHECK-LABEL:  func.func @test_reshape_fp8
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x1024xf8E5M2FNUZ>) -> tensor<1x128x16x64xf8E5M2FNUZ> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[-1, 128, 16, 64]> : tensor<4xi64>}> : () -> tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 128, 16, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_1_]] : (tensor<128x1024xf8E5M2FNUZ>, !tosa.shape<4>) -> tensor<1x128x16x64xf8E5M2FNUZ>
+// CHECK:           return [[VAR_2_]] : tensor<1x128x16x64xf8E5M2FNUZ>
   }

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Slice.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Slice.mlir
@@ -8,8 +8,12 @@ func.func @test_slice_constant_default_steps(%arg0 : tensor<2x4xf32>) -> tensor<
   %steps = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<2x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, none) -> tensor<1x3xf32>
   "func.return"(%1) : (tensor<1x3xf32>) -> ()
-// CHECK-LABEL: func @test_slice_constant_default_steps
-// CHECK: %0 = tosa.slice %arg0 {size = array<i64: 1, 3>, start = array<i64: 1, 0>} : (tensor<2x4xf32>) -> tensor<1x3xf32>
+// CHECK-LABEL:  func.func @test_slice_constant_default_steps
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4xf32>) -> tensor<1x3xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<2x4xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<1x3xf32>
+// CHECK:           return [[VAR_2_]] : tensor<1x3xf32>
 }
 
 func.func @test_slice_all_constant_negative(%arg0 : tensor<2x4xf32>) -> tensor<1x3xf32> {
@@ -19,8 +23,12 @@ func.func @test_slice_all_constant_negative(%arg0 : tensor<2x4xf32>) -> tensor<1
   %steps = "onnx.Constant"() {value = dense<[1, 1]> : tensor<2xi64> } : () -> tensor<2xi64>
   %1 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<2x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x3xf32>
   "func.return"(%1) : (tensor<1x3xf32>) -> ()
-// CHECK-LABEL: func @test_slice_all_constant_negative
-// CHECK: %0 = tosa.slice %arg0 {size = array<i64: 1, 3>, start = array<i64: 1, 0>} : (tensor<2x4xf32>) -> tensor<1x3xf32>
+// CHECK-LABEL:  func.func @test_slice_all_constant_negative
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4xf32>) -> tensor<1x3xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<2x4xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<1x3xf32>
+// CHECK:           return [[VAR_2_]] : tensor<1x3xf32>
 }
 
 func.func @test_slice_all_constant_end_outofbound(%arg0 : tensor<2x4xf32>) -> tensor<1x3xf32> {
@@ -30,8 +38,12 @@ func.func @test_slice_all_constant_end_outofbound(%arg0 : tensor<2x4xf32>) -> te
   %steps = "onnx.Constant"() {value = dense<[1, 1]> : tensor<2xi64> } : () -> tensor<2xi64>
   %1 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<2x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x3xf32>
   "func.return"(%1) : (tensor<1x3xf32>) -> ()
-// CHECK-LABEL: func @test_slice_all_constant_end_outofbound
-// CHECK: %0 = tosa.slice %arg0 {size = array<i64: 1, 3>, start = array<i64: 1, 0>} : (tensor<2x4xf32>) -> tensor<1x3xf32>
+// CHECK-LABEL:  func.func @test_slice_all_constant_end_outofbound
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4xf32>) -> tensor<1x3xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<2x4xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<1x3xf32>
+// CHECK:           return [[VAR_2_]] : tensor<1x3xf32>
 }
 
 // -----

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Slice.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Slice.mlir
@@ -57,10 +57,12 @@ func.func @slice_all_dynamic(%arg0: tensor<20x10x5xf32>,
   %0 = "onnx.Slice"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<20x10x5xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<20x9x5xf32>
   return %0 : tensor<20x9x5xf32>
 }
+// CHECK-LABEL:  func.func @slice_all_dynamic
+// CHECK: onnx.Slice
 
 // -----
 
-func.func @slice_default_axes(%arg0: tensor<20x10x5xf32>,
+func.func @slice_dynamic_axes(%arg0: tensor<20x10x5xf32>,
                              %arg1: tensor<3xi64>,
                              %arg2: tensor<3xi64>)
                               -> tensor<20x10x1xf32> {
@@ -69,6 +71,8 @@ func.func @slice_default_axes(%arg0: tensor<20x10x5xf32>,
   %2 = "onnx.Slice"(%arg0, %arg1, %arg2, %0, %1) {onnx_node_name = "onnx.Slice_0"} : (tensor<20x10x5xf32>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<20x10x1xf32>
   return %2 : tensor<20x10x1xf32>
 }
+// CHECK-LABEL:  func.func @slice_dynamic_axes
+// CHECK: onnx.Slice
 
 // -----
 
@@ -80,11 +84,17 @@ func.func @slice_just_steps(%arg0: tensor<100x200xf32>) -> tensor<20x20xf32> {
   %1 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<100x200xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<20x20xf32>
   return %1 : tensor<20x20xf32> 
 }
-// CHECK-LABEL: func @slice_just_steps
-// CHECK: %0 = tosa.reshape %arg0 {new_shape = array<i64: 20, 5, 20, 10>} : (tensor<100x200xf32>) -> tensor<20x5x20x10xf32>
-// CHECK: %1 = tosa.slice %0 {size = array<i64: 20, 1, 20, 1>, start = array<i64: 0, 0, 0, 0>} : (tensor<20x5x20x10xf32>) -> tensor<20x1x20x1xf32>
-// CHECK: %2 = tosa.reshape %1 {new_shape = array<i64: 20, 20>} : (tensor<20x1x20x1xf32>) -> tensor<20x20xf32>
-// CHECK: return %2 : tensor<20x20xf32>
+// CHECK-LABEL:  func.func @slice_just_steps
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<100x200xf32>) -> tensor<20x20xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[20, 5, 20, 10]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<100x200xf32>, !tosa.shape<4>) -> tensor<20x5x20x10xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[20, 1, 20, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.slice [[VAR_1_]], [[VAR_2_]], [[VAR_3_]] : (tensor<20x5x20x10xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<20x1x20x1xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.const_shape  {value = dense<20> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_6_:%.+]] = tosa.reshape [[VAR_4_]], [[VAR_5_]] : (tensor<20x1x20x1xf32>, !tosa.shape<2>) -> tensor<20x20xf32>
+// CHECK:           return [[VAR_6_]] : tensor<20x20xf32>
+// CHECK:         }
 
 // -----
 
@@ -96,12 +106,20 @@ func.func @slice_steps_and_edges(%arg0: tensor<100x200xf32>) -> tensor<16x17xf32
   %1 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<100x200xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<16x17xf32>
   return %1 : tensor<16x17xf32> 
 }
-// CHECK-LABEL: func @slice_steps_and_edges
-// CHECK: %0 = tosa.slice %arg0 {size = array<i64: 80, 170>, start = array<i64: 5, 10>} : (tensor<100x200xf32>) -> tensor<80x170xf32>
-// CHECK: %1 = tosa.reshape %0 {new_shape = array<i64: 16, 5, 17, 10>} : (tensor<80x170xf32>) -> tensor<16x5x17x10xf32>
-// CHECK: %2 = tosa.slice %1 {size = array<i64: 16, 1, 17, 1>, start = array<i64: 0, 0, 0, 0>} : (tensor<16x5x17x10xf32>) -> tensor<16x1x17x1xf32>
-// CHECK: %3 = tosa.reshape %2 {new_shape = array<i64: 16, 17>} : (tensor<16x1x17x1xf32>) -> tensor<16x17xf32>
-// CHECK: return %3 : tensor<16x17xf32>
+// CHECK-LABEL:  func.func @slice_steps_and_edges
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<100x200xf32>) -> tensor<16x17xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[5, 10]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[80, 170]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<100x200xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<80x170xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[16, 5, 17, 10]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.reshape [[VAR_2_]], [[VAR_3_]] : (tensor<80x170xf32>, !tosa.shape<4>) -> tensor<16x5x17x10xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.const_shape  {value = dense<[16, 1, 17, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.slice [[VAR_4_]], [[VAR_5_]], [[VAR_6_]] : (tensor<16x5x17x10xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<16x1x17x1xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.const_shape  {value = dense<[16, 17]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_9_:%.+]] = tosa.reshape [[VAR_7_]], [[VAR_8_]] : (tensor<16x1x17x1xf32>, !tosa.shape<2>) -> tensor<16x17xf32>
+// CHECK:           return [[VAR_9_]] : tensor<16x17xf32>
+// CHECK:         }
 
 // -----
 
@@ -113,15 +131,23 @@ func.func @slice_steps_and_edges_with_padding(%arg0: tensor<99x195xf32>) -> tens
   %1 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<99x195xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<19x19xf32>
   return %1 : tensor<19x19xf32> 
 }
-// CHECK-LABEL: func @slice_steps_and_edges_with_padding
-// CHECK: %0 = tosa.const_shape {value = dense<[0, 1, 0, 5]> : tensor<4xindex>} : () -> !tosa.shape<4>
-// CHECK: %1 = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
-// CHECK: %2 = tosa.pad %arg0, %0, %1 : (tensor<99x195xf32>, !tosa.shape<4>, tensor<f32>) -> tensor<100x200xf32>
-// CHECK: %3 = tosa.slice %2 {size = array<i64: 95, 190>, start = array<i64: 5, 10>} : (tensor<100x200xf32>) -> tensor<95x190xf32>
-// CHECK: %4 = tosa.reshape %3 {new_shape = array<i64: 19, 5, 19, 10>} : (tensor<95x190xf32>) -> tensor<19x5x19x10xf32>
-// CHECK: %5 = tosa.slice %4 {size = array<i64: 19, 1, 19, 1>, start = array<i64: 0, 0, 0, 0>} : (tensor<19x5x19x10xf32>) -> tensor<19x1x19x1xf32>
-// CHECK: %6 = tosa.reshape %5 {new_shape = array<i64: 19, 19>} : (tensor<19x1x19x1xf32>) -> tensor<19x19xf32>
-// CHECK: return %6 : tensor<19x19xf32>
+// CHECK-LABEL:  func.func @slice_steps_and_edges_with_padding
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<99x195xf32>) -> tensor<19x19xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[0, 1, 0, 5]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.pad [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<99x195xf32>, !tosa.shape<4>, tensor<f32>) -> tensor<100x200xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[5, 10]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[95, 190]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.slice [[VAR_2_]], [[VAR_3_]], [[VAR_4_]] : (tensor<100x200xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<95x190xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.const_shape  {value = dense<[19, 5, 19, 10]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.reshape [[VAR_5_]], [[VAR_6_]] : (tensor<95x190xf32>, !tosa.shape<4>) -> tensor<19x5x19x10xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.const_shape  {value = dense<[19, 1, 19, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.slice [[VAR_7_]], [[VAR_8_]], [[VAR_9_]] : (tensor<19x5x19x10xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<19x1x19x1xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.const_shape  {value = dense<19> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_12_:%.+]] = tosa.reshape [[VAR_10_]], [[VAR_11_]] : (tensor<19x1x19x1xf32>, !tosa.shape<2>) -> tensor<19x19xf32>
+// CHECK:           return [[VAR_12_]] : tensor<19x19xf32>
+// CHECK:         }
 
 // -----
 
@@ -133,14 +159,20 @@ func.func @slice_just_steps_with_padding(%arg0: tensor<99x195xf32>) -> tensor<20
   %1 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<99x195xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<20x20xf32>
   return %1 : tensor<20x20xf32> 
 }
-// CHECK-LABEL: func @slice_just_steps_with_padding
-// CHECK: %0 = tosa.const_shape {value = dense<[0, 1, 0, 5]> : tensor<4xindex>} : () -> !tosa.shape<4>
-// CHECK: %1 = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
-// CHECK: %2 = tosa.pad %arg0, %0, %1 : (tensor<99x195xf32>, !tosa.shape<4>, tensor<f32>) -> tensor<100x200xf32>
-// CHECK: %3 = tosa.reshape %2 {new_shape = array<i64: 20, 5, 20, 10>} : (tensor<100x200xf32>) -> tensor<20x5x20x10xf32>
-// CHECK: %4 = tosa.slice %3 {size = array<i64: 20, 1, 20, 1>, start = array<i64: 0, 0, 0, 0>} : (tensor<20x5x20x10xf32>) -> tensor<20x1x20x1xf32>
-// CHECK: %5 = tosa.reshape %4 {new_shape = array<i64: 20, 20>} : (tensor<20x1x20x1xf32>) -> tensor<20x20xf32>
-// CHECK: return %5 : tensor<20x20xf32>
+// CHECK-LABEL:  func.func @slice_just_steps_with_padding
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<99x195xf32>) -> tensor<20x20xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[0, 1, 0, 5]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.pad [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<99x195xf32>, !tosa.shape<4>, tensor<f32>) -> tensor<100x200xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[20, 5, 20, 10]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.reshape [[VAR_2_]], [[VAR_3_]] : (tensor<100x200xf32>, !tosa.shape<4>) -> tensor<20x5x20x10xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.const_shape  {value = dense<[20, 1, 20, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.slice [[VAR_4_]], [[VAR_5_]], [[VAR_6_]] : (tensor<20x5x20x10xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<20x1x20x1xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.const_shape  {value = dense<20> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_9_:%.+]] = tosa.reshape [[VAR_7_]], [[VAR_8_]] : (tensor<20x1x20x1xf32>, !tosa.shape<2>) -> tensor<20x20xf32>
+// CHECK:           return [[VAR_9_]] : tensor<20x20xf32>
+// CHECK:         }
 
 // -----
 
@@ -161,12 +193,17 @@ func.func @slice_start_greater_than_dim(%arg0: tensor<10x30xf32>) -> tensor<*xf3
   %axes = "onnx.Constant"() {value = dense<[0, 1]> : tensor<2xi64> } : () -> tensor<2xi64>
   %starts = "onnx.Constant"() {value = dense<[20, 20]> : tensor<2xi64> } : () -> tensor<2xi64>
   %ends = "onnx.Constant"() {value = dense<[21,21]> : tensor<2xi64> } : () -> tensor<2xi64>
-  %steps = "onnx.Constant"() {value = dense<0> : tensor<2xi64> } : () -> tensor<2xi64>
+  %steps = "onnx.Constant"() {value = dense<1> : tensor<2xi64> } : () -> tensor<2xi64>
   %1 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<10x30xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<*xf32>
   return %1 : tensor<*xf32> 
 }
-// CHECK-LABEL: func @slice_start_greater_than_dim
-// CHECK: onnx.Slice
+// CHECK-LABEL:  func.func @slice_start_greater_than_dim
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x30xf32>) -> tensor<0x1xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[10, 20]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[0, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<10x30xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<0x1xf32>
+// CHECK:           return [[VAR_2_]] : tensor<0x1xf32>
+// CHECK:         }
 
 // -----
 
@@ -178,15 +215,23 @@ func.func @slice_step_greater_than_dim(%arg0: tensor<9x30xf32>) -> tensor<1x2xf3
   %1 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<9x30xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x2xf32>
   return %1 : tensor<1x2xf32> 
 }
-// CHECK-LABEL: func @slice_step_greater_than_dim
-// CHECK: %0 = tosa.const_shape {value = dense<[0, 6, 0, 0]> : tensor<4xindex>} : () -> !tosa.shape<4>
-// CHECK: %1 = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
-// CHECK: %2 = tosa.pad %arg0, %0, %1 : (tensor<9x30xf32>, !tosa.shape<4>, tensor<f32>) -> tensor<15x30xf32>
-// CHECK: %3 = tosa.slice %2 {size = array<i64: 10, 20>, start = array<i64: 5, 5>} : (tensor<15x30xf32>) -> tensor<10x20xf32>
-// CHECK: %4 = tosa.reshape %3 {new_shape = array<i64: 1, 10, 2, 10>} : (tensor<10x20xf32>) -> tensor<1x10x2x10xf32>
-// CHECK: %5 = tosa.slice %4 {size = array<i64: 1, 1, 2, 1>, start = array<i64: 0, 0, 0, 0>} : (tensor<1x10x2x10xf32>) -> tensor<1x1x2x1xf32>
-// CHECK: %6 = tosa.reshape %5 {new_shape = array<i64: 1, 2>} : (tensor<1x1x2x1xf32>) -> tensor<1x2xf32>
-// CHECK: return %6 : tensor<1x2xf32>
+// CHECK-LABEL:  func.func @slice_step_greater_than_dim
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<9x30xf32>) -> tensor<1x2xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[0, 6, 0, 0]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.pad [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<9x30xf32>, !tosa.shape<4>, tensor<f32>) -> tensor<15x30xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<5> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[10, 20]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.slice [[VAR_2_]], [[VAR_3_]], [[VAR_4_]] : (tensor<15x30xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<10x20xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.const_shape  {value = dense<[1, 10, 2, 10]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.reshape [[VAR_5_]], [[VAR_6_]] : (tensor<10x20xf32>, !tosa.shape<4>) -> tensor<1x10x2x10xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.const_shape  {value = dense<[1, 1, 2, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.slice [[VAR_7_]], [[VAR_8_]], [[VAR_9_]] : (tensor<1x10x2x10xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<1x1x2x1xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.const_shape  {value = dense<[1, 2]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_12_:%.+]] = tosa.reshape [[VAR_10_]], [[VAR_11_]] : (tensor<1x1x2x1xf32>, !tosa.shape<2>) -> tensor<1x2xf32>
+// CHECK:           return [[VAR_12_]] : tensor<1x2xf32>
+// CHECK:         }
 
 // -----
 
@@ -198,12 +243,20 @@ func.func @slice_4d(%arg0: tensor<1x56x56x92xf32>) -> tensor<1x28x28x92xf32> {
   %1 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<1x56x56x92xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x28x28x92xf32>
   return %1 : tensor<1x28x28x92xf32> 
 }
-// CHECK-LABEL: func @slice_4d
-// CHECK: %0 = tosa.const_shape {value = dense<[0, 0, 0, 1, 0, 1, 0, 0]> : tensor<8xindex>} : () -> !tosa.shape<8>
-// CHECK: %1 = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
-// CHECK: %2 = tosa.pad %arg0, %0, %1 : (tensor<1x56x56x92xf32>, !tosa.shape<8>, tensor<f32>) -> tensor<1x57x57x92xf32>
-// CHECK: %3 = tosa.slice %2 {size = array<i64: 1, 56, 56, 92>, start = array<i64: 0, 1, 1, 0>} : (tensor<1x57x57x92xf32>) -> tensor<1x56x56x92xf32>
-// CHECK: %4 = tosa.reshape %3 {new_shape = array<i64: 1, 28, 2, 28, 2, 92>} : (tensor<1x56x56x92xf32>) -> tensor<1x28x2x28x2x92xf32>
-// CHECK: %5 = tosa.slice %4 {size = array<i64: 1, 28, 1, 28, 1, 92>, start = array<i64: 0, 0, 0, 0, 0, 0>} : (tensor<1x28x2x28x2x92xf32>) -> tensor<1x28x1x28x1x92xf32>
-// CHECK: %6 = tosa.reshape %5 {new_shape = array<i64: 1, 28, 28, 92>} : (tensor<1x28x1x28x1x92xf32>) -> tensor<1x28x28x92xf32>
-// CHECK: return %6 : tensor<1x28x28x92xf32>
+// CHECK-LABEL:  func.func @slice_4d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x56x56x92xf32>) -> tensor<1x28x28x92xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[0, 0, 0, 1, 0, 1, 0, 0]> : tensor<8xindex>} : () -> !tosa.shape<8>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.pad [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<1x56x56x92xf32>, !tosa.shape<8>, tensor<f32>) -> tensor<1x57x57x92xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[0, 1, 1, 0]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[1, 56, 56, 92]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.slice [[VAR_2_]], [[VAR_3_]], [[VAR_4_]] : (tensor<1x57x57x92xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<1x56x56x92xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.const_shape  {value = dense<[1, 28, 2, 28, 2, 92]> : tensor<6xindex>} : () -> !tosa.shape<6>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.reshape [[VAR_5_]], [[VAR_6_]] : (tensor<1x56x56x92xf32>, !tosa.shape<6>) -> tensor<1x28x2x28x2x92xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<6xindex>} : () -> !tosa.shape<6>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tosa.const_shape  {value = dense<[1, 28, 1, 28, 1, 92]> : tensor<6xindex>} : () -> !tosa.shape<6>
+// CHECK-DAG:       [[VAR_10_:%.+]] = tosa.slice [[VAR_7_]], [[VAR_8_]], [[VAR_9_]] : (tensor<1x28x2x28x2x92xf32>, !tosa.shape<6>, !tosa.shape<6>) -> tensor<1x28x1x28x1x92xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tosa.const_shape  {value = dense<[1, 28, 28, 92]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           [[VAR_12_:%.+]] = tosa.reshape [[VAR_10_]], [[VAR_11_]] : (tensor<1x28x1x28x1x92xf32>, !tosa.shape<4>) -> tensor<1x28x28x92xf32>
+// CHECK:           return [[VAR_12_]] : tensor<1x28x28x92xf32>
+// CHECK:         }

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Split.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Split.mlir
@@ -6,11 +6,14 @@ func.func @test_split_equal(%arg0 : tensor<16x32x64xf32>) -> (tensor<8x32x64xf32
     return %0, %1 : tensor<8x32x64xf32>, tensor<8x32x64xf32>
 }
 
-// CHECK-LABEL: func.func @test_split_equal
-// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<16x32x64xf32>) -> (tensor<8x32x64xf32>, tensor<8x32x64xf32>) {
-// CHECK-DAG:      [[VAR_0_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 8, 32, 64>, start = array<i64: 0, 0, 0>} : (tensor<16x32x64xf32>) -> tensor<8x32x64xf32>
-// CHECK-DAG:      [[VAR_1_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 8, 32, 64>, start = array<i64: 8, 0, 0>} : (tensor<16x32x64xf32>) -> tensor<8x32x64xf32>
-// CHECK:           return [[VAR_0_]], [[VAR_1_]] : tensor<8x32x64xf32>, tensor<8x32x64xf32>
+// CHECK-LABEL:  func.func @test_split_equal
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<16x32x64xf32>) -> (tensor<8x32x64xf32>, tensor<8x32x64xf32>) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[8, 32, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<16x32x64xf32>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<8x32x64xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[8, 0, 0]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_4_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_3_]], [[VAR_1_]] : (tensor<16x32x64xf32>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<8x32x64xf32>
+// CHECK:           return [[VAR_2_]], [[VAR_4_]] : tensor<8x32x64xf32>, tensor<8x32x64xf32>
 
 // -----
 
@@ -22,9 +25,13 @@ func.func @test_split_variable(%arg0 : tensor<16x32x64xf16>) -> (tensor<16x2x64x
 
 // CHECK-LABEL:  func.func @test_split_variable
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<16x32x64xf16>) -> (tensor<16x2x64xf16>, tensor<16x30x64xf16>) {
-// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 16, 2, 64>, start = array<i64: 0, 0, 0>} : (tensor<16x32x64xf16>) -> tensor<16x2x64xf16>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 16, 30, 64>, start = array<i64: 0, 2, 0>} : (tensor<16x32x64xf16>) -> tensor<16x30x64xf16>
-// CHECK:           return [[VAR_0_]], [[VAR_1_]] : tensor<16x2x64xf16>, tensor<16x30x64xf16>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[16, 2, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<16x32x64xf16>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<16x2x64xf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[0, 2, 0]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[16, 30, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_5_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_3_]], [[VAR_4_]] : (tensor<16x32x64xf16>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<16x30x64xf16>
+// CHECK:           return [[VAR_2_]], [[VAR_5_]] : tensor<16x2x64xf16>, tensor<16x30x64xf16>
 
 // -----
 
@@ -36,10 +43,16 @@ func.func @test_split_multiple(%arg0 : tensor<16x32x64xf16>) -> (tensor<16x4x64x
 
 // CHECK-LABEL:  func.func @test_split_multiple
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<16x32x64xf16>) -> (tensor<16x4x64xf16>, tensor<16x8x64xf16>, tensor<16x20x64xf16>) {
-// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 16, 4, 64>, start = array<i64: 0, 0, 0>} : (tensor<16x32x64xf16>) -> tensor<16x4x64xf16>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 16, 8, 64>, start = array<i64: 0, 4, 0>} : (tensor<16x32x64xf16>) -> tensor<16x8x64xf16>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 16, 20, 64>, start = array<i64: 0, 12, 0>} : (tensor<16x32x64xf16>) -> tensor<16x20x64xf16>
-// CHECK:           return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]] : tensor<16x4x64xf16>, tensor<16x8x64xf16>, tensor<16x20x64xf16>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[16, 4, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<16x32x64xf16>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<16x4x64xf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[0, 4, 0]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.const_shape  {value = dense<[16, 8, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_3_]], [[VAR_4_]] : (tensor<16x32x64xf16>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<16x8x64xf16>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tosa.const_shape  {value = dense<[0, 12, 0]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tosa.const_shape  {value = dense<[16, 20, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_8_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_6_]], [[VAR_7_]] : (tensor<16x32x64xf16>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<16x20x64xf16>
+// CHECK:           return [[VAR_2_]], [[VAR_5_]], [[VAR_8_]] : tensor<16x4x64xf16>, tensor<16x8x64xf16>, tensor<16x20x64xf16>
 
 
 // -----
@@ -52,8 +65,11 @@ func.func @test_no_split(%arg0 : tensor<16x32x64xi32>) -> tensor<16x16x64xi32> {
 
 // CHECK-LABEL:  func.func @test_no_split
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<16x32x64xi32>) -> tensor<16x16x64xi32> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 16, 16, 64>, start = array<i64: 0, 0, 0>} : (tensor<16x32x64xi32>) -> tensor<16x16x64xi32>
-// CHECK:           return [[VAR_0_]] : tensor<16x16x64xi32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[16, 16, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<16x32x64xi32>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<16x16x64xi32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[0, 16, 0]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           return [[VAR_2_]] : tensor<16x16x64xi32>
 
 
 // -----
@@ -66,9 +82,12 @@ func.func @test_split_negative_axis(%arg0 : tensor<16x32x64xbf16>) -> (tensor<16
 
 // CHECK-LABEL:  func.func @test_split_negative_axis
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<16x32x64xbf16>) -> (tensor<16x16x64xbf16>, tensor<16x16x64xbf16>) {
-// CHECK:           [[VAR_0_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 16, 16, 64>, start = array<i64: 0, 0, 0>} : (tensor<16x32x64xbf16>) -> tensor<16x16x64xbf16>
-// CHECK:           [[VAR_1_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 16, 16, 64>, start = array<i64: 0, 16, 0>} : (tensor<16x32x64xbf16>) -> tensor<16x16x64xbf16>
-// CHECK:           return [[VAR_0_]], [[VAR_1_]] : tensor<16x16x64xbf16>, tensor<16x16x64xbf16>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[16, 16, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<16x32x64xbf16>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<16x16x64xbf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[0, 16, 0]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_4_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_3_]], [[VAR_1_]] : (tensor<16x32x64xbf16>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<16x16x64xbf16>
+// CHECK:           return [[VAR_2_]], [[VAR_4_]] : tensor<16x16x64xbf16>, tensor<16x16x64xbf16>
 
 // -----
 
@@ -90,8 +109,12 @@ func.func @test_zero_split(%arg0 : tensor<16x32x64xi16>) -> tensor<16x0x64xi16> 
 
 // CHECK-LABEL:  func.func @test_zero_split
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<16x32x64xi16>) -> tensor<16x0x64xi16> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 16, 0, 64>, start = array<i64: 0, 32, 0>} : (tensor<16x32x64xi16>) -> tensor<16x0x64xi16>
-// CHECK:           return [[VAR_0_]] : tensor<16x0x64xi16>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[16, 32, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[0, 32, 0]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[16, 0, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_4_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_2_]], [[VAR_3_]] : (tensor<16x32x64xi16>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<16x0x64xi16>
+// CHECK:           return [[VAR_4_]] : tensor<16x0x64xi16>
 
 // -----
 // Legalization won't happen since tosa.slice doesn't
@@ -113,7 +136,10 @@ func.func @test_num_outputs(%arg0 : tensor<16x32x64xf32>) -> tensor<8x32x64xf32>
     return %0 : tensor<8x32x64xf32>
 }
 
-// CHECK-LABEL: func.func @test_num_outputs
-// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<16x32x64xf32>) -> tensor<8x32x64xf32> {
-// CHECK-DAG:      [[VAR_0_:%.+]] = tosa.slice [[PARAM_0_]] {size = array<i64: 8, 32, 64>, start = array<i64: 0, 0, 0>} : (tensor<16x32x64xf32>) -> tensor<8x32x64xf32>
-// CHECK:           return [[VAR_0_]] : tensor<8x32x64xf32>
+// CHECK-LABEL:  func.func @test_num_outputs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<16x32x64xf32>) -> tensor<8x32x64xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[8, 32, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.slice [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]] : (tensor<16x32x64xf32>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<8x32x64xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.const_shape  {value = dense<[8, 0, 0]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           return [[VAR_2_]] : tensor<8x32x64xf32>

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Squeeze.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Squeeze.mlir
@@ -6,8 +6,9 @@ func.func @test_squeeze(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<16x32x64xf32
   "func.return"(%1) : (tensor<16x32x64xf32>) -> ()
 // CHECK-LABEL:  func.func @test_squeeze
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<16x1x32x1x64xf32>) -> tensor<16x32x64xf32> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 16, 32, 64>} : (tensor<16x1x32x1x64xf32>) -> tensor<16x32x64xf32>
-// CHECK:           return [[VAR_0_]] : tensor<16x32x64xf32>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[16, 32, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<16x1x32x1x64xf32>, !tosa.shape<3>) -> tensor<16x32x64xf32>
+// CHECK:           return [[VAR_1_]] : tensor<16x32x64xf32>
 // CHECK:         }
 }
 
@@ -17,8 +18,9 @@ func.func @test_squeeze_unknown_dimensions(%arg0 : tensor<1x1x32x1x64xf32>) -> t
   "func.return"(%1) : (tensor<32x64xf32>) -> ()
 // CHECK-LABEL:  func.func @test_squeeze_unknown_dimensions
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x32x1x64xf32>) -> tensor<32x64xf32> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 32, 64>} : (tensor<1x1x32x1x64xf32>) -> tensor<32x64xf32>
-// CHECK:           return [[VAR_0_]] : tensor<32x64xf32>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[32, 64]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x32x1x64xf32>, !tosa.shape<2>) -> tensor<32x64xf32>
+// CHECK:           return [[VAR_1_]] : tensor<32x64xf32>
 // CHECK:         }
 }
 
@@ -27,8 +29,12 @@ func.func @test_squeeze_unknown_dimensions(%arg0 : tensor<1x1x32x1x64xf32>) -> t
 func.func @squeeze_runtime(%arg0: tensor<1x3x4x5xf32> , %arg1: tensor<1xi64> ) -> tensor<3x4x5xf32> {
   %0 = "onnx.Squeeze"(%arg0, %arg1) : (tensor<1x3x4x5xf32>, tensor<1xi64>) -> tensor<3x4x5xf32>
   return %0 : tensor<3x4x5xf32>
-// CHECK-LABEL: squeeze_runtime
-// CHECK: tosa.reshape {{.*}} {new_shape = array<i64: 3, 4, 5>} : (tensor<1x3x4x5xf32>) -> tensor<3x4x5xf32>
+// CHECK-LABEL:  func.func @squeeze_runtime
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x4x5xf32>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<3x4x5xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[3, 4, 5]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<1x3x4x5xf32>, !tosa.shape<3>) -> tensor<3x4x5xf32>
+// CHECK:           return [[VAR_1_]] : tensor<3x4x5xf32>
+// CHECK:         }
 }
 
 // -----

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Unsqueeze.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Unsqueeze.mlir
@@ -4,10 +4,11 @@ func.func @test_unsqueeze(%arg0 : tensor<10x10xf32>) -> tensor<1x10x10x1xf32> {
   %0 = "onnx.Constant"() {value = dense<[0, 3]> : tensor<2xi64>} : () -> tensor<2xi64>
   %1 = "onnx.Unsqueeze"(%arg0, %0) : (tensor<10x10xf32>, tensor<2xi64>) -> tensor<1x10x10x1xf32>
   func.return %1 : tensor<1x10x10x1xf32>
-// CHECK-LABEL:   func.func @test_unsqueeze(
-// CHECK-SAME:                              %[[VAL_0:.*]]: tensor<10x10xf32>) -> tensor<1x10x10x1xf32> {
-// CHECK:           %[[VAL_1:.*]] = tosa.reshape %[[VAL_0]] {new_shape = array<i64: 1, 10, 10, 1>} : (tensor<10x10xf32>) -> tensor<1x10x10x1xf32>
-// CHECK:           return %[[VAL_1]] : tensor<1x10x10x1xf32>
+// CHECK-LABEL:  func.func @test_unsqueeze
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x10xf32>) -> tensor<1x10x10x1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 10, 10, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<10x10xf32>, !tosa.shape<4>) -> tensor<1x10x10x1xf32>
+// CHECK:           return [[VAR_1_]] : tensor<1x10x10x1xf32>
 // CHECK:         }
 }
 
@@ -15,10 +16,11 @@ func.func @test_unsqueeze_negative_axis(%arg0 : tensor<16x32x64xf32>) -> tensor<
   %0 = "onnx.Constant"() {value = dense<[-2]> : tensor<1xi64>} : () -> tensor<1xi64>
   %1 = "onnx.Unsqueeze"(%arg0, %0) : (tensor<16x32x64xf32>, tensor<1xi64>) -> tensor<16x32x1x64xf32>
   func.return %1 : tensor<16x32x1x64xf32>
-// CHECK-LABEL:   func.func @test_unsqueeze_negative_axis(
-// CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<16x32x64xf32>) -> tensor<16x32x1x64xf32> {
-// CHECK:           %[[VAL_1:.*]] = tosa.reshape %[[VAL_0]] {new_shape = array<i64: 16, 32, 1, 64>} : (tensor<16x32x64xf32>) -> tensor<16x32x1x64xf32>
-// CHECK:           return %[[VAL_1]] : tensor<16x32x1x64xf32>
+// CHECK-LABEL:  func.func @test_unsqueeze_negative_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<16x32x64xf32>) -> tensor<16x32x1x64xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[16, 32, 1, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<16x32x64xf32>, !tosa.shape<4>) -> tensor<16x32x1x64xf32>
+// CHECK:           return [[VAR_1_]] : tensor<16x32x1x64xf32>
 // CHECK:         }
 }
 
@@ -26,10 +28,11 @@ func.func @test_unsqueeze_mix(%arg0 : tensor<16x32x64xf32>) -> tensor<16x1x32x1x
   %0 = "onnx.Constant"() {value = dense<[1, -2]> : tensor<2xi64>} : () -> tensor<2xi64>
   %1 = "onnx.Unsqueeze"(%arg0, %0) : (tensor<16x32x64xf32>, tensor<2xi64>) -> tensor<16x1x32x1x64xf32>
   func.return %1 : tensor<16x1x32x1x64xf32>
-// CHECK-LABEL:   func.func @test_unsqueeze_mix(
-// CHECK-SAME:                                  %[[VAL_0:.*]]: tensor<16x32x64xf32>) -> tensor<16x1x32x1x64xf32> {
-// CHECK:           %[[VAL_1:.*]] = tosa.reshape %[[VAL_0]] {new_shape = array<i64: 16, 1, 32, 1, 64>} : (tensor<16x32x64xf32>) -> tensor<16x1x32x1x64xf32>
-// CHECK:           return %[[VAL_1]] : tensor<16x1x32x1x64xf32>
+// CHECK-LABEL:  func.func @test_unsqueeze_mix
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<16x32x64xf32>) -> tensor<16x1x32x1x64xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[16, 1, 32, 1, 64]> : tensor<5xindex>} : () -> !tosa.shape<5>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<16x32x64xf32>, !tosa.shape<5>) -> tensor<16x1x32x1x64xf32>
+// CHECK:           return [[VAR_1_]] : tensor<16x1x32x1x64xf32>
 // CHECK:         }
 }
 
@@ -38,8 +41,12 @@ func.func @test_unsqueeze_mix(%arg0 : tensor<16x32x64xf32>) -> tensor<16x1x32x1x
 func.func @unsqueeze_runtime(%arg0: tensor<3x4x5xf32> , %arg1: tensor<1xi64> ) -> tensor<3x4x1x5xf32> {
   %0 = "onnx.Unsqueeze"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<1xi64>) -> tensor<3x4x1x5xf32>
   return %0 : tensor<3x4x1x5xf32>
-// CHECK-LABEL: unsqueeze_runtime
-// CHECK: tosa.reshape {{.*}} {new_shape = array<i64: 3, 4, 1, 5>} : (tensor<3x4x5xf32>) -> tensor<3x4x1x5xf32>
+// CHECK-LABEL:  func.func @unsqueeze_runtime
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<3x4x1x5xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[3, 4, 1, 5]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<3x4x5xf32>, !tosa.shape<4>) -> tensor<3x4x1x5xf32>
+// CHECK:           return [[VAR_1_]] : tensor<3x4x1x5xf32>
+// CHECK:         }
 }
 // -----
 

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Where.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Where.mlir
@@ -4,9 +4,10 @@
 func.func @test_where(%arg0: tensor<13x21x1xi1>, %arg1: tensor<13x21x1xf32>, %arg2: tensor<13x21x1xf32>) -> tensor<13x21x1xf32> {
   %0 = "onnx.Where"(%arg0, %arg1, %arg2) : (tensor<13x21x1xi1>, tensor<13x21x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
-// CHECK-LABEL:  func @test_where
+// CHECK-LABEL:  func.func @test_where
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<13x21x1xi1>, [[PARAM_1_:%.+]]: tensor<13x21x1xf32>, [[PARAM_2_:%.+]]: tensor<13x21x1xf32>) -> tensor<13x21x1xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = tosa.select [[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]] : (tensor<13x21x1xi1>, tensor<13x21x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           [[VAR_0_:%.+]] = tosa.select [[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]] : (tensor<13x21x1xi1>, tensor<13x21x1xf32>, tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           return [[VAR_0_]] : tensor<13x21x1xf32>
 }
 
 // -----
@@ -16,10 +17,12 @@ func.func @test_where_broadcast(%arg0: tensor<21x1xi1>, %arg1: tensor<13x21x1xf3
   "func.return"(%0) : (tensor<13x21x1xf32>) -> ()
 // CHECK-LABEL:  func.func @test_where_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<21x1xi1>, [[PARAM_1_:%.+]]: tensor<13x21x1xf32>, [[PARAM_2_:%.+]]: tensor<1xf32>) -> tensor<13x21x1xf32> {
-// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 21, 1>} : (tensor<21x1xi1>) -> tensor<1x21x1xi1>
-// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1, 1, 1>} : (tensor<1xf32>) -> tensor<1x1x1xf32>
-// CHECK:           [[VAR_2_:%.+]] = tosa.select [[VAR_0_]], [[PARAM_1_]], [[VAR_1_]] : (tensor<1x21x1xi1>, tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xf32>
-// CHECK:           return [[VAR_2_]] : tensor<13x21x1xf32>
+// CHECK:           [[VAR_0_:%.+]] = tosa.const_shape  {value = dense<[1, 21, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]], [[VAR_0_]] : (tensor<21x1xi1>, !tosa.shape<3>) -> tensor<1x21x1xi1>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<1> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[PARAM_2_]], [[VAR_2_]] : (tensor<1xf32>, !tosa.shape<3>) -> tensor<1x1x1xf32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.select [[VAR_1_]], [[PARAM_1_]], [[VAR_3_]] : (tensor<1x21x1xi1>, tensor<13x21x1xf32>, tensor<1x1x1xf32>) -> tensor<13x21x1xf32>
+// CHECK:           return [[VAR_4_]] : tensor<13x21x1xf32>
 }
 
 // -----

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/xilinx/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 776b07b472a12db1a451fb4bfc737e05c0ee0b1c && cd ..
+cd llvm-project && git checkout c27444ab4976dd9ff131212f87463f9945ab28d7 && cd ..


### PR DESCRIPTION
AMD changes: Update lowering and tests for onnx->tosa conversions that are not upstream

Partial cherry-pick of f03b2876581d34a13855736c3bd0db6e48aa4be5

LLVM update 43d71ba (#3086)

* update float types, tosa, other misc changes



* fix buildOnnxToTosaPaddingConstOp



* fix lit tests (wip)



* updte doc



* use stablehlo tagged version



* fixed more lit tests



* fix .clang-format



* fix lit (wip)



* revert .clang-format change



* fix lit tests



* fix formatting



* lit tests pass (except jni -- not tested)



* manually fix formatting; can't get clang-format to do it on any of my machines



* revert lit test changes unrelated to update



* update llvm and stablhlo shas, misc minor updates



* remove non-existent passes



* lit updates (wip)



* Bump Upsample to Opset 10 and change the opset versioning to allow to skip over opset versions if a newer, backwards compatible one exists. (#3065)

* Bump Upsample to Opset 10

This is a non-functional change, the only difference is that Upsample was marked as deprecated with Opset 10



* Use a map of the available opset versions in onnx to select the node opset to use.

Introduces a new built-time generated map that contains all versions of an operation as defined by onnx. To determine the opset version for a node/op:
1.	Determine the latest valid opset version. This is the newest version in this opset-version-map that is older or equal to the current graph opset.
2.	Select the newest version from the versions supported by onnx-mlir that is equal or newer to the latest valid opset version. This allows it to skip over opset versions, that have a newer backwards compatible version. Example:
	Versions in onnx and supported by onnx-mlir: [3, 5].
	Graph opset version to node version: 3 -> 3, 4 -> 3, 5 -> 5

	Versions in onnx: [7, 9, 10]. Version 10 is backwards compatible to version 9.
	Version supported by onnx-mlir: [7, 10].
	Graph opset version to node version: 7 -> 7, 8 -> 7, 9 -> 10, 10 -> 10



---------



* Improve scripts (#3089)



* Bump various ops to opset 21, adding int4/uint4 and 8 bit float support. (#3064)

* Add support for TensorProto::UINT4/INT4



* Upgrade onnx.Cast to opset 21



* Bump various ops to opset 21.

These are all backwards compatibel version bumps, only adding support for int/uint4.

Bumped ops:
Flatten
Identity
If
Loop
Pad
Reshape
Scan
Shape
Size
Squeeze
Transpose
Unsqueeze



---------



* Added minimal support to do some timing of OM Runtime functionality (#3095)



* adding __errno_location call for mvs (#3099)



* Rewriting pattern to remove WhereOp and EqualOp.  (#3094)

Remove ONNXWhereOp and ONNXEqualOp into newly created ConcatOp.

---------



* Enable NNPA saturation by default and change the option to --nnpa-disable-saturation (#3101)

* Enable NNPA saturation by default and change the option to --nnpa-disable-saturation



---------



* removing weak attribute of errorno (#3103)




* Fix the custom build link for docs/Docker.md (#3104)




* Python driver for torch model (#3093)

* implementation



* format



* test



* py format



* torch.compile



* refine



* add debug



* respond



* response



* format



---------





* implement (#3108)



* Followups for torch model driver (#3106)

* simplify



* complete



* fix



* fix



---------



* Fix an error in ZHighConstantPropagation for QuantizedStick (#3112)



* Add z17 for -march (#3113)

* done



* convert



* fix



* format



---------




* Decompose Hardswish into simpler ONNX ops (#3107)

* Decompose and lower Hardswish



* Providing the decomposition as compile time option with krnl dialect lowering as default



---------




* Reorder relu to maxpool optimization pass in ONNX dialect (#3109)

* Reorder Relu and maxpool optimization



* Swap Relu and maxpool only when Relu is not a consumer of conv



---------




* Move onnx.Constant before the root op when fusing onnx ops (#3119)



* Support QLinearMatMul on CPU (#3117)

* Support QLinearMatMul on CPU



---------



* Update black-format-check.yml (#3118)




* Merge nested concat Ops optimization pass in ONNX dialect (#3111)

* Merging nested concat ops



---------




* Enhance shape inference for ONNX Reshape (#3122)

* Add a special case in shape inference for reshape



---------



* update zdnn1.1.2 (#3130)



* Updating supported ops on NNPA md for z17.  (#3120)

* starting to update new z17 NNPA ops



---------





* fix CVE-2025-32434 (#3135)



* Fuse consecutive clips pattern (#3132)

* Fuse consecutive clips pattern



---------




* Replace deprecated applyPatternsAndFoldGreedily with applyPatternsGreedily. This functions also folds by default, so it is an NFC



* Fix clang-format



* Replace bufferization::createOwnershipBasedBufferDeallocationPass with mlir::createConvertBufferizationToMemRefPass



* Update onnx-to-tosa reshape lit test



* Move gemm_to_fc tests to gemm_to_matmul



* Change tosaBuilder::mul function signature to make clear that the shift is an int8



* Disable buffer_loop_hoisting test as it gets completly optimized away



* Guard against dynamic dim in result



* Use resize operaton input and output type to calculate the border, instead of using the calculated numerator/denominator



* Guard against linear interpolation of integer types



* Add test for disallowed onnx.Resize on its with linear interpolation to tosa



* Add 'Pure' annotation to some krnl ops and recreate documentation



* Build stablehlo with static libs



* Disable memref.prefetch since it does not work with the new bufferization



* Conv add const where the constant is a scalar (#3145)



* added support for Celu op (#3139)




* Fix some warnings related to stickification for NNPA (#3147)



* Removing duplicate file (#3146)



* migrated instance/group normalization from decompose to canonicalize (#3148)



* Fusion of Matmul add covering the stacked/unstacked/bcast1/bcast23 patterns (#3140)



* Support --march=native (#3134)

* changes



* format



* linkage



* lib



---------



* fix another error on s390x



* lower Ub to LLVM since vector.shape_cast is lowered to UB



---------