### PR TITLE
Fixing the Quant and Dequant node output shapes

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -689,8 +689,21 @@ bool hasDefaultDilation(ArrayAttr dilation) {
 bool hasNoActivationConsumer(Value convTransposeResult) {
   auto result = convTransposeResult.getDefiningOp<ONNXConvTransposeOp>().getY();
   if (result.hasOneUse()) {
-    Operation *user = *(result.getUsers().begin());
-    return !mlir::isa<ONNXReluOp, ONNXLeakyReluOp>(user);
+    Operation *userAtDepth1FromConvt = *(result.getUsers().begin());
+    // Check for ConvTranspose->Quant->Dequant->Activation chain.
+    if (mlir::isa<ONNXQuantizeLinearOp>(userAtDepth1FromConvt)) {
+      Operation *userAtDepth2FromConvt =
+          *(userAtDepth1FromConvt->getResult(0).getUsers().begin());
+      if (mlir::isa<ONNXDequantizeLinearOp>(userAtDepth2FromConvt)) {
+        Operation *userAtDepth3FromConvt =
+            *(userAtDepth2FromConvt->getResult(0).getUsers().begin());
+        return !mlir::isa<ONNXReluOp, ONNXLeakyReluOp>(userAtDepth3FromConvt);
+      }
+      // If no Dequant node exists under Quant node, consider no activation.
+      return true;
+    }
+    // If No Quantize node exists under Convt, check for activation directly.
+    return !mlir::isa<ONNXReluOp, ONNXLeakyReluOp>(userAtDepth1FromConvt);
   }
   return true;
 }
@@ -1435,6 +1448,7 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
     auto convtQuantAxis = convtQuantOp.getAxis();
     auto convtQuantSaturate = convtQuantOp.getSaturate();
     auto convtQuantLoc = convtQuantOp->getLoc();
+    Type quantElementType = getElementType(convtQuantOp.getType());
 
     // Properties from the ONNXDequantizeLinearOp Node taking input from Q node
     // which inturn taking input from ConvTranspose Node.
@@ -1442,16 +1456,20 @@ Value decomposeIntoPhasedConvs(PatternRewriter &rewriter, Location loc,
     auto convtDequantZeroPoint = convtDequantOp.getXZeroPoint();
     auto convtDequantAxis = convtDequantOp.getAxis();
     auto convtDequantLoc = convtDequantOp.getLoc();
+    Type dequantElementType = getElementType(convtDequantOp.getType());
 
-    RankedTensorType dequantOutputType =
-        mlir::cast<RankedTensorType>(convtDequantOp.getType());
+    RankedTensorType convOutputType =
+        mlir::cast<RankedTensorType>(conv.getType());
 
-    RankedTensorType qOutputType =
-        mlir::cast<RankedTensorType>(convtQuantOp.getType());
+    auto dequantOutputType =
+        RankedTensorType::get(convOutputType.getShape(), dequantElementType);
+
+    RankedTensorType quantOutputType =
+        RankedTensorType::get(convOutputType.getShape(), quantElementType);
 
     auto quantNode = rewriter.create<ONNXQuantizeLinearOp>(convtQuantLoc,
-        qOutputType, conv, convtQuantScale, convtQuantZeroPoint, convtQuantAxis,
-        convtQuantSaturate);
+        quantOutputType, conv, convtQuantScale, convtQuantZeroPoint,
+        convtQuantAxis, convtQuantSaturate);
 
     auto dequantNode = rewriter.create<ONNXDequantizeLinearOp>(convtDequantLoc,
         dequantOutputType, quantNode, convtDequantScale, convtDequantZeroPoint,

--- a/src/Dialect/ONNX/Transforms/DecomposeConvTransposePhased.td
+++ b/src/Dialect/ONNX/Transforms/DecomposeConvTransposePhased.td
@@ -65,7 +65,7 @@ def ConvTransposeOpAsConv2dWithLReluAndQDQPattern2: Pattern<
     (decomposeIntoPhasedConvs:$output $res, $x, $reversed_w, $b, $dilation, $group, $kernel_shape, $pads, $strides, $alpha, $ct_dq, $ct_q, $w_dq)
    ],
    [(HasRankAndShape:$res), (hasDefaultDilation:$res $dilation),(ShouldDecomposeConvTransposeOpToPhasedConvs:$res $kernel_shape,$pads,$strides,$output_shape)], [],
-   (addBenefit 4)
+   (addBenefit 3)
 >;
 def ConvTransposeOpAsConv2dWithLReluAndQDQPattern1: Pattern<
    (ONNXLeakyReluOp (ONNXConvTransposeOp:$res $x, (ONNXDequantizeLinearOp:$w_dq $w, $x_scale, $x_zero_point, $x_axis), $b,
@@ -76,7 +76,7 @@ def ConvTransposeOpAsConv2dWithLReluAndQDQPattern1: Pattern<
     (decomposeIntoPhasedConvs:$output $res, $x, $reversed_w, $b, $dilation, $group, $kernel_shape, $pads, $strides, $alpha, (CreateNoneValue), (CreateNoneValue), $w_dq)
    ],
    [(HasRankAndShape:$res), (hasDefaultDilation:$res $dilation),(ShouldDecomposeConvTransposeOpToPhasedConvs:$res $kernel_shape,$pads,$strides,$output_shape)], [],
-   (addBenefit 3)
+   (addBenefit 2)
 >;
 
 def ConvTransposeOpAsConv2dWithLReluPattern1: Pattern<
@@ -110,7 +110,7 @@ def ConvTransposeOpAsConv2dWithReluAndQDQPattern1: Pattern<
     (decomposeIntoPhasedConvs:$output $res, $x, $reversed_w, $b, $dilation, $group, $kernel_shape, $pads, $strides, (GetZeroFloatAttr), (CreateNoneValue), (CreateNoneValue), $w_dq)
    ],
    [(HasRankAndShape:$res), (hasDefaultDilation:$res $dilation),(ShouldDecomposeConvTransposeOpToPhasedConvs:$res $kernel_shape,$pads,$strides,$output_shape)], [],
-   (addBenefit 3)
+   (addBenefit 2)
 >;
 
 def ConvTransposeOpAsConv2dWithReluPattern1: Pattern<
@@ -133,7 +133,7 @@ def ConvTransposeOpAsConv2dWithQDQPattern1: Pattern<
     (decomposeIntoPhasedConvs:$output $res, $x, $reversed_w, $b, $dilation, $group, $kernel_shape, $pads, $strides,  (GetNullFloatAttr), (CreateNoneValue), (CreateNoneValue), $w_dq)
    ],
    [(HasRankAndShape:$res), (hasDefaultDilation:$res $dilation),(hasNoActivationConsumer:$res),(ShouldDecomposeConvTransposeOpToPhasedConvs:$res $kernel_shape,$pads,$strides,$output_shape)], [],
-   (addBenefit 2)
+   (addBenefit 1)
 >;
 
 def ConvTransposeOpAsConv2dPattern1: Pattern<

--- a/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv_qdq.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv_qdq.mlir
@@ -363,7 +363,7 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
     %13 = "onnx.DequantizeLinear"(%12, %0, %3) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
     onnx.Return %13 : tensor<1x256x10x42xf32>
 
-  // CHECK-LABEL:   func.func @test_convtrans_stide22(
+// CHECK-LABEL:   func.func @test_convtrans_stide22(
 // CHECK-SAME:                                      %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
 // CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
 // CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 5, 1, 42]> : tensor<5xi64>
@@ -460,7 +460,7 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
 // CONSTPROP:           %[[VAL_36:.*]] = "onnx.DequantizeLinear"(%[[VAL_35]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
 // CONSTPROP:           onnx.Return %[[VAL_36]] : tensor<1x256x10x42xf32>
 // CONSTPROP:         }
-  }
+}
 
   // -----
 
@@ -482,7 +482,7 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
     %14 = "onnx.DequantizeLinear"(%13, %0, %3) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
     onnx.Return %14 : tensor<1x256x10x42xf32>
 
-  // CHECK-LABEL:   func.func @test_convtrans_stride22_with_relu(
+// CHECK-LABEL:   func.func @test_convtrans_stride22_with_relu(
 // CHECK-SAME:                                                 %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
 // CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
 // CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 5, 1, 42]> : tensor<5xi64>
@@ -591,6 +591,132 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
 
   // -----
 
+  func.func @test_convtrans_stride22_with_lrelu(%arg0: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
+    %0 = onnx.Constant dense<5.000000e-01> : tensor<f32>
+    %1 = onnx.Constant dense<1.000000e+00> : tensor<f32>
+    %2 = onnx.Constant dense<1.22070313E-4> : tensor<f32>
+    %3 = onnx.Constant dense<2> : tensor<i8>
+    %4 = onnx.Constant dense<2> : tensor<512x256x6x6xi8>
+    %5 = onnx.Constant dense<3.125000e-02> : tensor<f32>
+    %6 = onnx.Constant dense<2> : tensor<256xi8>
+    %7 = "onnx.DequantizeLinear"(%6, %5, %3) {axis = 1 : si64} : (tensor<256xi8>, tensor<f32>, tensor<i8>) -> tensor<256xf32>
+    %8 = "onnx.DequantizeLinear"(%4, %2, %3) {axis = 1 : si64} : (tensor<512x256x6x6xi8>, tensor<f32>, tensor<i8>) -> tensor<512x256x6x6xf32>
+    %9 = "onnx.QuantizeLinear"(%arg0, %1, %3) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x512x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xi8>
+    %10 = "onnx.DequantizeLinear"(%9, %1, %3) {axis = 1 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
+    %11 = "onnx.ConvTranspose"(%10, %8, %7) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [6, 6], pads = [2, 2, 2, 2], strides = [2, 2]} : (tensor<1x512x5x21xf32>, tensor<512x256x6x6xf32>, tensor<256xf32>) -> tensor<1x256x10x42xf32>
+    %12 = "onnx.LeakyRelu"(%11) {} : (tensor<1x256x10x42xf32>) -> tensor<1x256x10x42xf32>    
+    %13 = "onnx.QuantizeLinear"(%12, %0, %3) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
+    %14 = "onnx.DequantizeLinear"(%13, %0, %3) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
+    onnx.Return %14 : tensor<1x256x10x42xf32>
+// CHECK-LABEL:   func.func @test_convtrans_stride22_with_lrelu(
+// CHECK-SAME:                                                  %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
+// CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
+// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 5, 1, 42]> : tensor<5xi64>
+// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 256, 5, 21, 1]> : tensor<5xi64>
+// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<7> : tensor<2xi64>
+// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
+// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
+// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
+// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<2> : tensor<i8>
+// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<2> : tensor<512x256x6x6xi8>
+// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
+// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<2> : tensor<256xi8>
+// CHECK:           %[[VAL_22:.*]] = "onnx.DequantizeLinear"(%[[VAL_21]], %[[VAL_20]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<256xi8>, tensor<f32>, tensor<i8>) -> tensor<256xf32>
+// CHECK:           %[[VAL_23:.*]] = "onnx.QuantizeLinear"(%[[VAL_0]], %[[VAL_16]], %[[VAL_18]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x512x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xi8>
+// CHECK:           %[[VAL_24:.*]] = "onnx.DequantizeLinear"(%[[VAL_23]], %[[VAL_16]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
+// CHECK:           %[[VAL_25:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xi8>) -> tensor<6x6x512x256xi8>
+// CHECK:           %[[VAL_26:.*]] = "onnx.ReverseSequence"(%[[VAL_25]], %[[VAL_14]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
+// CHECK:           %[[VAL_27:.*]] = "onnx.ReverseSequence"(%[[VAL_26]], %[[VAL_14]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
+// CHECK:           %[[VAL_28:.*]] = "onnx.Transpose"(%[[VAL_27]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xi8>) -> tensor<512x256x6x6xi8>
+// CHECK:           %[[VAL_29:.*]] = "onnx.Transpose"(%[[VAL_28]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xi8>) -> tensor<256x512x6x6xi8>
+// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_11]], %[[VAL_10]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_9]], %[[VAL_8]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_7]], %[[VAL_6]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_5]], %[[VAL_4]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK:           %[[VAL_34:.*]] = "onnx.DequantizeLinear"(%[[VAL_33]], %[[VAL_17]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_35:.*]] = "onnx.Conv"(%[[VAL_24]], %[[VAL_34]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.LeakyRelu"(%[[VAL_35]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_37:.*]] = "onnx.DequantizeLinear"(%[[VAL_30]], %[[VAL_17]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Conv"(%[[VAL_24]], %[[VAL_37]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_39:.*]] = "onnx.LeakyRelu"(%[[VAL_38]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_40:.*]] = "onnx.DequantizeLinear"(%[[VAL_31]], %[[VAL_17]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.Conv"(%[[VAL_24]], %[[VAL_40]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_42:.*]] = "onnx.LeakyRelu"(%[[VAL_41]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_43:.*]] = "onnx.DequantizeLinear"(%[[VAL_32]], %[[VAL_17]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
+// CHECK:           %[[VAL_44:.*]] = "onnx.Conv"(%[[VAL_24]], %[[VAL_43]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_45:.*]] = "onnx.LeakyRelu"(%[[VAL_44]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_46:.*]] = "onnx.Reshape"(%[[VAL_36]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
+// CHECK:           %[[VAL_47:.*]] = "onnx.Reshape"(%[[VAL_39]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
+// CHECK:           %[[VAL_48:.*]] = "onnx.Reshape"(%[[VAL_42]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
+// CHECK:           %[[VAL_49:.*]] = "onnx.Reshape"(%[[VAL_45]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
+// CHECK:           %[[VAL_50:.*]] = "onnx.Concat"(%[[VAL_46]], %[[VAL_48]]) {axis = -1 : si64} : (tensor<1x256x5x21x1xf32>, tensor<1x256x5x21x1xf32>) -> tensor<1x256x5x21x2xf32>
+// CHECK:           %[[VAL_51:.*]] = "onnx.Concat"(%[[VAL_49]], %[[VAL_47]]) {axis = -1 : si64} : (tensor<1x256x5x21x1xf32>, tensor<1x256x5x21x1xf32>) -> tensor<1x256x5x21x2xf32>
+// CHECK:           %[[VAL_52:.*]] = "onnx.Reshape"(%[[VAL_50]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x256x5x21x2xf32>, tensor<5xi64>) -> tensor<1x256x5x1x42xf32>
+// CHECK:           %[[VAL_53:.*]] = "onnx.Reshape"(%[[VAL_51]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x256x5x21x2xf32>, tensor<5xi64>) -> tensor<1x256x5x1x42xf32>
+// CHECK:           %[[VAL_54:.*]] = "onnx.Concat"(%[[VAL_52]], %[[VAL_53]]) {axis = -2 : si64} : (tensor<1x256x5x1x42xf32>, tensor<1x256x5x1x42xf32>) -> tensor<1x256x5x2x42xf32>
+// CHECK:           %[[VAL_55:.*]] = "onnx.Reshape"(%[[VAL_54]], %[[VAL_1]]) {allowzero = 0 : si64} : (tensor<1x256x5x2x42xf32>, tensor<4xi64>) -> tensor<1x256x10x42xf32>
+// CHECK:           %[[VAL_56:.*]] = "onnx.QuantizeLinear"(%[[VAL_55]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
+// CHECK:           %[[VAL_57:.*]] = "onnx.DequantizeLinear"(%[[VAL_56]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
+// CHECK:           onnx.Return %[[VAL_57]] : tensor<1x256x10x42xf32>
+// CHECK:         }
+// CONSTPROP-LABEL:   func.func @test_convtrans_stride22_with_lrelu(
+// CONSTPROP-SAME:                                                  %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
+// CONSTPROP:           %[[VAL_1:.*]] = onnx.Constant dense<2> : tensor<256x512x3x3xi8>
+// CONSTPROP:           %[[VAL_2:.*]] = onnx.Constant dense<2> : tensor<256x512x3x3xi8>
+// CONSTPROP:           %[[VAL_3:.*]] = onnx.Constant dense<2> : tensor<256x512x3x3xi8>
+// CONSTPROP:           %[[VAL_4:.*]] = onnx.Constant dense<2> : tensor<256x512x3x3xi8>
+// CONSTPROP:           %[[VAL_5:.*]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
+// CONSTPROP:           %[[VAL_6:.*]] = onnx.Constant dense<[1, 256, 5, 1, 42]> : tensor<5xi64>
+// CONSTPROP:           %[[VAL_7:.*]] = onnx.Constant dense<[1, 256, 5, 21, 1]> : tensor<5xi64>
+// CONSTPROP:           %[[VAL_8:.*]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CONSTPROP:           %[[VAL_9:.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CONSTPROP:           %[[VAL_10:.*]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
+// CONSTPROP:           %[[VAL_11:.*]] = onnx.Constant dense<2> : tensor<i8>
+// CONSTPROP:           %[[VAL_12:.*]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
+// CONSTPROP:           %[[VAL_13:.*]] = onnx.Constant dense<2> : tensor<256xi8>
+// CONSTPROP:           %[[VAL_14:.*]] = "onnx.DequantizeLinear"(%[[VAL_13]], %[[VAL_12]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<256xi8>, tensor<f32>, tensor<i8>) -> tensor<256xf32>
+// CONSTPROP:           %[[VAL_15:.*]] = "onnx.QuantizeLinear"(%[[VAL_0]], %[[VAL_9]], %[[VAL_11]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x512x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xi8>
+// CONSTPROP:           %[[VAL_16:.*]] = "onnx.DequantizeLinear"(%[[VAL_15]], %[[VAL_9]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
+// CONSTPROP:           %[[VAL_17:.*]] = "onnx.DequantizeLinear"(%[[VAL_1]], %[[VAL_10]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
+// CONSTPROP:           %[[VAL_18:.*]] = "onnx.Conv"(%[[VAL_16]], %[[VAL_17]], %[[VAL_14]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_19:.*]] = "onnx.LeakyRelu"(%[[VAL_18]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_20:.*]] = "onnx.DequantizeLinear"(%[[VAL_4]], %[[VAL_10]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
+// CONSTPROP:           %[[VAL_21:.*]] = "onnx.Conv"(%[[VAL_16]], %[[VAL_20]], %[[VAL_14]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_22:.*]] = "onnx.LeakyRelu"(%[[VAL_21]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_23:.*]] = "onnx.DequantizeLinear"(%[[VAL_3]], %[[VAL_10]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
+// CONSTPROP:           %[[VAL_24:.*]] = "onnx.Conv"(%[[VAL_16]], %[[VAL_23]], %[[VAL_14]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_25:.*]] = "onnx.LeakyRelu"(%[[VAL_24]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_26:.*]] = "onnx.DequantizeLinear"(%[[VAL_2]], %[[VAL_10]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
+// CONSTPROP:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_16]], %[[VAL_26]], %[[VAL_14]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_28:.*]] = "onnx.LeakyRelu"(%[[VAL_27]]) {alpha = 0.00999999977 : f32} : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_29:.*]] = "onnx.Reshape"(%[[VAL_19]], %[[VAL_7]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
+// CONSTPROP:           %[[VAL_30:.*]] = "onnx.Reshape"(%[[VAL_22]], %[[VAL_7]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
+// CONSTPROP:           %[[VAL_31:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_7]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
+// CONSTPROP:           %[[VAL_32:.*]] = "onnx.Reshape"(%[[VAL_28]], %[[VAL_7]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
+// CONSTPROP:           %[[VAL_33:.*]] = "onnx.Concat"(%[[VAL_29]], %[[VAL_31]]) {axis = -1 : si64} : (tensor<1x256x5x21x1xf32>, tensor<1x256x5x21x1xf32>) -> tensor<1x256x5x21x2xf32>
+// CONSTPROP:           %[[VAL_34:.*]] = "onnx.Concat"(%[[VAL_32]], %[[VAL_30]]) {axis = -1 : si64} : (tensor<1x256x5x21x1xf32>, tensor<1x256x5x21x1xf32>) -> tensor<1x256x5x21x2xf32>
+// CONSTPROP:           %[[VAL_35:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_6]]) {allowzero = 0 : si64} : (tensor<1x256x5x21x2xf32>, tensor<5xi64>) -> tensor<1x256x5x1x42xf32>
+// CONSTPROP:           %[[VAL_36:.*]] = "onnx.Reshape"(%[[VAL_34]], %[[VAL_6]]) {allowzero = 0 : si64} : (tensor<1x256x5x21x2xf32>, tensor<5xi64>) -> tensor<1x256x5x1x42xf32>
+// CONSTPROP:           %[[VAL_37:.*]] = "onnx.Concat"(%[[VAL_35]], %[[VAL_36]]) {axis = -2 : si64} : (tensor<1x256x5x1x42xf32>, tensor<1x256x5x1x42xf32>) -> tensor<1x256x5x2x42xf32>
+// CONSTPROP:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_37]], %[[VAL_5]]) {allowzero = 0 : si64} : (tensor<1x256x5x2x42xf32>, tensor<4xi64>) -> tensor<1x256x10x42xf32>
+// CONSTPROP:           %[[VAL_39:.*]] = "onnx.QuantizeLinear"(%[[VAL_38]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
+// CONSTPROP:           %[[VAL_40:.*]] = "onnx.DequantizeLinear"(%[[VAL_39]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
+// CONSTPROP:           onnx.Return %[[VAL_40]] : tensor<1x256x10x42xf32>
+// CONSTPROP:         }
+  }
+
+  // -----
+
   func.func @test_convtrans_stride22_with_qdq_relu(%arg0: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
     %0 = onnx.Constant dense<5.000000e-01> : tensor<f32>
     %1 = onnx.Constant dense<1.000000e+00> : tensor<f32>
@@ -647,24 +773,24 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
 // CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_29]], %[[VAL_5]], %[[VAL_4]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
 // CHECK:           %[[VAL_34:.*]] = "onnx.DequantizeLinear"(%[[VAL_33]], %[[VAL_17]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
 // CHECK:           %[[VAL_35:.*]] = "onnx.Conv"(%[[VAL_24]], %[[VAL_34]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.QuantizeLinear"(%[[VAL_35]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CHECK:           %[[VAL_37:.*]] = "onnx.DequantizeLinear"(%[[VAL_36]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Relu"(%[[VAL_37]]) : (tensor<1x256x10x42xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_36:.*]] = "onnx.QuantizeLinear"(%[[VAL_35]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xi8>
+// CHECK:           %[[VAL_37:.*]] = "onnx.DequantizeLinear"(%[[VAL_36]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<1x256x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_38:.*]] = "onnx.Relu"(%[[VAL_37]]) : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
 // CHECK:           %[[VAL_39:.*]] = "onnx.DequantizeLinear"(%[[VAL_30]], %[[VAL_17]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
 // CHECK:           %[[VAL_40:.*]] = "onnx.Conv"(%[[VAL_24]], %[[VAL_39]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.QuantizeLinear"(%[[VAL_40]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CHECK:           %[[VAL_42:.*]] = "onnx.DequantizeLinear"(%[[VAL_41]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CHECK:           %[[VAL_43:.*]] = "onnx.Relu"(%[[VAL_42]]) : (tensor<1x256x10x42xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_41:.*]] = "onnx.QuantizeLinear"(%[[VAL_40]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xi8>
+// CHECK:           %[[VAL_42:.*]] = "onnx.DequantizeLinear"(%[[VAL_41]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<1x256x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_43:.*]] = "onnx.Relu"(%[[VAL_42]]) : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
 // CHECK:           %[[VAL_44:.*]] = "onnx.DequantizeLinear"(%[[VAL_31]], %[[VAL_17]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
 // CHECK:           %[[VAL_45:.*]] = "onnx.Conv"(%[[VAL_24]], %[[VAL_44]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
-// CHECK:           %[[VAL_46:.*]] = "onnx.QuantizeLinear"(%[[VAL_45]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CHECK:           %[[VAL_47:.*]] = "onnx.DequantizeLinear"(%[[VAL_46]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CHECK:           %[[VAL_48:.*]] = "onnx.Relu"(%[[VAL_47]]) : (tensor<1x256x10x42xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_46:.*]] = "onnx.QuantizeLinear"(%[[VAL_45]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xi8>
+// CHECK:           %[[VAL_47:.*]] = "onnx.DequantizeLinear"(%[[VAL_46]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<1x256x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_48:.*]] = "onnx.Relu"(%[[VAL_47]]) : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
 // CHECK:           %[[VAL_49:.*]] = "onnx.DequantizeLinear"(%[[VAL_32]], %[[VAL_17]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
 // CHECK:           %[[VAL_50:.*]] = "onnx.Conv"(%[[VAL_24]], %[[VAL_49]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
-// CHECK:           %[[VAL_51:.*]] = "onnx.QuantizeLinear"(%[[VAL_50]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CHECK:           %[[VAL_52:.*]] = "onnx.DequantizeLinear"(%[[VAL_51]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CHECK:           %[[VAL_53:.*]] = "onnx.Relu"(%[[VAL_52]]) : (tensor<1x256x10x42xf32>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_51:.*]] = "onnx.QuantizeLinear"(%[[VAL_50]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xi8>
+// CHECK:           %[[VAL_52:.*]] = "onnx.DequantizeLinear"(%[[VAL_51]], %[[VAL_15]], %[[VAL_18]]) {axis = 1 : si64} : (tensor<1x256x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xf32>
+// CHECK:           %[[VAL_53:.*]] = "onnx.Relu"(%[[VAL_52]]) : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
 // CHECK:           %[[VAL_54:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
 // CHECK:           %[[VAL_55:.*]] = "onnx.Reshape"(%[[VAL_43]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
 // CHECK:           %[[VAL_56:.*]] = "onnx.Reshape"(%[[VAL_48]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
@@ -699,24 +825,24 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
 // CONSTPROP:           %[[VAL_16:.*]] = "onnx.DequantizeLinear"(%[[VAL_15]], %[[VAL_9]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
 // CONSTPROP:           %[[VAL_17:.*]] = "onnx.DequantizeLinear"(%[[VAL_1]], %[[VAL_10]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
 // CONSTPROP:           %[[VAL_18:.*]] = "onnx.Conv"(%[[VAL_16]], %[[VAL_17]], %[[VAL_14]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
-// CONSTPROP:           %[[VAL_19:.*]] = "onnx.QuantizeLinear"(%[[VAL_18]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CONSTPROP:           %[[VAL_20:.*]] = "onnx.DequantizeLinear"(%[[VAL_19]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CONSTPROP:           %[[VAL_21:.*]] = "onnx.Relu"(%[[VAL_20]]) : (tensor<1x256x10x42xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_19:.*]] = "onnx.QuantizeLinear"(%[[VAL_18]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xi8>
+// CONSTPROP:           %[[VAL_20:.*]] = "onnx.DequantizeLinear"(%[[VAL_19]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x256x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_21:.*]] = "onnx.Relu"(%[[VAL_20]]) : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
 // CONSTPROP:           %[[VAL_22:.*]] = "onnx.DequantizeLinear"(%[[VAL_4]], %[[VAL_10]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
 // CONSTPROP:           %[[VAL_23:.*]] = "onnx.Conv"(%[[VAL_16]], %[[VAL_22]], %[[VAL_14]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
-// CONSTPROP:           %[[VAL_24:.*]] = "onnx.QuantizeLinear"(%[[VAL_23]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CONSTPROP:           %[[VAL_25:.*]] = "onnx.DequantizeLinear"(%[[VAL_24]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CONSTPROP:           %[[VAL_26:.*]] = "onnx.Relu"(%[[VAL_25]]) : (tensor<1x256x10x42xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_24:.*]] = "onnx.QuantizeLinear"(%[[VAL_23]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xi8>
+// CONSTPROP:           %[[VAL_25:.*]] = "onnx.DequantizeLinear"(%[[VAL_24]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x256x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_26:.*]] = "onnx.Relu"(%[[VAL_25]]) : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
 // CONSTPROP:           %[[VAL_27:.*]] = "onnx.DequantizeLinear"(%[[VAL_3]], %[[VAL_10]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
 // CONSTPROP:           %[[VAL_28:.*]] = "onnx.Conv"(%[[VAL_16]], %[[VAL_27]], %[[VAL_14]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
-// CONSTPROP:           %[[VAL_29:.*]] = "onnx.QuantizeLinear"(%[[VAL_28]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CONSTPROP:           %[[VAL_30:.*]] = "onnx.DequantizeLinear"(%[[VAL_29]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CONSTPROP:           %[[VAL_31:.*]] = "onnx.Relu"(%[[VAL_30]]) : (tensor<1x256x10x42xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_29:.*]] = "onnx.QuantizeLinear"(%[[VAL_28]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xi8>
+// CONSTPROP:           %[[VAL_30:.*]] = "onnx.DequantizeLinear"(%[[VAL_29]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x256x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_31:.*]] = "onnx.Relu"(%[[VAL_30]]) : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
 // CONSTPROP:           %[[VAL_32:.*]] = "onnx.DequantizeLinear"(%[[VAL_2]], %[[VAL_10]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<256x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<256x512x3x3xf32>
 // CONSTPROP:           %[[VAL_33:.*]] = "onnx.Conv"(%[[VAL_16]], %[[VAL_32]], %[[VAL_14]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<256x512x3x3xf32>, tensor<256xf32>) -> tensor<1x256x5x21xf32>
-// CONSTPROP:           %[[VAL_34:.*]] = "onnx.QuantizeLinear"(%[[VAL_33]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CONSTPROP:           %[[VAL_35:.*]] = "onnx.DequantizeLinear"(%[[VAL_34]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CONSTPROP:           %[[VAL_36:.*]] = "onnx.Relu"(%[[VAL_35]]) : (tensor<1x256x10x42xf32>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_34:.*]] = "onnx.QuantizeLinear"(%[[VAL_33]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xi8>
+// CONSTPROP:           %[[VAL_35:.*]] = "onnx.DequantizeLinear"(%[[VAL_34]], %[[VAL_8]], %[[VAL_11]]) {axis = 1 : si64} : (tensor<1x256x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x5x21xf32>
+// CONSTPROP:           %[[VAL_36:.*]] = "onnx.Relu"(%[[VAL_35]]) : (tensor<1x256x5x21xf32>) -> tensor<1x256x5x21xf32>
 // CONSTPROP:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_21]], %[[VAL_7]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
 // CONSTPROP:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_26]], %[[VAL_7]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
 // CONSTPROP:           %[[VAL_39:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_7]]) {allowzero = 0 : si64} : (tensor<1x256x5x21xf32>, tensor<5xi64>) -> tensor<1x256x5x21x1xf32>
@@ -751,8 +877,7 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
     %12 = "onnx.QuantizeLinear"(%11, %0, %3) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x54x222xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
     %13 = "onnx.DequantizeLinear"(%12, %0, %3) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
     onnx.Return %13 : tensor<1x1x54x222xf32>
-
-  // CHECK-LABEL:   func.func @test_convtrans_stride33(
+// CHECK-LABEL:   func.func @test_convtrans_stride33(
 // CHECK-SAME:                                       %[[VAL_0:.*]]: tensor<1x1x18x74xf32>) -> tensor<1x1x54x222xf32> {
 // CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
 // CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
@@ -902,7 +1027,7 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
 // CONSTPROP:           %[[VAL_58:.*]] = "onnx.DequantizeLinear"(%[[VAL_57]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
 // CONSTPROP:           onnx.Return %[[VAL_58]] : tensor<1x1x54x222xf32>
 // CONSTPROP:         }
-  }
+}
 
   // -----
 
@@ -924,7 +1049,7 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
     %14 = "onnx.DequantizeLinear"(%13, %0, %3) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
     onnx.Return %14 : tensor<1x1x54x222xf32>
 
-  // CHECK-LABEL:   func.func @test_convtrans_stride33_with_relu(
+// CHECK-LABEL:   func.func @test_convtrans_stride33_with_relu(
 // CHECK-SAME:                                                 %[[VAL_0:.*]]: tensor<1x1x18x74xf32>) -> tensor<1x1x54x222xf32> {
 // CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
 // CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
@@ -1166,49 +1291,49 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
 // CHECK:           %[[VAL_47:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_5]], %[[VAL_4]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
 // CHECK:           %[[VAL_48:.*]] = "onnx.DequantizeLinear"(%[[VAL_47]], %[[VAL_26]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CHECK:           %[[VAL_49:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_48]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_50:.*]] = "onnx.QuantizeLinear"(%[[VAL_49]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_51:.*]] = "onnx.DequantizeLinear"(%[[VAL_50]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_52:.*]] = "onnx.Relu"(%[[VAL_51]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_50:.*]] = "onnx.QuantizeLinear"(%[[VAL_49]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           %[[VAL_51:.*]] = "onnx.DequantizeLinear"(%[[VAL_50]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_52:.*]] = "onnx.Relu"(%[[VAL_51]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CHECK:           %[[VAL_53:.*]] = "onnx.DequantizeLinear"(%[[VAL_44]], %[[VAL_26]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CHECK:           %[[VAL_54:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_53]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_55:.*]] = "onnx.QuantizeLinear"(%[[VAL_54]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_56:.*]] = "onnx.DequantizeLinear"(%[[VAL_55]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_57:.*]] = "onnx.Relu"(%[[VAL_56]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_55:.*]] = "onnx.QuantizeLinear"(%[[VAL_54]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           %[[VAL_56:.*]] = "onnx.DequantizeLinear"(%[[VAL_55]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_57:.*]] = "onnx.Relu"(%[[VAL_56]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CHECK:           %[[VAL_58:.*]] = "onnx.DequantizeLinear"(%[[VAL_45]], %[[VAL_26]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CHECK:           %[[VAL_59:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_58]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_60:.*]] = "onnx.QuantizeLinear"(%[[VAL_59]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_61:.*]] = "onnx.DequantizeLinear"(%[[VAL_60]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_62:.*]] = "onnx.Relu"(%[[VAL_61]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_60:.*]] = "onnx.QuantizeLinear"(%[[VAL_59]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           %[[VAL_61:.*]] = "onnx.DequantizeLinear"(%[[VAL_60]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_62:.*]] = "onnx.Relu"(%[[VAL_61]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CHECK:           %[[VAL_63:.*]] = "onnx.DequantizeLinear"(%[[VAL_46]], %[[VAL_26]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CHECK:           %[[VAL_64:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_63]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_65:.*]] = "onnx.QuantizeLinear"(%[[VAL_64]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_66:.*]] = "onnx.DequantizeLinear"(%[[VAL_65]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_67:.*]] = "onnx.Relu"(%[[VAL_66]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_65:.*]] = "onnx.QuantizeLinear"(%[[VAL_64]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           %[[VAL_66:.*]] = "onnx.DequantizeLinear"(%[[VAL_65]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_67:.*]] = "onnx.Relu"(%[[VAL_66]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CHECK:           %[[VAL_68:.*]] = "onnx.DequantizeLinear"(%[[VAL_43]], %[[VAL_26]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CHECK:           %[[VAL_69:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_68]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_70:.*]] = "onnx.QuantizeLinear"(%[[VAL_69]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_71:.*]] = "onnx.DequantizeLinear"(%[[VAL_70]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_72:.*]] = "onnx.Relu"(%[[VAL_71]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_70:.*]] = "onnx.QuantizeLinear"(%[[VAL_69]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           %[[VAL_71:.*]] = "onnx.DequantizeLinear"(%[[VAL_70]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_72:.*]] = "onnx.Relu"(%[[VAL_71]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CHECK:           %[[VAL_73:.*]] = "onnx.DequantizeLinear"(%[[VAL_40]], %[[VAL_26]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CHECK:           %[[VAL_74:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_73]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_75:.*]] = "onnx.QuantizeLinear"(%[[VAL_74]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_76:.*]] = "onnx.DequantizeLinear"(%[[VAL_75]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_77:.*]] = "onnx.Relu"(%[[VAL_76]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_75:.*]] = "onnx.QuantizeLinear"(%[[VAL_74]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           %[[VAL_76:.*]] = "onnx.DequantizeLinear"(%[[VAL_75]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_77:.*]] = "onnx.Relu"(%[[VAL_76]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CHECK:           %[[VAL_78:.*]] = "onnx.DequantizeLinear"(%[[VAL_41]], %[[VAL_26]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CHECK:           %[[VAL_79:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_78]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_80:.*]] = "onnx.QuantizeLinear"(%[[VAL_79]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_81:.*]] = "onnx.DequantizeLinear"(%[[VAL_80]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_82:.*]] = "onnx.Relu"(%[[VAL_81]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_80:.*]] = "onnx.QuantizeLinear"(%[[VAL_79]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           %[[VAL_81:.*]] = "onnx.DequantizeLinear"(%[[VAL_80]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_82:.*]] = "onnx.Relu"(%[[VAL_81]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CHECK:           %[[VAL_83:.*]] = "onnx.DequantizeLinear"(%[[VAL_42]], %[[VAL_26]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CHECK:           %[[VAL_84:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_83]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_85:.*]] = "onnx.QuantizeLinear"(%[[VAL_84]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_86:.*]] = "onnx.DequantizeLinear"(%[[VAL_85]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_87:.*]] = "onnx.Relu"(%[[VAL_86]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_85:.*]] = "onnx.QuantizeLinear"(%[[VAL_84]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           %[[VAL_86:.*]] = "onnx.DequantizeLinear"(%[[VAL_85]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_87:.*]] = "onnx.Relu"(%[[VAL_86]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CHECK:           %[[VAL_88:.*]] = "onnx.DequantizeLinear"(%[[VAL_39]], %[[VAL_26]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CHECK:           %[[VAL_89:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_88]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_90:.*]] = "onnx.QuantizeLinear"(%[[VAL_89]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_91:.*]] = "onnx.DequantizeLinear"(%[[VAL_90]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_92:.*]] = "onnx.Relu"(%[[VAL_91]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_90:.*]] = "onnx.QuantizeLinear"(%[[VAL_89]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           %[[VAL_91:.*]] = "onnx.DequantizeLinear"(%[[VAL_90]], %[[VAL_24]], %[[VAL_27]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK:           %[[VAL_92:.*]] = "onnx.Relu"(%[[VAL_91]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CHECK:           %[[VAL_93:.*]] = "onnx.Reshape"(%[[VAL_52]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
 // CHECK:           %[[VAL_94:.*]] = "onnx.Reshape"(%[[VAL_57]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
 // CHECK:           %[[VAL_95:.*]] = "onnx.Reshape"(%[[VAL_62]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
@@ -1255,49 +1380,49 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
 // CONSTPROP:           %[[VAL_21:.*]] = "onnx.DequantizeLinear"(%[[VAL_20]], %[[VAL_14]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
 // CONSTPROP:           %[[VAL_22:.*]] = "onnx.DequantizeLinear"(%[[VAL_1]], %[[VAL_15]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CONSTPROP:           %[[VAL_23:.*]] = "onnx.Conv"(%[[VAL_21]], %[[VAL_22]], %[[VAL_19]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CONSTPROP:           %[[VAL_24:.*]] = "onnx.QuantizeLinear"(%[[VAL_23]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CONSTPROP:           %[[VAL_25:.*]] = "onnx.DequantizeLinear"(%[[VAL_24]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CONSTPROP:           %[[VAL_26:.*]] = "onnx.Relu"(%[[VAL_25]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_24:.*]] = "onnx.QuantizeLinear"(%[[VAL_23]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CONSTPROP:           %[[VAL_25:.*]] = "onnx.DequantizeLinear"(%[[VAL_24]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_26:.*]] = "onnx.Relu"(%[[VAL_25]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CONSTPROP:           %[[VAL_27:.*]] = "onnx.DequantizeLinear"(%[[VAL_4]], %[[VAL_15]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CONSTPROP:           %[[VAL_28:.*]] = "onnx.Conv"(%[[VAL_21]], %[[VAL_27]], %[[VAL_19]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CONSTPROP:           %[[VAL_29:.*]] = "onnx.QuantizeLinear"(%[[VAL_28]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CONSTPROP:           %[[VAL_30:.*]] = "onnx.DequantizeLinear"(%[[VAL_29]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CONSTPROP:           %[[VAL_31:.*]] = "onnx.Relu"(%[[VAL_30]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_29:.*]] = "onnx.QuantizeLinear"(%[[VAL_28]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CONSTPROP:           %[[VAL_30:.*]] = "onnx.DequantizeLinear"(%[[VAL_29]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_31:.*]] = "onnx.Relu"(%[[VAL_30]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CONSTPROP:           %[[VAL_32:.*]] = "onnx.DequantizeLinear"(%[[VAL_3]], %[[VAL_15]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CONSTPROP:           %[[VAL_33:.*]] = "onnx.Conv"(%[[VAL_21]], %[[VAL_32]], %[[VAL_19]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CONSTPROP:           %[[VAL_34:.*]] = "onnx.QuantizeLinear"(%[[VAL_33]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CONSTPROP:           %[[VAL_35:.*]] = "onnx.DequantizeLinear"(%[[VAL_34]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CONSTPROP:           %[[VAL_36:.*]] = "onnx.Relu"(%[[VAL_35]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_34:.*]] = "onnx.QuantizeLinear"(%[[VAL_33]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CONSTPROP:           %[[VAL_35:.*]] = "onnx.DequantizeLinear"(%[[VAL_34]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_36:.*]] = "onnx.Relu"(%[[VAL_35]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CONSTPROP:           %[[VAL_37:.*]] = "onnx.DequantizeLinear"(%[[VAL_2]], %[[VAL_15]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CONSTPROP:           %[[VAL_38:.*]] = "onnx.Conv"(%[[VAL_21]], %[[VAL_37]], %[[VAL_19]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CONSTPROP:           %[[VAL_39:.*]] = "onnx.QuantizeLinear"(%[[VAL_38]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CONSTPROP:           %[[VAL_40:.*]] = "onnx.DequantizeLinear"(%[[VAL_39]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CONSTPROP:           %[[VAL_41:.*]] = "onnx.Relu"(%[[VAL_40]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_39:.*]] = "onnx.QuantizeLinear"(%[[VAL_38]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CONSTPROP:           %[[VAL_40:.*]] = "onnx.DequantizeLinear"(%[[VAL_39]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_41:.*]] = "onnx.Relu"(%[[VAL_40]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CONSTPROP:           %[[VAL_42:.*]] = "onnx.DequantizeLinear"(%[[VAL_5]], %[[VAL_15]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CONSTPROP:           %[[VAL_43:.*]] = "onnx.Conv"(%[[VAL_21]], %[[VAL_42]], %[[VAL_19]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CONSTPROP:           %[[VAL_44:.*]] = "onnx.QuantizeLinear"(%[[VAL_43]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CONSTPROP:           %[[VAL_45:.*]] = "onnx.DequantizeLinear"(%[[VAL_44]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CONSTPROP:           %[[VAL_46:.*]] = "onnx.Relu"(%[[VAL_45]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_44:.*]] = "onnx.QuantizeLinear"(%[[VAL_43]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CONSTPROP:           %[[VAL_45:.*]] = "onnx.DequantizeLinear"(%[[VAL_44]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_46:.*]] = "onnx.Relu"(%[[VAL_45]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CONSTPROP:           %[[VAL_47:.*]] = "onnx.DequantizeLinear"(%[[VAL_8]], %[[VAL_15]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CONSTPROP:           %[[VAL_48:.*]] = "onnx.Conv"(%[[VAL_21]], %[[VAL_47]], %[[VAL_19]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CONSTPROP:           %[[VAL_49:.*]] = "onnx.QuantizeLinear"(%[[VAL_48]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CONSTPROP:           %[[VAL_50:.*]] = "onnx.DequantizeLinear"(%[[VAL_49]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CONSTPROP:           %[[VAL_51:.*]] = "onnx.Relu"(%[[VAL_50]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_49:.*]] = "onnx.QuantizeLinear"(%[[VAL_48]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CONSTPROP:           %[[VAL_50:.*]] = "onnx.DequantizeLinear"(%[[VAL_49]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_51:.*]] = "onnx.Relu"(%[[VAL_50]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CONSTPROP:           %[[VAL_52:.*]] = "onnx.DequantizeLinear"(%[[VAL_7]], %[[VAL_15]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CONSTPROP:           %[[VAL_53:.*]] = "onnx.Conv"(%[[VAL_21]], %[[VAL_52]], %[[VAL_19]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CONSTPROP:           %[[VAL_54:.*]] = "onnx.QuantizeLinear"(%[[VAL_53]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CONSTPROP:           %[[VAL_55:.*]] = "onnx.DequantizeLinear"(%[[VAL_54]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CONSTPROP:           %[[VAL_56:.*]] = "onnx.Relu"(%[[VAL_55]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_54:.*]] = "onnx.QuantizeLinear"(%[[VAL_53]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CONSTPROP:           %[[VAL_55:.*]] = "onnx.DequantizeLinear"(%[[VAL_54]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_56:.*]] = "onnx.Relu"(%[[VAL_55]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CONSTPROP:           %[[VAL_57:.*]] = "onnx.DequantizeLinear"(%[[VAL_6]], %[[VAL_15]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CONSTPROP:           %[[VAL_58:.*]] = "onnx.Conv"(%[[VAL_21]], %[[VAL_57]], %[[VAL_19]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CONSTPROP:           %[[VAL_59:.*]] = "onnx.QuantizeLinear"(%[[VAL_58]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CONSTPROP:           %[[VAL_60:.*]] = "onnx.DequantizeLinear"(%[[VAL_59]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CONSTPROP:           %[[VAL_61:.*]] = "onnx.Relu"(%[[VAL_60]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_59:.*]] = "onnx.QuantizeLinear"(%[[VAL_58]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CONSTPROP:           %[[VAL_60:.*]] = "onnx.DequantizeLinear"(%[[VAL_59]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_61:.*]] = "onnx.Relu"(%[[VAL_60]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CONSTPROP:           %[[VAL_62:.*]] = "onnx.DequantizeLinear"(%[[VAL_9]], %[[VAL_15]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
 // CONSTPROP:           %[[VAL_63:.*]] = "onnx.Conv"(%[[VAL_21]], %[[VAL_62]], %[[VAL_19]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CONSTPROP:           %[[VAL_64:.*]] = "onnx.QuantizeLinear"(%[[VAL_63]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CONSTPROP:           %[[VAL_65:.*]] = "onnx.DequantizeLinear"(%[[VAL_64]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CONSTPROP:           %[[VAL_66:.*]] = "onnx.Relu"(%[[VAL_65]]) : (tensor<1x1x54x222xf32>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_64:.*]] = "onnx.QuantizeLinear"(%[[VAL_63]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CONSTPROP:           %[[VAL_65:.*]] = "onnx.DequantizeLinear"(%[[VAL_64]], %[[VAL_13]], %[[VAL_16]]) {axis = 1 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CONSTPROP:           %[[VAL_66:.*]] = "onnx.Relu"(%[[VAL_65]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
 // CONSTPROP:           %[[VAL_67:.*]] = "onnx.Reshape"(%[[VAL_26]], %[[VAL_12]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
 // CONSTPROP:           %[[VAL_68:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_12]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
 // CONSTPROP:           %[[VAL_69:.*]] = "onnx.Reshape"(%[[VAL_36]], %[[VAL_12]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>


### PR DESCRIPTION

1. Fixing the output shapes of quant and dequant nodes 
2. Fixing the hasNoActivationConsumer method to make pattern of convtranspose->Quant-> Dequant->Relu match instead of matching just convtranspose