### PR TITLE
Add option to convert onnx.slice to tosa only when the steps <= 1

### DIFF
--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -163,7 +163,8 @@ void populateLoweringONNXPadOpToTOSAPattern(mlir::ConversionTarget &,
 void populateLoweringONNXFlattenOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSliceOpToTOSAPattern(mlir::ConversionTarget &,
-    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *,
+    bool);
 void populateLoweringONNXSplitOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSqueezeOpToTOSAPattern(mlir::ConversionTarget &,


### PR DESCRIPTION
the decomposition of onnx.slice to tosa.slice is not always optimal for our xten_nn subgraph matching.
This would help us delay the matching of onnx.slice when step > 1 to a place more suited