### PR TITLE
WIP - removeBinary

### DIFF
--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -33,6 +33,7 @@
 
 #include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerPasses.hpp"
+#include "src/Compiler/DisposableGarbageCollector.hpp"
 #include "src/Compiler/OnnxToMlirPasses.hpp"
 #include "src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.hpp"
 #include "src/Dialect/Mlir/VectorMachineSupport.hpp"
@@ -65,7 +66,6 @@ void configurePasses() {
       enableParallel, parallelizeOps, optReport == OptReport::Simd,
       !disableSimdOption);
 }
-
 
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     bool donotScrubDisposableElementsAttr, OnnxToMlirOptions opts) {
@@ -199,7 +199,6 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createInstrumentONNXSignaturePass(
         instrumentSignatures, instrumentOnnxNode));
 }
-
 
 void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
     std::string ONNXOpsStatFormat) {

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -144,6 +144,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   // Passes for removing redundant concat, slice and cast QDQ Ops
   if (opts.enableRemoveDqQOp)
     pm.addPass(createQDQOptONNXToONNXPass());
+  if (opts.enableRemoveBinary)
+    pm.addPass(createFoldDQBinaryQPass());
 
   // One more call to ONNX shape inference/canonicalization/... to update
   // shape if possible.

--- a/src/Compiler/CompilerPasses.hpp
+++ b/src/Compiler/CompilerPasses.hpp
@@ -31,6 +31,7 @@ struct OnnxToMlirOptions {
   bool enableConvTransposeDecomposeToPhasedConv = false;
   bool enableConvTranspose1dDecomposeToPhasedConv = false;
   bool enableRemoveDqQOp = true;
+  bool enableRemoveBinary = true;
 };
 
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,

--- a/src/Compiler/CompilerPasses.hpp
+++ b/src/Compiler/CompilerPasses.hpp
@@ -25,7 +25,7 @@ namespace onnx_mlir {
 // Configures passes up front based on command line options.
 void configurePasses();
 
-
+/*
 struct OnnxToMlirOptions {
   bool enableQuarkQuantizedLegalization = false;
   bool enableConvTransposeDecompose = false;
@@ -37,7 +37,7 @@ struct OnnxToMlirOptions {
 
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     bool donotScrubDisposableElementsAttr = false, OnnxToMlirOptions opts = {});
-
+*/
 void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
     std::string ONNXOpsStatFilename);
 void addKrnlToAffinePasses(mlir::PassManager &pm);

--- a/src/Compiler/CompilerPasses.hpp
+++ b/src/Compiler/CompilerPasses.hpp
@@ -30,8 +30,8 @@ struct OnnxToMlirOptions {
   bool enableConvTransposeDecompose = false;
   bool enableConvTransposeDecomposeToPhasedConv = false;
   bool enableConvTranspose1dDecomposeToPhasedConv = false;
-  bool enableRemoveDqQOp = true;
-  bool enableRemoveBinary = true;
+  bool enableRemoveDqQOp = false;
+  bool enableRemoveBinary = false;
 };
 
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -18,6 +18,7 @@ struct OnnxToMlirOptions {
   bool enableConvTranspose1dDecomposeToPhasedConv = false;
   bool enableRemoveDqQOp = true;
   bool enableRemoveDqQAroundOp = true;
+  bool enableRemoveBinary = true;
 
   bool disableRecomposeOption = false;
   bool enableONNXHybridPass = true;

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -8,6 +8,8 @@ add_onnx_mlir_rewriter(DecomposeConvTranspose1dPhased)
 add_onnx_mlir_rewriter(ConstProp)
 add_onnx_mlir_rewriter(ConvOpt)
 add_onnx_mlir_rewriter(QDQOpt)
+add_onnx_mlir_rewriter(DQBinaryQOpt)
+
 
 add_onnx_mlir_library(OMShapeInference
   ShapeInference.cpp
@@ -44,6 +46,7 @@ add_onnx_mlir_library(OMInstrumentONNX
 add_onnx_mlir_library(OMONNXRewrite
   ConstProp.cpp
   QDQOpt.cpp    
+  DQBinaryQOpt.cpp  
   ConvOpt.cpp
   Decompose.cpp
   DecomposeEinsum.cpp

--- a/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
@@ -1,0 +1,294 @@
+//===- foldDqBinaryQPattern.cpp - Remove DQ-Binary-Q chains -----*- C++ -*-===//
+//
+// (c) Copyright 2022 - 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
+#include "src/Pass/Passes.hpp"
+#include "llvm/ADT/STLExtras.h"
+#include <optional>
+#include <variant>
+
+using namespace mlir;
+using namespace onnx_mlir;
+
+namespace {
+
+// Helper to print the ONNX node name (or fallback to NameLoc)
+static void printOnnxNodeName(mlir::Operation *op, llvm::StringRef tag = "") {
+  if (auto nameAttr = op->getAttrOfType<mlir::StringAttr>("onnx_node_name")) {
+    llvm::outs() << (tag.empty() ? "" : (tag.str() + ": "))
+                 << nameAttr.getValue() << "\n";
+    return;
+  }
+  mlir::Location loc = op->getLoc();
+  if (auto nameLoc = loc.dyn_cast<mlir::NameLoc>()) {
+    llvm::outs() << (tag.empty() ? "" : (tag.str() + ": "))
+                 << nameLoc.getName().str() << "\n";
+    return;
+  }
+  llvm::outs() << (tag.empty() ? "" : (tag.str() + ": "))
+               << "<no_onnx_node_name>\n";
+}
+
+// Checks if an ONNXConstantOp represents a scalar or a splat.
+// Returns an optional containing the value of type T if successful.
+template <typename T>
+std::optional<T> getScalarOrSplatValue(ONNXConstantOp constOp) {
+  // 1. Get the attribute that holds the tensor data.
+  auto elementsAttr = dyn_cast_or_null<ElementsAttr>(constOp.getValueAttr());
+  if (!elementsAttr || !elementsAttr.isSplat()) {
+    return std::nullopt;
+  }
+
+  // 2. Safely extract the value based on the element type.
+  mlir::Type elementType = elementsAttr.getElementType();
+
+  // Case 1: Floating-point types (f32, f64).
+  if (elementType.isF32() || elementType.isF64()) {
+    if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
+      // APFloat can handle both f32 and f64.
+      APFloat splatValue = elementsAttr.getSplatValue<APFloat>();
+      return static_cast<T>(splatValue.convertToDouble());
+    }
+  }
+
+  // Case 2: Integer types (i8, ui16, etc.).
+  if (auto intType = elementType.dyn_cast<IntegerType>()) {
+    if constexpr (std::is_integral_v<T>) {
+      APInt splatValue = elementsAttr.getSplatValue<APInt>();
+      if (intType.isUnsigned()) {
+        return static_cast<T>(splatValue.getZExtValue());
+      } else {
+        return static_cast<T>(splatValue.getSExtValue());
+      }
+    }
+  }
+  // Return std::nullopt if the type is not a match.
+  return std::nullopt;
+}
+
+template <typename T>
+std::optional<T> getScalarOrSplatConstant(Value value) {
+  if (!value) {
+    return std::nullopt;
+  }
+
+  auto constOp = value.getDefiningOp<ONNXConstantOp>();
+  if (!constOp) {
+    return std::nullopt;
+  }
+
+  // Call the templated helper function.
+  return getScalarOrSplatValue<T>(constOp);
+}
+
+static LogicalResult match_qdq(ONNXDequantizeLinearOp dq1,
+    ONNXDequantizeLinearOp dq2, double &kValue,
+    ONNXDequantizeLinearOp &activationDqOp, mlir::Type &scaleDtype,
+    mlir::Type &zpDtype) {
+
+  ONNXDequantizeLinearOp constantDqOp = nullptr;
+  ONNXConstantOp constantSourceOp = nullptr;
+
+  // Case 1: Direct ConstantOp as input to the DQ.
+  if (auto constOp = dq1.getX().getDefiningOp<ONNXConstantOp>()) {
+    constantDqOp = dq1;
+    activationDqOp = dq2;
+    constantSourceOp = constOp;
+  } else if (auto constOp = dq2.getX().getDefiningOp<ONNXConstantOp>()) {
+    constantDqOp = dq2;
+    activationDqOp = dq1;
+    constantSourceOp = constOp;
+  }
+  // Case 2: The input to the DQ op comes from a chain whose input is a
+  // constant.
+  else if (auto intermediateOp = dq1.getX().getDefiningOp()) {
+    if (auto constOp =
+            intermediateOp->getOperand(0).getDefiningOp<ONNXConstantOp>()) {
+      constantDqOp = dq1;
+      activationDqOp = dq2;
+      constantSourceOp = constOp;
+    }
+  } else if (auto intermediateOp = dq2.getX().getDefiningOp()) {
+    if (auto constOp =
+            intermediateOp->getOperand(0).getDefiningOp<ONNXConstantOp>()) {
+      constantDqOp = dq2;
+      activationDqOp = dq1;
+      constantSourceOp = constOp;
+    }
+  }
+
+  if (!constantDqOp) {
+    return failure();
+  }
+
+  // Use the templated helper to get the scalar value of the constant source.
+  auto scalar_value_opt = getScalarOrSplatValue<int64_t>(constantSourceOp);
+  if (!scalar_value_opt) {
+    return failure();
+  }
+  int64_t scalar_value = *scalar_value_opt;
+
+  // Use the templated helper to get the scale and zero-point values.
+  Value scaleVal = constantDqOp.getXScale();
+  Value zpVal = constantDqOp.getXZeroPoint();
+  auto scale_value_opt = getScalarOrSplatConstant<double>(scaleVal);
+  auto zp_value_opt = getScalarOrSplatConstant<int64_t>(zpVal);
+  if (!scale_value_opt || !zp_value_opt) {
+    return failure();
+  }
+  double scale_value = *scale_value_opt;
+  int64_t zp_value = *zp_value_opt;
+
+  // Store the data types.
+  scaleDtype = scaleVal.getType().cast<TensorType>().getElementType();
+  zpDtype = zpVal.getType().cast<TensorType>().getElementType();
+
+  // Calculate kValue.
+  kValue = (scalar_value - zp_value) * scale_value;
+
+  return success();
+}
+
+template <typename BinOp>
+static LogicalResult match_binary_op(BinOp binaryOp,
+    ONNXDequantizeLinearOp &dequantActivationOp, ONNXConstantOp &constantOp,
+    double &kValue, mlir::Type &scaleDtype, mlir::Type &zpDtype) {
+
+  Value lhs = binaryOp.getOperand(0);
+  Value rhs = binaryOp.getOperand(1);
+
+  // -------- Case A: lhs is DQ, rhs is Constant --------
+  if (auto dqOp = lhs.getDefiningOp<ONNXDequantizeLinearOp>()) {
+    if (auto constOp = rhs.getDefiningOp<ONNXConstantOp>()) {
+      dequantActivationOp = dqOp;
+      constantOp = constOp;
+    }
+  }
+  // -------- Case A reversed --------
+  else if (auto dqOp = rhs.getDefiningOp<ONNXDequantizeLinearOp>()) {
+    if (auto constOp = lhs.getDefiningOp<ONNXConstantOp>()) {
+      dequantActivationOp = dqOp;
+      constantOp = constOp;
+    }
+  }
+
+  // -------- Fill kValue --------
+  if (dequantActivationOp && constantOp) {
+    // if (!isScalarOrSplat(constantOp, kValue))
+    //   return failure();
+    auto kValueOpt = getScalarOrSplatValue<double>(constantOp);
+    if (!kValueOpt.has_value()) {
+      return failure();
+    }
+    double kValue = kValueOpt.value();
+
+    // Debug - To be removed
+    llvm::outs() << "A - SUCCESS\n";
+    printOnnxNodeName(binaryOp, "[RemoveBinary] matched");
+    return success();
+  }
+
+  // -------- Case B: both inputs are DQ --------
+  auto dqOp1 = lhs.getDefiningOp<ONNXDequantizeLinearOp>();
+  auto dqOp2 = rhs.getDefiningOp<ONNXDequantizeLinearOp>();
+
+  if (dqOp1 && dqOp2) {
+    if (failed(match_qdq(
+            dqOp1, dqOp2, kValue, dequantActivationOp, scaleDtype, zpDtype)))
+      return failure();
+
+    // Debug - To be removed
+    llvm::outs() << "B. SUCCESS\n";
+    llvm::outs() << "kValue = " << kValue << "\n";
+    printOnnxNodeName(binaryOp, "[RemoveBinary] matched");
+    return success();
+  }
+
+  return failure();
+}
+
+//===----------------------------------------------------------------------===//
+// Pattern to (eventually) fold DQ->Binary->Q when quantization parameters
+//===----------------------------------------------------------------------===//
+
+template <typename BinOp>
+struct FoldBinaryThroughQDQ : public OpRewritePattern<BinOp> {
+  using OpRewritePattern<BinOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(
+      BinOp op, PatternRewriter &rewriter) const override {
+
+    // STEP 1: Find the Quantize op after the binary op.
+    ONNXQuantizeLinearOp quantOutputOp = nullptr;
+    for (Value res : op->getResults()) {
+      for (Operation *user : res.getUsers()) {
+        if (auto q = dyn_cast<ONNXQuantizeLinearOp>(user)) {
+          quantOutputOp = q;
+          break;
+        }
+      }
+      if (quantOutputOp)
+        break;
+    }
+    if (!quantOutputOp)
+      return failure();
+
+    // STEP 2: Match the binary op's inputs.
+    ONNXDequantizeLinearOp dequantActivationOp = nullptr;
+    ONNXConstantOp constantOp = nullptr;
+    double kValue = 0.0;
+    mlir::Type scaleDtype, zeroPointDtype;
+
+    if (failed(match_binary_op<BinOp>(op, dequantActivationOp, constantOp,
+            kValue, scaleDtype, zeroPointDtype)))
+      return failure();
+
+    llvm::outs() << "kValue OUT " << kValue << "\n";
+    llvm::outs() << "scaleDtype OUT " << scaleDtype << "\n";
+    llvm::outs() << "zeroPointDtype OUT " << zeroPointDtype << "\n";
+    llvm::outs() << "dequantActivationOp " << *dequantActivationOp << "\n";
+    llvm::outs() << "\n";
+
+    return failure(); // TODO: replace with SUCCESS LATER
+  }
+};
+
+struct FoldDQBinaryQPass
+    : public PassWrapper<FoldDQBinaryQPass, OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FoldDQBinaryQPass)
+
+  StringRef getArgument() const final { return "fold-dq-binary-q"; }
+  StringRef getDescription() const final {
+    return "Fold Add/Sub/Mul/Div through Q/DQ by updating scale/zero_point, "
+           "then remove trivial Q->DQ chains when safe.";
+  }
+
+  void runOnOperation() override {
+    auto function = getOperation();
+    RewritePatternSet patterns(&getContext());
+    patterns
+        .add<FoldBinaryThroughQDQ<ONNXDivOp>, FoldBinaryThroughQDQ<ONNXSubOp>,
+            FoldBinaryThroughQDQ<ONNXMulOp>, FoldBinaryThroughQDQ<ONNXAddOp>>(
+            &getContext());
+    if (failed(applyPatternsAndFoldGreedily(function, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+} // namespace
+
+namespace onnx_mlir {
+std::unique_ptr<mlir::Pass> createFoldDQBinaryQPass() {
+  return std::make_unique<FoldDQBinaryQPass>();
+}
+} // namespace onnx_mlir

--- a/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
@@ -118,40 +118,75 @@ std::optional<T> get_scalar_tensor_value_from_val(Value value) {
   return get_scalar_tensor_value<T>(constOp);
 }
 
-// Build a 1-element DenseElementsAttr matching `likeTy`.
 static mlir::DenseElementsAttr makeScalarDEA(
-    mlir::ShapedType likeTy, double d) {
+    mlir::ShapedType likeTy, double d, mlir::Type clampElemTy) {
   using namespace mlir;
+
   auto ranked = likeTy.dyn_cast<RankedTensorType>();
   if (!ranked || !ranked.hasStaticShape() || ranked.getNumElements() != 1)
     return {};
 
-  Type et = ranked.getElementType();
-  if (auto ft = et.dyn_cast<FloatType>())
-    return DenseElementsAttr::get(ranked, FloatAttr::get(ft, d));
+  Type outET = ranked.getElementType();
+  Type useET = clampElemTy ? clampElemTy : outET;
 
-  if (auto it = et.dyn_cast<IntegerType>()) {
+  // If target is float, just create a float attr with outET semantics.
+  if (auto outFT = outET.dyn_cast<FloatType>()) {
+    // Round in the semantics of useET if it's float; otherwise just use d.
+    double dv = d;
+    if (auto useFT = useET.dyn_cast<FloatType>()) {
+      // Convert through APFloat with 'useET' semantics, then to double.
+      llvm::APFloat ap(d);
+      bool loses = false;
+      ap.convert(useFT.getFloatSemantics(), llvm::APFloat::rmNearestTiesToEven,
+          &loses);
+      dv = ap.convertToDouble();
+    }
+    return DenseElementsAttr::get(ranked, FloatAttr::get(outFT, dv));
+  }
+
+  // If target is integer, round+clamp as per 'useET' (if integer), then emit as
+  // outET.
+  if (auto outIT = outET.dyn_cast<IntegerType>()) {
+    // Decide signedness/width for clamping from useET if it's integer, else
+    // from outET.
+    IntegerType clampIT =
+        useET.isa<IntegerType>() ? useET.cast<IntegerType>() : outIT;
+
     int64_t iv = static_cast<int64_t>(std::llround(d));
-    const unsigned bw = it.getWidth();
-    const bool isSigned = it.isSigned();
+    const unsigned bw = clampIT.getWidth();
+    const bool isSigned = clampIT.isSigned();
+
     const int64_t minV = isSigned ? (-(int64_t(1) << (bw - 1))) : 0;
     const int64_t maxV =
         isSigned ? ((int64_t(1) << (bw - 1)) - 1) : ((int64_t(1) << bw) - 1);
     iv = std::min<int64_t>(std::max<int64_t>(iv, minV), maxV);
-    return DenseElementsAttr::get(ranked, IntegerAttr::get(it, iv));
+
+    // Now re-materialize as the *output* ET (which may differ in width/sign).
+    // This guarantees the result type matches `likeTy`.
+    if (auto outSigned = outIT.isSigned()) {
+      // For signed out type, encode iv as signed.
+      return DenseElementsAttr::get(ranked, IntegerAttr::get(outIT, iv));
+    } else {
+      // For unsigned out type, encode iv as unsigned (mask to width).
+      uint64_t u = static_cast<uint64_t>(iv);
+      if (outIT.getWidth() < 64)
+        u &= ((uint64_t(1) << outIT.getWidth()) - 1);
+      return DenseElementsAttr::get(ranked, IntegerAttr::get(outIT, u));
+    }
   }
+
   return {};
 }
 
-static void updateInitializerScalar(mlir::PatternRewriter &rewriter,
-    mlir::Operation *targetOp, mlir::Value oldInit, double newScalar) {
+static void updateInitializer(mlir::PatternRewriter &rewriter,
+    mlir::Operation *targetOp, mlir::Value oldInit, double newScalar,
+    mlir::Type clampElemTy) {
   using namespace mlir;
 
   if (!targetOp || !oldInit)
     return;
 
-  // NOTE: ONNXConstantOp is in the mlir namespace.
-  auto oldCst = oldInit.getDefiningOp<mlir::ONNXConstantOp>();
+  auto oldCst = oldInit.getDefiningOp<ONNXConstantOp>();
   if (!oldCst)
     return;
 
@@ -159,10 +194,11 @@ static void updateInitializerScalar(mlir::PatternRewriter &rewriter,
   if (!likeTy || !likeTy.hasStaticShape() || likeTy.getNumElements() != 1)
     return;
 
-  DenseElementsAttr payload = makeScalarDEA(likeTy, newScalar);
+  DenseElementsAttr payload = makeScalarDEA(likeTy, newScalar, clampElemTy);
   if (!payload)
     return;
 
+  // Single-use-by-target check.
   auto singleUseByTarget = [&]() -> bool {
     auto it = oldInit.use_begin(), e = oldInit.use_end();
     if (it == e)
@@ -175,6 +211,7 @@ static void updateInitializerScalar(mlir::PatternRewriter &rewriter,
   if (singleUseByTarget()) {
     rewriter.modifyOpInPlace(oldCst, [&] {
       oldCst->setAttr("value", payload);
+      // Keep constant canonical:
       oldCst->removeAttr("sparse_value");
       oldCst->removeAttr("value_float");
       oldCst->removeAttr("value_floats");
@@ -186,24 +223,27 @@ static void updateInitializerScalar(mlir::PatternRewriter &rewriter,
     return;
   }
 
-  // Multiple users: create a fresh mlir::ONNXConstantOp and retarget only this
-  // use.
+  // Multi-use: clone a fresh constant with same result type as oldInit.
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(targetOp);
 
-  OperationState st(
-      targetOp->getLoc(), mlir::ONNXConstantOp::getOperationName());
+  OperationState st(targetOp->getLoc(), ONNXConstantOp::getOperationName());
   st.addTypes(likeTy);
   st.addAttribute("value", payload);
 
   Operation *raw = Operation::create(st);
   rewriter.insert(raw);
-  auto newCst = mlir::dyn_cast<mlir::ONNXConstantOp>(raw);
+  auto newCst = llvm::dyn_cast<ONNXConstantOp>(raw);
   if (!newCst)
     return;
 
-  rewriter.replaceUsesWithIf(oldInit, newCst.getOutput(),
-      [&](OpOperand &use) { return use.getOwner() == targetOp; });
+  // Replace exactly the matching operand.
+  for (unsigned i = 0, e = targetOp->getNumOperands(); i < e; ++i) {
+    if (targetOp->getOperand(i) == oldInit) {
+      targetOp->setOperand(i, newCst.getOutput());
+      break;
+    }
+  }
 }
 
 static LogicalResult tryRemoveQThenDQChain(
@@ -271,37 +311,15 @@ struct FoldBinaryThroughQDQ : public OpRewritePattern<BinOp> {
 private:
   struct MatchState {
     ONNXDequantizeLinearOp dequantActivationOp = nullptr;
-    mlir::Type dstScaleDtype;
-    mlir::Type dstZeroPointDtype;
+    mlir::Type ScaleDtype;
+    mlir::Type zeroPointDtype;
     double kValue = 0.0;
     double dstScale = 0.0;
     int64_t dstZeroPoint = 0;
     double newScale = 0.0;
     int64_t newZp = 0;
   };
-  LogicalResult populateState(MatchState &state) const {
 
-    // The user's original logic, now inside a dedicated function.
-    Value scaleVal = state.dequantActivationOp.getXScale();
-    Value zpVal = state.dequantActivationOp.getXZeroPoint();
-    auto scale_value_opt = get_scalar_tensor_value_from_val<double>(scaleVal);
-    auto zp_value_opt = get_scalar_tensor_value_from_val<int64_t>(zpVal);
-
-    if (!scale_value_opt || !zp_value_opt) {
-      return failure();
-    }
-
-    state.dstScale = scale_value_opt.value();
-    state.dstZeroPoint = zp_value_opt.value();
-
-    // Store the data types using the modern `mlir::cast`.
-    state.dstScaleDtype =
-        mlir::cast<ShapedType>(scaleVal.getType()).getElementType();
-    state.dstZeroPointDtype =
-        mlir::cast<ShapedType>(zpVal.getType()).getElementType();
-
-    return success();
-  }
   LogicalResult match_qdq(MatchState &state, ONNXDequantizeLinearOp dq1,
       ONNXDequantizeLinearOp dq2) const {
 
@@ -340,13 +358,13 @@ private:
       return failure();
     }
 
+    // Find kvalue and store scale_dtype and zeroPointDtype
     {
       auto scalar_value_opt =
           get_scalar_tensor_value<int64_t>(constantSourceOp);
       if (!scalar_value_opt) {
         return failure();
       }
-      // Use the templated helper to get the scale and zero-point values.
       Value scaleVal = constantDqOp.getXScale();
       Value zpVal = constantDqOp.getXZeroPoint();
       auto scale_value_opt = get_scalar_tensor_value_from_val<double>(scaleVal);
@@ -356,9 +374,12 @@ private:
       }
       // Calculate and store kValue.
       state.kValue = (*scalar_value_opt - *zp_value_opt) * *scale_value_opt;
-    }
-    if (failed(populateState(state))) {
-      return failure();
+
+      // # store dtype for creating new initializers with the same dtype
+      state.ScaleDtype =
+          mlir::cast<ShapedType>(scaleVal.getType()).getElementType();
+      state.zeroPointDtype =
+          mlir::cast<ShapedType>(zpVal.getType()).getElementType();
     }
     return success();
   }
@@ -391,9 +412,6 @@ private:
         return failure();
       }
       state.kValue = kValueOpt.value();
-      if (failed(populateState(state))) {
-        return failure();
-      }
       return success();
     }
 
@@ -457,7 +475,7 @@ public:
   LogicalResult matchAndRewrite(
       BinOp op, PatternRewriter &rewriter) const override {
 
-    // STEP 1: Find the Quantize op after the binary op. Assuming only one user
+    // STEP 1: Match begin: Assuming only one user
     auto quantOutputOp = dyn_cast<ONNXQuantizeLinearOp>(*op->user_begin());
     if (!quantOutputOp) {
       return failure();
@@ -471,12 +489,25 @@ public:
       return failure();
     }
 
+    // Store the value of the scale and zero point of the destination node
+    {
+      Value scaleVal = state.dequantActivationOp.getXScale();
+      Value zpVal = state.dequantActivationOp.getXZeroPoint();
+      auto scale_value_opt = get_scalar_tensor_value_from_val<double>(scaleVal);
+      auto zp_value_opt = get_scalar_tensor_value_from_val<int64_t>(zpVal);
+      if (!scale_value_opt || !zp_value_opt) {
+        return failure();
+      }
+      state.dstScale = scale_value_opt.value();
+      state.dstZeroPoint = zp_value_opt.value();
+    }
+
     // STEP 3
     if (failed(check_needed_values(state, op))) {
       return failure();
     }
 
-    // STEP 4
+    // STEP 4 -Modify
     if (!compute_new_scale_and_zp_values(state, op)) {
       return failure();
     }
@@ -486,20 +517,14 @@ public:
     if constexpr (std::is_same_v<BinOp, ONNXAddOp> ||
                   std::is_same_v<BinOp, ONNXSubOp>) {
       Value zpVal = dqAct.getXZeroPoint();
-      if (!zpVal) {
-        return failure();
-      }
-      updateInitializerScalar(rewriter, dqAct.getOperation(), zpVal,
-          static_cast<double>(state.newZp));
+      updateInitializer(rewriter, dqAct.getOperation(), zpVal,
+          static_cast<double>(state.newZp), state.zeroPointDtype);
 
     } else if constexpr (std::is_same_v<BinOp, ONNXMulOp> ||
                          std::is_same_v<BinOp, ONNXDivOp>) {
       Value scaleVal = dqAct.getXScale();
-      if (!scaleVal) {
-        return failure();
-      }
-      updateInitializerScalar(
-          rewriter, dqAct.getOperation(), scaleVal, state.newScale);
+      updateInitializer(rewriter, dqAct.getOperation(), scaleVal,
+          state.newScale, state.ScaleDtype);
     }
 
     // STEP 6: Remove binary op
@@ -511,7 +536,6 @@ public:
         (void)tryRemoveQThenDQChain(rewriter, tailDQ);
       }
     }
-
     return success();
   }
 };

--- a/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
@@ -93,132 +93,6 @@ std::optional<T> getScalarOrSplatConstant(Value value) {
   return getScalarOrSplatValue<T>(constOp);
 }
 
-static LogicalResult match_qdq(ONNXDequantizeLinearOp dq1,
-    ONNXDequantizeLinearOp dq2, double &kValue,
-    ONNXDequantizeLinearOp &activationDqOp, mlir::Type &scaleDtype,
-    mlir::Type &zpDtype) {
-
-  ONNXDequantizeLinearOp constantDqOp = nullptr;
-  ONNXConstantOp constantSourceOp = nullptr;
-
-  // Case 1: Direct ConstantOp as input to the DQ.
-  if (auto constOp = dq1.getX().getDefiningOp<ONNXConstantOp>()) {
-    constantDqOp = dq1;
-    activationDqOp = dq2;
-    constantSourceOp = constOp;
-  } else if (auto constOp = dq2.getX().getDefiningOp<ONNXConstantOp>()) {
-    constantDqOp = dq2;
-    activationDqOp = dq1;
-    constantSourceOp = constOp;
-  }
-  // Case 2: The input to the DQ op comes from a chain whose input is a
-  // constant.
-  else if (auto intermediateOp = dq1.getX().getDefiningOp()) {
-    if (auto constOp =
-            intermediateOp->getOperand(0).getDefiningOp<ONNXConstantOp>()) {
-      constantDqOp = dq1;
-      activationDqOp = dq2;
-      constantSourceOp = constOp;
-    }
-  } else if (auto intermediateOp = dq2.getX().getDefiningOp()) {
-    if (auto constOp =
-            intermediateOp->getOperand(0).getDefiningOp<ONNXConstantOp>()) {
-      constantDqOp = dq2;
-      activationDqOp = dq1;
-      constantSourceOp = constOp;
-    }
-  }
-
-  if (!constantDqOp) {
-    return failure();
-  }
-
-  // Use the templated helper to get the scalar value of the constant source.
-  auto scalar_value_opt = getScalarOrSplatValue<int64_t>(constantSourceOp);
-  if (!scalar_value_opt) {
-    return failure();
-  }
-  int64_t scalar_value = *scalar_value_opt;
-
-  // Use the templated helper to get the scale and zero-point values.
-  Value scaleVal = constantDqOp.getXScale();
-  Value zpVal = constantDqOp.getXZeroPoint();
-  auto scale_value_opt = getScalarOrSplatConstant<double>(scaleVal);
-  auto zp_value_opt = getScalarOrSplatConstant<int64_t>(zpVal);
-  if (!scale_value_opt || !zp_value_opt) {
-    return failure();
-  }
-  double scale_value = *scale_value_opt;
-  int64_t zp_value = *zp_value_opt;
-
-  // Store the data types.
-  scaleDtype = scaleVal.getType().cast<TensorType>().getElementType();
-  zpDtype = zpVal.getType().cast<TensorType>().getElementType();
-
-  // Calculate kValue.
-  kValue = (scalar_value - zp_value) * scale_value;
-
-  return success();
-}
-
-template <typename BinOp>
-static LogicalResult match_binary_op(BinOp binaryOp,
-    ONNXDequantizeLinearOp &dequantActivationOp, ONNXConstantOp &constantOp,
-    double &kValue, mlir::Type &scaleDtype, mlir::Type &zpDtype) {
-
-  Value lhs = binaryOp.getOperand(0);
-  Value rhs = binaryOp.getOperand(1);
-
-  // -------- Case A: lhs is DQ, rhs is Constant --------
-  if (auto dqOp = lhs.getDefiningOp<ONNXDequantizeLinearOp>()) {
-    if (auto constOp = rhs.getDefiningOp<ONNXConstantOp>()) {
-      dequantActivationOp = dqOp;
-      constantOp = constOp;
-    }
-  }
-  // -------- Case A reversed --------
-  else if (auto dqOp = rhs.getDefiningOp<ONNXDequantizeLinearOp>()) {
-    if (auto constOp = lhs.getDefiningOp<ONNXConstantOp>()) {
-      dequantActivationOp = dqOp;
-      constantOp = constOp;
-    }
-  }
-
-  // -------- Fill kValue --------
-  if (dequantActivationOp && constantOp) {
-    // if (!isScalarOrSplat(constantOp, kValue))
-    //   return failure();
-    auto kValueOpt = getScalarOrSplatValue<double>(constantOp);
-    if (!kValueOpt.has_value()) {
-      return failure();
-    }
-    double kValue = kValueOpt.value();
-
-    // Debug - To be removed
-    llvm::outs() << "A - SUCCESS\n";
-    printOnnxNodeName(binaryOp, "[RemoveBinary] matched");
-    return success();
-  }
-
-  // -------- Case B: both inputs are DQ --------
-  auto dqOp1 = lhs.getDefiningOp<ONNXDequantizeLinearOp>();
-  auto dqOp2 = rhs.getDefiningOp<ONNXDequantizeLinearOp>();
-
-  if (dqOp1 && dqOp2) {
-    if (failed(match_qdq(
-            dqOp1, dqOp2, kValue, dequantActivationOp, scaleDtype, zpDtype)))
-      return failure();
-
-    // Debug - To be removed
-    llvm::outs() << "B. SUCCESS\n";
-    llvm::outs() << "kValue = " << kValue << "\n";
-    printOnnxNodeName(binaryOp, "[RemoveBinary] matched");
-    return success();
-  }
-
-  return failure();
-}
-
 //===----------------------------------------------------------------------===//
 // Pattern to (eventually) fold DQ->Binary->Q when quantization parameters
 //===----------------------------------------------------------------------===//
@@ -226,9 +100,144 @@ static LogicalResult match_binary_op(BinOp binaryOp,
 template <typename BinOp>
 struct FoldBinaryThroughQDQ : public OpRewritePattern<BinOp> {
   using OpRewritePattern<BinOp>::OpRewritePattern;
+
+private:
+  // ** State variables are now encapsulated in this private struct. **
+  struct MatchState {
+    ONNXDequantizeLinearOp dequantActivationOp = nullptr;
+    ONNXConstantOp constantOp = nullptr;
+    mlir::Type dstScaleDtype;
+    mlir::Type dstZeroPointDtype;
+    double kValue = 0.0;
+    double dstScale;
+    int64_t dstZeroPoint;
+  };
+
+  // ** Helper methods are now private members of the class. **
+  // They operate on the MatchState struct to populate it.
+
+  LogicalResult match_qdq(MatchState &state, ONNXDequantizeLinearOp dq1,
+      ONNXDequantizeLinearOp dq2) const {
+
+    ONNXDequantizeLinearOp constantDqOp = nullptr;
+    ONNXConstantOp constantSourceOp = nullptr;
+
+    // Case 1: Direct ConstantOp as input to the DQ.
+    if (auto constOp = dq1.getX().getDefiningOp<ONNXConstantOp>()) {
+      constantDqOp = dq1;
+      state.dequantActivationOp = dq2;
+      constantSourceOp = constOp;
+    } else if (auto constOp = dq2.getX().getDefiningOp<ONNXConstantOp>()) {
+      constantDqOp = dq2;
+      state.dequantActivationOp = dq1;
+      constantSourceOp = constOp;
+    }
+    // Case 2: The input to the DQ op comes from a chain whose input is a
+    // constant.
+    else if (auto intermediateOp = dq1.getX().getDefiningOp()) {
+      if (auto constOp =
+              intermediateOp->getOperand(0).getDefiningOp<ONNXConstantOp>()) {
+        constantDqOp = dq1;
+        state.dequantActivationOp = dq2;
+        constantSourceOp = constOp;
+      }
+    } else if (auto intermediateOp = dq2.getX().getDefiningOp()) {
+      if (auto constOp =
+              intermediateOp->getOperand(0).getDefiningOp<ONNXConstantOp>()) {
+        constantDqOp = dq2;
+        state.dequantActivationOp = dq1;
+        constantSourceOp = constOp;
+      }
+    }
+
+    if (!constantDqOp) {
+      return failure();
+    }
+
+    // Use the templated helper to get the scalar value of the constant source.
+    auto scalar_value_opt = getScalarOrSplatValue<int64_t>(constantSourceOp);
+    if (!scalar_value_opt) {
+      return failure();
+    }
+    int64_t scalar_value = *scalar_value_opt;
+
+    // Use the templated helper to get the scale and zero-point values.
+    Value scaleVal = constantDqOp.getXScale();
+    Value zpVal = constantDqOp.getXZeroPoint();
+    auto scale_value_opt = getScalarOrSplatConstant<double>(scaleVal);
+    auto zp_value_opt = getScalarOrSplatConstant<int64_t>(zpVal);
+    if (!scale_value_opt || !zp_value_opt) {
+      return failure();
+    }
+    double scale_value = *scale_value_opt;
+    int64_t zp_value = *zp_value_opt;
+
+    // Store the data types.
+    state.dstScaleDtype =
+        scaleVal.getType().cast<TensorType>().getElementType();
+    state.dstZeroPointDtype =
+        zpVal.getType().cast<TensorType>().getElementType();
+
+    // Calculate and store kValue.
+    state.kValue = (scalar_value - zp_value) * scale_value;
+
+    return success();
+  }
+
+  LogicalResult match_binary_op(MatchState &state, BinOp binaryOp) const {
+    Value lhs = binaryOp.getOperand(0);
+    Value rhs = binaryOp.getOperand(1);
+
+    // -------- Case A: lhs is DQ, rhs is Constant --------
+    if (auto dqOp = lhs.getDefiningOp<ONNXDequantizeLinearOp>()) {
+      if (auto constOp = rhs.getDefiningOp<ONNXConstantOp>()) {
+        state.dequantActivationOp = dqOp;
+        state.constantOp = constOp;
+      }
+    }
+    // -------- Case A reversed --------
+    else if (auto dqOp = rhs.getDefiningOp<ONNXDequantizeLinearOp>()) {
+      if (auto constOp = lhs.getDefiningOp<ONNXConstantOp>()) {
+        state.dequantActivationOp = dqOp;
+        state.constantOp = constOp;
+      }
+    }
+
+    // -------- Fill kValue for Case A --------
+    if (state.dequantActivationOp && state.constantOp) {
+      auto kValueOpt = getScalarOrSplatValue<double>(state.constantOp);
+      if (!kValueOpt.has_value()) {
+        return failure();
+      }
+      state.kValue = kValueOpt.value();
+
+      // Debug - To be removed
+      llvm::outs() << "A - SUCCESS\n";
+      printOnnxNodeName(binaryOp, "[RemoveBinary] matched");
+      return success();
+    }
+
+    // -------- Case B: both inputs are DQ --------
+    auto dqOp1 = lhs.getDefiningOp<ONNXDequantizeLinearOp>();
+    auto dqOp2 = rhs.getDefiningOp<ONNXDequantizeLinearOp>();
+
+    if (dqOp1 && dqOp2) {
+      if (failed(match_qdq(state, dqOp1, dqOp2)))
+        return failure();
+
+      // Debug - To be removed
+      llvm::outs() << "B. SUCCESS\n";
+      llvm::outs() << "kValue = " << state.kValue << "\n";
+      printOnnxNodeName(binaryOp, "[RemoveBinary] matched");
+      return success();
+    }
+
+    return failure();
+  }
+
+public:
   LogicalResult matchAndRewrite(
       BinOp op, PatternRewriter &rewriter) const override {
-
     // STEP 1: Find the Quantize op after the binary op.
     ONNXQuantizeLinearOp quantOutputOp = nullptr;
     for (Value res : op->getResults()) {
@@ -244,21 +253,25 @@ struct FoldBinaryThroughQDQ : public OpRewritePattern<BinOp> {
     if (!quantOutputOp)
       return failure();
 
-    // STEP 2: Match the binary op's inputs.
-    ONNXDequantizeLinearOp dequantActivationOp = nullptr;
-    ONNXConstantOp constantOp = nullptr;
-    double kValue = 0.0;
-    mlir::Type scaleDtype, zeroPointDtype;
+    // ** Instantiate the state struct for this match attempt. **
+    MatchState state;
 
-    if (failed(match_binary_op<BinOp>(op, dequantActivationOp, constantOp,
-            kValue, scaleDtype, zeroPointDtype)))
+    // STEP 2: Match the binary op's inputs, populating the state.
+    if (failed(match_binary_op(state, op)))
       return failure();
 
-    llvm::outs() << "kValue OUT " << kValue << "\n";
-    llvm::outs() << "scaleDtype OUT " << scaleDtype << "\n";
-    llvm::outs() << "zeroPointDtype OUT " << zeroPointDtype << "\n";
-    llvm::outs() << "dequantActivationOp " << *dequantActivationOp << "\n";
+    // ** Access the matched values via the state object. **
+    llvm::outs() << "kValue OUT " << state.kValue << "\n";
+    llvm::outs() << "dstScaleDtype OUT " << state.dstScaleDtype << "\n";
+    llvm::outs() << "dstZeroPointDtype OUT " << state.dstZeroPointDtype << "\n";
+    llvm::outs() << "dequantActivationOp " << *state.dequantActivationOp
+                 << "\n";
     llvm::outs() << "\n";
+
+    // STEP 3: Check_needed_values
+    // if(failed(check_needed_values<BinOp>(state.kValue, ...)))
+    // std::optional<FusionDestination> dstOpt;
+    // bool branchOnDequantActivation = false;
 
     return failure(); // TODO: replace with SUCCESS LATER
   }

--- a/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
@@ -35,37 +35,79 @@ static ElementsAttr getElementAttributeFromConstant(Value val) {
   return nullptr;
 }
 
+// Equivalent to Python's NoMatch exception: here Nullopt indicates failure.
 template <typename T>
-std::optional<T> getScalarOrSplatValue(ONNXConstantOp constOp) {
+std::optional<T> get_scalar_tensor_value(ONNXConstantOp constOp) {
   auto elementsAttr = dyn_cast_or_null<ElementsAttr>(constOp.getValueAttr());
-  if (!elementsAttr || !elementsAttr.isSplat()) {
+  if (!elementsAttr)
     return std::nullopt;
-  }
-  mlir::Type elementType = elementsAttr.getElementType();
-  // Case 1: Floating-point types (f32, f64).
-  if (elementType.isF32() || elementType.isF64()) {
-    if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
-      // APFloat can handle both f32 and f64.
-      APFloat splatValue = elementsAttr.getSplatValue<APFloat>();
-      return static_cast<T>(splatValue.convertToDouble());
-    }
-  }
-  // Case 2: Integer types (i8, ui16, etc.).
-  if (auto intType = elementType.dyn_cast<IntegerType>()) {
-    if constexpr (std::is_integral_v<T>) {
-      APInt splatValue = elementsAttr.getSplatValue<APInt>();
-      if (intType.isUnsigned()) {
-        return static_cast<T>(splatValue.getZExtValue());
-      } else {
-        return static_cast<T>(splatValue.getSExtValue());
+
+  Type elementType = elementsAttr.getElementType();
+
+  // Fast path: splat
+  if (elementsAttr.isSplat()) {
+    if (elementType.isa<FloatType>()) {
+      if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
+        APFloat splatValue = elementsAttr.getSplatValue<APFloat>();
+        return static_cast<T>(splatValue.convertToDouble());
       }
     }
+    if (auto intType = elementType.dyn_cast<IntegerType>()) {
+      if constexpr (std::is_integral_v<T>) {
+        APInt splatValue = elementsAttr.getSplatValue<APInt>();
+        if (intType.isUnsigned())
+          return static_cast<T>(splatValue.getZExtValue());
+        else
+          return static_cast<T>(splatValue.getSExtValue());
+      }
+    }
+    return std::nullopt;
   }
-  return std::nullopt;
+
+  // Non‑splat case: check rank
+  auto shapedTy = elementsAttr.getType().dyn_cast<ShapedType>();
+  if (!shapedTy || !shapedTy.hasStaticShape())
+    return std::nullopt;
+
+  // Case: rank 0 → scalar element directly
+  if (shapedTy.getRank() == 0) {
+    auto firstAttr = *elementsAttr.getValues<Attribute>().begin();
+    if (auto fAttr = firstAttr.dyn_cast<FloatAttr>()) {
+      if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>)
+        return static_cast<T>(fAttr.getValueAsDouble());
+    }
+    if (auto iAttr = firstAttr.dyn_cast<IntegerAttr>()) {
+      if constexpr (std::is_integral_v<T>)
+        return static_cast<T>(iAttr.getInt()); // signed ok
+    }
+    return std::nullopt;
+  }
+
+  // Case: rank >= 1 → flatten & check all the same
+  std::set<double> flattenedFP;
+  std::set<int64_t> flattenedInt;
+
+  if (elementType.isa<FloatType>()) {
+    if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
+      for (auto a : elementsAttr.getValues<FloatAttr>())
+        flattenedFP.insert(a.getValueAsDouble());
+      if (flattenedFP.size() == 1)
+        return static_cast<T>(*flattenedFP.begin());
+    }
+  } else if (auto intType = elementType.dyn_cast<IntegerType>()) {
+    if constexpr (std::is_integral_v<T>) {
+      for (auto a : elementsAttr.getValues<IntegerAttr>())
+        flattenedInt.insert(intType.isUnsigned() ? a.getUInt() : a.getInt());
+      if (flattenedInt.size() == 1)
+        return static_cast<T>(*flattenedInt.begin());
+    }
+  }
+
+  return std::nullopt; // mismatch or more than one unique value
 }
 
 template <typename T>
-std::optional<T> getScalarOrSplatConstant(Value value) {
+std::optional<T> get_scalar_tensor_value_from_val(Value value) {
   if (!value) {
     return std::nullopt;
   }
@@ -73,52 +115,43 @@ std::optional<T> getScalarOrSplatConstant(Value value) {
   if (!constOp) {
     return std::nullopt;
   }
-  return getScalarOrSplatValue<T>(constOp);
+  return get_scalar_tensor_value<T>(constOp);
 }
 
-static mlir::DenseElementsAttr buildScalarDEA(
+// Build a 1-element DenseElementsAttr matching `likeTy`.
+static mlir::DenseElementsAttr makeScalarDEA(
     mlir::ShapedType likeTy, double d) {
   using namespace mlir;
   auto ranked = likeTy.dyn_cast<RankedTensorType>();
   if (!ranked || !ranked.hasStaticShape() || ranked.getNumElements() != 1)
-    return DenseElementsAttr();
+    return {};
+
   Type et = ranked.getElementType();
-  // Floats: let MLIR handle semantics (f8/f16/bf16/f32/f64, etc).
-  if (auto ft = et.dyn_cast<FloatType>()) {
-    auto fa = FloatAttr::get(ft, d);
-    return DenseElementsAttr::get(ranked, fa);
-  }
-  // Integers: round & clamp, then use IntegerAttr.
+  if (auto ft = et.dyn_cast<FloatType>())
+    return DenseElementsAttr::get(ranked, FloatAttr::get(ft, d));
+
   if (auto it = et.dyn_cast<IntegerType>()) {
     int64_t iv = static_cast<int64_t>(std::llround(d));
     const unsigned bw = it.getWidth();
     const bool isSigned = it.isSigned();
-    int64_t minV = isSigned ? (-(int64_t(1) << (bw - 1))) : 0;
-    int64_t maxV =
+    const int64_t minV = isSigned ? (-(int64_t(1) << (bw - 1))) : 0;
+    const int64_t maxV =
         isSigned ? ((int64_t(1) << (bw - 1)) - 1) : ((int64_t(1) << bw) - 1);
     iv = std::min<int64_t>(std::max<int64_t>(iv, minV), maxV);
-    auto ia = IntegerAttr::get(it, iv);
-    return DenseElementsAttr::get(ranked, ia);
+    return DenseElementsAttr::get(ranked, IntegerAttr::get(it, iv));
   }
-  return DenseElementsAttr();
-}
-
-static bool hasSingleUseBy(mlir::Value v, mlir::Operation *who) {
-  bool seen = false;
-  for (mlir::OpOperand &use : v.getUses()) {
-    if (use.getOwner() == who && !seen) {
-      seen = true;
-      continue;
-    }
-    return false;
-  }
-  return seen;
+  return {};
 }
 
 static void updateInitializerScalar(mlir::PatternRewriter &rewriter,
     mlir::Operation *targetOp, mlir::Value oldInit, double newScalar) {
   using namespace mlir;
-  auto oldCst = oldInit.getDefiningOp<ONNXConstantOp>();
+
+  if (!targetOp || !oldInit)
+    return;
+
+  // NOTE: ONNXConstantOp is in the mlir namespace.
+  auto oldCst = oldInit.getDefiningOp<mlir::ONNXConstantOp>();
   if (!oldCst)
     return;
 
@@ -126,12 +159,20 @@ static void updateInitializerScalar(mlir::PatternRewriter &rewriter,
   if (!likeTy || !likeTy.hasStaticShape() || likeTy.getNumElements() != 1)
     return;
 
-  DenseElementsAttr payload = buildScalarDEA(likeTy, newScalar);
+  DenseElementsAttr payload = makeScalarDEA(likeTy, newScalar);
   if (!payload)
     return;
 
-  // Case A: mutate in place iff the *only* use is by targetOp.
-  if (hasSingleUseBy(oldInit, targetOp)) {
+  auto singleUseByTarget = [&]() -> bool {
+    auto it = oldInit.use_begin(), e = oldInit.use_end();
+    if (it == e)
+      return false;
+    auto *owner = it->getOwner();
+    ++it;
+    return (it == e) && (owner == targetOp);
+  };
+
+  if (singleUseByTarget()) {
     rewriter.modifyOpInPlace(oldCst, [&] {
       oldCst->setAttr("value", payload);
       oldCst->removeAttr("sparse_value");
@@ -145,24 +186,24 @@ static void updateInitializerScalar(mlir::PatternRewriter &rewriter,
     return;
   }
 
-  // Case B: multi-use → clone a fresh Constant with the same result type.
+  // Multiple users: create a fresh mlir::ONNXConstantOp and retarget only this
+  // use.
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(targetOp);
 
-  OperationState st(targetOp->getLoc(), ONNXConstantOp::getOperationName());
+  OperationState st(
+      targetOp->getLoc(), mlir::ONNXConstantOp::getOperationName());
   st.addTypes(likeTy);
   st.addAttribute("value", payload);
+
   Operation *raw = Operation::create(st);
   rewriter.insert(raw);
-  auto newCst = llvm::dyn_cast<ONNXConstantOp>(raw);
+  auto newCst = mlir::dyn_cast<mlir::ONNXConstantOp>(raw);
   if (!newCst)
     return;
-  // Replace exactly this operand
-  for (unsigned i = 0, e = targetOp->getNumOperands(); i < e; ++i)
-    if (targetOp->getOperand(i) == oldInit) {
-      targetOp->setOperand(i, newCst.getOutput());
-      break;
-    }
+
+  rewriter.replaceUsesWithIf(oldInit, newCst.getOutput(),
+      [&](OpOperand &use) { return use.getOwner() == targetOp; });
 }
 
 static LogicalResult tryRemoveQThenDQChain(
@@ -230,7 +271,6 @@ struct FoldBinaryThroughQDQ : public OpRewritePattern<BinOp> {
 private:
   struct MatchState {
     ONNXDequantizeLinearOp dequantActivationOp = nullptr;
-    ONNXConstantOp constantOp = nullptr;
     mlir::Type dstScaleDtype;
     mlir::Type dstZeroPointDtype;
     double kValue = 0.0;
@@ -239,7 +279,29 @@ private:
     double newScale = 0.0;
     int64_t newZp = 0;
   };
+  LogicalResult populateState(MatchState &state) const {
 
+    // The user's original logic, now inside a dedicated function.
+    Value scaleVal = state.dequantActivationOp.getXScale();
+    Value zpVal = state.dequantActivationOp.getXZeroPoint();
+    auto scale_value_opt = get_scalar_tensor_value_from_val<double>(scaleVal);
+    auto zp_value_opt = get_scalar_tensor_value_from_val<int64_t>(zpVal);
+
+    if (!scale_value_opt || !zp_value_opt) {
+      return failure();
+    }
+
+    state.dstScale = scale_value_opt.value();
+    state.dstZeroPoint = zp_value_opt.value();
+
+    // Store the data types using the modern `mlir::cast`.
+    state.dstScaleDtype =
+        mlir::cast<ShapedType>(scaleVal.getType()).getElementType();
+    state.dstZeroPointDtype =
+        mlir::cast<ShapedType>(zpVal.getType()).getElementType();
+
+    return success();
+  }
   LogicalResult match_qdq(MatchState &state, ONNXDequantizeLinearOp dq1,
       ONNXDequantizeLinearOp dq2) const {
 
@@ -274,48 +336,36 @@ private:
       }
     }
 
-    if (!constantDqOp) {
+    if (!constantDqOp || !constantSourceOp || !state.dequantActivationOp) {
       return failure();
     }
 
-    // Use the templated helper to get the scalar value of the constant source.
     {
-      auto scalar_value_opt = getScalarOrSplatValue<int64_t>(constantSourceOp);
+      auto scalar_value_opt =
+          get_scalar_tensor_value<int64_t>(constantSourceOp);
       if (!scalar_value_opt) {
         return failure();
       }
       // Use the templated helper to get the scale and zero-point values.
       Value scaleVal = constantDqOp.getXScale();
       Value zpVal = constantDqOp.getXZeroPoint();
-      auto scale_value_opt = getScalarOrSplatConstant<double>(scaleVal);
-      auto zp_value_opt = getScalarOrSplatConstant<int64_t>(zpVal);
+      auto scale_value_opt = get_scalar_tensor_value_from_val<double>(scaleVal);
+      auto zp_value_opt = get_scalar_tensor_value_from_val<int64_t>(zpVal);
       if (!scale_value_opt || !zp_value_opt) {
         return failure();
       }
       // Calculate and store kValue.
       state.kValue = (*scalar_value_opt - *zp_value_opt) * *scale_value_opt;
     }
-    {
-      // Use the templated helper to get the scale and zero-point values.
-      Value scaleVal = state.dequantActivationOp.getXScale();
-      Value zpVal = state.dequantActivationOp.getXZeroPoint();
-      auto scale_value_opt = getScalarOrSplatConstant<double>(scaleVal);
-      auto zp_value_opt = getScalarOrSplatConstant<int64_t>(zpVal);
-      if (!scale_value_opt || !zp_value_opt) {
-        return failure();
-      }
-      state.dstScale = *scale_value_opt;
-      state.dstZeroPoint = *zp_value_opt;
-      // Store the data types.
-      state.dstScaleDtype =
-          scaleVal.getType().cast<TensorType>().getElementType();
-      state.dstZeroPointDtype =
-          zpVal.getType().cast<TensorType>().getElementType();
+    if (failed(populateState(state))) {
+      return failure();
     }
     return success();
   }
 
   LogicalResult match_binary_op(MatchState &state, BinOp binaryOp) const {
+    ONNXConstantOp constantOp = nullptr;
+
     Value lhs = binaryOp.getOperand(0);
     Value rhs = binaryOp.getOperand(1);
 
@@ -323,24 +373,27 @@ private:
     if (auto dqOp = lhs.getDefiningOp<ONNXDequantizeLinearOp>()) {
       if (auto constOp = rhs.getDefiningOp<ONNXConstantOp>()) {
         state.dequantActivationOp = dqOp;
-        state.constantOp = constOp;
+        constantOp = constOp;
       }
     }
     // -------- Case A reversed --------
     else if (auto dqOp = rhs.getDefiningOp<ONNXDequantizeLinearOp>()) {
       if (auto constOp = lhs.getDefiningOp<ONNXConstantOp>()) {
         state.dequantActivationOp = dqOp;
-        state.constantOp = constOp;
+        constantOp = constOp;
       }
     }
 
-    // -------- Fill kValue for Case A --------
-    if (state.dequantActivationOp && state.constantOp) {
-      auto kValueOpt = getScalarOrSplatValue<double>(state.constantOp);
-      if (!kValueOpt.has_value()) {
+    // -------- Fill state values for Case A and Case A reversed --------
+    if (state.dequantActivationOp && constantOp) {
+      auto kValueOpt = get_scalar_tensor_value<double>(constantOp);
+      if (!kValueOpt) {
         return failure();
       }
       state.kValue = kValueOpt.value();
+      if (failed(populateState(state))) {
+        return failure();
+      }
       return success();
     }
 

--- a/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
@@ -6,16 +6,19 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 #include "src/Pass/Passes.hpp"
 #include "llvm/ADT/STLExtras.h"
+#include <cmath> // For std::llround
 #include <optional>
 #include <variant>
 
@@ -24,36 +27,21 @@ using namespace onnx_mlir;
 
 namespace {
 
-// Helper to print the ONNX node name (or fallback to NameLoc)
-static void printOnnxNodeName(mlir::Operation *op, llvm::StringRef tag = "") {
-  if (auto nameAttr = op->getAttrOfType<mlir::StringAttr>("onnx_node_name")) {
-    llvm::outs() << (tag.empty() ? "" : (tag.str() + ": "))
-                 << nameAttr.getValue() << "\n";
-    return;
-  }
-  mlir::Location loc = op->getLoc();
-  if (auto nameLoc = loc.dyn_cast<mlir::NameLoc>()) {
-    llvm::outs() << (tag.empty() ? "" : (tag.str() + ": "))
-                 << nameLoc.getName().str() << "\n";
-    return;
-  }
-  llvm::outs() << (tag.empty() ? "" : (tag.str() + ": "))
-               << "<no_onnx_node_name>\n";
+static ElementsAttr getElementAttributeFromConstant(Value val) {
+  if (!val)
+    return nullptr;
+  if (auto constOp = val.getDefiningOp<ONNXConstantOp>())
+    return mlir::dyn_cast<ElementsAttr>(constOp.getValueAttr());
+  return nullptr;
 }
 
-// Checks if an ONNXConstantOp represents a scalar or a splat.
-// Returns an optional containing the value of type T if successful.
 template <typename T>
 std::optional<T> getScalarOrSplatValue(ONNXConstantOp constOp) {
-  // 1. Get the attribute that holds the tensor data.
   auto elementsAttr = dyn_cast_or_null<ElementsAttr>(constOp.getValueAttr());
   if (!elementsAttr || !elementsAttr.isSplat()) {
     return std::nullopt;
   }
-
-  // 2. Safely extract the value based on the element type.
   mlir::Type elementType = elementsAttr.getElementType();
-
   // Case 1: Floating-point types (f32, f64).
   if (elementType.isF32() || elementType.isF64()) {
     if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
@@ -62,7 +50,6 @@ std::optional<T> getScalarOrSplatValue(ONNXConstantOp constOp) {
       return static_cast<T>(splatValue.convertToDouble());
     }
   }
-
   // Case 2: Integer types (i8, ui16, etc.).
   if (auto intType = elementType.dyn_cast<IntegerType>()) {
     if constexpr (std::is_integral_v<T>) {
@@ -74,7 +61,6 @@ std::optional<T> getScalarOrSplatValue(ONNXConstantOp constOp) {
       }
     }
   }
-  // Return std::nullopt if the type is not a match.
   return std::nullopt;
 }
 
@@ -83,38 +69,176 @@ std::optional<T> getScalarOrSplatConstant(Value value) {
   if (!value) {
     return std::nullopt;
   }
-
   auto constOp = value.getDefiningOp<ONNXConstantOp>();
   if (!constOp) {
     return std::nullopt;
   }
-
-  // Call the templated helper function.
   return getScalarOrSplatValue<T>(constOp);
 }
 
-//===----------------------------------------------------------------------===//
-// Pattern to (eventually) fold DQ->Binary->Q when quantization parameters
-//===----------------------------------------------------------------------===//
+static mlir::DenseElementsAttr buildScalarDEA(
+    mlir::ShapedType likeTy, double d) {
+  using namespace mlir;
+  auto ranked = likeTy.dyn_cast<RankedTensorType>();
+  if (!ranked || !ranked.hasStaticShape() || ranked.getNumElements() != 1)
+    return DenseElementsAttr();
+  Type et = ranked.getElementType();
+  // Floats: let MLIR handle semantics (f8/f16/bf16/f32/f64, etc).
+  if (auto ft = et.dyn_cast<FloatType>()) {
+    auto fa = FloatAttr::get(ft, d);
+    return DenseElementsAttr::get(ranked, fa);
+  }
+  // Integers: round & clamp, then use IntegerAttr.
+  if (auto it = et.dyn_cast<IntegerType>()) {
+    int64_t iv = static_cast<int64_t>(std::llround(d));
+    const unsigned bw = it.getWidth();
+    const bool isSigned = it.isSigned();
+    int64_t minV = isSigned ? (-(int64_t(1) << (bw - 1))) : 0;
+    int64_t maxV =
+        isSigned ? ((int64_t(1) << (bw - 1)) - 1) : ((int64_t(1) << bw) - 1);
+    iv = std::min<int64_t>(std::max<int64_t>(iv, minV), maxV);
+    auto ia = IntegerAttr::get(it, iv);
+    return DenseElementsAttr::get(ranked, ia);
+  }
+  return DenseElementsAttr();
+}
+
+static bool hasSingleUseBy(mlir::Value v, mlir::Operation *who) {
+  bool seen = false;
+  for (mlir::OpOperand &use : v.getUses()) {
+    if (use.getOwner() == who && !seen) {
+      seen = true;
+      continue;
+    }
+    return false;
+  }
+  return seen;
+}
+
+static void updateInitializerScalar(mlir::PatternRewriter &rewriter,
+    mlir::Operation *targetOp, mlir::Value oldInit, double newScalar) {
+  using namespace mlir;
+  auto oldCst = oldInit.getDefiningOp<ONNXConstantOp>();
+  if (!oldCst)
+    return;
+
+  auto likeTy = oldInit.getType().dyn_cast<ShapedType>();
+  if (!likeTy || !likeTy.hasStaticShape() || likeTy.getNumElements() != 1)
+    return;
+
+  DenseElementsAttr payload = buildScalarDEA(likeTy, newScalar);
+  if (!payload)
+    return;
+
+  // Case A: mutate in place iff the *only* use is by targetOp.
+  if (hasSingleUseBy(oldInit, targetOp)) {
+    rewriter.modifyOpInPlace(oldCst, [&] {
+      oldCst->setAttr("value", payload);
+      oldCst->removeAttr("sparse_value");
+      oldCst->removeAttr("value_float");
+      oldCst->removeAttr("value_floats");
+      oldCst->removeAttr("value_int");
+      oldCst->removeAttr("value_ints");
+      oldCst->removeAttr("value_string");
+      oldCst->removeAttr("value_strings");
+    });
+    return;
+  }
+
+  // Case B: multi-use → clone a fresh Constant with the same result type.
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(targetOp);
+
+  OperationState st(targetOp->getLoc(), ONNXConstantOp::getOperationName());
+  st.addTypes(likeTy);
+  st.addAttribute("value", payload);
+  Operation *raw = Operation::create(st);
+  rewriter.insert(raw);
+  auto newCst = llvm::dyn_cast<ONNXConstantOp>(raw);
+  if (!newCst)
+    return;
+  // Replace exactly this operand
+  for (unsigned i = 0, e = targetOp->getNumOperands(); i < e; ++i)
+    if (targetOp->getOperand(i) == oldInit) {
+      targetOp->setOperand(i, newCst.getOutput());
+      break;
+    }
+}
+
+static LogicalResult tryRemoveQThenDQChain(
+    mlir::PatternRewriter &rewriter, mlir::ONNXDequantizeLinearOp dqOp) {
+  using namespace mlir;
+
+  // Match Q -> DQ
+  auto qOp = dqOp.getX().template getDefiningOp<ONNXQuantizeLinearOp>();
+  if (!qOp) {
+    return failure();
+  }
+
+  // 1) Axis / block_size must match
+  if (qOp.getAxis() != dqOp.getAxis()) {
+    return failure();
+  }
+  if (qOp.getBlockSize() != dqOp.getBlockSize()) {
+    return failure();
+  }
+
+  // 2) Zero-points must match scalars/splats
+  auto zpQ = getElementAttributeFromConstant(qOp.getYZeroPoint());
+  auto zpDQ = getElementAttributeFromConstant(dqOp.getXZeroPoint());
+  if (!zpQ || !zpDQ || zpQ != zpDQ) {
+    return failure();
+  }
+
+  // 3) Scales must match scalars/splats
+  auto sQ = getElementAttributeFromConstant(qOp.getYScale());
+  auto sDQ = getElementAttributeFromConstant(dqOp.getXScale());
+  if (!sQ || !sDQ || sQ != sDQ) {
+    return failure();
+  }
+
+  // 4) Data type consistency: input of Q and output of DQ must have same elem
+  // type.
+  auto qInTypeOp = qOp.getX().getType();
+  auto dqOutTypeOp = dqOp.getResult().getType();
+
+  if (auto qInTensorType = qInTypeOp.dyn_cast<TensorType>()) {
+    if (auto dqOutTensorType = dqOutTypeOp.dyn_cast<TensorType>()) {
+      if (dqOutTensorType.getElementType() != qInTensorType.getElementType()) {
+        return failure();
+      }
+    } else {
+      return failure();
+    }
+  } else {
+    return failure();
+  }
+
+  // Replace DQ with Q's float input; erase Q if it becomes dead.
+  rewriter.replaceOp(dqOp, qOp.getX());
+  if (qOp->use_empty()) {
+    rewriter.eraseOp(qOp);
+  }
+
+  return success();
+}
 
 template <typename BinOp>
 struct FoldBinaryThroughQDQ : public OpRewritePattern<BinOp> {
   using OpRewritePattern<BinOp>::OpRewritePattern;
 
 private:
-  // ** State variables are now encapsulated in this private struct. **
   struct MatchState {
     ONNXDequantizeLinearOp dequantActivationOp = nullptr;
     ONNXConstantOp constantOp = nullptr;
     mlir::Type dstScaleDtype;
     mlir::Type dstZeroPointDtype;
     double kValue = 0.0;
-    double dstScale;
-    int64_t dstZeroPoint;
+    double dstScale = 0.0;
+    int64_t dstZeroPoint = 0;
+    double newScale = 0.0;
+    int64_t newZp = 0;
   };
-
-  // ** Helper methods are now private members of the class. **
-  // They operate on the MatchState struct to populate it.
 
   LogicalResult match_qdq(MatchState &state, ONNXDequantizeLinearOp dq1,
       ONNXDequantizeLinearOp dq2) const {
@@ -155,32 +279,39 @@ private:
     }
 
     // Use the templated helper to get the scalar value of the constant source.
-    auto scalar_value_opt = getScalarOrSplatValue<int64_t>(constantSourceOp);
-    if (!scalar_value_opt) {
-      return failure();
+    {
+      auto scalar_value_opt = getScalarOrSplatValue<int64_t>(constantSourceOp);
+      if (!scalar_value_opt) {
+        return failure();
+      }
+      // Use the templated helper to get the scale and zero-point values.
+      Value scaleVal = constantDqOp.getXScale();
+      Value zpVal = constantDqOp.getXZeroPoint();
+      auto scale_value_opt = getScalarOrSplatConstant<double>(scaleVal);
+      auto zp_value_opt = getScalarOrSplatConstant<int64_t>(zpVal);
+      if (!scale_value_opt || !zp_value_opt) {
+        return failure();
+      }
+      // Calculate and store kValue.
+      state.kValue = (*scalar_value_opt - *zp_value_opt) * *scale_value_opt;
     }
-    int64_t scalar_value = *scalar_value_opt;
-
-    // Use the templated helper to get the scale and zero-point values.
-    Value scaleVal = constantDqOp.getXScale();
-    Value zpVal = constantDqOp.getXZeroPoint();
-    auto scale_value_opt = getScalarOrSplatConstant<double>(scaleVal);
-    auto zp_value_opt = getScalarOrSplatConstant<int64_t>(zpVal);
-    if (!scale_value_opt || !zp_value_opt) {
-      return failure();
+    {
+      // Use the templated helper to get the scale and zero-point values.
+      Value scaleVal = state.dequantActivationOp.getXScale();
+      Value zpVal = state.dequantActivationOp.getXZeroPoint();
+      auto scale_value_opt = getScalarOrSplatConstant<double>(scaleVal);
+      auto zp_value_opt = getScalarOrSplatConstant<int64_t>(zpVal);
+      if (!scale_value_opt || !zp_value_opt) {
+        return failure();
+      }
+      state.dstScale = *scale_value_opt;
+      state.dstZeroPoint = *zp_value_opt;
+      // Store the data types.
+      state.dstScaleDtype =
+          scaleVal.getType().cast<TensorType>().getElementType();
+      state.dstZeroPointDtype =
+          zpVal.getType().cast<TensorType>().getElementType();
     }
-    double scale_value = *scale_value_opt;
-    int64_t zp_value = *zp_value_opt;
-
-    // Store the data types.
-    state.dstScaleDtype =
-        scaleVal.getType().cast<TensorType>().getElementType();
-    state.dstZeroPointDtype =
-        zpVal.getType().cast<TensorType>().getElementType();
-
-    // Calculate and store kValue.
-    state.kValue = (scalar_value - zp_value) * scale_value;
-
     return success();
   }
 
@@ -210,10 +341,6 @@ private:
         return failure();
       }
       state.kValue = kValueOpt.value();
-
-      // Debug - To be removed
-      llvm::outs() << "A - SUCCESS\n";
-      printOnnxNodeName(binaryOp, "[RemoveBinary] matched");
       return success();
     }
 
@@ -224,56 +351,115 @@ private:
     if (dqOp1 && dqOp2) {
       if (failed(match_qdq(state, dqOp1, dqOp2)))
         return failure();
-
-      // Debug - To be removed
-      llvm::outs() << "B. SUCCESS\n";
-      llvm::outs() << "kValue = " << state.kValue << "\n";
-      printOnnxNodeName(binaryOp, "[RemoveBinary] matched");
       return success();
     }
-
     return failure();
+  }
+
+  LogicalResult check_needed_values(
+      const MatchState &state, Operation *binaryOp) const {
+    if (state.kValue == 0.0) {
+      if (isa<ONNXDivOp>(binaryOp)) {
+        return failure();
+      }
+    }
+    if (state.dstScale == 0.0) {
+      if (isa<ONNXAddOp, ONNXSubOp>(binaryOp)) {
+        return failure();
+      }
+    }
+    return success();
+  }
+
+  static bool compute_new_scale_and_zp_values(
+      MatchState &state, Operation *binaryOp) {
+    double newScale = state.dstScale;
+    double newZpFloat = static_cast<double>(state.dstZeroPoint);
+    const double kVal = state.kValue;
+
+    if (isa<ONNXAddOp>(binaryOp)) {
+      newZpFloat -= (kVal / newScale);
+
+    } else if (isa<ONNXSubOp>(binaryOp)) {
+      newZpFloat += (kVal / newScale);
+
+    } else if (isa<ONNXMulOp>(binaryOp)) {
+      newScale *= kVal;
+
+    } else if (isa<ONNXDivOp>(binaryOp)) {
+      newScale /= kVal;
+
+    } else {
+      return false;
+    }
+
+    int64_t newZp = static_cast<int64_t>(std::llround(newZpFloat));
+    state.newScale = newScale;
+    state.newZp = newZp;
+
+    return true;
   }
 
 public:
   LogicalResult matchAndRewrite(
       BinOp op, PatternRewriter &rewriter) const override {
-    // STEP 1: Find the Quantize op after the binary op.
-    ONNXQuantizeLinearOp quantOutputOp = nullptr;
-    for (Value res : op->getResults()) {
-      for (Operation *user : res.getUsers()) {
-        if (auto q = dyn_cast<ONNXQuantizeLinearOp>(user)) {
-          quantOutputOp = q;
-          break;
-        }
-      }
-      if (quantOutputOp)
-        break;
-    }
-    if (!quantOutputOp)
-      return failure();
 
-    // ** Instantiate the state struct for this match attempt. **
+    // STEP 1: Find the Quantize op after the binary op. Assuming only one user
+    auto quantOutputOp = dyn_cast<ONNXQuantizeLinearOp>(*op->user_begin());
+    if (!quantOutputOp) {
+      return failure();
+    }
+
+    // Instantiate the state struct
     MatchState state;
 
-    // STEP 2: Match the binary op's inputs, populating the state.
-    if (failed(match_binary_op(state, op)))
+    // STEP 2
+    if (failed(match_binary_op(state, op))) {
       return failure();
+    }
 
-    // ** Access the matched values via the state object. **
-    llvm::outs() << "kValue OUT " << state.kValue << "\n";
-    llvm::outs() << "dstScaleDtype OUT " << state.dstScaleDtype << "\n";
-    llvm::outs() << "dstZeroPointDtype OUT " << state.dstZeroPointDtype << "\n";
-    llvm::outs() << "dequantActivationOp " << *state.dequantActivationOp
-                 << "\n";
-    llvm::outs() << "\n";
+    // STEP 3
+    if (failed(check_needed_values(state, op))) {
+      return failure();
+    }
 
-    // STEP 3: Check_needed_values
-    // if(failed(check_needed_values<BinOp>(state.kValue, ...)))
-    // std::optional<FusionDestination> dstOpt;
-    // bool branchOnDequantActivation = false;
+    // STEP 4
+    if (!compute_new_scale_and_zp_values(state, op)) {
+      return failure();
+    }
 
-    return failure(); // TODO: replace with SUCCESS LATER
+    // STEP 5: call initializer based on the binary op
+    ONNXDequantizeLinearOp dqAct = state.dequantActivationOp;
+    if constexpr (std::is_same_v<BinOp, ONNXAddOp> ||
+                  std::is_same_v<BinOp, ONNXSubOp>) {
+      Value zpVal = dqAct.getXZeroPoint();
+      if (!zpVal) {
+        return failure();
+      }
+      updateInitializerScalar(rewriter, dqAct.getOperation(), zpVal,
+          static_cast<double>(state.newZp));
+
+    } else if constexpr (std::is_same_v<BinOp, ONNXMulOp> ||
+                         std::is_same_v<BinOp, ONNXDivOp>) {
+      Value scaleVal = dqAct.getXScale();
+      if (!scaleVal) {
+        return failure();
+      }
+      updateInitializerScalar(
+          rewriter, dqAct.getOperation(), scaleVal, state.newScale);
+    }
+
+    // STEP 6: Remove binary op
+    rewriter.replaceOp(op, dqAct.getResult());
+
+    // STEP 7: Remove Q->DQ chain
+    for (Operation *user : quantOutputOp.getY().getUsers()) {
+      if (auto tailDQ = llvm::dyn_cast<ONNXDequantizeLinearOp>(user)) {
+        (void)tryRemoveQThenDQChain(rewriter, tailDQ);
+      }
+    }
+
+    return success();
   }
 };
 
@@ -281,7 +467,7 @@ struct FoldDQBinaryQPass
     : public PassWrapper<FoldDQBinaryQPass, OperationPass<func::FuncOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FoldDQBinaryQPass)
 
-  StringRef getArgument() const final { return "fold-dq-binary-q"; }
+  StringRef getArgument() const final { return "dq-binary-q-opt-onnx-to-onnx"; }
   StringRef getDescription() const final {
     return "Fold Add/Sub/Mul/Div through Q/DQ by updating scale/zero_point, "
            "then remove trivial Q->DQ chains when safe.";

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -56,6 +56,7 @@ void configureConstPropONNXToONNXPass(bool roundFPToInt, int expansionBound,
 std::unique_ptr<mlir::Pass> createConstPropONNXToONNXPass();
 
 std::unique_ptr<mlir::Pass> createQDQOptONNXToONNXPass();
+std::unique_ptr<mlir::Pass> createFoldDQBinaryQPass();
 
 /// Pass for instrument the ops in specific stage.
 std::unique_ptr<mlir::Pass> createInstrumentPass();

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -71,6 +71,10 @@ void registerOMPasses(int optLevel) {
     return createQDQOptONNXToONNXPass();
   });
 
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return createFoldDQBinaryQPass();
+  });
+
   mlir::registerPass(
       []() -> std::unique_ptr<mlir::Pass> { return createInstrumentPass(); });
 

--- a/test/mlir/onnx/onnx_remove_add.mlir
+++ b/test/mlir/onnx/onnx_remove_add.mlir
@@ -1,11 +1,12 @@
 // RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s --split-input-file | FileCheck %s
 
-// CHECK-LABEL: func.func @test_removebinary_pattern1
+// 1) dq1-dq2(const input)-add-q-dq. remove->add,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1a
 // CHECK-NOT: onnx.Add
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-func.func @test_removebinary_pattern1(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
 %36 = onnx.Constant dense<0> : tensor<ui16>
 %37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
 %38 = onnx.Constant dense<65535> : tensor<ui16>
@@ -35,13 +36,147 @@ return %1180 : tensor<1x1x1x128xf32>
 }
 
 // -----
+// Test fusing a DQ -> Sub -> Q -> DQ pattern.
+// The constant input to the Sub is produced by a chain: Constant -> Identity -> DequantizeLinear.
+// The pass should look through the Identity op, perform the fusion, and remove the redundant Q->DQ chain.
+// 2) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1b
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
 
-// CHECK-LABEL: func.func @test_removebinary_pattern2
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_input_for_chain = onnx.Constant dense<0> : tensor<ui16>
+
+%intermediate_op = "onnx.Identity"(%const_input_for_chain) : (tensor<ui16>) -> tensor<ui16>
+%const_dq = "onnx.DequantizeLinear"(%intermediate_op, %cst_scale_large, %cst_zp_large) : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%dq_in = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%Sub_op = "onnx.Add"(%dq_in, %const_dq) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%q_out = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%final_dq_out = "onnx.DequantizeLinear"(%q_out, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %final_dq_out : tensor<1x1x1x128xf32>
+}
+//-----
+// 3) dq1-const-add-q-dq. remove->add, q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
 // CHECK-NOT: onnx.Add
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-func.func @test_removebinary_pattern2(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Sub op now uses the pre-calculated constant.
+%Sub_op = "onnx.Add"(%dq1, %const_neg_10k) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 4) const-dq1-add-q-dq. remove->add,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2b
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+
+func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Sub op now uses the pre-calculated constant.
+%Sub_op = "onnx.Add"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 5) const-dq1-add-q-dq. kval=0. remove->add,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3a
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+
+func.func @test_removebinary_pattern3a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_neg_10k = onnx.Constant dense<0.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Sub op now uses the pre-calculated constant.
+%Sub_op = "onnx.Add"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+//-----
+// 6) const-dq1-Sub-q-dq. dst_scale=0. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3b
+// CHECK: onnx.Add
+// CHECK: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Sub op now uses the pre-calculated constant.
+%Sub_op = "onnx.Add"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+//-----
+// 7) dq1-dq2(const input)-add-q-dq. remove->add,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern4
+// CHECK-NOT: onnx.Add
+// CHECK: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
 %36 = onnx.Constant dense<0> : tensor<ui16>
 %37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
 %38 = onnx.Constant dense<65535> : tensor<ui16>
@@ -64,8 +199,173 @@ block_size = 0 : si64,
 output_dtype = 0 : si64,
 saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
 
-%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
+%1180 = "onnx.DequantizeLinear"(%1178, %15, %36) {
 axis = 1 : si64,
 block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
 return %1180 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 8) const-dq1-Sub-tanh. remove->none
+// CHECK-LABEL: func.func @test_removebinary_pattern5
+// CHECK: onnx.Add
+// CHECK: onnx.Tanh
+
+func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%14 = onnx.Constant dense<39664> : tensor<ui16>
+%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+
+%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1176 = "onnx.Add"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%tanh = "onnx.Tanh"(%1176) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+return %tanh : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 9) dq1-dq2-add-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, add
+// CHECK-LABEL: func.func @test_removebinary_pattern6
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.Add
+
+func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%39 = onnx.Constant dense<0.152590215> : tensor<f32>
+%14 = onnx.Constant dense<39664> : tensor<ui16>
+%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+
+%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1176 = "onnx.Add"(%960, %1174) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1182 = "onnx.Add"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %1186 : tensor<1x1x1x128xf32>
+}
+//-----
+//
+// 10) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// vectors wiht same values -> fusion
+// CHECK-LABEL: func.func @test_removebinary_pattern7
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern7(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+// Per-axis (axis=0) constants (length-2 params stay the same)
+%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
+%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
+%zpMax = onnx.Constant dense<[65535, 65535]> : tensor<2xui16>
+%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
+
+// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
+%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+
+%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+
+// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
+%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+// Sub now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
+%mul = "onnx.Add"(%x_dq, %c_dq)
+: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+
+// Re-quantize per-axis with the same (length-2) params on axis=0.
+%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
+} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+
+// Final DQ (per-axis, axis=0).
+%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+return %y : tensor<2x1x1x128xf32>
+}
+//-----
+//
+// 11) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// vectors wiht different values -> no fusion
+// CHECK-LABEL: func.func @test_removebinary_pattern8
+// CHECK: onnx.Add
+// CHECK: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern8(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+// Per-axis (axis=0) constants (length-2 params stay the same)
+%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
+%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
+%zpMax = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
+
+// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
+%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+
+%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+
+// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
+%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+// Sub now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
+%mul = "onnx.Add"(%x_dq, %c_dq)
+: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+
+// Re-quantize per-axis with the same (length-2) params on axis=0.
+%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
+} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+
+// Final DQ (per-axis, axis=0).
+%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+return %y : tensor<2x1x1x128xf32>
 }

--- a/test/mlir/onnx/onnx_remove_add.mlir
+++ b/test/mlir/onnx/onnx_remove_add.mlir
@@ -1,0 +1,71 @@
+// RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func.func @test_removebinary_pattern1
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%14 = onnx.Constant dense<39664> : tensor<ui16>
+%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+
+%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1176 = "onnx.Add"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %1180 : tensor<1x1x1x128xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_removebinary_pattern2
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%14 = onnx.Constant dense<39664> : tensor<ui16>
+%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+
+%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1176 = "onnx.Add"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %1180 : tensor<1x1x1x128xf32>
+}

--- a/test/mlir/onnx/onnx_remove_add.mlir
+++ b/test/mlir/onnx/onnx_remove_add.mlir
@@ -2,370 +2,254 @@
 
 // 1) dq1-dq2(const input)-add-q-dq. remove->add,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern1a
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<336> : tensor<ui16>
 // CHECK-NOT: onnx.Add
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
 func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%14 = onnx.Constant dense<39664> : tensor<ui16>
-%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
-
-%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1176 = "onnx.Add"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-return %1180 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<39664> : tensor<ui16>
+%3 = onnx.Constant dense<40000> : tensor<ui16>
+%4 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %3) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
 
 // -----
-// Test fusing a DQ -> Sub -> Q -> DQ pattern.
-// The constant input to the Sub is produced by a chain: Constant -> Identity -> DequantizeLinear.
-// The pass should look through the Identity op, perform the fusion, and remove the redundant Q->DQ chain.
-// 2) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// 2) dq1-dq2(const input)-add-q-dq. remove->add,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern1b
-// CHECK-NOT: onnx.Add
-// CHECK-NOT: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_input_for_chain = onnx.Constant dense<0> : tensor<ui16>
-
-%intermediate_op = "onnx.Identity"(%const_input_for_chain) : (tensor<ui16>) -> tensor<ui16>
-%const_dq = "onnx.DequantizeLinear"(%intermediate_op, %cst_scale_large, %cst_zp_large) : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%dq_in = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%Sub_op = "onnx.Add"(%dq_in, %const_dq) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%q_out = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%final_dq_out = "onnx.DequantizeLinear"(%q_out, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %final_dq_out : tensor<1x1x1x128xf32>
-}
-//-----
-// 3) dq1-const-add-q-dq. remove->add, q-dq.
-// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<336> : tensor<ui16>
 // CHECK-NOT: onnx.Add
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
-func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Sub op now uses the pre-calculated constant.
-%Sub_op = "onnx.Add"(%dq1, %const_neg_10k) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<39664> : tensor<ui16>
+%3 = onnx.Constant dense<40000> : tensor<ui16>
+%4 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %3) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
 
+// -----
+// 3) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1c
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1c(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Add"(%7, %6) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+
+// -----
+// 4) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1d
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1d(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Add"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
 //-----
-// 4) const-dq1-add-q-dq. remove->add,q-dq.
+// 5) dq1-const-add-q-dq. remove->add, q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<100> : tensor<ui16>
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<100> : tensor<ui16>
+%1 = onnx.Constant dense<1.000000e+01> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<1.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 6) const-dq1-add-q-dq. remove->add,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern2b
 // CHECK-NOT: onnx.Add
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
 func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Sub op now uses the pre-calculated constant.
-%Sub_op = "onnx.Add"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 5) const-dq1-add-q-dq. kval=0. remove->add,q-dq.
+// 7) const-dq1-add-q-dq. kval=0. remove->add,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern3a
 // CHECK-NOT: onnx.Add
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
 func.func @test_removebinary_pattern3a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_neg_10k = onnx.Constant dense<0.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Sub op now uses the pre-calculated constant.
-%Sub_op = "onnx.Add"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
 //-----
-// 6) const-dq1-Sub-q-dq. dst_scale=0. remove->Sub,q-dq.
+// 8) const-dq1-Sub-q-dq. dst_scale=0. remove->Sub,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern3b
 // CHECK: onnx.Add
 // CHECK: onnx.QuantizeLinear
-
 func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Sub op now uses the pre-calculated constant.
-%Sub_op = "onnx.Add"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
 //-----
-// 7) dq1-dq2(const input)-add-q-dq. remove->add,q-dq.
+// 9) dq1-dq2(const input)-add-q-dq. remove->add,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern4
 // CHECK-NOT: onnx.Add
 // CHECK: onnx.QuantizeLinear
-
 func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%14 = onnx.Constant dense<39664> : tensor<ui16>
-%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
-
-%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1176 = "onnx.Add"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1180 = "onnx.DequantizeLinear"(%1178, %15, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-return %1180 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Add"(%5, %6) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %4, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %9 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 8) const-dq1-Sub-tanh. remove->none
+// 10) const-dq1-Sub-tanh. remove->none
 // CHECK-LABEL: func.func @test_removebinary_pattern5
 // CHECK: onnx.Add
 // CHECK: onnx.Tanh
-
 func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%14 = onnx.Constant dense<39664> : tensor<ui16>
-%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
-
-%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1176 = "onnx.Add"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-%tanh = "onnx.Tanh"(%1176) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-return %tanh : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Add"(%5, %6) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Tanh"(%7) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 9) dq1-dq2-add-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, add
+// 11) dq1-dq2-add-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, add
 // CHECK-LABEL: func.func @test_removebinary_pattern6
 // CHECK-NOT: onnx.Add
 // CHECK-NOT: onnx.Add
-
 func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%39 = onnx.Constant dense<0.152590215> : tensor<f32>
-%14 = onnx.Constant dense<39664> : tensor<ui16>
-%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
-
-%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1176 = "onnx.Add"(%960, %1174) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1182 = "onnx.Add"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %1186 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<39664> : tensor<ui16>
+%5 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%6 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Div"(%6, %7) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%11 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%12 = "onnx.Add"(%10, %11) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%13 = "onnx.QuantizeLinear"(%12, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%14 = "onnx.DequantizeLinear"(%13, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %14 : tensor<1x1x1x128xf32>
 }
 //-----
 //
-// 10) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// 12) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
 // vectors wiht same values -> fusion
-// CHECK-LABEL: func.func @test_removebinary_pattern7
+// CHECK-LABEL: func.func @test_removebinary_pattern7a
 // CHECK-NOT: onnx.Add
 // CHECK-NOT: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern7(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
-// Per-axis (axis=0) constants (length-2 params stay the same)
-%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
-%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
-%zpMax = onnx.Constant dense<[65535, 65535]> : tensor<2xui16>
-%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
-
-// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
-%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
-
-%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
-
-// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
-%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-// Sub now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
-%mul = "onnx.Add"(%x_dq, %c_dq)
-: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
-
-// Re-quantize per-axis with the same (length-2) params on axis=0.
-%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
-} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
-
-// Final DQ (per-axis, axis=0).
-%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-return %y : tensor<2x1x1x128xf32>
+func.func @test_removebinary_pattern7a(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<65535> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Add"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
 }
 //-----
 //
-// 11) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// 13) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
 // vectors wiht different values -> no fusion
-// CHECK-LABEL: func.func @test_removebinary_pattern8
+// CHECK-LABEL: func.func @test_removebinary_pattern7b
 // CHECK: onnx.Add
 // CHECK: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern8(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
-// Per-axis (axis=0) constants (length-2 params stay the same)
-%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
-%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
-%zpMax = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
-%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
-
-// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
-%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
-
-%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
-
-// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
-%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-// Sub now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
-%mul = "onnx.Add"(%x_dq, %c_dq)
-: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
-
-// Re-quantize per-axis with the same (length-2) params on axis=0.
-%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
-} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
-
-// Final DQ (per-axis, axis=0).
-%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-return %y : tensor<2x1x1x128xf32>
+func.func @test_removebinary_pattern7b(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Add"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
 }

--- a/test/mlir/onnx/onnx_remove_div.mlir
+++ b/test/mlir/onnx/onnx_remove_div.mlir
@@ -1,0 +1,71 @@
+// RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func.func @test_removebinary_pattern1
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%39 = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1180 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1182 = "onnx.Div"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %1186 : tensor<1x1x1x128xf32>
+}
+
+//-----
+
+// CHECK-LABEL: func.func @test_removebinary_pattern2
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%39 = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1180 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1182 = "onnx.Div"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %1186 : tensor<1x1x1x128xf32>
+}

--- a/test/mlir/onnx/onnx_remove_div.mlir
+++ b/test/mlir/onnx/onnx_remove_div.mlir
@@ -1,11 +1,12 @@
-// RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s --split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s -split-input-file | FileCheck %s
 
-// CHECK-LABEL: func.func @test_removebinary_pattern1
+// 1) dq1-dq2(const input)-div-q-dq. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1a
 // CHECK-NOT: onnx.Div
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-func.func @test_removebinary_pattern1(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
 %36 = onnx.Constant dense<0> : tensor<ui16>
 %37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
 %38 = onnx.Constant dense<65535> : tensor<ui16>
@@ -33,27 +34,238 @@ block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> 
 
 return %1186 : tensor<1x1x1x128xf32>
 }
-
 //-----
 
-// CHECK-LABEL: func.func @test_removebinary_pattern2
+// Test fusing a DQ -> Div -> Q -> DQ pattern.
+// The constant input to the Div is produced by a chain: Constant -> Identity -> DequantizeLinear.
+// The pass should look through the Identity op, perform the fusion, and remove the redundant Q->DQ chain.
+// 2) dq1-dq2(const input)-div-q-dq. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1b
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_input_for_chain = onnx.Constant dense<0> : tensor<ui16>
+
+%intermediate_op = "onnx.Identity"(%const_input_for_chain) : (tensor<ui16>) -> tensor<ui16>
+%const_dq = "onnx.DequantizeLinear"(%intermediate_op, %cst_scale_large, %cst_zp_large) : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%dq_in = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%mul_op = "onnx.Div"(%dq_in, %const_dq) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%q_out = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%final_dq_out = "onnx.DequantizeLinear"(%q_out, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %final_dq_out : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 3) dq1-const-div-q-dq. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
 // CHECK-NOT: onnx.Div
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-func.func @test_removebinary_pattern2(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Div op now uses the pre-calculated constant.
+%mul_op = "onnx.Div"(%dq1, %const_neg_10k) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 4) const-dq1-div-q-dq. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2b
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+
+func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Div op now uses the pre-calculated constant.
+%mul_op = "onnx.Div"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 5) const-dq1-div-q-dq. kval=0. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3c
+// CHECK: onnx.Div
+// CHECK: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern3c(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_neg_10k = onnx.Constant dense<0.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Div op now uses the pre-calculated constant.
+%mul_op = "onnx.Div"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 6) const-dq1-div-q-dq. dst_scale=0. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3b
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+
+func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Div op now uses the pre-calculated constant.
+%mul_op = "onnx.Div"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 7) const-dq1-div-q-dq. q!=dq. remove->only div
+// CHECK-LABEL: func.func @test_removebinary_pattern4
+// CHECK-NOT: onnx.Div
+// CHECK: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Div op now uses the pre-calculated constant.
+%mul_op = "onnx.Div"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_small, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 8) const-dq1-div-tanh. remove->none
+// CHECK-LABEL: func.func @test_removebinary_pattern5
+// CHECK: onnx.Div
+// CHECK: onnx.Tanh
+
+func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Div op now uses the pre-calculated constant.
+%mul_op = "onnx.Div"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%tanh = "onnx.Tanh"(%mul_op) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+return %tanh : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 9) dq1-dq2-sub-q-dq1-dq2-div-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->div, sub
+// CHECK-LABEL: func.func @test_removebinary_pattern6
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.Sub
+
+func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
 %36 = onnx.Constant dense<0> : tensor<ui16>
 %37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
 %38 = onnx.Constant dense<65535> : tensor<ui16>
 %39 = onnx.Constant dense<0.152590215> : tensor<f32>
+%14 = onnx.Constant dense<39664> : tensor<ui16>
+%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+
+%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1176 = "onnx.Sub"(%960, %1174) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
 
 %961 = "onnx.DequantizeLinear"(%36, %39, %38) {
 axis = 1 : si64,
 block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1180 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
 
 %1182 = "onnx.Div"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
 
@@ -68,4 +280,92 @@ axis = 1 : si64,
 block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
 
 return %1186 : tensor<1x1x1x128xf32>
+}
+
+//-----
+//
+// 10) dq1-dq2(const input, per-axis length-2 on axis=0)-div-q-dq.
+// Keep Div and QuantizeLinear present.
+// CHECK-LABEL: func.func @test_removebinary_pattern7
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern7(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+// Per-axis (axis=0) constants (length-2 params stay the same)
+%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
+%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
+%zpMax = onnx.Constant dense<[65535, 65535]> : tensor<2xui16>
+%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
+
+// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
+%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+
+%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+
+// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
+%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+// Div now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
+%div = "onnx.Div"(%x_dq, %c_dq)
+: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+
+// Re-quantize per-axis with the same (length-2) params on axis=0.
+%q = "onnx.QuantizeLinear"(%div, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
+} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+
+// Final DQ (per-axis, axis=0).
+%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+return %y : tensor<2x1x1x128xf32>
+}
+
+//-----
+//
+// 11) dq1-dq2(const input, per-axis length-2 on axis=0)-div-q-dq.
+// Keep Div and QuantizeLinear present.
+// CHECK-LABEL: func.func @test_removebinary_pattern8
+// CHECK: onnx.Div
+// CHECK: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern8(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+// Per-axis (axis=0) constants (length-2 params stay the same)
+%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
+%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
+%zpMax = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
+
+// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
+%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+
+%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+
+// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
+%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+// Div now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
+%div = "onnx.Div"(%x_dq, %c_dq)
+: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+
+// Re-quantize per-axis with the same (length-2) params on axis=0.
+%q = "onnx.QuantizeLinear"(%div, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
+} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+
+// Final DQ (per-axis, axis=0).
+%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+return %y : tensor<2x1x1x128xf32>
 }

--- a/test/mlir/onnx/onnx_remove_div.mlir
+++ b/test/mlir/onnx/onnx_remove_div.mlir
@@ -2,370 +2,248 @@
 
 // 1) dq1-dq2(const input)-div-q-dq. remove->div,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern1a
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-1.52590218E-9> : tensor<f32>
 // CHECK-NOT: onnx.Div
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
 func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%39 = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1180 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1182 = "onnx.Div"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %1186 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
 //-----
-
-// Test fusing a DQ -> Div -> Q -> DQ pattern.
-// The constant input to the Div is produced by a chain: Constant -> Identity -> DequantizeLinear.
-// The pass should look through the Identity op, perform the fusion, and remove the redundant Q->DQ chain.
 // 2) dq1-dq2(const input)-div-q-dq. remove->div,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern1b
-// CHECK-NOT: onnx.Div
-// CHECK-NOT: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_input_for_chain = onnx.Constant dense<0> : tensor<ui16>
-
-%intermediate_op = "onnx.Identity"(%const_input_for_chain) : (tensor<ui16>) -> tensor<ui16>
-%const_dq = "onnx.DequantizeLinear"(%intermediate_op, %cst_scale_large, %cst_zp_large) : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%dq_in = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%mul_op = "onnx.Div"(%dq_in, %const_dq) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%q_out = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%final_dq_out = "onnx.DequantizeLinear"(%q_out, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %final_dq_out : tensor<1x1x1x128xf32>
-}
-
-//-----
-// 3) dq1-const-div-q-dq. remove->div,q-dq.
-// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-1.52590218E-9> : tensor<f32>
 // CHECK-NOT: onnx.Div
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
-func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Div op now uses the pre-calculated constant.
-%mul_op = "onnx.Div"(%dq1, %const_neg_10k) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 4) const-dq1-div-q-dq. remove->div,q-dq.
+// 3) dq1-dq2(const input)-div-q-dq. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1c
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1c(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Div"(%7, %6) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+//-----
+// 4) dq1-dq2(const input)-div-q-dq. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1d
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1d(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Div"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+//-----
+// 5) dq1-const-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-1.49999991E-7> : tensor<f32>
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.500000e-05> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+02> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 6) const-dq1-div-q-dq. remove->div,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern2b
 // CHECK-NOT: onnx.Div
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
 func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Div op now uses the pre-calculated constant.
-%mul_op = "onnx.Div"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 5) const-dq1-div-q-dq. kval=0. remove->div,q-dq.
+// 7) const-dq1-div-q-dq. kval=0. remove->div,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern3c
 // CHECK: onnx.Div
 // CHECK: onnx.QuantizeLinear
-
 func.func @test_removebinary_pattern3c(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_neg_10k = onnx.Constant dense<0.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Div op now uses the pre-calculated constant.
-%mul_op = "onnx.Div"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 6) const-dq1-div-q-dq. dst_scale=0. remove->div,q-dq.
+// 8) const-dq1-div-q-dq. dst_scale=0. remove->div,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern3b
 // CHECK-NOT: onnx.Div
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
 func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Div op now uses the pre-calculated constant.
-%mul_op = "onnx.Div"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 7) const-dq1-div-q-dq. q!=dq. remove->only div
+// 9) const-dq1-div-q-dq. q!=dq. remove->only div
 // CHECK-LABEL: func.func @test_removebinary_pattern4
 // CHECK-NOT: onnx.Div
 // CHECK: onnx.QuantizeLinear
-
 func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Div op now uses the pre-calculated constant.
-%mul_op = "onnx.Div"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_small, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 8) const-dq1-div-tanh. remove->none
+// 10) const-dq1-div-tanh. remove->none
 // CHECK-LABEL: func.func @test_removebinary_pattern5
 // CHECK: onnx.Div
 // CHECK: onnx.Tanh
-
 func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Div op now uses the pre-calculated constant.
-%mul_op = "onnx.Div"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-%tanh = "onnx.Tanh"(%mul_op) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-return %tanh : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Tanh"(%6) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+return %7 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 9) dq1-dq2-sub-q-dq1-dq2-div-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->div, sub
+// 11) dq1-dq2-sub-q-dq1-dq2-div-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->div, sub
 // CHECK-LABEL: func.func @test_removebinary_pattern6
 // CHECK-NOT: onnx.Div
 // CHECK-NOT: onnx.Sub
-
 func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%39 = onnx.Constant dense<0.152590215> : tensor<f32>
-%14 = onnx.Constant dense<39664> : tensor<ui16>
-%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
-
-%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1176 = "onnx.Sub"(%960, %1174) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1182 = "onnx.Div"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %1186 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<39664> : tensor<ui16>
+%5 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%6 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Sub"(%6, %7) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%11 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%12 = "onnx.Div"(%10, %11) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%13 = "onnx.QuantizeLinear"(%12, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%14 = "onnx.DequantizeLinear"(%13, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %14 : tensor<1x1x1x128xf32>
 }
-
 //-----
 //
-// 10) dq1-dq2(const input, per-axis length-2 on axis=0)-div-q-dq.
+// 12) dq1-dq2(const input, per-axis length-2 on axis=0)-div-q-dq.
 // Keep Div and QuantizeLinear present.
-// CHECK-LABEL: func.func @test_removebinary_pattern7
+// CHECK-LABEL: func.func @test_removebinary_pattern7a
 // CHECK-NOT: onnx.Div
 // CHECK-NOT: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern7(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
-// Per-axis (axis=0) constants (length-2 params stay the same)
-%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
-%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
-%zpMax = onnx.Constant dense<[65535, 65535]> : tensor<2xui16>
-%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
-
-// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
-%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
-
-%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
-
-// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
-%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-// Div now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
-%div = "onnx.Div"(%x_dq, %c_dq)
-: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
-
-// Re-quantize per-axis with the same (length-2) params on axis=0.
-%q = "onnx.QuantizeLinear"(%div, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
-} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
-
-// Final DQ (per-axis, axis=0).
-%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-return %y : tensor<2x1x1x128xf32>
+func.func @test_removebinary_pattern7a(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<65535> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Div"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
 }
-
 //-----
-//
-// 11) dq1-dq2(const input, per-axis length-2 on axis=0)-div-q-dq.
+// 13) dq1-dq2(const input, per-axis length-2 on axis=0)-div-q-dq.
 // Keep Div and QuantizeLinear present.
-// CHECK-LABEL: func.func @test_removebinary_pattern8
+// CHECK-LABEL: func.func @test_removebinary_pattern7b
 // CHECK: onnx.Div
 // CHECK: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern8(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
-// Per-axis (axis=0) constants (length-2 params stay the same)
-%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
-%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
-%zpMax = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
-%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
-
-// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
-%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
-
-%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
-
-// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
-%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-// Div now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
-%div = "onnx.Div"(%x_dq, %c_dq)
-: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
-
-// Re-quantize per-axis with the same (length-2) params on axis=0.
-%q = "onnx.QuantizeLinear"(%div, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
-} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
-
-// Final DQ (per-axis, axis=0).
-%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-return %y : tensor<2x1x1x128xf32>
+func.func @test_removebinary_pattern7b(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Div"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
 }

--- a/test/mlir/onnx/onnx_remove_mul.mlir
+++ b/test/mlir/onnx/onnx_remove_mul.mlir
@@ -1,0 +1,70 @@
+// RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s -split-input-file | FileCheck %s
+
+// CHECK-LABEL: func.func @test_removebinary_pattern1
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%39 = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1180 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1182 = "onnx.Mul"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %1186 : tensor<1x1x1x128xf32>
+}
+
+//-----
+
+// CHECK-LABEL: func.func @test_removebinary_pattern2
+// CHECK-NOT: onnx.Mul
+// CHECK: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern2(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%39 = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1180 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1182 = "onnx.Mul"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1186 = "onnx.DequantizeLinear"(%1184, %37, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %1186 : tensor<1x1x1x128xf32>
+}

--- a/test/mlir/onnx/onnx_remove_mul.mlir
+++ b/test/mlir/onnx/onnx_remove_mul.mlir
@@ -1,11 +1,12 @@
 // RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s -split-input-file | FileCheck %s
 
-// CHECK-LABEL: func.func @test_removebinary_pattern1
+// 1) dq1-dq2(const input)-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1a
 // CHECK-NOT: onnx.Mul
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-func.func @test_removebinary_pattern1(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
 %36 = onnx.Constant dense<0> : tensor<ui16>
 %37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
 %38 = onnx.Constant dense<65535> : tensor<ui16>
@@ -33,26 +34,240 @@ block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> 
 
 return %1186 : tensor<1x1x1x128xf32>
 }
-
 //-----
 
-// CHECK-LABEL: func.func @test_removebinary_pattern2
+// Test fusing a DQ -> Mul -> Q -> DQ pattern.
+// The constant input to the Mul is produced by a chain: Constant -> Identity -> DequantizeLinear.
+// The pass should look through the Identity op, perform the fusion, and remove the redundant Q->DQ chain.
+// 2) dq1-dq2(const input)-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1b
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_input_for_chain = onnx.Constant dense<0> : tensor<ui16>
+
+%intermediate_op = "onnx.Identity"(%const_input_for_chain) : (tensor<ui16>) -> tensor<ui16>
+%const_dq = "onnx.DequantizeLinear"(%intermediate_op, %cst_scale_large, %cst_zp_large) : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%dq_in = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%mul_op = "onnx.Mul"(%dq_in, %const_dq) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%q_out = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%final_dq_out = "onnx.DequantizeLinear"(%q_out, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %final_dq_out : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 3) dq1-const-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Mul op now uses the pre-calculated constant.
+%mul_op = "onnx.Mul"(%dq1, %const_neg_10k) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 4) const-dq1-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2b
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+
+func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Mul op now uses the pre-calculated constant.
+%mul_op = "onnx.Mul"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 5) const-dq1-mul-q-dq. kval=0. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3a
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+
+func.func @test_removebinary_pattern3a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_neg_10k = onnx.Constant dense<0.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Mul op now uses the pre-calculated constant.
+%mul_op = "onnx.Mul"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 6) const-dq1-mul-q-dq. dst_scale=0. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3b
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+
+func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Mul op now uses the pre-calculated constant.
+%mul_op = "onnx.Mul"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 7) const-dq1-mul-q-dq. q!=dq. remove->only mul
+// CHECK-LABEL: func.func @test_removebinary_pattern4
 // CHECK-NOT: onnx.Mul
 // CHECK: onnx.QuantizeLinear
 
-func.func @test_removebinary_pattern2(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Mul op now uses the pre-calculated constant.
+%mul_op = "onnx.Mul"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_small, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 8) const-dq1-mul-tanh. remove->none
+// CHECK-LABEL: func.func @test_removebinary_pattern5
+// CHECK: onnx.Mul
+// CHECK: onnx.Tanh
+
+func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Mul op now uses the pre-calculated constant.
+%mul_op = "onnx.Mul"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%tanh = "onnx.Tanh"(%mul_op) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+return %tanh : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 9) dq1-dq2-sub-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, sub
+// CHECK-LABEL: func.func @test_removebinary_pattern6
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.Sub
+
+func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
 %36 = onnx.Constant dense<0> : tensor<ui16>
 %37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
 %38 = onnx.Constant dense<65535> : tensor<ui16>
 %39 = onnx.Constant dense<0.152590215> : tensor<f32>
+%14 = onnx.Constant dense<39664> : tensor<ui16>
+%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+
+%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1176 = "onnx.Sub"(%960, %1174) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
 
 %961 = "onnx.DequantizeLinear"(%36, %39, %38) {
 axis = 1 : si64,
 block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1180 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
 
 %1182 = "onnx.Mul"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
 
@@ -62,9 +277,97 @@ block_size = 0 : si64,
 output_dtype = 0 : si64,
 saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
 
-%1186 = "onnx.DequantizeLinear"(%1184, %37, %38) {
+%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
 axis = 1 : si64,
 block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
 
 return %1186 : tensor<1x1x1x128xf32>
+}
+
+//-----
+//
+// 10) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// Keep Mul and QuantizeLinear present.
+// CHECK-LABEL: func.func @test_removebinary_pattern7
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern7(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+// Per-axis (axis=0) constants (length-2 params stay the same)
+%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
+%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
+%zpMax = onnx.Constant dense<[65535, 65535]> : tensor<2xui16>
+%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
+
+// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
+%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+
+%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+
+// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
+%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+// Mul now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
+%mul = "onnx.Mul"(%x_dq, %c_dq)
+: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+
+// Re-quantize per-axis with the same (length-2) params on axis=0.
+%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
+} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+
+// Final DQ (per-axis, axis=0).
+%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+return %y : tensor<2x1x1x128xf32>
+}
+
+//-----
+//
+// 11) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// Keep Mul and QuantizeLinear present.
+// CHECK-LABEL: func.func @test_removebinary_pattern8
+// CHECK: onnx.Mul
+// CHECK: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern8(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+// Per-axis (axis=0) constants (length-2 params stay the same)
+%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
+%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
+%zpMax = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
+
+// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
+%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+
+%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+
+// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
+%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+// Mul now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
+%mul = "onnx.Mul"(%x_dq, %c_dq)
+: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+
+// Re-quantize per-axis with the same (length-2) params on axis=0.
+%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
+} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+
+// Final DQ (per-axis, axis=0).
+%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+return %y : tensor<2x1x1x128xf32>
 }

--- a/test/mlir/onnx/onnx_remove_mul.mlir
+++ b/test/mlir/onnx/onnx_remove_mul.mlir
@@ -2,372 +2,253 @@
 
 // 1) dq1-dq2(const input)-mul-q-dq. remove->mul,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern1a
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-0.152590215> : tensor<f32>
 // CHECK-NOT: onnx.Mul
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
 func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%39 = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1180 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1182 = "onnx.Mul"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %1186 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
 //-----
 
-// Test fusing a DQ -> Mul -> Q -> DQ pattern.
-// The constant input to the Mul is produced by a chain: Constant -> Identity -> DequantizeLinear.
-// The pass should look through the Identity op, perform the fusion, and remove the redundant Q->DQ chain.
 // 2) dq1-dq2(const input)-mul-q-dq. remove->mul,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern1b
-// CHECK-NOT: onnx.Mul
-// CHECK-NOT: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_input_for_chain = onnx.Constant dense<0> : tensor<ui16>
-
-%intermediate_op = "onnx.Identity"(%const_input_for_chain) : (tensor<ui16>) -> tensor<ui16>
-%const_dq = "onnx.DequantizeLinear"(%intermediate_op, %cst_scale_large, %cst_zp_large) : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%dq_in = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%mul_op = "onnx.Mul"(%dq_in, %const_dq) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%q_out = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%final_dq_out = "onnx.DequantizeLinear"(%q_out, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %final_dq_out : tensor<1x1x1x128xf32>
-}
-
-//-----
-// 3) dq1-const-mul-q-dq. remove->mul,q-dq.
-// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-0.152590215> : tensor<f32>
 // CHECK-NOT: onnx.Mul
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
-func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Mul op now uses the pre-calculated constant.
-%mul_op = "onnx.Mul"(%dq1, %const_neg_10k) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 4) const-dq1-mul-q-dq. remove->mul,q-dq.
+// Test fusing a DQ -> Mul -> Q -> DQ pattern.
+// The constant input to the Mul is produced by a chain: Constant -> Identity -> DequantizeLinear.
+// The pass should look through the Identity op, perform the fusion, and remove the redundant Q->DQ chain.
+// 3) dq1-dq2(const input)-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1c
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1c(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Mul"(%7, %6) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+//-----
+// 4) dq1-dq2(const input)-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1d
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1d(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Mul"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+//-----
+// 5) dq1-const-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-0.00152590219> : tensor<f32>
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+02> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 6) const-dq1-mul-q-dq. remove->mul,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern2b
 // CHECK-NOT: onnx.Mul
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
 func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Mul op now uses the pre-calculated constant.
-%mul_op = "onnx.Mul"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 5) const-dq1-mul-q-dq. kval=0. remove->mul,q-dq.
+// 7) const-dq1-mul-q-dq. kval=0. remove->mul,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern3a
 // CHECK-NOT: onnx.Mul
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
 func.func @test_removebinary_pattern3a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_neg_10k = onnx.Constant dense<0.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Mul op now uses the pre-calculated constant.
-%mul_op = "onnx.Mul"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 6) const-dq1-mul-q-dq. dst_scale=0. remove->mul,q-dq.
+// 8) const-dq1-mul-q-dq. dst_scale=0. remove->mul,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern3b
 // CHECK-NOT: onnx.Mul
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
 func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Mul op now uses the pre-calculated constant.
-%mul_op = "onnx.Mul"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 7) const-dq1-mul-q-dq. q!=dq. remove->only mul
+// 9) const-dq1-mul-q-dq. q!=dq. remove->only mul
 // CHECK-LABEL: func.func @test_removebinary_pattern4
 // CHECK-NOT: onnx.Mul
 // CHECK: onnx.QuantizeLinear
-
 func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Mul op now uses the pre-calculated constant.
-%mul_op = "onnx.Mul"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%mul_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_small, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 8) const-dq1-mul-tanh. remove->none
+// 10) const-dq1-mul-tanh. remove->none
 // CHECK-LABEL: func.func @test_removebinary_pattern5
 // CHECK: onnx.Mul
 // CHECK: onnx.Tanh
-
 func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Mul op now uses the pre-calculated constant.
-%mul_op = "onnx.Mul"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-%tanh = "onnx.Tanh"(%mul_op) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-return %tanh : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Tanh"(%6) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+return %7 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 9) dq1-dq2-sub-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, sub
+// 11) dq1-dq2-sub-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, sub
 // CHECK-LABEL: func.func @test_removebinary_pattern6
 // CHECK-NOT: onnx.Mul
 // CHECK-NOT: onnx.Sub
-
 func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%39 = onnx.Constant dense<0.152590215> : tensor<f32>
-%14 = onnx.Constant dense<39664> : tensor<ui16>
-%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
-
-%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1176 = "onnx.Sub"(%960, %1174) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1182 = "onnx.Mul"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %1186 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<39664> : tensor<ui16>
+%5 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%6 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Add"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%11 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%12 = "onnx.Mul"(%10, %11) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%13 = "onnx.QuantizeLinear"(%12, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%14 = "onnx.DequantizeLinear"(%13, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %14 : tensor<1x1x1x128xf32>
 }
-
 //-----
-//
-// 10) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// 12) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
 // Keep Mul and QuantizeLinear present.
-// CHECK-LABEL: func.func @test_removebinary_pattern7
+// CHECK-LABEL: func.func @test_removebinary_pattern7a
 // CHECK-NOT: onnx.Mul
 // CHECK-NOT: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern7(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
-// Per-axis (axis=0) constants (length-2 params stay the same)
-%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
-%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
-%zpMax = onnx.Constant dense<[65535, 65535]> : tensor<2xui16>
-%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
-
-// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
-%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
-
-%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
-
-// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
-%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-// Mul now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
-%mul = "onnx.Mul"(%x_dq, %c_dq)
-: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
-
-// Re-quantize per-axis with the same (length-2) params on axis=0.
-%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
-} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
-
-// Final DQ (per-axis, axis=0).
-%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-return %y : tensor<2x1x1x128xf32>
+func.func @test_removebinary_pattern7a(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<65535> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Mul"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
 }
-
 //-----
-//
-// 11) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// 13) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
 // Keep Mul and QuantizeLinear present.
-// CHECK-LABEL: func.func @test_removebinary_pattern8
+// CHECK-LABEL: func.func @test_removebinary_pattern7b
 // CHECK: onnx.Mul
 // CHECK: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern8(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
-// Per-axis (axis=0) constants (length-2 params stay the same)
-%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
-%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
-%zpMax = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
-%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
-
-// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
-%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
-
-%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
-
-// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
-%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-// Mul now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
-%mul = "onnx.Mul"(%x_dq, %c_dq)
-: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
-
-// Re-quantize per-axis with the same (length-2) params on axis=0.
-%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
-} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
-
-// Final DQ (per-axis, axis=0).
-%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-return %y : tensor<2x1x1x128xf32>
+func.func @test_removebinary_pattern7b(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Mul"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
 }

--- a/test/mlir/onnx/onnx_remove_sub.mlir
+++ b/test/mlir/onnx/onnx_remove_sub.mlir
@@ -2,370 +2,256 @@
 
 // 1) dq1-dq2(const input)-sub-q-dq. remove->sub,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern1a
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<65535> : tensor<ui16>
 // CHECK-NOT: onnx.Sub
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
 func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%14 = onnx.Constant dense<39664> : tensor<ui16>
-%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
-
-%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1176 = "onnx.Sub"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-return %1180 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Sub"(%6, %5) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %9 : tensor<1x1x1x128xf32>
 }
 
 // -----
-// Test fusing a DQ -> Sub -> Q -> DQ pattern.
-// The constant input to the Sub is produced by a chain: Constant -> Identity -> DequantizeLinear.
-// The pass should look through the Identity op, perform the fusion, and remove the redundant Q->DQ chain.
-// 2) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// 2) dq1-dq2(const input)-sub-q-dq. remove->sub,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern1b
-// CHECK-NOT: onnx.Sub
-// CHECK-NOT: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_input_for_chain = onnx.Constant dense<0> : tensor<ui16>
-
-%intermediate_op = "onnx.Identity"(%const_input_for_chain) : (tensor<ui16>) -> tensor<ui16>
-%const_dq = "onnx.DequantizeLinear"(%intermediate_op, %cst_scale_large, %cst_zp_large) : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%dq_in = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%Sub_op = "onnx.Sub"(%dq_in, %const_dq) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%q_out = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%final_dq_out = "onnx.DequantizeLinear"(%q_out, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %final_dq_out : tensor<1x1x1x128xf32>
-}
-//-----
-// 3) dq1-const-sub-q-dq. remove->sub, q-dq.
-// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<65535> : tensor<ui16>
 // CHECK-NOT: onnx.Sub
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Sub"(%5, %6) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %9 : tensor<1x1x1x128xf32>
+}
 
-func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+// -----
+// 3) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1c
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1c(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Sub"(%7, %6) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
 
-// This DequantizeLinear was folded into a new constant:
-// (0 - 65535) * 0.15259 = -10000.0
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Sub op now uses the pre-calculated constant.
-%Sub_op = "onnx.Sub"(%dq1, %const_neg_10k) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+// -----
+// 4) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1d
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1d(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Sub"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
 }
 
 //-----
-// 4) const-dq1-sub-q-dq. remove->sub,q-dq.
+// 5) dq1-const-add-q-dq. remove->add, q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<102> : tensor<ui16>
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<101> : tensor<ui16>
+%1 = onnx.Constant dense<1.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<1.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Sub"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 6) const-dq1-sub-q-dq. remove->sub,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern2b
 // CHECK-NOT: onnx.Sub
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
 func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Sub op now uses the pre-calculated constant.
-%Sub_op = "onnx.Sub"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Sub"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 5) const-dq1-sub-q-dq. kval=0. remove->sub,q-dq.
+// 7) const-dq1-sub-q-dq. kval=0. remove->sub,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern3a
 // CHECK-NOT: onnx.Sub
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-
 func.func @test_removebinary_pattern3a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_neg_10k = onnx.Constant dense<0.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Sub op now uses the pre-calculated constant.
-%Sub_op = "onnx.Sub"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Sub"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
 //-----
-// 6) const-dq1-Sub-q-dq. dst_scale=0. remove->Sub,q-dq.
+// 8) const-dq1-Sub-q-dq. dst_scale=0. remove->Sub,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern3b
 // CHECK: onnx.Sub
 // CHECK: onnx.QuantizeLinear
-
 func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-// Original constants used in the graph.
-%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
-%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
-%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
-%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
-
-%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
-%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-// The Sub op now uses the pre-calculated constant.
-%Sub_op = "onnx.Sub"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %dq2 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Sub"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
 //-----
-// 7) dq1-dq2(const input)-sub-q-dq. remove->sub,q-dq.
+// 9) dq1-dq2(const input)-sub-q-dq. remove->sub,q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern4
 // CHECK-NOT: onnx.Sub
 // CHECK: onnx.QuantizeLinear
-
 func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%14 = onnx.Constant dense<39664> : tensor<ui16>
-%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
-
-%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1176 = "onnx.Sub"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1180 = "onnx.DequantizeLinear"(%1178, %15, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-return %1180 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Sub"(%5, %6) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %4, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %9 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 8) const-dq1-Sub-tanh. remove->none
+// 10) const-dq1-Sub-tanh. remove->none
 // CHECK-LABEL: func.func @test_removebinary_pattern5
 // CHECK: onnx.Sub
 // CHECK: onnx.Tanh
-
 func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%14 = onnx.Constant dense<39664> : tensor<ui16>
-%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
-
-%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1176 = "onnx.Sub"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-%tanh = "onnx.Tanh"(%1176) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-return %tanh : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Sub"(%5, %6) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Tanh"(%7) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
 }
-
 //-----
-// 9) dq1-dq2-sub-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, sub
+// 11) dq1-dq2-sub-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, sub
 // CHECK-LABEL: func.func @test_removebinary_pattern6
 // CHECK-NOT: onnx.Sub
 // CHECK-NOT: onnx.Sub
-
 func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
-%36 = onnx.Constant dense<0> : tensor<ui16>
-%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
-%38 = onnx.Constant dense<65535> : tensor<ui16>
-%39 = onnx.Constant dense<0.152590215> : tensor<f32>
-%14 = onnx.Constant dense<39664> : tensor<ui16>
-%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
-
-%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%1176 = "onnx.Sub"(%960, %1174) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
-
-%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
-
-%1182 = "onnx.Sub"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
-
-%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64,
-output_dtype = 0 : si64,
-saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
-
-%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
-axis = 1 : si64,
-block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-
-return %1186 : tensor<1x1x1x128xf32>
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<39664> : tensor<ui16>
+%5 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%6 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Mul"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%11 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%12 = "onnx.Sub"(%10, %11) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%13 = "onnx.QuantizeLinear"(%12, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%14 = "onnx.DequantizeLinear"(%13, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %14 : tensor<1x1x1x128xf32>
 }
 //-----
-//
-// 10) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// 12) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
 // vectors wiht same values -> fusion
-// CHECK-LABEL: func.func @test_removebinary_pattern7
+// CHECK-LABEL: func.func @test_removebinary_pattern7a
 // CHECK-NOT: onnx.Sub
 // CHECK-NOT: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern7(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
-// Per-axis (axis=0) constants (length-2 params stay the same)
-%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
-%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
-%zpMax = onnx.Constant dense<[65535, 65535]> : tensor<2xui16>
-%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
-
-// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
-%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
-
-%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
-
-// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
-%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-// Sub now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
-%mul = "onnx.Sub"(%x_dq, %c_dq)
-: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
-
-// Re-quantize per-axis with the same (length-2) params on axis=0.
-%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
-} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
-
-// Final DQ (per-axis, axis=0).
-%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-return %y : tensor<2x1x1x128xf32>
+func.func @test_removebinary_pattern7a(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<65535> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Sub"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
 }
 //-----
 //
-// 11) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// 13) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
 // vectors wiht different values -> no fusion
-// CHECK-LABEL: func.func @test_removebinary_pattern8
+// CHECK-LABEL: func.func @test_removebinary_pattern7b
 // CHECK: onnx.Sub
 // CHECK: onnx.QuantizeLinear
-
-func.func @test_removebinary_pattern8(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
-// Per-axis (axis=0) constants (length-2 params stay the same)
-%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
-%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
-%zpMax = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
-%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
-
-// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
-%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
-
-%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
-
-// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
-%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-// Sub now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
-%mul = "onnx.Sub"(%x_dq, %c_dq)
-: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
-
-// Re-quantize per-axis with the same (length-2) params on axis=0.
-%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
-} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
-
-// Final DQ (per-axis, axis=0).
-%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
-axis = 0 : si64, block_size = 0 : si64
-} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
-
-return %y : tensor<2x1x1x128xf32>
+func.func @test_removebinary_pattern7b(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Sub"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
 }

--- a/test/mlir/onnx/onnx_remove_sub.mlir
+++ b/test/mlir/onnx/onnx_remove_sub.mlir
@@ -1,11 +1,12 @@
 // RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s --split-input-file | FileCheck %s
 
-// CHECK-LABEL: func.func @test_removebinary_pattern1
+// 1) dq1-dq2(const input)-sub-q-dq. remove->sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1a
 // CHECK-NOT: onnx.Sub
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-func.func @test_removebinary_pattern1(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
 %36 = onnx.Constant dense<0> : tensor<ui16>
 %37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
 %38 = onnx.Constant dense<65535> : tensor<ui16>
@@ -20,7 +21,7 @@ block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32
 axis = 1 : si64,
 block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
 
-%1176 = "onnx.Sub"(%960, %1174) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%1176 = "onnx.Sub"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
 
 %1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
 axis = 1 : si64,
@@ -35,16 +36,212 @@ return %1180 : tensor<1x1x1x128xf32>
 }
 
 // -----
+// Test fusing a DQ -> Sub -> Q -> DQ pattern.
+// The constant input to the Sub is produced by a chain: Constant -> Identity -> DequantizeLinear.
+// The pass should look through the Identity op, perform the fusion, and remove the redundant Q->DQ chain.
+// 2) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1b
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
 
-// CHECK-LABEL: func.func @test_removebinary_pattern2
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_input_for_chain = onnx.Constant dense<0> : tensor<ui16>
+
+%intermediate_op = "onnx.Identity"(%const_input_for_chain) : (tensor<ui16>) -> tensor<ui16>
+%const_dq = "onnx.DequantizeLinear"(%intermediate_op, %cst_scale_large, %cst_zp_large) : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%dq_in = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%Sub_op = "onnx.Sub"(%dq_in, %const_dq) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%q_out = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%final_dq_out = "onnx.DequantizeLinear"(%q_out, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %final_dq_out : tensor<1x1x1x128xf32>
+}
+//-----
+// 3) dq1-const-sub-q-dq. remove->sub, q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
 // CHECK-NOT: onnx.Sub
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return
 // CHECK-NOT: onnx.DequantizeLinear
-func.func @test_removebinary_pattern2(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+// This DequantizeLinear was folded into a new constant:
+// (0 - 65535) * 0.15259 = -10000.0
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Sub op now uses the pre-calculated constant.
+%Sub_op = "onnx.Sub"(%dq1, %const_neg_10k) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 4) const-dq1-sub-q-dq. remove->sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2b
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+
+func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Sub op now uses the pre-calculated constant.
+%Sub_op = "onnx.Sub"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 5) const-dq1-sub-q-dq. kval=0. remove->sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3a
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+
+func.func @test_removebinary_pattern3a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_neg_10k = onnx.Constant dense<0.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Sub op now uses the pre-calculated constant.
+%Sub_op = "onnx.Sub"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+//-----
+// 6) const-dq1-Sub-q-dq. dst_scale=0. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3b
+// CHECK: onnx.Sub
+// CHECK: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+// Original constants used in the graph.
+%cst_zp_zero = onnx.Constant dense<0> : tensor<ui16>
+%cst_scale_small = onnx.Constant dense<0.0> : tensor<f32>
+%cst_zp_large = onnx.Constant dense<65535> : tensor<ui16>
+%cst_scale_large = onnx.Constant dense<0.152590215> : tensor<f32>
+
+%const_neg_10k = onnx.Constant dense<-10000.0> : tensor<f32>
+%dq1 = "onnx.DequantizeLinear"(%arg0, %cst_scale_small, %cst_zp_zero) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+// The Sub op now uses the pre-calculated constant.
+%Sub_op = "onnx.Sub"(%const_neg_10k,%dq1) : (tensor<f32>,tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%q2 = "onnx.QuantizeLinear"(%Sub_op, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%dq2 = "onnx.DequantizeLinear"(%q2, %cst_scale_large, %cst_zp_large) : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %dq2 : tensor<1x1x1x128xf32>
+}
+//-----
+// 7) dq1-dq2(const input)-sub-q-dq. remove->sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern4
+// CHECK-NOT: onnx.Sub
+// CHECK: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
 %36 = onnx.Constant dense<0> : tensor<ui16>
 %37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
 %38 = onnx.Constant dense<65535> : tensor<ui16>
+%14 = onnx.Constant dense<39664> : tensor<ui16>
+%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+
+%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1176 = "onnx.Sub"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1180 = "onnx.DequantizeLinear"(%1178, %15, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %1180 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 8) const-dq1-Sub-tanh. remove->none
+// CHECK-LABEL: func.func @test_removebinary_pattern5
+// CHECK: onnx.Sub
+// CHECK: onnx.Tanh
+
+func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%14 = onnx.Constant dense<39664> : tensor<ui16>
+%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+
+%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1176 = "onnx.Sub"(%960, %1174) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%tanh = "onnx.Tanh"(%1176) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+return %tanh : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 9) dq1-dq2-sub-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, sub
+// CHECK-LABEL: func.func @test_removebinary_pattern6
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.Sub
+
+func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%39 = onnx.Constant dense<0.152590215> : tensor<f32>
 %14 = onnx.Constant dense<39664> : tensor<ui16>
 %15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
 
@@ -67,5 +264,108 @@ saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> ten
 %1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
 axis = 1 : si64,
 block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
-return %1180 : tensor<1x1x1x128xf32>
+
+%961 = "onnx.DequantizeLinear"(%36, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1182 = "onnx.Sub"(%1180, %961) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+
+%1184 = "onnx.QuantizeLinear"(%1182, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1186 = "onnx.DequantizeLinear"(%1184, %39, %38) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+return %1186 : tensor<1x1x1x128xf32>
+}
+//-----
+//
+// 10) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// vectors wiht same values -> fusion
+// CHECK-LABEL: func.func @test_removebinary_pattern7
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern7(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+// Per-axis (axis=0) constants (length-2 params stay the same)
+%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
+%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
+%zpMax = onnx.Constant dense<[65535, 65535]> : tensor<2xui16>
+%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
+
+// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
+%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+
+%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+
+// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
+%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+// Sub now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
+%mul = "onnx.Sub"(%x_dq, %c_dq)
+: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+
+// Re-quantize per-axis with the same (length-2) params on axis=0.
+%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
+} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+
+// Final DQ (per-axis, axis=0).
+%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+return %y : tensor<2x1x1x128xf32>
+}
+//-----
+//
+// 11) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// vectors wiht different values -> no fusion
+// CHECK-LABEL: func.func @test_removebinary_pattern8
+// CHECK: onnx.Sub
+// CHECK: onnx.QuantizeLinear
+
+func.func @test_removebinary_pattern8(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+// Per-axis (axis=0) constants (length-2 params stay the same)
+%zp = onnx.Constant dense<[0, 0]> : tensor<2xui16>
+%scale = onnx.Constant dense<[1.52590219E-5, 1.52590219E-5]> : tensor<2xf32>
+%zpMax = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%k = onnx.Constant dense<[0.152590215, 0.152590215]> : tensor<2xf32>
+
+// Constant-side x: shape 2x1x1x1 (use a splat to avoid bracket hell)
+%cx = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+
+%c_dq = "onnx.DequantizeLinear"(%cx, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+
+// Activation-side DQ (per-axis, axis=0) → 2x1x1x128xf32
+%x_dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+// Sub now broadcasts (2x1x1x1) over (2x1x1x128) → (2x1x1x128)
+%mul = "onnx.Sub"(%x_dq, %c_dq)
+: (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+
+// Re-quantize per-axis with the same (length-2) params on axis=0.
+%q = "onnx.QuantizeLinear"(%mul, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64
+} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+
+// Final DQ (per-axis, axis=0).
+%y = "onnx.DequantizeLinear"(%q, %k, %zpMax) {
+axis = 0 : si64, block_size = 0 : si64
+} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+
+return %y : tensor<2x1x1x128xf32>
 }

--- a/test/mlir/onnx/onnx_remove_sub.mlir
+++ b/test/mlir/onnx/onnx_remove_sub.mlir
@@ -1,0 +1,71 @@
+// RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func.func @test_removebinary_pattern1
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%14 = onnx.Constant dense<39664> : tensor<ui16>
+%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+
+%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1176 = "onnx.Sub"(%960, %1174) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %1180 : tensor<1x1x1x128xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_removebinary_pattern2
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%36 = onnx.Constant dense<0> : tensor<ui16>
+%37 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%38 = onnx.Constant dense<65535> : tensor<ui16>
+%14 = onnx.Constant dense<39664> : tensor<ui16>
+%15 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+
+%960 = "onnx.DequantizeLinear"(%38, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+
+%1174 = "onnx.DequantizeLinear"(%arg0, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+
+%1176 = "onnx.Sub"(%960, %1174) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+
+%1178 = "onnx.QuantizeLinear"(%1176, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64,
+output_dtype = 0 : si64,
+saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+
+%1180 = "onnx.DequantizeLinear"(%1178, %37, %36) {
+axis = 1 : si64,
+block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %1180 : tensor<1x1x1x128xf32>
+}


### PR DESCRIPTION
 **REMOVE_BINARY summary:**
 
 This RemoveBinary class is a pattern-matching and rewrite utility that finds and removes binary ops (Add, Sub, Mul, Div) in quantized ONNX graphs when one input is effectively a constant. It folds the constant into the quantization parameters instead of keeping an explicit binary op in the graph.
 
 This class rewrites patterns like:
 
     Dequant(x) ----\
                                 Binary(Add/Sub/Mul/Div) → Quant → Dequant
    Dequant(const)-/
    
    into something like
    
      Dequant'(x, new_scale/zp) → Quant → Dequant
      
      Where the constant is folded into scale or zero-point. 
      
      Then, a check is performed to see if we can possibly remove the Quant → Dequant chain.
