### PR TITLE
Use a std::error_code, llvm::ErrorOr and a specialization of std::err…

### DIFF
--- a/src/Builder/FrontendDialectTransformer.hpp
+++ b/src/Builder/FrontendDialectTransformer.hpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/StringRef.h"
 
 #include "src/Builder/FrontendDialectHelper.hpp"
+#include "src/Support/ErrorHandling.hpp"
 
 namespace mlir {
 class MLIRContext;
@@ -81,30 +82,30 @@ struct ImportOptions {
  *  @param onnxBuffer buffer containing onnx model protobuf.
  *  @param bufferSize size of buffer containing onnx model protobuf.
  *  @param MLIR::module generated for the ONNX model.
- *  @return 0 on success, error number of failure.
  */
-int ImportFrontendModelArray(const void *onnxBuffer, int bufferSize,
-    mlir::MLIRContext &context, mlir::OwningOpRef<mlir::ModuleOp> &module,
-    std::string *errorMessage, ImportOptions options = ImportOptions());
+[[nodiscard]] std::error_code ImportFrontendModelArray(const void *onnxBuffer,
+    int bufferSize, mlir::MLIRContext &context,
+    mlir::OwningOpRef<mlir::ModuleOp> &module, std::string &errorMessage,
+    ImportOptions options = ImportOptions());
 
 /*!
  *  Import an ONNX model file into the ONNX Dialect.
  *  @param model_fname file name pointing to the onnx model protobuf.
  *  @param MLIR::module generated for the ONNX model.
- *  @return 0 on success, error number of failure.
  */
-int ImportFrontendModelFile(llvm::StringRef model_fname,
-    mlir::MLIRContext &context, mlir::OwningOpRef<mlir::ModuleOp> &module,
-    std::string *errorMessage, ImportOptions options = ImportOptions());
+[[nodiscard]] std::error_code ImportFrontendModelFile(
+    llvm::StringRef model_fname, mlir::MLIRContext &context,
+    mlir::OwningOpRef<mlir::ModuleOp> &module, std::string &errorMessage,
+    ImportOptions options = ImportOptions());
 
 /*!
  *  Import an ONNX model proto into the ONNX Dialect.
  *  @param model the onnx model protobuf.
- *  @return MLIR::module generated for the ONNX model.
+ *  @param MLIR::module generated for the ONNX model.
  */
-void ImportFrontendModel(const onnx::ModelProto &model,
+[[nodiscard]] std::error_code ImportFrontendModel(const onnx::ModelProto &model,
     mlir::MLIRContext &context, mlir::OwningOpRef<mlir::ModuleOp> &module,
-    ImportOptions options = ImportOptions());
+    std::string &errorMessage, ImportOptions options = ImportOptions());
 
 /*!
  *  TODO: Import models into other extension dialects that cover the

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -697,9 +697,9 @@ std::string dirName(StringRef inputFilename) {
 }
 } // namespace
 
-// Return 0 on success, error number on failure.
-int processInputFile(StringRef inputFilename, mlir::MLIRContext &context,
-    mlir::OwningOpRef<ModuleOp> &module, std::string *errorMessage) {
+[[nodiscard]] std::error_code processInputFile(StringRef inputFilename,
+    mlir::MLIRContext &context, mlir::OwningOpRef<ModuleOp> &module,
+    std::string &errorMessage) {
   // Decide if the input file is an ONNX model (either ONNX protobuf, ONNX text,
   // or JSON) or a model specified in MLIR.
   // The extension of the file is the decider.
@@ -711,9 +711,9 @@ int processInputFile(StringRef inputFilename, mlir::MLIRContext &context,
 
   if (!inputIsSTDIN && !inputIsONNX && !inputIsONNXText && !inputIsJSON &&
       !inputIsMLIR) {
-    *errorMessage = "Invalid input file \"" + inputFilename.str() +
+    errorMessage += "Invalid input file \"" + inputFilename.str() +
                     "\": Either an ONNX model (.onnx or .onnxtext or .json), "
-                    "or an MLIR file (.mlir) needs to be provided.";
+                    "or an MLIR file (.mlir) needs to be provided.\n";
     return InvalidInputFile;
   }
 
@@ -737,10 +737,9 @@ int processInputFile(StringRef inputFilename, mlir::MLIRContext &context,
   return CompilerSuccess;
 }
 
-// Return 0 on success, error code on error.
-int processInputArray(const void *onnxBuffer, int bufferSize,
-    mlir::MLIRContext &context, mlir::OwningOpRef<ModuleOp> &module,
-    std::string *errorMessage) {
+[[nodiscard]] std::error_code processInputArray(const void *onnxBuffer,
+    int bufferSize, mlir::MLIRContext &context,
+    mlir::OwningOpRef<ModuleOp> &module, std::string &errorMessage) {
   ImportOptions options;
   options.useOnnxModelTypes = useOnnxModelTypes;
   options.useOutputNameAsLocation = useOutputNameAsLocation;

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -71,12 +71,12 @@ void showCompilePhase(std::string msg);
 // end to end. Initializes accelerator(s) if required.
 void loadDialects(mlir::MLIRContext &context);
 
-// ProcessInput* return 0 on success, OnnxMlirCompilerErrorCodes on error.
-int processInputFile(llvm::StringRef inputFilename, mlir::MLIRContext &context,
-    mlir::OwningOpRef<mlir::ModuleOp> &module, std::string *errorMessage);
-int processInputArray(const void *onnxBuffer, int bufferSize,
+[[nodiscard]] std::error_code processInputFile(llvm::StringRef inputFilename,
     mlir::MLIRContext &context, mlir::OwningOpRef<mlir::ModuleOp> &module,
-    std::string *errorMessage);
+    std::string &errorMessage);
+[[nodiscard]] std::error_code processInputArray(const void *onnxBuffer,
+    int bufferSize, mlir::MLIRContext &context,
+    mlir::OwningOpRef<mlir::ModuleOp> &module, std::string &errorMessage);
 
 onnx_mlir::InputIRLevelType determineInputIRLevel(
     mlir::OwningOpRef<mlir::ModuleOp> &module);

--- a/src/Compiler/OnnxMlirCompiler.cpp
+++ b/src/Compiler/OnnxMlirCompiler.cpp
@@ -146,7 +146,7 @@ ONNX_MLIR_EXPORT int64_t omCompileFromArray(const void *inputBuffer,
   loadDialects(context);
 
   std::string internalErrorMessage;
-  const auto rc = processInputArray(
+  const std::error_code rc = processInputArray(
       inputBuffer, bufferSize, context, module, internalErrorMessage);
   if (rc) {
     if (errorMessage != NULL)

--- a/src/Compiler/OnnxMlirCompiler.cpp
+++ b/src/Compiler/OnnxMlirCompiler.cpp
@@ -146,22 +146,23 @@ ONNX_MLIR_EXPORT int64_t omCompileFromArray(const void *inputBuffer,
   loadDialects(context);
 
   std::string internalErrorMessage;
-  int rc = processInputArray(
-      inputBuffer, bufferSize, context, module, &internalErrorMessage);
-  if (rc != CompilerSuccess) {
+  const auto rc = processInputArray(
+      inputBuffer, bufferSize, context, module, internalErrorMessage);
+  if (rc) {
     if (errorMessage != NULL)
       *errorMessage = strdup(internalErrorMessage.c_str());
-    return rc;
+    return rc.value();
   }
 
   std::string outputBaseNameStr(outputBaseName);
-  rc = compileModule(module, context, outputBaseNameStr, emissionTarget);
-  if (rc == CompilerSuccess && outputFilename) {
+  const int cmrc =
+      compileModule(module, context, outputBaseNameStr, emissionTarget);
+  if (cmrc == CompilerSuccess && outputFilename) {
     // Copy Filename
     std::string name = getTargetFilename(outputBaseNameStr, emissionTarget);
     *outputFilename = strdup(name.c_str());
   }
-  return rc;
+  return cmrc;
 }
 
 ONNX_MLIR_EXPORT char *omCompileOutputFileName(

--- a/src/Support/CMakeLists.txt
+++ b/src/Support/CMakeLists.txt
@@ -21,6 +21,7 @@ add_onnx_mlir_library(OMSupport
   )
 
 add_onnx_mlir_library(OMMlirUtilities
+  ErrorHandling.cpp
   SmallFP.cpp
   TypeUtilities.cpp
   # Expect to have other utilities for Attribute and Value in the future.

--- a/src/Support/ErrorHandling.cpp
+++ b/src/Support/ErrorHandling.cpp
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//====----------------------- ErrorHandling.cpp ---------------------------===//
+//
+// This file contains common error handling utilities for ONNX-MLIR.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ErrorHandling.hpp"
+#include "llvm/Support/ErrorHandling.h"
+
+namespace onnx_mlir {
+
+namespace {
+
+struct OnnxMlirCompilerErrorCategory : public std::error_category {
+  const char *name() const noexcept override { return "ONNX-MLIR"; }
+
+  std::string message(int ev) const override {
+    switch (static_cast<OnnxMlirCompilerErrorCodes>(ev)) {
+    case CompilerSuccess:
+      return "Compiler succeeded";
+    case InvalidCompilerOption:
+      return "Could not process given compiler option";
+    case InvalidInputFile:
+      return "Got a file with an unexpected format";
+    case InvalidInputFileAccess:
+      return "Could not successfully open input file";
+    case InvalidOutputFileAccess:
+      return "Could not successfully open output file";
+    case InvalidTemporaryFileAccess:
+      return "Could not access a temporary file";
+    case InvalidOnnxFormat:
+      return "Could not successfully parse ONNX file";
+    case CompilerFailureInMLIRToLLVM:
+      return "Failed to lower MLIR to LLVM";
+    case CompilerFailureInLLVMOpt:
+      return "Failed running LLVM's optimizations";
+    case CompilerFailureInLLVMToObj:
+      return "Failed to lower LLVM to object file";
+    case CompilerFailureInGenJniObj:
+      return "Failed to lower object to JNI object";
+    case CompilerFailureInGenJni:
+      return "Failed to lower JNI object to JNI";
+    case CompilerFailureInObjToLib:
+      return "Failed to link object to a library";
+    case CompilerFailure:
+      return "Failed to compile valid input file";
+    }
+    llvm_unreachable("Unhandled error code");
+  }
+};
+
+const OnnxMlirCompilerErrorCategory onnxMlirCompilerErrorCategoryInstance{};
+} // namespace
+
+std::error_code make_error_code(OnnxMlirCompilerErrorCodes e) {
+  return {static_cast<int>(e), onnxMlirCompilerErrorCategoryInstance};
+}
+
+} // namespace onnx_mlir

--- a/src/Support/ErrorHandling.hpp
+++ b/src/Support/ErrorHandling.hpp
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//====----------------------- ErrorHandling.hpp ---------------------------===//
+//
+// This file contains common error handling utilities for ONNX-MLIR.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ONNX_MLIR_ERROR_HANDLING_HPP
+#define ONNX_MLIR_ERROR_HANDLING_HPP
+
+#include "include/onnx-mlir/Compiler/OMCompilerTypes.h"
+
+#include <system_error>
+
+namespace std {
+template <>
+struct is_error_code_enum<onnx_mlir::OnnxMlirCompilerErrorCodes> : true_type {};
+} // namespace std
+
+namespace onnx_mlir {
+[[nodiscard]] std::error_code make_error_code(OnnxMlirCompilerErrorCodes);
+} // namespace onnx_mlir
+
+#endif // ONNX_MLIR_ERROR_HANDLING_HPP

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -101,8 +101,11 @@ int main(int argc, char *argv[]) {
   auto inputFileTiming = rootTimingScope.nest("[onnx-mlir] " + msg);
   mlir::OwningOpRef<mlir::ModuleOp> module;
   std::string errorMessage;
-  int rc = processInputFile(inputFilename, context, module, &errorMessage);
-  if (rc != 0) {
+  const auto rc =
+      processInputFile(inputFilename, context, module, errorMessage);
+  if (rc) {
+    llvm::errs() << "Error processing: " << inputFilename << "\n";
+    llvm::errs() << rc.message() << "\n";
     if (!errorMessage.empty())
       llvm::errs() << errorMessage << "\n";
     return 1;

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[]) {
   auto inputFileTiming = rootTimingScope.nest("[onnx-mlir] " + msg);
   mlir::OwningOpRef<mlir::ModuleOp> module;
   std::string errorMessage;
-  const auto rc =
+  const std::error_code rc =
       processInputFile(inputFilename, context, module, errorMessage);
   if (rc) {
     llvm::errs() << "Error processing: " << inputFilename << "\n";

--- a/test/mlir/onnx/parse/zipmap.onnxtext
+++ b/test/mlir/onnx/parse/zipmap.onnxtext
@@ -13,4 +13,4 @@
 zipmapper (float[3] input) => (seq(map(int64, float)) output) {
    output = ZipMap <classlabels_int64s = [10, 20, 30]> (input)
 }
-// FAILED: "expect tensor inside sequence type"
+// FAILED: In ONNX-MLIR only tensors are (yet) supported as element type of Sequences.

--- a/test/unit/CustomFn/TestCustomFn.cpp
+++ b/test/unit/CustomFn/TestCustomFn.cpp
@@ -85,7 +85,12 @@ int check(ModelProto &model) {
 
   onnx_mlir::ImportOptions options;
   options.useOnnxModelTypes = true;
-  onnx_mlir::ImportFrontendModel(model, context, module, options);
+  std::string errorMessage;
+  if (auto ec = onnx_mlir::ImportFrontendModel(
+          model, context, module, errorMessage, options)) {
+    std::cerr << "Error importing model: " << errorMessage << "\n";
+    return 1;
+  }
 
   mlir::PassManager pm(
       module.get()->getName(), mlir::OpPassManager::Nesting::Implicit);


### PR DESCRIPTION
…or_category to improve the error handling in FrontendDialectTransformer.

This allows to easier propagate errors and make decisions based on them. Also, switch some asserts/unreachables that were used for error handling to use error codes, which allows to handle them instead of hard crashing.