### PR TITLE
Fix duplicate symbol getGenOpMix<ONNXRoundOp>

### DIFF
--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -268,6 +268,10 @@ GenOpMix getGenOpMix(mlir::Type elementType, mlir::Operation *op) {
   return {{GenericOps::ScalarOnlyGop, 1}};
 }
 
+template <>
+GenOpMix getGenOpMix<mlir::ONNXRoundOp>(
+    mlir::Type elementType, mlir::Operation *op);
+
 //===----------------------------------------------------------------------===//
 // Type conversion from Onnx types to Krnl types:
 //   - from Tensor type to the Standard dialect MemRef type


### PR DESCRIPTION
`getGenOpMix<ONNXRoundOp>` is used in src/Conversion/ONNXToKrnl/Quantization/QuantizeLinear.cpp. There, it can only see the generic definition of the template in `src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp`.

But there is also a explicit specialization in src/Conversion/ONNXToKrnl/Math/Elementwise.cpp. To ensure that the explicit specialization is used instead of instantiating the generic template, forward declare the explicit specialization.