### PR TITLE
Separate OnnxToMlirPasses from CompilerPasses

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -74,11 +74,44 @@ add_onnx_mlir_library(OMCompilerDialects
   MLIRIR
   MLIROpenMPToLLVMIRTranslation
   ${dialect_libs}
-  )
+)
+
+add_onnx_mlir_library(OMDisposableGarbageCollector
+ DisposableGarbageCollector.cpp
+
+  EXCLUDE_FROM_OM_LIBS
+
+  INCLUDE_DIRS PRIVATE
+  ${FILE_GENERATE_DIR}
+
+  INCLUDE_DIRS PUBLIC
+  ${ONNX_MLIR_SRC_ROOT}/include
+
+  LINK_LIBS PUBLIC
+  OMONNXOps
+)
+
+add_onnx_mlir_library(OMOnnxToMlirPasses
+  OnnxToMlirPasses.cpp
+  
+  EXCLUDE_FROM_OM_LIBS
+
+  INCLUDE_DIRS PRIVATE
+  ${FILE_GENERATE_DIR}
+
+  INCLUDE_DIRS PUBLIC
+  ${ONNX_MLIR_SRC_ROOT}/include
+
+  LINK_LIBS PUBLIC
+  OMHybridTransform
+  OMONNXStandardFuncReturnPass
+  OMONNXSimplifyShapeRelatedOps
+  OMDisposableGarbageCollector
+  MLIRFuncDialect
+)
 
 add_onnx_mlir_library(OMCompilerPasses
   CompilerPasses.cpp
-  DisposableGarbageCollector.cpp
 
   EXCLUDE_FROM_OM_LIBS
 
@@ -90,6 +123,7 @@ add_onnx_mlir_library(OMCompilerPasses
 
   LINK_LIBS PUBLIC
   ${OMLibs}
+  OMOnnxToMlirPasses
   OMCompilerOptions
   MLIRAffineTransforms
   MLIRBufferizationPipelines

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -102,7 +102,7 @@ add_onnx_mlir_library(OMOnnxToMlirPasses
   INCLUDE_DIRS PUBLIC
   ${ONNX_MLIR_SRC_ROOT}/include
 
-  LINK_LIBS PUBLIC
+  LINK_LIBS PRIVATE
   OMHybridTransform
   OMONNXStandardFuncReturnPass
   OMONNXSimplifyShapeRelatedOps

--- a/src/Compiler/CompilerOptionEnums.hpp
+++ b/src/Compiler/CompilerOptionEnums.hpp
@@ -1,0 +1,19 @@
+#ifndef ONNX_MLIR_COMPILER_OPTION_ENUMS_H
+#define ONNX_MLIR_COMPILER_OPTION_ENUMS_H
+
+#include "src/Accelerators/Accelerator.hpp"
+
+namespace onnx_mlir {
+
+typedef enum {
+  // clang-format off
+  None,
+  Onnx
+  APPLY_TO_ACCELERATORS(ACCEL_INSTRUMENTSTAGE_ENUM)
+  // clang-format on
+} InstrumentStages;
+
+using ProfileIRs = InstrumentStages;
+} // namespace onnx_mlir
+
+#endif // ONNX_MLIR_COMPILER_OPTION_ENUMS_H

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -16,6 +16,7 @@
 #define ONNX_MLIR_COMPILER_OPTIONS_H
 
 #include "src/Accelerators/Accelerator.hpp"
+#include "src/Compiler/CompilerOptionEnums.hpp"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
@@ -33,16 +34,6 @@
 extern const std::string OnnxMlirEnvOptionName;
 
 namespace onnx_mlir {
-
-typedef enum {
-  // clang-format off
-  None,
-  Onnx
-  APPLY_TO_ACCELERATORS(ACCEL_INSTRUMENTSTAGE_ENUM)
-  // clang-format on
-} InstrumentStages;
-
-using ProfileIRs = InstrumentStages;
 
 typedef enum {
   // clang-format off

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -33,7 +33,7 @@
 
 #include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerPasses.hpp"
-#include "src/Compiler/DisposableGarbageCollector.hpp"
+#include "src/Compiler/OnnxToMlirPasses.hpp"
 #include "src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.hpp"
 #include "src/Dialect/Mlir/VectorMachineSupport.hpp"
 #include "src/Dialect/ONNX/ONNXDialect.hpp"
@@ -64,137 +64,6 @@ void configurePasses() {
   configureOnnxToKrnlLoweringPass(optReport == OptReport::Parallel,
       enableParallel, parallelizeOps, optReport == OptReport::Simd,
       !disableSimdOption);
-}
-
-void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
-    bool donotScrubDisposableElementsAttr, OnnxToMlirOptions opts) {
-  // This is a transition from previous static passes to full dynamic passes
-  // Static passes are kept and the dynamic pass is added as IF-THEN
-  // with the static iteration.
-  // The reasons are
-  // 1. The debug flag, --print-ir-after/befor-all, can display IR for each
-  //    static pass, but the dynamic pipeline will be viewed as one. MLIR
-  //    may have solution that I am not aware of yet.
-  // 2. Easy to compare two approaches.
-  // In future, only the dynamic pass, ONNXOpTransformPass, will be used for
-  // this function.
-
-  if (!donotScrubDisposableElementsAttr)
-    pm.addInstrumentation(
-        std::make_unique<DisposableGarbageCollector>(pm.getContext()));
-
-  // Decompose first. Eliminates some unsupported ops without shape inference.
-  pm.addNestedPass<func::FuncOp>(onnx_mlir::createDecomposeONNXToONNXPass(
-      /*target=*/"", opts.enableConvTransposeDecompose,
-      opts.enableConvTransposeDecomposeToPhasedConv,
-      opts.enableConvTranspose1dDecomposeToPhasedConv));
-  if (!disableRecomposeOption)
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass());
-  if (enableONNXHybridPass) {
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
-        !disableRecomposeOption, opts.enableQuarkQuantizedLegalization,
-        opts.enableConvTransposeDecompose,
-        opts.enableConvTransposeDecomposeToPhasedConv,
-        opts.enableConvTranspose1dDecomposeToPhasedConv));
-    // Convolution Optimization for CPU: enable when there are no accelerators.
-    if (targetCPU && enableConvOptPass) {
-      pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
-          enableSimdDataLayout && !disableSimdOption));
-      pm.addNestedPass<func::FuncOp>(
-          onnx_mlir::createONNXHybridTransformPass(!disableRecomposeOption,
-              /*enableQuarkQuantizedOpsLegalization=*/false,
-              opts.enableConvTransposeDecompose,
-              opts.enableConvTransposeDecomposeToPhasedConv,
-              opts.enableConvTranspose1dDecomposeToPhasedConv));
-    }
-  } else {
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
-    pm.addPass(mlir::createCanonicalizerPass());
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
-    // Convolution Optimization for CPU: enable when there are no accelerators.
-    if (targetCPU && enableConvOptPass) {
-      pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
-          enableSimdDataLayout && !disableSimdOption));
-      pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
-    }
-    pm.addNestedPass<func::FuncOp>(
-        onnx_mlir::createLegalizeQuarkQuantizedOpsPass());
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
-    if (onnxOpTransformThreshold > 0) {
-      // Dynamic iterate in ONNXOpTransformPass
-      pm.addPass(onnx_mlir::createONNXOpTransformPass(onnxOpTransformThreshold,
-          onnxOpTransformReport, targetCPU,
-          enableSimdDataLayout && !disableSimdOption, enableConvOptPass,
-          !disableRecomposeOption));
-    } else {
-      // Statically add extra passes
-      for (int i = 0; i < repeatOnnxTransform; i++) {
-        pm.addPass(mlir::createCanonicalizerPass());
-        pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
-        pm.addNestedPass<func::FuncOp>(
-            onnx_mlir::createConstPropONNXToONNXPass());
-      }
-    }
-  }
-
-  // Simplify shape-related ops.
-  pm.addPass(onnx_mlir::createSimplifyShapeRelatedOpsPass(
-      opts.enableQuarkQuantizedLegalization));
-
-  // Passes for removing redundant concat, slice and cast QDQ Ops
-  if (opts.enableRemoveDqQOp)
-    pm.addPass(createQDQOptONNXToONNXPass());
-
-  // One more call to ONNX shape inference/canonicalization/... to update
-  // shape if possible.
-  if (enableONNXHybridPass) {
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
-        !disableRecomposeOption, opts.enableQuarkQuantizedLegalization,
-        opts.enableConvTransposeDecompose,
-        opts.enableConvTransposeDecomposeToPhasedConv,
-        opts.enableConvTranspose1dDecomposeToPhasedConv));
-  } else {
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
-    pm.addPass(mlir::createCanonicalizerPass());
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
-  }
-
-  // Replace ONNXReturnOp with func::ReturnOp.
-  pm.addPass(onnx_mlir::createStandardFuncReturnPass());
-
-  // Clean dead code.
-  pm.addPass(mlir::createSymbolDCEPass());
-
-  // Replace every DisposableElementsAttr with DenseElementsAttr.
-  if (!donotScrubDisposableElementsAttr)
-    pm.addPass(createScrubDisposablePass());
-
-  // Set onnx_node_name if it is missing. Keep this pass at the end of this
-  // function and just before instrumentation.
-  pm.addPass(createSetONNXNodeNamePass());
-
-  // Add instrumentation for Onnx Ops
-  // Keep this pass at the end of this function.
-  unsigned instrumentActions = instrumentControlBits;
-  if (profileIR == onnx_mlir::ProfileIRs::Onnx) {
-    instrumentStage = onnx_mlir::InstrumentStages::Onnx;
-    instrumentOps = "onnx.*";
-    // Enable the first three bits for InstrumentBeforOp, InstrumentAfterOp
-    // and InstrumentReportTime. Disable the last bit for
-    // InstrumentReportMemory because of its big overhead. Users can
-    // optionally enable the last bit by using
-    // --InstrumentReportMemory option.
-    instrumentActions |= (1 << 3) - 1;
-  }
-  if (instrumentStage == onnx_mlir::InstrumentStages::Onnx)
-    pm.addNestedPass<func::FuncOp>(
-        onnx_mlir::createInstrumentPass(instrumentOps, instrumentActions));
-  // Print Signatures of each op at runtime if enabled. Should not run
-  // signature and instrument passes at the same time as time may include printf
-  // overheads.
-  if (instrumentSignatures != "NONE" || instrumentOnnxNode != "NONE")
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createInstrumentONNXSignaturePass(
-        instrumentSignatures, instrumentOnnxNode));
 }
 
 void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
@@ -359,6 +228,21 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
         enableConvTransposeDecomposeToPhasedConv;
     opts.enableConvTranspose1dDecomposeToPhasedConv =
         enableConvTranspose1dDecomposeToPhasedConv;
+    opts.disableRecomposeOption = disableRecomposeOption;
+    opts.enableONNXHybridPass = enableONNXHybridPass;
+    opts.enableConvOptPass = enableConvOptPass;
+    opts.enableSimdDataLayout = enableSimdDataLayout;
+    opts.disableSimdOption = disableSimdOption;
+    opts.onnxOpTransformThreshold = onnxOpTransformThreshold;
+    opts.onnxOpTransformReport = onnxOpTransformReport;
+    opts.repeatOnnxTransform = repeatOnnxTransform;
+    opts.instrumentControlBits = instrumentControlBits;
+    opts.instrumentOps = instrumentOps;
+    opts.instrumentSignatures = instrumentSignatures;
+    opts.instrumentOnnxNode = instrumentOnnxNode;
+    opts.profileIR = profileIR;
+    opts.instrumentStage = instrumentStage;
+
     addONNXToMLIRPasses(pm, /*target CPU*/ false,
         /*donotScrubDisposableElementsAttr=*/false, opts);
   }

--- a/src/Compiler/CompilerPasses.hpp
+++ b/src/Compiler/CompilerPasses.hpp
@@ -25,16 +25,6 @@ namespace onnx_mlir {
 // Configures passes up front based on command line options.
 void configurePasses();
 
-struct OnnxToMlirOptions {
-  bool enableQuarkQuantizedLegalization = false;
-  bool enableConvTransposeDecompose = false;
-  bool enableConvTransposeDecomposeToPhasedConv = false;
-  bool enableConvTranspose1dDecomposeToPhasedConv = false;
-  bool enableRemoveDqQOp = true;
-};
-
-void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
-    bool donotScrubDisposableElementsAttr = false, OnnxToMlirOptions opts = {});
 void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
     std::string ONNXOpsStatFilename);
 void addKrnlToAffinePasses(mlir::PassManager &pm);

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -1,0 +1,135 @@
+#include "OnnxToMlirPasses.hpp"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+#include "src/Compiler/DisposableGarbageCollector.hpp"
+#include "src/Pass/Passes.hpp"
+
+using namespace mlir;
+namespace onnx_mlir {
+
+void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
+    bool donotScrubDisposableElementsAttr, OnnxToMlirOptions opts) {
+  // This is a transition from previous static passes to full dynamic passes
+  // Static passes are kept and the dynamic pass is added as IF-THEN
+  // with the static iteration.
+  // The reasons are
+  // 1. The debug flag, --print-ir-after/befor-all, can display IR for each
+  //    static pass, but the dynamic pipeline will be viewed as one. MLIR
+  //    may have solution that I am not aware of yet.
+  // 2. Easy to compare two approaches.
+  // In future, only the dynamic pass, ONNXOpTransformPass, will be used for
+  // this function.
+
+  if (!donotScrubDisposableElementsAttr)
+    pm.addInstrumentation(
+        std::make_unique<DisposableGarbageCollector>(pm.getContext()));
+
+  // Decompose first. Eliminates some unsupported ops without shape inference.
+  pm.addNestedPass<func::FuncOp>(onnx_mlir::createDecomposeONNXToONNXPass(
+      /*target=*/"", opts.enableConvTransposeDecompose,
+      opts.enableConvTransposeDecomposeToPhasedConv,
+      opts.enableConvTranspose1dDecomposeToPhasedConv));
+  if (!opts.disableRecomposeOption)
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass());
+  if (opts.enableONNXHybridPass) {
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
+        !opts.disableRecomposeOption, opts.enableQuarkQuantizedLegalization,
+        opts.enableConvTransposeDecompose,
+        opts.enableConvTransposeDecomposeToPhasedConv,
+        opts.enableConvTranspose1dDecomposeToPhasedConv));
+    // Convolution Optimization for CPU: enable when there are no accelerators.
+    if (targetCPU && opts.enableConvOptPass) {
+      pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
+          opts.enableSimdDataLayout && !opts.disableSimdOption));
+      pm.addNestedPass<func::FuncOp>(
+          onnx_mlir::createONNXHybridTransformPass(!opts.disableRecomposeOption,
+              /*enableQuarkQuantizedOpsLegalization=*/false,
+              opts.enableConvTransposeDecompose,
+              opts.enableConvTransposeDecomposeToPhasedConv,
+              opts.enableConvTranspose1dDecomposeToPhasedConv));
+    }
+  } else {
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
+    // Convolution Optimization for CPU: enable when there are no accelerators.
+    if (targetCPU && opts.enableConvOptPass) {
+      pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
+          opts.enableSimdDataLayout && !opts.disableSimdOption));
+      pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
+    }
+    pm.addNestedPass<func::FuncOp>(
+        onnx_mlir::createLegalizeQuarkQuantizedOpsPass());
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
+    if (opts.onnxOpTransformThreshold > 0) {
+      // Dynamic iterate in ONNXOpTransformPass
+      pm.addPass(onnx_mlir::createONNXOpTransformPass(
+          opts.onnxOpTransformThreshold, opts.onnxOpTransformReport, targetCPU,
+          opts.enableSimdDataLayout && !opts.disableSimdOption,
+          opts.enableConvOptPass, !opts.disableRecomposeOption));
+    } else {
+      // Statically add extra passes
+      for (int i = 0; i < opts.repeatOnnxTransform; i++) {
+        pm.addPass(mlir::createCanonicalizerPass());
+        pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
+        pm.addNestedPass<func::FuncOp>(
+            onnx_mlir::createConstPropONNXToONNXPass());
+      }
+    }
+  }
+
+  // Simplify shape-related ops.
+  pm.addPass(onnx_mlir::createSimplifyShapeRelatedOpsPass(
+      opts.enableQuarkQuantizedLegalization));
+
+  // Passes for removing redundant concat, slice and cast QDQ Ops
+  if (opts.enableRemoveDqQOp)
+    pm.addPass(createQDQOptONNXToONNXPass());
+
+  // One more call to ONNX shape inference/canonicalization/... to update
+  // shape if possible.
+  if (opts.enableONNXHybridPass) {
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
+        !opts.disableRecomposeOption, opts.enableQuarkQuantizedLegalization,
+        opts.enableConvTransposeDecompose,
+        opts.enableConvTransposeDecomposeToPhasedConv,
+        opts.enableConvTranspose1dDecomposeToPhasedConv));
+  } else {
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
+  }
+
+  // Replace ONNXReturnOp with func::ReturnOp.
+  pm.addPass(onnx_mlir::createStandardFuncReturnPass());
+
+  // Clean dead code.
+  pm.addPass(mlir::createSymbolDCEPass());
+
+  // Replace every DisposableElementsAttr with DenseElementsAttr.
+  if (!donotScrubDisposableElementsAttr)
+    pm.addPass(createScrubDisposablePass());
+
+  // Set onnx_node_name if it is missing. Keep this pass at the end of this
+  // function and just before instrumentation.
+  pm.addPass(createSetONNXNodeNamePass());
+
+  // Add instrumentation for Onnx Ops
+  // Keep this pass at the end of this function.
+  unsigned instrumentActions = opts.instrumentControlBits;
+  if (opts.profileIR == onnx_mlir::ProfileIRs::Onnx) {
+    opts.instrumentStage = onnx_mlir::InstrumentStages::Onnx;
+    opts.instrumentOps = "onnx.*";
+    instrumentActions |= (1 << 3) - 1;
+  }
+  if (opts.instrumentStage == onnx_mlir::InstrumentStages::Onnx)
+    pm.addNestedPass<func::FuncOp>(
+        onnx_mlir::createInstrumentPass(opts.instrumentOps, instrumentActions));
+  if (opts.instrumentSignatures != "NONE" || opts.instrumentOnnxNode != "NONE")
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createInstrumentONNXSignaturePass(
+        opts.instrumentSignatures, opts.instrumentOnnxNode));
+}
+
+} // namespace onnx_mlir

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -1,0 +1,41 @@
+#ifndef ONNX_MLIR_ONNX_TO_MLIR_PASSES_H
+#define ONNX_MLIR_ONNX_TO_MLIR_PASSES_H
+
+#include "src/Compiler/CompilerOptionEnums.hpp"
+#include <string>
+
+namespace mlir {
+class ModuleOp;
+class PassManager;
+} // namespace mlir
+
+namespace onnx_mlir {
+
+struct OnnxToMlirOptions {
+  bool enableQuarkQuantizedLegalization = false;
+  bool enableConvTransposeDecompose = false;
+  bool enableConvTransposeDecomposeToPhasedConv = false;
+  bool enableConvTranspose1dDecomposeToPhasedConv = false;
+  bool enableRemoveDqQOp = true;
+
+  bool disableRecomposeOption = false;
+  bool enableONNXHybridPass = true;
+  bool enableConvOptPass = true;
+  bool enableSimdDataLayout = false;
+  bool disableSimdOption = false;
+  int onnxOpTransformThreshold = 3;
+  bool onnxOpTransformReport = false;
+  int repeatOnnxTransform = 0;
+  unsigned instrumentControlBits = 0;
+  std::string instrumentOps;
+  std::string instrumentSignatures = "NONE";
+  std::string instrumentOnnxNode = "NONE";
+  ProfileIRs profileIR = ProfileIRs::None;
+  InstrumentStages instrumentStage = InstrumentStages::Onnx;
+};
+
+void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
+    bool donotScrubDisposableElementsAttr = false, OnnxToMlirOptions opts = {});
+} // namespace onnx_mlir
+
+#endif


### PR DESCRIPTION
To reduce dependencies.
This also splits out CompilerOptionEnums.hpp from CompilerOptions.hpp and DisposableGarbageCollector.cpp from OMCompilerPasses as those are needed by the new OMOnnxToMlirPasses library.