### PR TITLE
call relevant getter for signed, unsigned and signless ints

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -599,7 +599,13 @@ RESULT_TYPE getScalarValue(ElementsAttr denseAttr, Type type) {
   if (elementaryType.isInteger(8) || elementaryType.isInteger(16) ||
       elementaryType.isInteger(32) || elementaryType.isInteger(64)) {
     auto valueIt = denseAttr.getValues<IntegerAttr>().begin();
-    return static_cast<RESULT_TYPE>(mlir::cast<IntegerAttr>(*valueIt).getInt());
+    if (type.isSignedInteger()) {
+      return static_cast<RESULT_TYPE>(
+          mlir::cast<IntegerAttr>(*valueIt).getSInt());
+    } else {
+      return static_cast<RESULT_TYPE>(
+          mlir::cast<IntegerAttr>(*valueIt).getUInt());
+    }
   } else if (mlir::isa<FloatType>(elementaryType)) {
     auto valueIt = denseAttr.getValues<APFloat>().begin();
     return static_cast<RESULT_TYPE>((*valueIt).convertToDouble());

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -602,9 +602,12 @@ RESULT_TYPE getScalarValue(ElementsAttr denseAttr, Type type) {
     if (type.isSignedInteger()) {
       return static_cast<RESULT_TYPE>(
           mlir::cast<IntegerAttr>(*valueIt).getSInt());
-    } else {
+    } else if (type.isUnsignedInteger()) {
       return static_cast<RESULT_TYPE>(
           mlir::cast<IntegerAttr>(*valueIt).getUInt());
+    } else {
+      return static_cast<RESULT_TYPE>(
+          mlir::cast<IntegerAttr>(*valueIt).getInt());
     }
   } else if (mlir::isa<FloatType>(elementaryType)) {
     auto valueIt = denseAttr.getValues<APFloat>().begin();


### PR DESCRIPTION
While running an ONNX model, it crashes with the following backtrace

``` 
#16 0x00007f5bd712ab1a double onnx_mlir::getScalarValue<double>(mlir::ElementsAttr, mlir::Type) 
   /scratch/vitis_flexml/build/../third-party/onnx-mlir/src/Dialect/ONNX/ONNXOps/OpHelper.cpp:603:3

#17 0x00007f5bd712f33a onnx_mlir::hasIntegerPowerExponent(mlir::ONNXPowOp*, long&) 
   /scratch/vitis_flexml/build/../third-party/onnx-mlir/src/Dialect/ONNX/ONNXOps/OpHelper.cpp:0:14

#18 0x00007f5bd71c2acd PowToMulRewritePattern::CanExpandPowOpToMul(mlir::ONNXPowOp, long&) const 
   /scratch/vitis_flexml/build/../third-party/onnx-mlir/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp:1262:50
```

Adding cases 
If the type is signed/unsigned/signless then use getSInt()/getUInt()/getInt() respectively