### PR TITLE
remove_qdq_binary

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -84,6 +84,10 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   pm.addPass(onnx_mlir::createSimplifyShapeRelatedOpsPass(
       opts.enableQuarkQuantizedLegalization));
 
+  // Pass for removing binary ops if one of the inputs is fed by a Constant
+  if (opts.enableRemoveBinary)
+    pm.addPass(createFoldDQBinaryQPass());
+
   // Pass for removing Dq and Q around data movement in Dq->op->Q Ops chain
   if (opts.enableRemoveDqQAroundOp)
     pm.addPass(createQDQAroundOpOptONNXToONNXPass());

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -18,7 +18,7 @@ struct OnnxToMlirOptions {
   bool enableConvTranspose1dDecomposeToPhasedConv = false;
   bool enableRemoveDqQOp = true;
   bool enableRemoveDqQAroundOp = true;
-  bool enableRemoveBinary = true;
+  bool enableRemoveBinary = false;
 
   bool disableRecomposeOption = false;
   bool enableONNXHybridPass = true;

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -18,6 +18,7 @@ struct OnnxToMlirOptions {
   bool enableConvTranspose1dDecomposeToPhasedConv = false;
   bool enableRemoveDqQOp = true;
   bool enableRemoveDqQAroundOp = true;
+  bool enableRemoveBinary = true;
 
   bool disableRecomposeOption = false;
   bool enableONNXHybridPass = true;

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -43,7 +43,8 @@ add_onnx_mlir_library(OMInstrumentONNX
 add_onnx_mlir_library(OMONNXRewrite
   ConstProp.cpp
   QDQAroundOpOpt.cpp    
-  QDQOpt.cpp    
+  QDQOpt.cpp
+  DQBinaryQOpt.cpp  
   ConvOpt.cpp
   Decompose.cpp
   DecomposeEinsum.cpp

--- a/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
@@ -437,7 +437,6 @@ private:
     return success();
   }
 
-  template <typename BinOp>
   static bool compute_new_scale_and_zp_values(MatchState &state) {
     double newScale = state.dstScale;
     double newZpFloat = static_cast<double>(state.dstZeroPoint);
@@ -514,7 +513,7 @@ public:
     }
 
     // STEP 4 -Modify
-    if (!compute_new_scale_and_zp_values<BinOp>(state)) {
+    if (!compute_new_scale_and_zp_values(state)) {
       return failure();
     }
 

--- a/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
@@ -18,7 +18,7 @@
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 #include "src/Pass/Passes.hpp"
 #include "llvm/ADT/STLExtras.h"
-#include <cmath> // For std::llround
+#include <cmath>
 #include <optional>
 #include <variant>
 
@@ -93,8 +93,7 @@ std::optional<T> getScalarTensorValue(ONNXConstantOp constOp) {
         return static_cast<T>(*flattenedInt.begin());
     }
   }
-
-  return std::nullopt; // mismatch or more than one unique value
+  return std::nullopt;
 }
 
 template <typename T>
@@ -151,7 +150,6 @@ static mlir::DenseElementsAttr makeScalarDEA(
         isSigned ? ((int64_t(1) << (bw - 1)) - 1) : ((int64_t(1) << bw) - 1);
     iv = std::min<int64_t>(std::max<int64_t>(iv, minV), maxV);
 
-    // Now re-materialize as the *output* ET (which may differ in width/sign).
     // This guarantees the result type matches `likeTy`.
     if (auto outSigned = outIT.isSigned()) {
       // For signed out type, encode iv as signed.
@@ -459,7 +457,6 @@ private:
       return false;
     }
 
-    // The rounding and state update logic remains the same.
     int64_t newZp = (newZpFloat >= 0.0) ? (int64_t)std::floor(newZpFloat)
                                         : (int64_t)std::ceil(newZpFloat);
     state.newScale = newScale;

--- a/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
@@ -1,0 +1,573 @@
+//===- foldDqBinaryQPattern.cpp - Remove DQ-Binary-Q chains -----*- C++ -*-===//
+//
+// (c) Copyright 2022 - 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
+#include "src/Pass/Passes.hpp"
+#include "llvm/ADT/STLExtras.h"
+#include <cmath> // For std::llround
+#include <optional>
+#include <variant>
+
+using namespace mlir;
+using namespace onnx_mlir;
+
+namespace {
+
+static ElementsAttr getElementAttributeFromConstant(Value val) {
+  if (!val)
+    return nullptr;
+  if (auto constOp = val.getDefiningOp<ONNXConstantOp>())
+    return mlir::dyn_cast<ElementsAttr>(constOp.getValueAttr());
+  return nullptr;
+}
+
+// Equivalent to Python's NoMatch exception: here Nullopt indicates failure.
+template <typename T>
+std::optional<T> get_scalar_tensor_value(ONNXConstantOp constOp) {
+  auto elementsAttr = dyn_cast_or_null<ElementsAttr>(constOp.getValueAttr());
+  if (!elementsAttr)
+    return std::nullopt;
+
+  Type elementType = elementsAttr.getElementType();
+
+  // Fast path: splat
+  if (elementsAttr.isSplat()) {
+    if (elementType.isa<FloatType>()) {
+      if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
+        APFloat splatValue = elementsAttr.getSplatValue<APFloat>();
+        return static_cast<T>(splatValue.convertToDouble());
+      }
+    }
+    if (auto intType = elementType.dyn_cast<IntegerType>()) {
+      if constexpr (std::is_integral_v<T>) {
+        APInt splatValue = elementsAttr.getSplatValue<APInt>();
+        if (intType.isUnsigned())
+          return static_cast<T>(splatValue.getZExtValue());
+        else
+          return static_cast<T>(splatValue.getSExtValue());
+      }
+    }
+    return std::nullopt;
+  }
+
+  // Non‑splat case: check rank
+  auto shapedTy = elementsAttr.getType().dyn_cast<ShapedType>();
+  if (!shapedTy || !shapedTy.hasStaticShape())
+    return std::nullopt;
+
+  // Case: rank 0 → scalar element directly
+  if (shapedTy.getRank() == 0) {
+    auto firstAttr = *elementsAttr.getValues<Attribute>().begin();
+    if (auto fAttr = firstAttr.dyn_cast<FloatAttr>()) {
+      if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>)
+        return static_cast<T>(fAttr.getValueAsDouble());
+    }
+    if (auto iAttr = firstAttr.dyn_cast<IntegerAttr>()) {
+      if constexpr (std::is_integral_v<T>)
+        return static_cast<T>(iAttr.getInt()); // signed ok
+    }
+    return std::nullopt;
+  }
+
+  // Case: rank >= 1 → flatten & check all the same
+  std::set<double> flattenedFP;
+  std::set<int64_t> flattenedInt;
+
+  if (elementType.isa<FloatType>()) {
+    if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
+      for (auto a : elementsAttr.getValues<FloatAttr>())
+        flattenedFP.insert(a.getValueAsDouble());
+      if (flattenedFP.size() == 1)
+        return static_cast<T>(*flattenedFP.begin());
+    }
+  } else if (auto intType = elementType.dyn_cast<IntegerType>()) {
+    if constexpr (std::is_integral_v<T>) {
+      for (auto a : elementsAttr.getValues<IntegerAttr>())
+        flattenedInt.insert(intType.isUnsigned() ? a.getUInt() : a.getInt());
+      if (flattenedInt.size() == 1)
+        return static_cast<T>(*flattenedInt.begin());
+    }
+  }
+
+  return std::nullopt; // mismatch or more than one unique value
+}
+
+template <typename T>
+std::optional<T> get_scalar_tensor_value_from_val(Value value) {
+  if (!value) {
+    return std::nullopt;
+  }
+  auto constOp = value.getDefiningOp<ONNXConstantOp>();
+  if (!constOp) {
+    return std::nullopt;
+  }
+  return get_scalar_tensor_value<T>(constOp);
+}
+
+static mlir::DenseElementsAttr makeScalarDEA(
+    mlir::ShapedType likeTy, double d, mlir::Type clampElemTy) {
+  using namespace mlir;
+
+  auto ranked = likeTy.dyn_cast<RankedTensorType>();
+  if (!ranked || !ranked.hasStaticShape() || ranked.getNumElements() != 1)
+    return {};
+
+  Type outET = ranked.getElementType();
+  Type useET = clampElemTy ? clampElemTy : outET;
+
+  // If target is float, just create a float attr with outET semantics.
+  if (auto outFT = outET.dyn_cast<FloatType>()) {
+    // Round in the semantics of useET if it's float; otherwise just use d.
+    double dv = d;
+    if (auto useFT = useET.dyn_cast<FloatType>()) {
+      // Convert through APFloat with 'useET' semantics, then to double.
+      llvm::APFloat ap(d);
+      bool loses = false;
+      ap.convert(useFT.getFloatSemantics(), llvm::APFloat::rmNearestTiesToEven,
+          &loses);
+      dv = ap.convertToDouble();
+    }
+    return DenseElementsAttr::get(ranked, FloatAttr::get(outFT, dv));
+  }
+
+  // If target is integer, round+clamp as per 'useET' (if integer), then emit as
+  // outET.
+  if (auto outIT = outET.dyn_cast<IntegerType>()) {
+    // Decide signedness/width for clamping from useET if it's integer, else
+    // from outET.
+    IntegerType clampIT =
+        useET.isa<IntegerType>() ? useET.cast<IntegerType>() : outIT;
+
+    int64_t iv = static_cast<int64_t>(std::llround(d));
+    const unsigned bw = clampIT.getWidth();
+    const bool isSigned = clampIT.isSigned();
+
+    const int64_t minV = isSigned ? (-(int64_t(1) << (bw - 1))) : 0;
+    const int64_t maxV =
+        isSigned ? ((int64_t(1) << (bw - 1)) - 1) : ((int64_t(1) << bw) - 1);
+    iv = std::min<int64_t>(std::max<int64_t>(iv, minV), maxV);
+
+    // Now re-materialize as the *output* ET (which may differ in width/sign).
+    // This guarantees the result type matches `likeTy`.
+    if (auto outSigned = outIT.isSigned()) {
+      // For signed out type, encode iv as signed.
+      return DenseElementsAttr::get(ranked, IntegerAttr::get(outIT, iv));
+    } else {
+      // For unsigned out type, encode iv as unsigned (mask to width).
+      uint64_t u = static_cast<uint64_t>(iv);
+      if (outIT.getWidth() < 64)
+        u &= ((uint64_t(1) << outIT.getWidth()) - 1);
+      return DenseElementsAttr::get(ranked, IntegerAttr::get(outIT, u));
+    }
+  }
+
+  return {};
+}
+
+static void updateInitializer(mlir::PatternRewriter &rewriter,
+    mlir::Operation *targetOp, mlir::Value oldInit, double newScalar,
+    mlir::Type clampElemTy) {
+  using namespace mlir;
+
+  if (!targetOp || !oldInit)
+    return;
+
+  auto oldCst = oldInit.getDefiningOp<ONNXConstantOp>();
+  if (!oldCst)
+    return;
+
+  auto likeTy = oldInit.getType().dyn_cast<ShapedType>();
+  llvm::outs() << "likeTy = " << likeTy << " clampElemTy = " << clampElemTy
+               << " newScalar = " << newScalar << "\n";
+  if (!likeTy || !likeTy.hasStaticShape() || likeTy.getNumElements() != 1)
+    return;
+
+  DenseElementsAttr payload = makeScalarDEA(likeTy, newScalar, clampElemTy);
+  if (!payload)
+    return;
+
+  // Single-use-by-target check.
+  auto singleUseByTarget = [&]() -> bool {
+    auto it = oldInit.use_begin(), e = oldInit.use_end();
+    if (it == e)
+      return false;
+    auto *owner = it->getOwner();
+    ++it;
+    return (it == e) && (owner == targetOp);
+  };
+
+  if (singleUseByTarget()) {
+    rewriter.modifyOpInPlace(oldCst, [&] {
+      oldCst->setAttr("value", payload);
+      // Keep constant canonical:
+      oldCst->removeAttr("sparse_value");
+      oldCst->removeAttr("value_float");
+      oldCst->removeAttr("value_floats");
+      oldCst->removeAttr("value_int");
+      oldCst->removeAttr("value_ints");
+      oldCst->removeAttr("value_string");
+      oldCst->removeAttr("value_strings");
+    });
+    return;
+  }
+
+  // Multi-use: clone a fresh constant with same result type as oldInit.
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(targetOp);
+
+  OperationState st(targetOp->getLoc(), ONNXConstantOp::getOperationName());
+  st.addTypes(likeTy);
+  st.addAttribute("value", payload);
+
+  Operation *raw = Operation::create(st);
+  rewriter.insert(raw);
+  auto newCst = llvm::dyn_cast<ONNXConstantOp>(raw);
+  if (!newCst)
+    return;
+
+  // Replace exactly the matching operand.
+  for (unsigned i = 0, e = targetOp->getNumOperands(); i < e; ++i) {
+    if (targetOp->getOperand(i) == oldInit) {
+      targetOp->setOperand(i, newCst.getOutput());
+      break;
+    }
+  }
+}
+
+static LogicalResult tryRemoveQThenDQChain(
+    mlir::PatternRewriter &rewriter, mlir::ONNXDequantizeLinearOp dqOp) {
+  using namespace mlir;
+
+  // Match Q -> DQ
+  auto qOp = dqOp.getX().template getDefiningOp<ONNXQuantizeLinearOp>();
+  if (!qOp) {
+    return failure();
+  }
+
+  // 1) Axis / block_size must match
+  if (qOp.getAxis() != dqOp.getAxis()) {
+    return failure();
+  }
+  if (qOp.getBlockSize() != dqOp.getBlockSize()) {
+    return failure();
+  }
+
+  // 2) Zero-points must match scalars/splats
+  auto zpQ = getElementAttributeFromConstant(qOp.getYZeroPoint());
+  auto zpDQ = getElementAttributeFromConstant(dqOp.getXZeroPoint());
+  if (!zpQ || !zpDQ || zpQ != zpDQ) {
+    return failure();
+  }
+
+  // 3) Scales must match scalars/splats
+  auto sQ = getElementAttributeFromConstant(qOp.getYScale());
+  auto sDQ = getElementAttributeFromConstant(dqOp.getXScale());
+  if (!sQ || !sDQ || sQ != sDQ) {
+    return failure();
+  }
+
+  // 4) Data type consistency: input of Q and output of DQ must have same elem
+  // type.
+  auto qInTypeOp = qOp.getX().getType();
+  auto dqOutTypeOp = dqOp.getResult().getType();
+
+  if (auto qInTensorType = qInTypeOp.dyn_cast<TensorType>()) {
+    if (auto dqOutTensorType = dqOutTypeOp.dyn_cast<TensorType>()) {
+      if (dqOutTensorType.getElementType() != qInTensorType.getElementType()) {
+        return failure();
+      }
+    } else {
+      return failure();
+    }
+  } else {
+    return failure();
+  }
+
+  // Replace DQ with Q's float input; erase Q if it becomes dead.
+  rewriter.replaceOp(dqOp, qOp.getX());
+  if (qOp->use_empty()) {
+    rewriter.eraseOp(qOp);
+  }
+
+  return success();
+}
+
+template <typename BinOp>
+struct FoldBinaryThroughQDQ : public OpRewritePattern<BinOp> {
+  using OpRewritePattern<BinOp>::OpRewritePattern;
+
+private:
+  struct MatchState {
+    ONNXDequantizeLinearOp dequantActivationOp = nullptr;
+    mlir::Type ScaleDtype;
+    mlir::Type zeroPointDtype;
+    double kValue = 0.0;
+    double dstScale = 0.0;
+    int64_t dstZeroPoint = 0;
+    double newScale = 0.0;
+    int64_t newZp = 0;
+  };
+
+  LogicalResult match_qdq(MatchState &state, ONNXDequantizeLinearOp dq1,
+      ONNXDequantizeLinearOp dq2) const {
+
+    ONNXDequantizeLinearOp constantDqOp = nullptr;
+    ONNXConstantOp constantSourceOp = nullptr;
+
+    // Case 1: Direct ConstantOp as input to the DQ.
+    if (auto constOp = dq1.getX().getDefiningOp<ONNXConstantOp>()) {
+      constantDqOp = dq1;
+      state.dequantActivationOp = dq2;
+      constantSourceOp = constOp;
+    } else if (auto constOp = dq2.getX().getDefiningOp<ONNXConstantOp>()) {
+      constantDqOp = dq2;
+      state.dequantActivationOp = dq1;
+      constantSourceOp = constOp;
+    }
+    // Case 2: The input to the DQ op comes from a chain whose input is a
+    // constant.
+    else if (auto intermediateOp = dq1.getX().getDefiningOp()) {
+      if (auto constOp =
+              intermediateOp->getOperand(0).getDefiningOp<ONNXConstantOp>()) {
+        constantDqOp = dq1;
+        state.dequantActivationOp = dq2;
+        constantSourceOp = constOp;
+      }
+    } else if (auto intermediateOp = dq2.getX().getDefiningOp()) {
+      if (auto constOp =
+              intermediateOp->getOperand(0).getDefiningOp<ONNXConstantOp>()) {
+        constantDqOp = dq2;
+        state.dequantActivationOp = dq1;
+        constantSourceOp = constOp;
+      }
+    }
+
+    if (!constantDqOp || !constantSourceOp || !state.dequantActivationOp) {
+      return failure();
+    }
+
+    // Find kvalue and store scale_dtype and zeroPointDtype
+    {
+      auto scalar_value_opt =
+          get_scalar_tensor_value<int64_t>(constantSourceOp);
+      if (!scalar_value_opt) {
+        return failure();
+      }
+      Value scaleVal = constantDqOp.getXScale();
+      Value zpVal = constantDqOp.getXZeroPoint();
+      auto scale_value_opt = get_scalar_tensor_value_from_val<double>(scaleVal);
+      auto zp_value_opt = get_scalar_tensor_value_from_val<int64_t>(zpVal);
+      if (!scale_value_opt || !zp_value_opt) {
+        return failure();
+      }
+      // Calculate and store kValue.
+      state.kValue = (*scalar_value_opt - *zp_value_opt) * *scale_value_opt;
+
+      // # store dtype for creating new initializers with the same dtype
+      state.ScaleDtype =
+          mlir::cast<ShapedType>(scaleVal.getType()).getElementType();
+      state.zeroPointDtype =
+          mlir::cast<ShapedType>(zpVal.getType()).getElementType();
+    }
+    return success();
+  }
+
+  LogicalResult match_binary_op(MatchState &state, BinOp binaryOp) const {
+    ONNXConstantOp constantOp = nullptr;
+
+    Value lhs = binaryOp.getOperand(0);
+    Value rhs = binaryOp.getOperand(1);
+
+    // -------- Case A: lhs is DQ, rhs is Constant --------
+    if (auto dqOp = lhs.getDefiningOp<ONNXDequantizeLinearOp>()) {
+      if (auto constOp = rhs.getDefiningOp<ONNXConstantOp>()) {
+        state.dequantActivationOp = dqOp;
+        constantOp = constOp;
+      }
+    }
+    // -------- Case A reversed --------
+    else if (auto dqOp = rhs.getDefiningOp<ONNXDequantizeLinearOp>()) {
+      if (auto constOp = lhs.getDefiningOp<ONNXConstantOp>()) {
+        state.dequantActivationOp = dqOp;
+        constantOp = constOp;
+      }
+    }
+
+    // -------- Fill state values for Case A and Case A reversed --------
+    if (state.dequantActivationOp && constantOp) {
+      auto kValueOpt = get_scalar_tensor_value<double>(constantOp);
+      if (!kValueOpt) {
+        return failure();
+      }
+      state.kValue = kValueOpt.value();
+      return success();
+    }
+
+    // -------- Case B: both inputs are DQ --------
+    auto dqOp1 = lhs.getDefiningOp<ONNXDequantizeLinearOp>();
+    auto dqOp2 = rhs.getDefiningOp<ONNXDequantizeLinearOp>();
+
+    if (dqOp1 && dqOp2) {
+      if (failed(match_qdq(state, dqOp1, dqOp2)))
+        return failure();
+      return success();
+    }
+    return failure();
+  }
+
+  LogicalResult check_needed_values(
+      const MatchState &state, Operation *binaryOp) const {
+    if (state.kValue == 0.0) {
+      if (isa<ONNXDivOp>(binaryOp)) {
+        return failure();
+      }
+    }
+    if (state.dstScale == 0.0) {
+      if (isa<ONNXAddOp, ONNXSubOp>(binaryOp)) {
+        return failure();
+      }
+    }
+    return success();
+  }
+
+  static bool compute_new_scale_and_zp_values(
+      MatchState &state, Operation *binaryOp) {
+    double newScale = state.dstScale;
+    double newZpFloat = static_cast<double>(state.dstZeroPoint);
+    const double kVal = state.kValue;
+
+    if (isa<ONNXAddOp>(binaryOp)) {
+      newZpFloat -= (kVal / newScale);
+
+    } else if (isa<ONNXSubOp>(binaryOp)) {
+      newZpFloat += (kVal / newScale);
+
+    } else if (isa<ONNXMulOp>(binaryOp)) {
+      newScale *= kVal;
+
+    } else if (isa<ONNXDivOp>(binaryOp)) {
+      newScale /= kVal;
+
+    } else {
+      return false;
+    }
+
+    int64_t newZp = static_cast<int64_t>(std::llround(newZpFloat));
+    state.newScale = newScale;
+    state.newZp = newZp;
+
+    return true;
+  }
+
+public:
+  LogicalResult matchAndRewrite(
+      BinOp op, PatternRewriter &rewriter) const override {
+
+    // STEP 1: Match begin: Assuming only one user
+    auto quantOutputOp = dyn_cast<ONNXQuantizeLinearOp>(*op->user_begin());
+    if (!quantOutputOp) {
+      return failure();
+    }
+
+    // Instantiate the state struct
+    MatchState state;
+
+    // STEP 2
+    if (failed(match_binary_op(state, op))) {
+      return failure();
+    }
+
+    // Store the value of the scale and zero point of the destination node
+    {
+      Value scaleVal = state.dequantActivationOp.getXScale();
+      Value zpVal = state.dequantActivationOp.getXZeroPoint();
+      auto scale_value_opt = get_scalar_tensor_value_from_val<double>(scaleVal);
+      auto zp_value_opt = get_scalar_tensor_value_from_val<int64_t>(zpVal);
+      if (!scale_value_opt || !zp_value_opt) {
+        return failure();
+      }
+      state.dstScale = scale_value_opt.value();
+      state.dstZeroPoint = zp_value_opt.value();
+    }
+
+    // STEP 3
+    if (failed(check_needed_values(state, op))) {
+      return failure();
+    }
+
+    // STEP 4 -Modify
+    if (!compute_new_scale_and_zp_values(state, op)) {
+      return failure();
+    }
+
+    // STEP 5: call initializer based on the binary op
+    ONNXDequantizeLinearOp dqAct = state.dequantActivationOp;
+    if constexpr (std::is_same_v<BinOp, ONNXAddOp> ||
+                  std::is_same_v<BinOp, ONNXSubOp>) {
+      Value zpVal = dqAct.getXZeroPoint();
+      updateInitializer(rewriter, dqAct.getOperation(), zpVal,
+          static_cast<double>(state.newZp), state.zeroPointDtype);
+
+    } else if constexpr (std::is_same_v<BinOp, ONNXMulOp> ||
+                         std::is_same_v<BinOp, ONNXDivOp>) {
+      Value scaleVal = dqAct.getXScale();
+      updateInitializer(rewriter, dqAct.getOperation(), scaleVal,
+          state.newScale, state.ScaleDtype);
+    }
+
+    // STEP 6: Remove binary op
+    rewriter.replaceOp(op, dqAct.getResult());
+
+    // STEP 7: Remove Q->DQ chain
+    for (Operation *user : quantOutputOp.getY().getUsers()) {
+      if (auto tailDQ = llvm::dyn_cast<ONNXDequantizeLinearOp>(user)) {
+        (void)tryRemoveQThenDQChain(rewriter, tailDQ);
+      }
+    }
+
+    return success();
+  }
+};
+
+struct FoldDQBinaryQPass
+    : public PassWrapper<FoldDQBinaryQPass, OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FoldDQBinaryQPass)
+
+  StringRef getArgument() const final { return "dq-binary-q-opt-onnx-to-onnx"; }
+  StringRef getDescription() const final {
+    return "Fold Add/Sub/Mul/Div through Q/DQ by updating scale/zero_point, "
+           "then remove trivial Q->DQ chains when safe.";
+  }
+
+  void runOnOperation() override {
+    auto function = getOperation();
+    RewritePatternSet patterns(&getContext());
+    patterns
+        .add<FoldBinaryThroughQDQ<ONNXDivOp>, FoldBinaryThroughQDQ<ONNXSubOp>,
+            FoldBinaryThroughQDQ<ONNXMulOp>, FoldBinaryThroughQDQ<ONNXAddOp>>(
+            &getContext());
+    if (failed(applyPatternsAndFoldGreedily(function, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+} // namespace
+
+namespace onnx_mlir {
+std::unique_ptr<mlir::Pass> createFoldDQBinaryQPass() {
+  return std::make_unique<FoldDQBinaryQPass>();
+}
+} // namespace onnx_mlir

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -57,6 +57,7 @@ std::unique_ptr<mlir::Pass> createConstPropONNXToONNXPass();
 std::unique_ptr<mlir::Pass> createQDQAroundOpOptONNXToONNXPass();
 
 std::unique_ptr<mlir::Pass> createQDQOptONNXToONNXPass();
+std::unique_ptr<mlir::Pass> createFoldDQBinaryQPass();
 
 /// Pass for instrument the ops in specific stage.
 std::unique_ptr<mlir::Pass> createInstrumentPass();

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -79,6 +79,10 @@ void registerOMPasses(int optLevel) {
     return createQDQOptONNXToONNXPass();
   });
 
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return createFoldDQBinaryQPass();
+  });
+
   mlir::registerPass(
       []() -> std::unique_ptr<mlir::Pass> { return createInstrumentPass(); });
 

--- a/test/mlir/onnx/onnx_remove_add.mlir
+++ b/test/mlir/onnx/onnx_remove_add.mlir
@@ -1,0 +1,255 @@
+// RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s --split-input-file | FileCheck %s
+
+// 1) dq1-dq2(const input)-add-q-dq. remove->add,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1a
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<336> : tensor<ui16>
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<39664> : tensor<ui16>
+%3 = onnx.Constant dense<40000> : tensor<ui16>
+%4 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %3) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+
+// -----
+// 2) dq1-dq2(const input)-add-q-dq. remove->add,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1b
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<336> : tensor<ui16>
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<39664> : tensor<ui16>
+%3 = onnx.Constant dense<40000> : tensor<ui16>
+%4 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %3) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+
+// -----
+// 3) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1c
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1c(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Add"(%7, %6) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+
+// -----
+// 4) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1d
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1d(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Add"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+//-----
+// 5) dq1-const-add-q-dq. remove->add, q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<100> : tensor<ui16>
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<100> : tensor<ui16>
+%1 = onnx.Constant dense<1.000000e+01> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<1.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 6) const-dq1-add-q-dq. remove->add,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2b
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 7) const-dq1-add-q-dq. kval=0. remove->add,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3a
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern3a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 8) const-dq1-Sub-q-dq. dst_scale=0. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3b
+// CHECK: onnx.Add
+// CHECK: onnx.QuantizeLinear
+func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Add"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 9) dq1-dq2(const input)-add-q-dq. remove->add,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern4
+// CHECK-NOT: onnx.Add
+// CHECK: onnx.QuantizeLinear
+func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Add"(%5, %6) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %4, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %9 : tensor<1x1x1x128xf32>
+}
+//-----
+// 10) const-dq1-Sub-tanh. remove->none
+// CHECK-LABEL: func.func @test_removebinary_pattern5
+// CHECK: onnx.Add
+// CHECK: onnx.Tanh
+func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Add"(%5, %6) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Tanh"(%7) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 11) dq1-dq2-add-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, add
+// CHECK-LABEL: func.func @test_removebinary_pattern6
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.Add
+func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<39664> : tensor<ui16>
+%5 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%6 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Div"(%6, %7) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%11 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%12 = "onnx.Add"(%10, %11) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%13 = "onnx.QuantizeLinear"(%12, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%14 = "onnx.DequantizeLinear"(%13, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %14 : tensor<1x1x1x128xf32>
+}
+//-----
+//
+// 12) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// vectors wiht same values -> fusion
+// CHECK-LABEL: func.func @test_removebinary_pattern7a
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern7a(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<65535> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Add"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
+}
+//-----
+//
+// 13) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// vectors wiht different values -> no fusion
+// CHECK-LABEL: func.func @test_removebinary_pattern7b
+// CHECK: onnx.Add
+// CHECK: onnx.QuantizeLinear
+func.func @test_removebinary_pattern7b(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Add"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
+}

--- a/test/mlir/onnx/onnx_remove_add.mlir
+++ b/test/mlir/onnx/onnx_remove_add.mlir
@@ -83,7 +83,7 @@ return %10 : tensor<1x1x1x128xf32>
 //-----
 // 5) dq1-const-add-q-dq. remove->add, q-dq.
 // CHECK-LABEL: func.func @test_removebinary_pattern2a
-// CHECK: %[[ZP:.*]] = onnx.Constant dense<100> : tensor<ui16>
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<99> : tensor<ui16>
 // CHECK-NOT: onnx.Add
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: return

--- a/test/mlir/onnx/onnx_remove_div.mlir
+++ b/test/mlir/onnx/onnx_remove_div.mlir
@@ -1,0 +1,249 @@
+// RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s -split-input-file | FileCheck %s
+
+// 1) dq1-dq2(const input)-div-q-dq. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1a
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-1.52590218E-9> : tensor<f32>
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 2) dq1-dq2(const input)-div-q-dq. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1b
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-1.52590218E-9> : tensor<f32>
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 3) dq1-dq2(const input)-div-q-dq. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1c
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1c(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Div"(%7, %6) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+//-----
+// 4) dq1-dq2(const input)-div-q-dq. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1d
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1d(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Div"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+//-----
+// 5) dq1-const-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-1.49999991E-7> : tensor<f32>
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.500000e-05> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+02> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 6) const-dq1-div-q-dq. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2b
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 7) const-dq1-div-q-dq. kval=0. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3c
+// CHECK: onnx.Div
+// CHECK: onnx.QuantizeLinear
+func.func @test_removebinary_pattern3c(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 8) const-dq1-div-q-dq. dst_scale=0. remove->div,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3b
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 9) const-dq1-div-q-dq. q!=dq. remove->only div
+// CHECK-LABEL: func.func @test_removebinary_pattern4
+// CHECK-NOT: onnx.Div
+// CHECK: onnx.QuantizeLinear
+func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 10) const-dq1-div-tanh. remove->none
+// CHECK-LABEL: func.func @test_removebinary_pattern5
+// CHECK: onnx.Div
+// CHECK: onnx.Tanh
+func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Div"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Tanh"(%6) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+return %7 : tensor<1x1x1x128xf32>
+}
+//-----
+// 11) dq1-dq2-sub-q-dq1-dq2-div-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->div, sub
+// CHECK-LABEL: func.func @test_removebinary_pattern6
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.Sub
+func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<39664> : tensor<ui16>
+%5 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%6 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Sub"(%6, %7) {onnx_node_name = "/bert/Sub"} : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%11 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%12 = "onnx.Div"(%10, %11) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%13 = "onnx.QuantizeLinear"(%12, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%14 = "onnx.DequantizeLinear"(%13, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %14 : tensor<1x1x1x128xf32>
+}
+//-----
+//
+// 12) dq1-dq2(const input, per-axis length-2 on axis=0)-div-q-dq.
+// Keep Div and QuantizeLinear present.
+// CHECK-LABEL: func.func @test_removebinary_pattern7a
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern7a(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<65535> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Div"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
+}
+//-----
+// 13) dq1-dq2(const input, per-axis length-2 on axis=0)-div-q-dq.
+// Keep Div and QuantizeLinear present.
+// CHECK-LABEL: func.func @test_removebinary_pattern7b
+// CHECK: onnx.Div
+// CHECK: onnx.QuantizeLinear
+func.func @test_removebinary_pattern7b(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Div"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
+}

--- a/test/mlir/onnx/onnx_remove_mul.mlir
+++ b/test/mlir/onnx/onnx_remove_mul.mlir
@@ -1,0 +1,254 @@
+// RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s -split-input-file | FileCheck %s
+
+// 1) dq1-dq2(const input)-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1a
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-0.152590215> : tensor<f32>
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+
+// 2) dq1-dq2(const input)-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1b
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-0.152590215> : tensor<f32>
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// Test fusing a DQ -> Mul -> Q -> DQ pattern.
+// The constant input to the Mul is produced by a chain: Constant -> Identity -> DequantizeLinear.
+// The pass should look through the Identity op, perform the fusion, and remove the redundant Q->DQ chain.
+// 3) dq1-dq2(const input)-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1c
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1c(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Mul"(%7, %6) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+//-----
+// 4) dq1-dq2(const input)-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1d
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1d(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Mul"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+//-----
+// 5) dq1-const-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[SCALE:.*]] = onnx.Constant dense<-0.00152590219> : tensor<f32>
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+02> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 6) const-dq1-mul-q-dq. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2b
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 7) const-dq1-mul-q-dq. kval=0. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3a
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern3a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 8) const-dq1-mul-q-dq. dst_scale=0. remove->mul,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3b
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 9) const-dq1-mul-q-dq. q!=dq. remove->only mul
+// CHECK-LABEL: func.func @test_removebinary_pattern4
+// CHECK-NOT: onnx.Mul
+// CHECK: onnx.QuantizeLinear
+func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 10) const-dq1-mul-tanh. remove->none
+// CHECK-LABEL: func.func @test_removebinary_pattern5
+// CHECK: onnx.Mul
+// CHECK: onnx.Tanh
+func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Mul"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Tanh"(%6) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+return %7 : tensor<1x1x1x128xf32>
+}
+//-----
+// 11) dq1-dq2-sub-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, sub
+// CHECK-LABEL: func.func @test_removebinary_pattern6
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.Sub
+func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<39664> : tensor<ui16>
+%5 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%6 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Add"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%11 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%12 = "onnx.Mul"(%10, %11) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%13 = "onnx.QuantizeLinear"(%12, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%14 = "onnx.DequantizeLinear"(%13, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %14 : tensor<1x1x1x128xf32>
+}
+//-----
+// 12) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// Keep Mul and QuantizeLinear present.
+// CHECK-LABEL: func.func @test_removebinary_pattern7a
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern7a(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<65535> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Mul"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
+}
+//-----
+// 13) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// Keep Mul and QuantizeLinear present.
+// CHECK-LABEL: func.func @test_removebinary_pattern7b
+// CHECK: onnx.Mul
+// CHECK: onnx.QuantizeLinear
+func.func @test_removebinary_pattern7b(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Mul"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
+}

--- a/test/mlir/onnx/onnx_remove_sub.mlir
+++ b/test/mlir/onnx/onnx_remove_sub.mlir
@@ -1,0 +1,257 @@
+// RUN: onnx-mlir-opt --dq-binary-q-opt-onnx-to-onnx %s --split-input-file | FileCheck %s
+
+// 1) dq1-dq2(const input)-sub-q-dq. remove->sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1a
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<65535> : tensor<ui16>
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Sub"(%6, %5) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %9 : tensor<1x1x1x128xf32>
+}
+
+// -----
+// 2) dq1-dq2(const input)-sub-q-dq. remove->sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1b
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<65535> : tensor<ui16>
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern1b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Sub"(%5, %6) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %9 : tensor<1x1x1x128xf32>
+}
+
+// -----
+// 3) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1c
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1c(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Sub"(%7, %6) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+
+// -----
+// 4) dq1-dq2(const input)-Sub-q-dq. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern1d
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern1d(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0> : tensor<ui16>
+%5 = "onnx.Identity"(%4) : (tensor<ui16>) -> tensor<ui16>
+%6 = "onnx.DequantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Sub"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %10 : tensor<1x1x1x128xf32>
+}
+
+//-----
+// 5) dq1-const-add-q-dq. remove->add, q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2a
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<102> : tensor<ui16>
+// CHECK-NOT: onnx.Add
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<101> : tensor<ui16>
+%1 = onnx.Constant dense<1.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<1.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Sub"(%5, %4) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 6) const-dq1-sub-q-dq. remove->sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern2b
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern2b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Sub"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 7) const-dq1-sub-q-dq. kval=0. remove->sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3a
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+// CHECK: return
+// CHECK-NOT: onnx.DequantizeLinear
+func.func @test_removebinary_pattern3a(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Sub"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 8) const-dq1-Sub-q-dq. dst_scale=0. remove->Sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern3b
+// CHECK: onnx.Sub
+// CHECK: onnx.QuantizeLinear
+func.func @test_removebinary_pattern3b(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%6 = "onnx.Sub"(%4, %5) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.QuantizeLinear"(%6, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%8 = "onnx.DequantizeLinear"(%7, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 9) dq1-dq2(const input)-sub-q-dq. remove->sub,q-dq.
+// CHECK-LABEL: func.func @test_removebinary_pattern4
+// CHECK-NOT: onnx.Sub
+// CHECK: onnx.QuantizeLinear
+func.func @test_removebinary_pattern4(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Sub"(%5, %6) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %4, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %9 : tensor<1x1x1x128xf32>
+}
+//-----
+// 10) const-dq1-Sub-tanh. remove->none
+// CHECK-LABEL: func.func @test_removebinary_pattern5
+// CHECK: onnx.Sub
+// CHECK: onnx.Tanh
+func.func @test_removebinary_pattern5(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<39664> : tensor<ui16>
+%4 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%5 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%7 = "onnx.Sub"(%5, %6) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Tanh"(%7) : (tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+return %8 : tensor<1x1x1x128xf32>
+}
+//-----
+// 11) dq1-dq2-sub-q-dq1-dq2-mul-Q-DQ. multi-use of scale and zp of dq-act before binary op. remove->mul, sub
+// CHECK-LABEL: func.func @test_removebinary_pattern6
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.Sub
+func.func @test_removebinary_pattern6(%arg0: tensor<1x1x1x128xui16>) -> tensor<1x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<ui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<f32>
+%2 = onnx.Constant dense<65535> : tensor<ui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<f32>
+%4 = onnx.Constant dense<39664> : tensor<ui16>
+%5 = onnx.Constant dense<2.57987776E-5> : tensor<f32>
+%6 = "onnx.DequantizeLinear"(%2, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%7 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%8 = "onnx.Mul"(%6, %7) : (tensor<f32>, tensor<1x1x1x128xf32>) -> tensor<1x1x1x128xf32>
+%9 = "onnx.QuantizeLinear"(%8, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%10 = "onnx.DequantizeLinear"(%9, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+%11 = "onnx.DequantizeLinear"(%0, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+%12 = "onnx.Sub"(%10, %11) : (tensor<1x1x1x128xf32>, tensor<f32>) -> tensor<1x1x1x128xf32>
+%13 = "onnx.QuantizeLinear"(%12, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x1x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xui16>
+%14 = "onnx.DequantizeLinear"(%13, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x1x128xf32>
+return %14 : tensor<1x1x1x128xf32>
+}
+//-----
+// 12) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// vectors wiht same values -> fusion
+// CHECK-LABEL: func.func @test_removebinary_pattern7a
+// CHECK-NOT: onnx.Sub
+// CHECK-NOT: onnx.QuantizeLinear
+func.func @test_removebinary_pattern7a(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<65535> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Sub"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
+}
+//-----
+//
+// 13) dq1-dq2(const input, per-axis length-2 on axis=0)-mul-q-dq.
+// vectors wiht different values -> no fusion
+// CHECK-LABEL: func.func @test_removebinary_pattern7b
+// CHECK: onnx.Sub
+// CHECK: onnx.QuantizeLinear
+func.func @test_removebinary_pattern7b(%arg0: tensor<2x1x1x128xui16>) -> tensor<2x1x1x128xf32> {
+%0 = onnx.Constant dense<0> : tensor<2xui16>
+%1 = onnx.Constant dense<1.52590219E-5> : tensor<2xf32>
+%2 = onnx.Constant dense<[65535, 1]> : tensor<2xui16>
+%3 = onnx.Constant dense<0.152590215> : tensor<2xf32>
+%4 = onnx.Constant dense<0> : tensor<2x1x1x1xui16>
+%5 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x1xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x1xf32>
+%6 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+%7 = "onnx.Sub"(%6, %5) : (tensor<2x1x1x128xf32>, tensor<2x1x1x1xf32>) -> tensor<2x1x1x128xf32>
+%8 = "onnx.QuantizeLinear"(%7, %3, %2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1x1x128xf32>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xui16>
+%9 = "onnx.DequantizeLinear"(%8, %3, %2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1x1x128xui16>, tensor<2xf32>, tensor<2xui16>) -> tensor<2x1x1x128xf32>
+return %9 : tensor<2x1x1x128xf32>
+}


### PR DESCRIPTION
REMOVE_BINARY summary:

This RemoveBinary class is a pattern-matching and rewrite utility that finds and removes binary ops (Add, Sub, Mul, Div) in quantized ONNX graphs when one input is effectively a constant. It folds the constant into the quantization parameters instead of keeping an explicit binary op in the graph.

This class rewrites patterns like:
 Dequant(x) ----\
                             Binary(Add/Sub/Mul/Div) → Quant → Dequant
Dequant(const)-/

into something like

  Dequant'(x, new_scale/zp) → Quant → Dequant
  
  Where the constant is folded into scale or zero-point of Dequant(x) node
  
  Then, a check is performed to see if we can possibly remove the Quant → Dequant chain.