### PR TITLE
Add new option useOnnxModelTypesForCustomOps to allow using types fro…

### DIFF
--- a/src/Builder/FrontendDialectTransformer.hpp
+++ b/src/Builder/FrontendDialectTransformer.hpp
@@ -43,7 +43,9 @@ struct ImportOptions {
   bool verboseOutput = false;
   // Use types/shapes in the input-model for translation (for intermediate
   // variables)
-  bool useOnnxModelTypes = false;
+  bool useOnnxModelTypes = true;
+  bool runOnnxShapeInference = true;
+  bool useOnnxModelTypesForCustomOps = true;
   bool invokeOnnxVersionConverter = false;
   bool allowSorting = true;
   bool useOutputNameAsLocation = false;

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -64,6 +64,8 @@ bool preserveBitcode;                      // onnx-mlir only
 bool preserveLLVMIR;                       // onnx-mlir only
 bool preserveMLIR;                         // onnx-mlir only
 bool useOnnxModelTypes;                    // onnx-mlir only
+bool runOnnxShapeInference;                // onnx-mlir only
+bool useOnnxModelTypesForCustomOps;        // onnx-mlir only
 int repeatOnnxTransform;                   // onnx-mlir only
 std::string shapeInformation;              // onnx-mlir only
 std::string dimParams;                     // onnx-mlir only
@@ -387,6 +389,20 @@ static llvm::cl::opt<bool, true> preserveMLIROpt("preserveMLIR",
 static llvm::cl::opt<bool, true> useOnnxModelTypesOpt("useOnnxModelTypes",
     llvm::cl::desc("Use types and shapes from ONNX model."),
     llvm::cl::location(useOnnxModelTypes), llvm::cl::init(true),
+    llvm::cl::cat(OnnxMlirOptions));
+
+static llvm::cl::opt<bool, true> runOnnxShapeInferenceOpt(
+    "runOnnxShapeInference",
+    llvm::cl::desc("Run ONNX shape inference when importing a model. This is "
+                   "indepenendent of the shape inference in ONNX-MLIR"),
+    llvm::cl::location(runOnnxShapeInference), llvm::cl::init(true),
+    llvm::cl::cat(OnnxMlirOptions));
+
+static llvm::cl::opt<bool, true> useOnnxModelTypesForCustomOpsOpt(
+    "useOnnxModelTypesForCustomOps",
+    llvm::cl::desc("Use types and shapes from ONNX model for custom ops, even "
+                   "if `useOnnxModelTypes` is disabled."),
+    llvm::cl::location(useOnnxModelTypesForCustomOps), llvm::cl::init(true),
     llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<bool, true> useOutputNameAsLocationOpt(

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -394,7 +394,7 @@ static llvm::cl::opt<bool, true> useOnnxModelTypesOpt("useOnnxModelTypes",
 static llvm::cl::opt<bool, true> runOnnxShapeInferenceOpt(
     "runOnnxShapeInference",
     llvm::cl::desc("Run ONNX shape inference when importing a model. This is "
-                   "indepenendent of the shape inference in ONNX-MLIR"),
+                   "independent of the shape inference in ONNX-MLIR"),
     llvm::cl::location(runOnnxShapeInference), llvm::cl::init(true),
     llvm::cl::cat(OnnxMlirOptions));
 

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -99,6 +99,8 @@ extern bool preserveLLVMIR;                       // onnx-mlir only
 extern bool preserveMLIR;                         // onnx-mlir only
 extern bool doNotEmitFullMLIRCode;                // onnx-mlir only
 extern bool useOnnxModelTypes;                    // onnx-mlir only
+extern bool runOnnxShapeInference;                // onnx-mlir only
+extern bool useOnnxModelTypesForCustomOps;        // onnx-mlir only
 extern int repeatOnnxTransform;                   // onnx-mlir only
 extern std::string shapeInformation;              // onnx-mlir only
 extern std::string dimParams;                     // onnx-mlir only

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -721,6 +721,8 @@ std::string dirName(StringRef inputFilename) {
     ImportOptions options;
     options.verboseOutput = VerboseOutput;
     options.useOnnxModelTypes = useOnnxModelTypes;
+    options.runOnnxShapeInference = runOnnxShapeInference;
+    options.useOnnxModelTypesForCustomOps = useOnnxModelTypesForCustomOps;
     options.useOutputNameAsLocation = useOutputNameAsLocation;
     options.allowMissingOutputTypes = allowMissingOutputTypes;
     options.invokeOnnxVersionConverter = invokeOnnxVersionConverter;

--- a/test/mlir/onnx/parse/add_missing_output_types.json
+++ b/test/mlir/onnx/parse/add_missing_output_types.json
@@ -1,13 +1,13 @@
 // Json generated with utils/testing/add_missing_output_types.py
 
-// RUN: onnx-mlir --EmitONNXIR --useOnnxModelTypes=false --allowMissingOutputTypes=false --printIR %s 2> failed.log; cat failed.log  | FileCheck --check-prefix=FAILURE %s 
+// RUN: onnx-mlir --EmitONNXIR --useOnnxModelTypes=false --useOnnxModelTypesForCustomOps=false --allowMissingOutputTypes=false --printIR %s 2> failed.log; cat failed.log  | FileCheck --check-prefix=FAILURE %s
 
 // FAILURE: Could not successfully parse ONNX file
 // FAILURE: ONNX type with id: 0 is not a valid type
 // FAILURE: Failed to import output type for
 // FAILURE: Failed to import main graph, could not get its function type
 
-// RUN: onnx-mlir --EmitONNXIR --useOnnxModelTypes=false --allowMissingOutputTypes=true --printIR %s  | FileCheck --check-prefix=INFERRED %s
+// RUN: onnx-mlir --EmitONNXIR --useOnnxModelTypes=false --useOnnxModelTypesForCustomOps=false --allowMissingOutputTypes=true --printIR %s  | FileCheck --check-prefix=INFERRED %s
 // INFERRED-LABEL:  func.func @main_graph
 // INFERRED-SAME:   ([[PARAM_0_:%.+]]: tensor<3x1xf32> {onnx.name = "input_a"}, [[PARAM_1_:%.+]]: tensor<1x3xf32> {onnx.name = "input_b"}) -> (tensor<*xf32> {onnx.name = "output_c"}, tensor<3x3xf32> {onnx.name = "output_d"}) {
 // INFERRED-DAG:       [[VAR_0_:%.+]] = "onnx.Custom"([[PARAM_0_]], [[PARAM_1_]]) {domain_name = "test", function_name = "test.Add", onnx_node_name = "add_node_custom"} : (tensor<3x1xf32>, tensor<1x3xf32>) -> tensor<*xf32>
@@ -15,7 +15,7 @@
 // INFERRED:           return [[VAR_0_]], [[VAR_1_]] : tensor<*xf32>, tensor<3x3xf32>
 // INFERRED:         }
 
-// RUN: onnx-mlir --EmitONNXIR --useOnnxModelTypes=true --allowMissingOutputTypes=true --printIR %s  | FileCheck --check-prefix=MODEL-TYPE %s
+// RUN: onnx-mlir --EmitONNXIR --useOnnxModelTypes=true --useOnnxModelTypesForCustomOps=true --allowMissingOutputTypes=true --printIR %s  | FileCheck --check-prefix=MODEL-TYPE %s
 // MODEL-TYPE-LABEL:  func.func @main_graph
 // MODEL-TYPE-SAME:   ([[PARAM_0_:%.+]]: tensor<3x1xf32> {onnx.name = "input_a"}, [[PARAM_1_:%.+]]: tensor<1x3xf32> {onnx.name = "input_b"}) -> (tensor<*xf32> {onnx.name = "output_c"}, tensor<3x3xf32> {onnx.name = "output_d"}) {
 // MODEL-TYPE-DAG:       [[VAR_0_:%.+]] = "onnx.Custom"([[PARAM_0_]], [[PARAM_1_]]) {domain_name = "test", function_name = "test.Add", onnx_node_name = "add_node_custom"} : (tensor<3x1xf32>, tensor<1x3xf32>) -> tensor<*xf32>

--- a/test/mlir/onnx/parse/custom_shape_from_model.json
+++ b/test/mlir/onnx/parse/custom_shape_from_model.json
@@ -1,0 +1,115 @@
+// RUN: onnx-mlir --EmitONNXIR --useOnnxModelTypes=false --useOnnxModelTypesForCustomOps=true --printIR %s | FileCheck %s
+// RUN: onnx-mlir --EmitONNXIR --useOnnxModelTypes=false --useOnnxModelTypesForCustomOps=false --printIR %s | FileCheck %s --check-prefix=NO-TYPES-FROM-MODEL
+
+// Json generated with utils/testing/custom_shape_from_model.py
+
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x5xf32> {onnx.name = "X"}) -> (tensor<5x6xf32> {onnx.name = "Z"}) {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Custom"([[PARAM_0_]]) {domain_name = "test", function_name = "MyCustomOp", onnx_node_name = "onnx.Custom_0"} : (tensor<4x5xf32>) -> tensor<5x6xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Relu"([[VAR_0_]]) {onnx_node_name = "onnx.Relu_1"} : (tensor<5x6xf32>) -> tensor<5x6xf32>
+// CHECK:           return [[VAR_1_]] : tensor<5x6xf32>
+// CHECK:         }
+// NO-TYPES-FROM-MODEL-LABEL:  func.func @main_graph
+// NO-TYPES-FROM-MODEL-SAME:   ([[PARAM_0_:%.+]]: tensor<4x5xf32> {onnx.name = "X"}) -> (tensor<5x6xf32> {onnx.name = "Z"}) {
+// NO-TYPES-FROM-MODEL:           [[VAR_0_:%.+]] = "onnx.Custom"([[PARAM_0_]]) {domain_name = "test", function_name = "MyCustomOp", onnx_node_name = "onnx.Custom_0"} : (tensor<4x5xf32>) -> tensor<*xf32>
+// NO-TYPES-FROM-MODEL:           [[VAR_1_:%.+]] = "onnx.Relu"([[VAR_0_]]) {onnx_node_name = "onnx.Relu_1"} : (tensor<*xf32>) -> tensor<5x6xf32>
+// NO-TYPES-FROM-MODEL:           return [[VAR_1_]] : tensor<5x6xf32>
+// NO-TYPES-FROM-MODEL:         }
+{
+  "irVersion": "10",
+  "producerName": "onnx-mlir",
+  "graph": {
+    "node": [
+      {
+        "input": [
+          "X"
+        ],
+        "output": [
+          "Y"
+        ],
+        "opType": "MyCustomOp",
+        "domain": "test"
+      },
+      {
+        "input": [
+          "Y"
+        ],
+        "output": [
+          "Z"
+        ],
+        "opType": "Relu"
+      }
+    ],
+    "name": "test-custom",
+    "input": [
+      {
+        "name": "X",
+        "type": {
+          "tensorType": {
+            "elemType": 1,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "4"
+                },
+                {
+                  "dimValue": "5"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "output": [
+      {
+        "name": "Z",
+        "type": {
+          "tensorType": {
+            "elemType": 1,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "5"
+                },
+                {
+                  "dimValue": "6"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "valueInfo": [
+      {
+        "name": "Y",
+        "type": {
+          "tensorType": {
+            "elemType": 1,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "5"
+                },
+                {
+                  "dimValue": "6"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "opsetImport": [
+    {
+      "domain": "",
+      "version": "22"
+    },
+    {
+      "domain": "test",
+      "version": "1"
+    }
+  ]
+}

--- a/test/mlir/onnx/parse/custom_shape_from_model_wrong_shape.json
+++ b/test/mlir/onnx/parse/custom_shape_from_model_wrong_shape.json
@@ -1,0 +1,110 @@
+// RUN: onnx-mlir --EmitONNXIR --useOnnxModelTypes=false --useOnnxModelTypesForCustomOps=true --printIR %s 2>&1 | FileCheck %s
+// Json generated with utils/testing/custom_shape_from_model_wrong_shape.py
+
+// CHECK: Warning for operation onnx.Gelu: [Shape inference, dim 0] the inferred dim (4) is different from the existing dim (5). Use the existing dim instead.
+
+
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x5xf32> {onnx.name = "X"}) -> (tensor<5x6xf32> {onnx.name = "Z"}) {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Gelu"([[PARAM_0_]]) {approximate = "none", onnx_node_name = "onnx.Gelu_0"} : (tensor<4x5xf32>) -> tensor<5x6xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Relu"([[VAR_0_]]) {onnx_node_name = "onnx.Relu_1"} : (tensor<5x6xf32>) -> tensor<5x6xf32>
+// CHECK:           return [[VAR_1_]] : tensor<5x6xf32>
+// CHECK:         }
+{
+  "irVersion": "10",
+  "producerName": "onnx-mlir",
+  "graph": {
+    "node": [
+      {
+        "input": [
+          "X"
+        ],
+        "output": [
+          "Y"
+        ],
+        "opType": "Gelu",
+        "domain": "com.microsoft"
+      },
+      {
+        "input": [
+          "Y"
+        ],
+        "output": [
+          "Z"
+        ],
+        "opType": "Relu"
+      }
+    ],
+    "name": "test-custom",
+    "input": [
+      {
+        "name": "X",
+        "type": {
+          "tensorType": {
+            "elemType": 1,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "4"
+                },
+                {
+                  "dimValue": "5"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "output": [
+      {
+        "name": "Z",
+        "type": {
+          "tensorType": {
+            "elemType": 1,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "5"
+                },
+                {
+                  "dimValue": "6"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "valueInfo": [
+      {
+        "name": "Y",
+        "type": {
+          "tensorType": {
+            "elemType": 1,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "5"
+                },
+                {
+                  "dimValue": "6"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "opsetImport": [
+    {
+      "domain": "",
+      "version": "22"
+    },
+    {
+      "domain": "com.microsoft",
+      "version": "1"
+    }
+  ]
+}

--- a/utils/testing/custom_shape_from_model.py
+++ b/utils/testing/custom_shape_from_model.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+################################################################################
+#
+# Generates a model with a custom op and a relu, with shape information
+# in the model
+#
+################################################################################
+
+import onnx
+from onnx import helper
+from onnx import TensorProto
+from google.protobuf.json_format import MessageToJson
+
+
+X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [4, 5])
+
+
+Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [5, 6])
+
+# Create one output (ValueInfoProto)
+Z = helper.make_tensor_value_info("Z", TensorProto.FLOAT, [5, 6])
+
+# Create a node (NodeProto)
+custom_def = helper.make_node(
+    "testOp",
+    ["X"],
+    ["Y"],
+    domain="test",
+)
+
+relu_def = helper.make_node(
+    "Relu",
+    ["Y"],
+    ["Z"],
+)
+
+# Create the graph (GraphProto)
+graph_def = helper.make_graph(
+    [custom_def, relu_def],
+    "test-custom",
+    [X],
+    [Z],
+    value_info=[Y],
+)
+
+# Create the model (ModelProto)
+model_def = helper.make_model(
+    graph_def,
+    producer_name="onnx-mlir",
+    opset_imports=[
+        helper.make_opsetid("", 22),
+        helper.make_opsetid("test", 1),
+    ],
+)
+
+onnx.checker.check_model(model_def)
+print(MessageToJson(model_def))

--- a/utils/testing/custom_shape_from_model_wrong_shape.py
+++ b/utils/testing/custom_shape_from_model_wrong_shape.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+################################################################################
+#
+# Generates a model with a microsoft.Gelu and a relu, with WRONG shape
+# information in the model
+#
+################################################################################
+
+import onnx
+from onnx import helper
+from onnx import TensorProto
+from google.protobuf.json_format import MessageToJson
+
+
+X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [4, 5])
+
+
+Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [5, 6])
+
+# Create one output (ValueInfoProto)
+Z = helper.make_tensor_value_info("Z", TensorProto.FLOAT, [5, 6])
+
+# Create a node (NodeProto)
+custom_def = helper.make_node(
+    "Gelu",
+    ["X"],
+    ["Y"],
+    domain="com.microsoft",
+)
+
+relu_def = helper.make_node(
+    "Relu",
+    ["Y"],
+    ["Z"],
+)
+
+# Create the graph (GraphProto)
+graph_def = helper.make_graph(
+    [custom_def, relu_def],
+    "test-custom",
+    [X],
+    [Z],
+    value_info=[Y],
+)
+
+# Create the model (ModelProto)
+model_def = helper.make_model(
+    graph_def,
+    producer_name="onnx-mlir",
+    opset_imports=[
+        helper.make_opsetid("", 22),
+        helper.make_opsetid("com.microsoft", 1),
+    ],
+)
+
+onnx.checker.check_model(model_def)
+print(MessageToJson(model_def))


### PR DESCRIPTION
…m the model for custom ops.

Add a new option runOnnxShapeInference to allow to control it independently of model types.

Update default values to be the same in all places.