### PR TITLE
Make parsing of models more robust if useOnnxModelTypes is enabled.

### DIFF
--- a/src/Builder/FrontendDialectTransformer.hpp
+++ b/src/Builder/FrontendDialectTransformer.hpp
@@ -13,7 +13,6 @@
 #ifndef ONNX_MLIR_FRONTEND_TRANSFORMER_H
 #define ONNX_MLIR_FRONTEND_TRANSFORMER_H
 
-#include <set>
 #include <string>
 
 #include "onnx/onnx_pb.h"
@@ -49,7 +48,11 @@ struct ImportOptions {
   bool allowSorting = true;
   bool useOutputNameAsLocation = false;
 
-  // Allow missing output types and use type inference to determine them.
+  // If true, type inference will be used to
+  // infer missing output types. This is done by copying the, potential
+  // inferred, output type of the node connected to the output. According to
+  // ONNX, all outputs MUST have types. Therefore this option has to be
+  // considered as a stretch best effort.
   bool allowMissingOutputTypes = false;
 
   // Custom shape information for the graph inputs.
@@ -90,7 +93,7 @@ struct ImportOptions {
 [[nodiscard]] std::error_code ImportFrontendModelArray(const void *onnxBuffer,
     int bufferSize, mlir::MLIRContext &context,
     mlir::OwningOpRef<mlir::ModuleOp> &module, std::string &errorMessage,
-    ImportOptions options = ImportOptions());
+    const ImportOptions &options = ImportOptions());
 
 /*!
  *  Import an ONNX model file into the ONNX Dialect.
@@ -100,7 +103,7 @@ struct ImportOptions {
 [[nodiscard]] std::error_code ImportFrontendModelFile(
     llvm::StringRef model_fname, mlir::MLIRContext &context,
     mlir::OwningOpRef<mlir::ModuleOp> &module, std::string &errorMessage,
-    ImportOptions options = ImportOptions());
+    const ImportOptions &options = ImportOptions());
 
 /*!
  *  Import an ONNX model proto into the ONNX Dialect.
@@ -109,7 +112,7 @@ struct ImportOptions {
  */
 [[nodiscard]] std::error_code ImportFrontendModel(const onnx::ModelProto &model,
     mlir::MLIRContext &context, mlir::OwningOpRef<mlir::ModuleOp> &module,
-    std::string &errorMessage, ImportOptions options = ImportOptions());
+    std::string &errorMessage, const ImportOptions &options = ImportOptions());
 
 /*!
  *  TODO: Import models into other extension dialects that cover the

--- a/test/mlir/onnx/parse/add_missing_output_types.json
+++ b/test/mlir/onnx/parse/add_missing_output_types.json
@@ -15,6 +15,14 @@
 // INFERRED:           return [[VAR_0_]], [[VAR_1_]] : tensor<*xf32>, tensor<3x3xf32>
 // INFERRED:         }
 
+// RUN: onnx-mlir --EmitONNXIR --useOnnxModelTypes=true --allowMissingOutputTypes=true --printIR %s  | FileCheck --check-prefix=MODEL-TYPE %s
+// MODEL-TYPE-LABEL:  func.func @main_graph
+// MODEL-TYPE-SAME:   ([[PARAM_0_:%.+]]: tensor<3x1xf32> {onnx.name = "input_a"}, [[PARAM_1_:%.+]]: tensor<1x3xf32> {onnx.name = "input_b"}) -> (tensor<*xf32> {onnx.name = "output_c"}, tensor<3x3xf32> {onnx.name = "output_d"}) {
+// MODEL-TYPE-DAG:       [[VAR_0_:%.+]] = "onnx.Custom"([[PARAM_0_]], [[PARAM_1_]]) {domain_name = "test", function_name = "test.Add", onnx_node_name = "add_node_custom"} : (tensor<3x1xf32>, tensor<1x3xf32>) -> tensor<*xf32>
+// MODEL-TYPE-DAG:       [[VAR_1_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) {onnx_node_name = "add_node"} : (tensor<3x1xf32>, tensor<1x3xf32>) -> tensor<3x3xf32>
+// MODEL-TYPE:           return [[VAR_0_]], [[VAR_1_]] : tensor<*xf32>, tensor<3x3xf32>
+// MODEL-TYPE:         }
+
 {
   "irVersion": "10",
   "producerName": "onnx-example",


### PR DESCRIPTION
This is done by catching exceptions during shape inference (as they happen for example if the model
 uses custom ops) and by falling back to an onnx-mlir based type mapping for some kinds of invalid
 models.

Pass ImportOptions by const reference instead of value to avoid unnecessay copying.