### PR TITLE
Convert qdq conv pattern to QLinearConv

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -96,6 +96,9 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   // Passes for removing redundant concat, slice and cast QDQ Ops
   if (opts.enableRemoveDqQOp)
     pm.addPass(createQDQOptONNXToONNXPass());
+  //Pass to convert conv with bias to onnx.QLinearConv
+  if (opts.enableQConvLinear)
+    pm.addPass(createConvToQLinearConvPass());  
 
   // One more call to ONNX shape inference/canonicalization/... to update
   // shape if possible.

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -96,9 +96,9 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   // Passes for removing redundant concat, slice and cast QDQ Ops
   if (opts.enableRemoveDqQOp)
     pm.addPass(createQDQOptONNXToONNXPass());
-  //Pass to convert conv with bias to onnx.QLinearConv
+  // Pass to convert conv with bias to onnx.QLinearConv
   if (opts.enableQConvLinear)
-    pm.addPass(createConvToQLinearConvPass());  
+    pm.addPass(createConvToQLinearConvPass());
 
   // One more call to ONNX shape inference/canonicalization/... to update
   // shape if possible.

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -19,6 +19,7 @@ struct OnnxToMlirOptions {
   bool enableRemoveDqQOp = true;
   bool enableRemoveDqQAroundOp = true;
   bool enableRemoveBinary = false;
+  bool enableQConvLinear = false;
 
   bool disableRecomposeOption = false;
   bool enableONNXHybridPass = true;

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -44,7 +44,8 @@ add_onnx_mlir_library(OMONNXRewrite
   ConstProp.cpp
   QDQAroundOpOpt.cpp    
   QDQOpt.cpp
-  DQBinaryQOpt.cpp  
+  DQBinaryQOpt.cpp
+  QlinearConvPass.cpp  
   ConvOpt.cpp
   Decompose.cpp
   DecomposeEinsum.cpp

--- a/src/Dialect/ONNX/Transforms/QlinearConvPass.cpp
+++ b/src/Dialect/ONNX/Transforms/QlinearConvPass.cpp
@@ -1,11 +1,12 @@
-//===- ConvToQLinearConvPass.cpp ---------------------------------*- C++ -*-===//
+//===- ConvToQLinearConvPass.cpp ---------------------------------*- C++
+//-*-===//
 //
 // Convert pattern: DQ(X_q) -> DQ(W_q) -> [DQ(B_q)] -> Conv -> Q
 // into: QLinearConv
 //
-// This pass looks for the exact shape of a quantized conv subgraph and replaces it
-// with a single QLinearConv that consumes the real quantization parameters already
-// present in the graph.
+// This pass looks for the exact shape of a quantized conv subgraph and replaces
+// it with a single QLinearConv that consumes the real quantization parameters
+// already present in the graph.
 //
 
 #include "mlir/IR/PatternMatch.h"
@@ -43,9 +44,8 @@ static bool extractScalarFloatFromConst(mlir::Value v, float &out) {
   return false;
 }
 
-static mlir::DenseElementsAttr
-extractDenseFloatFromConst(ONNXConstantOp constBiasOp,
-                           mlir::Value biasFloatValue) {
+static mlir::DenseElementsAttr extractDenseFloatFromConst(
+    ONNXConstantOp constBiasOp, mlir::Value biasFloatValue) {
   mlir::DenseElementsAttr denseBiasF;
 
   if (!constBiasOp.getValue().has_value())
@@ -67,17 +67,16 @@ extractDenseFloatFromConst(ONNXConstantOp constBiasOp,
       return mlir::DenseElementsAttr(); // invalid → return empty
 
     // Build DenseElementsAttr
-    denseBiasF = mlir::DenseElementsAttr::get(
-        desiredTy, llvm::ArrayRef<float>(floats));
+    denseBiasF =
+        mlir::DenseElementsAttr::get(desiredTy, llvm::ArrayRef<float>(floats));
   }
 
   return denseBiasF;
 }
 
-static llvm::SmallVector<mlir::Attribute, 32>
-createBiasI32Attrs(mlir::DenseElementsAttr denseBiasF,
-                   double xScaleS, double wScaleS,
-                   mlir::PatternRewriter &rewriter) {
+static llvm::SmallVector<mlir::Attribute, 32> createBiasI32Attrs(
+    mlir::DenseElementsAttr denseBiasF, double xScaleS, double wScaleS,
+    mlir::PatternRewriter &rewriter) {
   llvm::SmallVector<mlir::Attribute, 32> biasI32Attrs;
 
   double denom = static_cast<double>(xScaleS) * static_cast<double>(wScaleS);
@@ -96,165 +95,160 @@ createBiasI32Attrs(mlir::DenseElementsAttr denseBiasF,
     if (qi < std::numeric_limits<int32_t>::min())
       qi = std::numeric_limits<int32_t>::min();
 
-    biasI32Attrs.push_back(rewriter.getI32IntegerAttr(static_cast<int32_t>(qi)));
+    biasI32Attrs.push_back(
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(qi)));
   }
 
   return biasI32Attrs;
 }
 
-/// Pattern that matches Conv fed by DequantizeLinear(s) and consumed by QuantizeLinear.
+/// Pattern that matches Conv fed by DequantizeLinear(s) and consumed by
+/// QuantizeLinear.
 struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
   using OpRewritePattern<ONNXConvOp>::OpRewritePattern;
 
-LogicalResult matchAndRewrite(ONNXConvOp convOp, PatternRewriter &rewriter) const override {
-  Location loc = convOp.getLoc();
+  LogicalResult matchAndRewrite(
+      ONNXConvOp convOp, PatternRewriter &rewriter) const override {
+    Location loc = convOp.getLoc();
 
-  //Conv has bias B and its defining op is DequantizeLinear
-  Value biasVal = convOp.getB();
-  if (!biasVal || isa<ONNXNoneOp>(biasVal.getDefiningOp()))
-    return failure();
-
-  auto dqBiasOp = dyn_cast<ONNXDequantizeLinearOp>(biasVal.getDefiningOp());
-  if (!dqBiasOp){
-    return failure();
-  }
-
-  // QuantizeLinear that produces the quantized bias (input to DQ)
-  auto qBiasOp = dyn_cast<ONNXQuantizeLinearOp>(dqBiasOp.getX().getDefiningOp());
-  if (!qBiasOp){
-    return failure();
-  }
-
-  // Conv input X must come from DequantizeLinear ----
-  auto dqInputOp = dyn_cast_or_null<ONNXDequantizeLinearOp>(convOp.getX().getDefiningOp());
-  if (!dqInputOp){
-    return failure();
-  }
-  
-  Value qInput = dqInputOp.getX();
-  Value xScale = dqInputOp.getXScale();
-  Value xZp = dqInputOp.getXZeroPoint();
-
-  // Conv weight W must come from DequantizeLinear ----
-  auto dqWeightOp = dyn_cast_or_null<ONNXDequantizeLinearOp>(convOp.getW().getDefiningOp());
-  if (!dqWeightOp){
-    return failure();
-  }
-  Value qWeight = dqWeightOp.getX();
-  Value wScale = dqWeightOp.getXScale();
-  Value wZp = dqWeightOp.getXZeroPoint();
-
-  // Conv output consumed by QuantizeLinear (qOutOp) ----
-  if (convOp->getUsers().empty())
-    return failure();
-  Operation *firstUser = *convOp->getUsers().begin();
-  auto qOutOp = dyn_cast<ONNXQuantizeLinearOp>(firstUser);
-  if (!qOutOp)
-    return failure();
-
-  Value yScale = qOutOp.getYScale();
-  Value yZp = qOutOp.getYZeroPoint();
-  // ---- Extract float bias values from qBiasOp.getX() (which points to the float constant) ----
-  Value biasFloatValue = qBiasOp.getX();
-  auto biasFloatDefOp = biasFloatValue.getDefiningOp();
-  if (!biasFloatDefOp)
-    return failure();
-
-  auto constBiasOp = dyn_cast<ONNXConstantOp>(biasFloatDefOp);
-  if (!constBiasOp)
-    return failure();
-  
-  Value biasQ = dqBiasOp.getX();
-  auto biasQType = biasQ.getType().dyn_cast<mlir::RankedTensorType>();
-  if (!biasQType)
-    return failure();  
-  
-  Value biasInt32Val;
-
-  // Case 1: Bias is already int32 -----------------------
-  if (biasQType.getElementType().isInteger(32)) {
-    biasInt32Val = biasQ;
-  } else {  
-  // Case 2: Bias is int8. float32 → quantize -----------------
-
-    // Try to get the ElementsAttr
-    auto denseBiasF = extractDenseFloatFromConst(constBiasOp, biasFloatValue);
-
-    if (!denseBiasF)
-      return failure();
-  
-    float xScaleS = 0.0f;
-    if (!extractScalarFloatFromConst(xScale, xScaleS))
+    // Conv has bias B and its defining op is DequantizeLinear
+    Value biasVal = convOp.getB();
+    if (!biasVal || isa<ONNXNoneOp>(biasVal.getDefiningOp()))
       return failure();
 
-    float wScaleS = 0.0f;
-    if (!extractScalarFloatFromConst(wScale, wScaleS))
-      return failure();
-
-    auto biasI32Attrs = createBiasI32Attrs(denseBiasF, xScaleS, wScaleS, rewriter);
-    if (biasI32Attrs.empty()) {
+    auto dqBiasOp = dyn_cast<ONNXDequantizeLinearOp>(biasVal.getDefiningOp());
+    if (!dqBiasOp) {
       return failure();
     }
 
-    // ---- Build tensor type for i32 bias with same shape as denseBiasF ----
-    auto biasTensorTy = denseBiasF.getType().cast<mlir::RankedTensorType>();
-    auto biasTypeI32 = mlir::RankedTensorType::get(biasTensorTy.getShape(), rewriter.getIntegerType(32));
+    // QuantizeLinear that produces the quantized bias (input to DQ)
+    auto qBiasOp =
+        dyn_cast<ONNXQuantizeLinearOp>(dqBiasOp.getX().getDefiningOp());
+    if (!qBiasOp) {
+      return failure();
+    }
 
-    // Build DenseElementsAttr<i32> from integer attrs
-    auto denseAttrI32 = mlir::DenseElementsAttr::get(biasTypeI32, biasI32Attrs);
+    // Conv input X must come from DequantizeLinear ----
+    auto dqInputOp =
+        dyn_cast_or_null<ONNXDequantizeLinearOp>(convOp.getX().getDefiningOp());
+    if (!dqInputOp) {
+      return failure();
+    }
 
-    // ---- Create ONNXConstantOp for i32 bias (pass the full argument list as required) ----
-    auto biasConstI32 = rewriter.create<ONNXConstantOp>(
-        loc,
-        biasTypeI32,
-        mlir::Attribute(),
-        denseAttrI32,
-        mlir::FloatAttr(),
-        mlir::ArrayAttr(),
-        mlir::IntegerAttr(),
-        mlir::ArrayAttr(),
-        mlir::StringAttr(),
-        mlir::ArrayAttr()
-      );
+    Value qInput = dqInputOp.getX();
+    Value xScale = dqInputOp.getXScale();
+    Value xZp = dqInputOp.getXZeroPoint();
 
-    biasInt32Val = biasConstI32.getResult();
+    // Conv weight W must come from DequantizeLinear ----
+    auto dqWeightOp =
+        dyn_cast_or_null<ONNXDequantizeLinearOp>(convOp.getW().getDefiningOp());
+    if (!dqWeightOp) {
+      return failure();
+    }
+    Value qWeight = dqWeightOp.getX();
+    Value wScale = dqWeightOp.getXScale();
+    Value wZp = dqWeightOp.getXZeroPoint();
+
+    // Conv output consumed by QuantizeLinear (qOutOp) ----
+    if (convOp->getUsers().empty())
+      return failure();
+    Operation *firstUser = *convOp->getUsers().begin();
+    auto qOutOp = dyn_cast<ONNXQuantizeLinearOp>(firstUser);
+    if (!qOutOp)
+      return failure();
+
+    Value yScale = qOutOp.getYScale();
+    Value yZp = qOutOp.getYZeroPoint();
+    // ---- Extract float bias values from qBiasOp.getX() (which points to the
+    // float constant) ----
+    Value biasFloatValue = qBiasOp.getX();
+    auto biasFloatDefOp = biasFloatValue.getDefiningOp();
+    if (!biasFloatDefOp)
+      return failure();
+
+    auto constBiasOp = dyn_cast<ONNXConstantOp>(biasFloatDefOp);
+    if (!constBiasOp)
+      return failure();
+
+    Value biasQ = dqBiasOp.getX();
+    auto biasQType = biasQ.getType().dyn_cast<mlir::RankedTensorType>();
+    if (!biasQType)
+      return failure();
+
+    Value biasInt32Val;
+
+    // Case 1: Bias is already int32 -----------------------
+    if (biasQType.getElementType().isInteger(32)) {
+      biasInt32Val = biasQ;
+    } else {
+      // Case 2: Bias is int8. float32 → quantize -----------------
+
+      // Try to get the ElementsAttr
+      auto denseBiasF = extractDenseFloatFromConst(constBiasOp, biasFloatValue);
+
+      if (!denseBiasF)
+        return failure();
+
+      float xScaleS = 0.0f;
+      if (!extractScalarFloatFromConst(xScale, xScaleS))
+        return failure();
+
+      float wScaleS = 0.0f;
+      if (!extractScalarFloatFromConst(wScale, wScaleS))
+        return failure();
+
+      auto biasI32Attrs =
+          createBiasI32Attrs(denseBiasF, xScaleS, wScaleS, rewriter);
+      if (biasI32Attrs.empty()) {
+        return failure();
+      }
+
+      // ---- Build tensor type for i32 bias with same shape as denseBiasF ----
+      auto biasTensorTy = denseBiasF.getType().cast<mlir::RankedTensorType>();
+      auto biasTypeI32 = mlir::RankedTensorType::get(
+          biasTensorTy.getShape(), rewriter.getIntegerType(32));
+
+      // Build DenseElementsAttr<i32> from integer attrs
+      auto denseAttrI32 =
+          mlir::DenseElementsAttr::get(biasTypeI32, biasI32Attrs);
+
+      // ---- Create ONNXConstantOp for i32 bias (pass the full argument list as
+      // required) ----
+      auto biasConstI32 = rewriter.create<ONNXConstantOp>(loc, biasTypeI32,
+          mlir::Attribute(), denseAttrI32, mlir::FloatAttr(), mlir::ArrayAttr(),
+          mlir::IntegerAttr(), mlir::ArrayAttr(), mlir::StringAttr(),
+          mlir::ArrayAttr());
+
+      biasInt32Val = biasConstI32.getResult();
+    }
+
+    // ---- Create QLinearConv: operand order:
+    SmallVector<Value, 9> qconvOperands{
+        qInput, xScale, xZp, qWeight, wScale, wZp, yScale, yZp, biasInt32Val};
+
+    Type qOutType = qOutOp.getResult().getType();
+
+    // Create QLinearConv
+    auto qconv =
+        rewriter.create<ONNXQLinearConvOp>(loc, qOutType, qconvOperands);
+
+    // Replace the QuantizeLinear (qOutOp) result with qconv result
+    rewriter.replaceOp(qOutOp, qconv.getResult());
+
+    // Erase dead ops
+    if (dqBiasOp->use_empty())
+      rewriter.eraseOp(dqBiasOp);
+    if (qBiasOp && qBiasOp->use_empty())
+      rewriter.eraseOp(qBiasOp);
+    if (dqInputOp && dqInputOp->use_empty())
+      rewriter.eraseOp(dqInputOp);
+    if (dqWeightOp && dqWeightOp->use_empty())
+      rewriter.eraseOp(dqWeightOp);
+    if (convOp->use_empty())
+      rewriter.eraseOp(convOp);
+
+    return success();
   }
-
-  // ---- Create QLinearConv: operand order:
-  SmallVector<Value, 9> qconvOperands{
-      qInput,                      
-      xScale,                       
-      xZp,                          
-      qWeight,                      
-      wScale,                       
-      wZp,                          
-      yScale,                       
-      yZp,
-      biasInt32Val                        
-  };
-
-  Type qOutType = qOutOp.getResult().getType();
-
-  // Create QLinearConv
-  auto qconv = rewriter.create<ONNXQLinearConvOp>(loc, qOutType, qconvOperands);
-
-  // Replace the QuantizeLinear (qOutOp) result with qconv result
-  rewriter.replaceOp(qOutOp, qconv.getResult());
-
-  // Erase dead ops
-  if (dqBiasOp->use_empty())
-    rewriter.eraseOp(dqBiasOp);
-  if (qBiasOp && qBiasOp->use_empty())
-    rewriter.eraseOp(qBiasOp);
-  if (dqInputOp && dqInputOp->use_empty())
-    rewriter.eraseOp(dqInputOp);
-  if (dqWeightOp && dqWeightOp->use_empty())
-    rewriter.eraseOp(dqWeightOp);
-  if (convOp->use_empty())
-    rewriter.eraseOp(convOp);
-
-  return success();
-}
 };
 
 /// The pass wrapper
@@ -262,7 +256,9 @@ struct ConvToQLinearConvPass
     : public PassWrapper<ConvToQLinearConvPass, OperationPass<func::FuncOp>> {
 
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvToQLinearConvPass)
-  StringRef getArgument() const override { return "conv-to-qlinearconv-onnx-to-onnx";}
+  StringRef getArgument() const override {
+    return "conv-to-qlinearconv-onnx-to-onnx";
+  }
   StringRef getDescription() const override {
     return "Replace Conv operation with a QlinearConv op";
   }
@@ -271,8 +267,8 @@ struct ConvToQLinearConvPass
     RewritePatternSet patterns(&ctx);
     patterns.add<ConvToQLinearConvPattern>(&ctx);
 
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))){
-       signalPassFailure();
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
     }
   }
 };
@@ -283,4 +279,4 @@ namespace onnx_mlir {
 std::unique_ptr<Pass> createConvToQLinearConvPass() {
   return std::make_unique<ConvToQLinearConvPass>();
 }
-}
+} // namespace onnx_mlir

--- a/src/Dialect/ONNX/Transforms/QlinearConvPass.cpp
+++ b/src/Dialect/ONNX/Transforms/QlinearConvPass.cpp
@@ -1,0 +1,272 @@
+//===- ConvToQLinearConvPass.cpp ---------------------------------*- C++ -*-===//
+//
+// Convert pattern: DQ(X_q) -> DQ(W_q) -> [DQ(B_q)] -> Conv -> Q
+// into: QLinearConv
+//
+// This pass looks for a quantized conv subgraph and replaces it
+// with a single QLinearConv that consumes the real quantization parameters already
+// present in the graph.
+//
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
+#include "src/Pass/Passes.hpp"
+#include <cmath>
+
+using namespace mlir;
+using namespace onnx_mlir;
+
+namespace {
+
+static bool extractScalarFloatFromConst(mlir::Value v, float &out) {
+  auto def = v.getDefiningOp<ONNXConstantOp>();
+  if (!def)
+    return false;
+
+  mlir::Attribute raw;
+  if (def.getValue().has_value())
+    raw = *def.getValue();
+  else
+    raw = def.getValueAttr();
+
+  if (auto elts = raw.dyn_cast<mlir::ElementsAttr>()) {
+    for (auto apf : elts.getValues<llvm::APFloat>()) {
+      out = apf.convertToFloat();
+      return true;
+    }
+    return false;
+  }
+
+  return false;
+}
+
+static mlir::DenseElementsAttr
+extractDenseFloatFromConst(ONNXConstantOp constBiasOp,
+                           mlir::Value biasFloatValue) {
+  mlir::DenseElementsAttr denseBiasF;
+
+  if (!constBiasOp.getValue().has_value())
+    return denseBiasF; // empty, caller must check
+
+  mlir::Attribute opt = *constBiasOp.getValue();
+
+  if (auto elts = opt.dyn_cast<mlir::ElementsAttr>()) {
+    // Collect floats
+    llvm::SmallVector<float, 32> floats;
+    floats.reserve(elts.getNumElements());
+    for (auto v : elts.getValues<llvm::APFloat>())
+      floats.push_back(v.convertToFloat());
+
+    // Ensure correct tensor type shape
+    auto desiredTy =
+        biasFloatValue.getType().dyn_cast<mlir::RankedTensorType>();
+    if (!desiredTy)
+      return mlir::DenseElementsAttr(); // invalid → return empty
+
+    // Build DenseElementsAttr
+    denseBiasF = mlir::DenseElementsAttr::get(
+        desiredTy, llvm::ArrayRef<float>(floats));
+  }
+
+  return denseBiasF;
+}
+
+static llvm::SmallVector<mlir::Attribute, 32>
+createBiasI32Attrs(mlir::DenseElementsAttr denseBiasF,
+                   double xScaleS, double wScaleS,
+                   mlir::PatternRewriter &rewriter) {
+  llvm::SmallVector<mlir::Attribute, 32> biasI32Attrs;
+
+  double denom = static_cast<double>(xScaleS) * static_cast<double>(wScaleS);
+  if (denom == 0.0)
+    return biasI32Attrs; // empty, caller should check
+
+  biasI32Attrs.reserve(denseBiasF.getNumElements());
+  for (auto apf : denseBiasF.getValues<llvm::APFloat>()) {
+    double f = apf.convertToFloat();
+    double qd = std::nearbyint(f / denom);
+    int64_t qi = static_cast<int64_t>(qd);
+
+    // clamp to int32 range
+    if (qi > std::numeric_limits<int32_t>::max())
+      qi = std::numeric_limits<int32_t>::max();
+    if (qi < std::numeric_limits<int32_t>::min())
+      qi = std::numeric_limits<int32_t>::min();
+
+    biasI32Attrs.push_back(rewriter.getI32IntegerAttr(static_cast<int32_t>(qi)));
+  }
+
+  return biasI32Attrs;
+}
+
+/// Pattern that matches Conv fed by DequantizeLinear(s) and consumed by QuantizeLinear.
+struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
+  using OpRewritePattern<ONNXConvOp>::OpRewritePattern;
+
+LogicalResult matchAndRewrite(ONNXConvOp convOp, PatternRewriter &rewriter) const override {
+  Location loc = convOp.getLoc();
+
+  //Conv has bias B and its defining op is DequantizeLinear
+  Value biasVal = convOp.getB();
+  if (!biasVal || isa<ONNXNoneOp>(biasVal.getDefiningOp()))
+    return failure();
+
+  auto dqBiasOp = dyn_cast<ONNXDequantizeLinearOp>(biasVal.getDefiningOp());
+  if (!dqBiasOp){
+    return failure();
+  }
+
+  // QuantizeLinear that produces the quantized bias (input to DQ)
+  auto qBiasOp = dyn_cast<ONNXQuantizeLinearOp>(dqBiasOp.getX().getDefiningOp());
+  if (!qBiasOp){
+    return failure();
+  }
+
+  // Conv input X must come from DequantizeLinear ----
+  auto dqInputOp = dyn_cast_or_null<ONNXDequantizeLinearOp>(convOp.getX().getDefiningOp());
+  if (!dqInputOp){
+    return failure();
+  }
+  
+  Value qInput = dqInputOp.getX();
+  Value xScale = dqInputOp.getXScale();
+  Value xZp = dqInputOp.getXZeroPoint();
+
+  // Conv weight W must come from DequantizeLinear ----
+  auto dqWeightOp = dyn_cast_or_null<ONNXDequantizeLinearOp>(convOp.getW().getDefiningOp());
+  if (!dqWeightOp){
+    return failure();
+  }
+  Value qWeight = dqWeightOp.getX();
+  Value wScale = dqWeightOp.getXScale();
+  Value wZp = dqWeightOp.getXZeroPoint();
+
+  // Conv output consumed by QuantizeLinear (qOutOp) ----
+  if (convOp->getUsers().empty())
+    return failure();
+  Operation *firstUser = *convOp->getUsers().begin();
+  auto qOutOp = dyn_cast<ONNXQuantizeLinearOp>(firstUser);
+  if (!qOutOp)
+    return failure();
+
+  Value yScale = qOutOp.getYScale();
+  Value yZp = qOutOp.getYZeroPoint();
+  // ---- Extract float bias values from qBiasOp.getX() (which points to the float constant) ----
+  Value biasFloatValue = qBiasOp.getX();
+  auto biasFloatDefOp = biasFloatValue.getDefiningOp();
+  if (!biasFloatDefOp)
+    return failure();
+
+  auto constBiasOp = dyn_cast<ONNXConstantOp>(biasFloatDefOp);
+  if (!constBiasOp)
+    return failure();
+
+  // Try to get the ElementsAttr
+  auto denseBiasF = extractDenseFloatFromConst(constBiasOp, biasFloatValue);
+
+  if (!denseBiasF)
+    return failure();
+ 
+  float xScaleS = 0.0f;
+  if (!extractScalarFloatFromConst(xScale, xScaleS))
+    return failure();
+
+  float wScaleS = 0.0f;
+  if (!extractScalarFloatFromConst(wScale, wScaleS))
+    return failure();
+
+  auto biasI32Attrs = createBiasI32Attrs(denseBiasF, xScaleS, wScaleS, rewriter);
+  if (biasI32Attrs.empty()) {
+    return failure();
+  }
+
+  // ---- Build tensor type for i32 bias with same shape as denseBiasF ----
+  auto biasTensorTy = denseBiasF.getType().cast<mlir::RankedTensorType>();
+  auto biasTypeI32 = mlir::RankedTensorType::get(biasTensorTy.getShape(), rewriter.getIntegerType(32));
+
+  // Build DenseElementsAttr<i32> from integer attrs
+  auto denseAttrI32 = mlir::DenseElementsAttr::get(biasTypeI32, biasI32Attrs);
+
+  // ---- Create ONNXConstantOp for i32 bias (pass the full argument list as required) ----
+  auto biasConstI32 = rewriter.create<ONNXConstantOp>(
+      loc,
+      biasTypeI32,
+      mlir::Attribute(),
+      denseAttrI32,
+      mlir::FloatAttr(),
+      mlir::ArrayAttr(),
+      mlir::IntegerAttr(),
+      mlir::ArrayAttr(),
+      mlir::StringAttr(),
+      mlir::ArrayAttr()
+    );
+
+  Value biasInt32Val = biasConstI32.getResult();
+
+  // ---- Create QLinearConv: operand order:
+  SmallVector<Value, 9> qconvOperands{
+      qInput,                      
+      xScale,                       
+      xZp,                          
+      qWeight,                      
+      wScale,                       
+      wZp,                          
+      yScale,                       
+      yZp,
+      biasInt32Val                        
+  };
+
+  Type qOutType = qOutOp.getResult().getType();
+
+  // Create QLinearConv
+  auto qconv = rewriter.create<ONNXQLinearConvOp>(loc, qOutType, qconvOperands);
+
+  // Replace the QuantizeLinear (qOutOp) result with qconv result
+  rewriter.replaceOp(qOutOp, qconv.getResult());
+
+  // Erase dead ops
+  if (dqBiasOp->use_empty())
+    rewriter.eraseOp(dqBiasOp);
+  if (qBiasOp && qBiasOp->use_empty())
+    rewriter.eraseOp(qBiasOp);
+  if (dqInputOp && dqInputOp->use_empty())
+    rewriter.eraseOp(dqInputOp);
+  if (dqWeightOp && dqWeightOp->use_empty())
+    rewriter.eraseOp(dqWeightOp);
+  if (convOp->use_empty())
+    rewriter.eraseOp(convOp);
+
+  return success();
+}
+};
+
+/// The pass wrapper
+struct ConvToQLinearConvPass
+    : public PassWrapper<ConvToQLinearConvPass, OperationPass<func::FuncOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvToQLinearConvPass)
+  StringRef getArgument() const override { return "conv-to-qlinearconv-onnx-to-onnx";}
+  StringRef getDescription() const override {
+    return "Replace Conv operation with a QlinearConv op";
+  }
+  void runOnOperation() override {
+    MLIRContext &ctx = getContext();
+    RewritePatternSet patterns(&ctx);
+    patterns.add<ConvToQLinearConvPattern>(&ctx);
+
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))){
+       signalPassFailure();
+    }
+  }
+};
+
+} // end anonymous namespace
+namespace onnx_mlir {
+// Factory to create the pass (useful for registration)
+std::unique_ptr<Pass> createConvToQLinearConvPass() {
+  return std::make_unique<ConvToQLinearConvPass>();
+}
+}

--- a/src/Dialect/ONNX/Transforms/QlinearConvPass.cpp
+++ b/src/Dialect/ONNX/Transforms/QlinearConvPass.cpp
@@ -3,7 +3,7 @@
 // Convert pattern: DQ(X_q) -> DQ(W_q) -> [DQ(B_q)] -> Conv -> Q
 // into: QLinearConv
 //
-// This pass looks for a quantized conv subgraph and replaces it
+// This pass looks for the exact shape of a quantized conv subgraph and replaces it
 // with a single QLinearConv that consumes the real quantization parameters already
 // present in the graph.
 //
@@ -163,48 +163,62 @@ LogicalResult matchAndRewrite(ONNXConvOp convOp, PatternRewriter &rewriter) cons
   auto constBiasOp = dyn_cast<ONNXConstantOp>(biasFloatDefOp);
   if (!constBiasOp)
     return failure();
+  
+  Value biasQ = dqBiasOp.getX();
+  auto biasQType = biasQ.getType().dyn_cast<mlir::RankedTensorType>();
+  if (!biasQType)
+    return failure();  
+  
+  Value biasInt32Val;
 
-  // Try to get the ElementsAttr
-  auto denseBiasF = extractDenseFloatFromConst(constBiasOp, biasFloatValue);
+  // Case 1: Bias is already int32 -----------------------
+  if (biasQType.getElementType().isInteger(32)) {
+    biasInt32Val = biasQ;
+  } else {  
+  // Case 2: Bias is int8. float32 → quantize -----------------
 
-  if (!denseBiasF)
-    return failure();
- 
-  float xScaleS = 0.0f;
-  if (!extractScalarFloatFromConst(xScale, xScaleS))
-    return failure();
+    // Try to get the ElementsAttr
+    auto denseBiasF = extractDenseFloatFromConst(constBiasOp, biasFloatValue);
 
-  float wScaleS = 0.0f;
-  if (!extractScalarFloatFromConst(wScale, wScaleS))
-    return failure();
+    if (!denseBiasF)
+      return failure();
+  
+    float xScaleS = 0.0f;
+    if (!extractScalarFloatFromConst(xScale, xScaleS))
+      return failure();
 
-  auto biasI32Attrs = createBiasI32Attrs(denseBiasF, xScaleS, wScaleS, rewriter);
-  if (biasI32Attrs.empty()) {
-    return failure();
+    float wScaleS = 0.0f;
+    if (!extractScalarFloatFromConst(wScale, wScaleS))
+      return failure();
+
+    auto biasI32Attrs = createBiasI32Attrs(denseBiasF, xScaleS, wScaleS, rewriter);
+    if (biasI32Attrs.empty()) {
+      return failure();
+    }
+
+    // ---- Build tensor type for i32 bias with same shape as denseBiasF ----
+    auto biasTensorTy = denseBiasF.getType().cast<mlir::RankedTensorType>();
+    auto biasTypeI32 = mlir::RankedTensorType::get(biasTensorTy.getShape(), rewriter.getIntegerType(32));
+
+    // Build DenseElementsAttr<i32> from integer attrs
+    auto denseAttrI32 = mlir::DenseElementsAttr::get(biasTypeI32, biasI32Attrs);
+
+    // ---- Create ONNXConstantOp for i32 bias (pass the full argument list as required) ----
+    auto biasConstI32 = rewriter.create<ONNXConstantOp>(
+        loc,
+        biasTypeI32,
+        mlir::Attribute(),
+        denseAttrI32,
+        mlir::FloatAttr(),
+        mlir::ArrayAttr(),
+        mlir::IntegerAttr(),
+        mlir::ArrayAttr(),
+        mlir::StringAttr(),
+        mlir::ArrayAttr()
+      );
+
+    biasInt32Val = biasConstI32.getResult();
   }
-
-  // ---- Build tensor type for i32 bias with same shape as denseBiasF ----
-  auto biasTensorTy = denseBiasF.getType().cast<mlir::RankedTensorType>();
-  auto biasTypeI32 = mlir::RankedTensorType::get(biasTensorTy.getShape(), rewriter.getIntegerType(32));
-
-  // Build DenseElementsAttr<i32> from integer attrs
-  auto denseAttrI32 = mlir::DenseElementsAttr::get(biasTypeI32, biasI32Attrs);
-
-  // ---- Create ONNXConstantOp for i32 bias (pass the full argument list as required) ----
-  auto biasConstI32 = rewriter.create<ONNXConstantOp>(
-      loc,
-      biasTypeI32,
-      mlir::Attribute(),
-      denseAttrI32,
-      mlir::FloatAttr(),
-      mlir::ArrayAttr(),
-      mlir::IntegerAttr(),
-      mlir::ArrayAttr(),
-      mlir::StringAttr(),
-      mlir::ArrayAttr()
-    );
-
-  Value biasInt32Val = biasConstI32.getResult();
 
   // ---- Create QLinearConv: operand order:
   SmallVector<Value, 9> qconvOperands{

--- a/src/Dialect/ONNX/Transforms/QlinearConvPass.cpp
+++ b/src/Dialect/ONNX/Transforms/QlinearConvPass.cpp
@@ -22,6 +22,45 @@ using namespace onnx_mlir;
 
 namespace {
 
+// ---- Helper: check scale is scalar f32 ----
+static bool isScalarF32(Value v) {
+  auto ty = v.getType().dyn_cast<RankedTensorType>();
+  if (!ty)
+    return false;
+  if (!ty.getElementType().isF32())
+    return false;
+  // Must be scalar (rank-0) or single element tensor (rank-1 with size=1)
+  if (ty.getRank() == 0)
+    return true;
+  if (ty.getRank() == 1 && ty.getDimSize(0) == 1)
+    return true;
+  return false;
+}
+
+// ---- Helper: check zero point is scalar int8/uint8 ----
+static bool isScalarI8OrU8(Value v) {
+  auto ty = v.getType().dyn_cast<RankedTensorType>();
+  if (!ty)
+    return false;
+  auto elemTy = ty.getElementType();
+  if (!(elemTy.isInteger(8) || elemTy.isUnsignedInteger(8)))
+    return false;
+  if (ty.getRank() == 0)
+    return true;
+  if (ty.getRank() == 1 && ty.getDimSize(0) == 1)
+    return true;
+  return false;
+}
+
+// ---- Helper: check tensor is int8/uint8 ----
+static bool isTensorI8OrU8(Value v) {
+  auto ty = v.getType().dyn_cast<RankedTensorType>();
+  if (!ty)
+    return false;
+  auto elemTy = ty.getElementType();
+  return elemTy.isInteger(8) || elemTy.isUnsignedInteger(8);
+}
+
 static bool extractScalarFloatFromConst(mlir::Value v, float &out) {
   auto def = v.getDefiningOp<ONNXConstantOp>();
   if (!def)
@@ -110,17 +149,6 @@ struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
   LogicalResult matchAndRewrite(
       ONNXConvOp convOp, PatternRewriter &rewriter) const override {
     Location loc = convOp.getLoc();
-    // Conv has bias B and its defining op is DequantizeLinear
-    Value biasVal = convOp.getB();
-    if (!biasVal || isa<ONNXNoneOp>(biasVal.getDefiningOp()))
-      return failure();
-
-    auto dqBiasOp = dyn_cast<ONNXDequantizeLinearOp>(biasVal.getDefiningOp());
-    if (!dqBiasOp) {
-      return failure();
-    }
-    auto qBiasOp =
-        dyn_cast<ONNXQuantizeLinearOp>(dqBiasOp.getX().getDefiningOp());
 
     // Conv input X must come from DequantizeLinear ----
     auto dqInputOp =
@@ -133,6 +161,10 @@ struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
     Value xScale = dqInputOp.getXScale();
     Value xZp = dqInputOp.getXZeroPoint();
 
+    // ---- Check input type ----
+    if (!isTensorI8OrU8(qInput))
+      return failure();
+
     // Conv weight W must come from DequantizeLinear ----
     auto dqWeightOp =
         dyn_cast_or_null<ONNXDequantizeLinearOp>(convOp.getW().getDefiningOp());
@@ -144,9 +176,13 @@ struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
     Value wScale = dqWeightOp.getXScale();
     Value wZp = dqWeightOp.getXZeroPoint();
 
-    // Conv output consumed by QuantizeLinear (qOutOp) ----
-    if (convOp->getUsers().empty())
+    if (!isTensorI8OrU8(qWeight))
       return failure();
+
+    // Conv output consumed by QuantizeLinear (qOutOp) ----
+    if (convOp->getUsers().empty() && convOp->getNumResults() != 1)
+      return failure();
+
     Operation *firstUser = *convOp->getUsers().begin();
     auto qOutOp = dyn_cast<ONNXQuantizeLinearOp>(firstUser);
     if (!qOutOp)
@@ -154,68 +190,93 @@ struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
     Value yScale = qOutOp.getYScale();
     Value yZp = qOutOp.getYZeroPoint();
 
-    Value biasQ = dqBiasOp.getX();
-    auto biasQType = biasQ.getType().dyn_cast<mlir::RankedTensorType>();
-    if (!biasQType)
+    if (!isScalarF32(xScale) || !isScalarF32(wScale) || !isScalarF32(yScale)) {
       return failure();
+    }
+
+    if (!isScalarI8OrU8(xZp) || !isScalarI8OrU8(wZp) || !isScalarI8OrU8(yZp)) {
+      return failure();
+    }
+
+    Value biasVal = convOp.getB();
 
     Value biasInt32Val;
-
-    // Case 1: Bias is already int32 -----------------------
-    if (biasQType.getElementType().isInteger(32)) {
-      biasInt32Val = biasQ;
+    if (!biasVal || isa<ONNXNoneOp>(biasVal.getDefiningOp())) {
+      // Case 0: No bias at all
+      biasInt32Val = Value();
     } else {
-      // Case 2: Bias is int8. float32 → quantize -----------------
-      if (!qBiasOp) {
-        return failure();
-      }
-      // ---- Extract float bias values from qBiasOp.getX() (which points to the
-      // float constant) ----
-      Value biasFloatValue = qBiasOp.getX();
-      auto biasFloatDefOp = biasFloatValue.getDefiningOp();
-      if (!biasFloatDefOp)
-        return failure();
 
-      auto constBiasOp = dyn_cast<ONNXConstantOp>(biasFloatDefOp);
-      if (!constBiasOp)
-        return failure();
-
-      // Try to get the ElementsAttr
-      auto denseBiasF = extractDenseFloatFromConst(constBiasOp, biasFloatValue);
-
-      if (!denseBiasF)
-        return failure();
-      float xScaleS = 0.0f;
-      if (!extractScalarFloatFromConst(xScale, xScaleS))
-        return failure();
-
-      float wScaleS = 0.0f;
-      if (!extractScalarFloatFromConst(wScale, wScaleS))
-        return failure();
-
-      auto biasI32Attrs =
-          createBiasI32Attrs(denseBiasF, xScaleS, wScaleS, rewriter);
-      if (biasI32Attrs.empty()) {
+      // Conv has bias B and its defining op is DequantizeLinear
+      auto dqBiasOp = dyn_cast<ONNXDequantizeLinearOp>(biasVal.getDefiningOp());
+      if (!dqBiasOp) {
         return failure();
       }
 
-      // ---- Build tensor type for i32 bias with same shape as denseBiasF ----
-      auto biasTensorTy = denseBiasF.getType().cast<mlir::RankedTensorType>();
-      auto biasTypeI32 = mlir::RankedTensorType::get(
-          biasTensorTy.getShape(), rewriter.getIntegerType(32));
+      Value biasQ = dqBiasOp.getX();
+      auto biasQType = biasQ.getType().dyn_cast<mlir::RankedTensorType>();
+      if (!biasQType)
+        return failure();
 
-      // Build DenseElementsAttr<i32> from integer attrs
-      auto denseAttrI32 =
-          mlir::DenseElementsAttr::get(biasTypeI32, biasI32Attrs);
+      // Case 1: Bias is already int32 -----------------------
+      if (biasQType.getElementType().isInteger(32)) {
+        biasInt32Val = biasQ;
+      } else {
+        // Case 2: Bias is int8. float32 → quantize -----------------
+        auto qBiasOp =
+            dyn_cast<ONNXQuantizeLinearOp>(dqBiasOp.getX().getDefiningOp());
+        if (!qBiasOp) {
+          return failure();
+        }
+        // ---- Extract float bias values from qBiasOp.getX() (which points to
+        // the float constant) ----
+        Value biasFloatValue = qBiasOp.getX();
+        auto biasFloatDefOp = biasFloatValue.getDefiningOp();
+        if (!biasFloatDefOp)
+          return failure();
 
-      // ---- Create ONNXConstantOp for i32 bias (pass the full argument list as
-      // required) ----
-      auto biasConstI32 = rewriter.create<ONNXConstantOp>(loc, biasTypeI32,
-          mlir::Attribute(), denseAttrI32, mlir::FloatAttr(), mlir::ArrayAttr(),
-          mlir::IntegerAttr(), mlir::ArrayAttr(), mlir::StringAttr(),
-          mlir::ArrayAttr());
+        auto constBiasOp = dyn_cast<ONNXConstantOp>(biasFloatDefOp);
+        if (!constBiasOp)
+          return failure();
 
-      biasInt32Val = biasConstI32.getResult();
+        // Try to get the ElementsAttr
+        auto denseBiasF =
+            extractDenseFloatFromConst(constBiasOp, biasFloatValue);
+
+        if (!denseBiasF)
+          return failure();
+        float xScaleS = 0.0f;
+        if (!extractScalarFloatFromConst(xScale, xScaleS))
+          return failure();
+
+        float wScaleS = 0.0f;
+        if (!extractScalarFloatFromConst(wScale, wScaleS))
+          return failure();
+
+        auto biasI32Attrs =
+            createBiasI32Attrs(denseBiasF, xScaleS, wScaleS, rewriter);
+        if (biasI32Attrs.empty()) {
+          return failure();
+        }
+
+        // ---- Build tensor type for i32 bias with same shape as denseBiasF
+        // ----
+        auto biasTensorTy = denseBiasF.getType().cast<mlir::RankedTensorType>();
+        auto biasTypeI32 = mlir::RankedTensorType::get(
+            biasTensorTy.getShape(), rewriter.getIntegerType(32));
+
+        // Build DenseElementsAttr<i32> from integer attrs
+        auto denseAttrI32 =
+            mlir::DenseElementsAttr::get(biasTypeI32, biasI32Attrs);
+
+        // ---- Create ONNXConstantOp for i32 bias (pass the full argument list
+        // as required) ----
+        auto biasConstI32 = rewriter.create<ONNXConstantOp>(loc, biasTypeI32,
+            mlir::Attribute(), denseAttrI32, mlir::FloatAttr(),
+            mlir::ArrayAttr(), mlir::IntegerAttr(), mlir::ArrayAttr(),
+            mlir::StringAttr(), mlir::ArrayAttr());
+
+        biasInt32Val = biasConstI32.getResult();
+      }
     }
 
     // ---- Create QLinearConv: operand order:
@@ -230,18 +291,6 @@ struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
 
     // Replace the QuantizeLinear (qOutOp) result with qconv result
     rewriter.replaceOp(qOutOp, qconv.getResult());
-
-    // Erase dead ops
-    if (dqBiasOp->use_empty())
-      rewriter.eraseOp(dqBiasOp);
-    if (qBiasOp && qBiasOp->use_empty())
-      rewriter.eraseOp(qBiasOp);
-    if (dqInputOp && dqInputOp->use_empty())
-      rewriter.eraseOp(dqInputOp);
-    if (dqWeightOp && dqWeightOp->use_empty())
-      rewriter.eraseOp(dqWeightOp);
-    if (convOp->use_empty())
-      rewriter.eraseOp(convOp);
 
     return success();
   }

--- a/src/Dialect/ONNX/Transforms/QlinearConvPass.cpp
+++ b/src/Dialect/ONNX/Transforms/QlinearConvPass.cpp
@@ -110,7 +110,6 @@ struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
   LogicalResult matchAndRewrite(
       ONNXConvOp convOp, PatternRewriter &rewriter) const override {
     Location loc = convOp.getLoc();
-
     // Conv has bias B and its defining op is DequantizeLinear
     Value biasVal = convOp.getB();
     if (!biasVal || isa<ONNXNoneOp>(biasVal.getDefiningOp()))
@@ -120,13 +119,8 @@ struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
     if (!dqBiasOp) {
       return failure();
     }
-
-    // QuantizeLinear that produces the quantized bias (input to DQ)
     auto qBiasOp =
         dyn_cast<ONNXQuantizeLinearOp>(dqBiasOp.getX().getDefiningOp());
-    if (!qBiasOp) {
-      return failure();
-    }
 
     // Conv input X must come from DequantizeLinear ----
     auto dqInputOp =
@@ -145,6 +139,7 @@ struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
     if (!dqWeightOp) {
       return failure();
     }
+
     Value qWeight = dqWeightOp.getX();
     Value wScale = dqWeightOp.getXScale();
     Value wZp = dqWeightOp.getXZeroPoint();
@@ -156,19 +151,8 @@ struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
     auto qOutOp = dyn_cast<ONNXQuantizeLinearOp>(firstUser);
     if (!qOutOp)
       return failure();
-
     Value yScale = qOutOp.getYScale();
     Value yZp = qOutOp.getYZeroPoint();
-    // ---- Extract float bias values from qBiasOp.getX() (which points to the
-    // float constant) ----
-    Value biasFloatValue = qBiasOp.getX();
-    auto biasFloatDefOp = biasFloatValue.getDefiningOp();
-    if (!biasFloatDefOp)
-      return failure();
-
-    auto constBiasOp = dyn_cast<ONNXConstantOp>(biasFloatDefOp);
-    if (!constBiasOp)
-      return failure();
 
     Value biasQ = dqBiasOp.getX();
     auto biasQType = biasQ.getType().dyn_cast<mlir::RankedTensorType>();
@@ -182,13 +166,25 @@ struct ConvToQLinearConvPattern : public OpRewritePattern<ONNXConvOp> {
       biasInt32Val = biasQ;
     } else {
       // Case 2: Bias is int8. float32 → quantize -----------------
+      if (!qBiasOp) {
+        return failure();
+      }
+      // ---- Extract float bias values from qBiasOp.getX() (which points to the
+      // float constant) ----
+      Value biasFloatValue = qBiasOp.getX();
+      auto biasFloatDefOp = biasFloatValue.getDefiningOp();
+      if (!biasFloatDefOp)
+        return failure();
+
+      auto constBiasOp = dyn_cast<ONNXConstantOp>(biasFloatDefOp);
+      if (!constBiasOp)
+        return failure();
 
       // Try to get the ElementsAttr
       auto denseBiasF = extractDenseFloatFromConst(constBiasOp, biasFloatValue);
 
       if (!denseBiasF)
         return failure();
-
       float xScaleS = 0.0f;
       if (!extractScalarFloatFromConst(xScale, xScaleS))
         return failure();

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -58,6 +58,7 @@ std::unique_ptr<mlir::Pass> createQDQAroundOpOptONNXToONNXPass();
 
 std::unique_ptr<mlir::Pass> createQDQOptONNXToONNXPass();
 std::unique_ptr<mlir::Pass> createFoldDQBinaryQPass();
+std::unique_ptr<mlir::Pass> createConvToQLinearConvPass();
 
 /// Pass for instrument the ops in specific stage.
 std::unique_ptr<mlir::Pass> createInstrumentPass();

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -82,6 +82,11 @@ void registerOMPasses(int optLevel) {
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return createFoldDQBinaryQPass();
   });
+  
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return createConvToQLinearConvPass();
+  });
+
 
   mlir::registerPass(
       []() -> std::unique_ptr<mlir::Pass> { return createInstrumentPass(); });

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -82,11 +82,10 @@ void registerOMPasses(int optLevel) {
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return createFoldDQBinaryQPass();
   });
-  
+
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return createConvToQLinearConvPass();
   });
-
 
   mlir::registerPass(
       []() -> std::unique_ptr<mlir::Pass> { return createInstrumentPass(); });

--- a/test/mlir/onnx/onnx_qlinearconv.mlir
+++ b/test/mlir/onnx/onnx_qlinearconv.mlir
@@ -1,0 +1,105 @@
+// RUN: onnx-mlir-opt --conv-to-qlinearconv-onnx-to-onnx %s -split-input-file | FileCheck %s
+
+ 
+  func.func @test_bias_int32(%arg0: tensor<1x2x4x4xi8>) -> tensor<1x4x4x4xi8> {
+
+    %scaleX = onnx.Constant dense<2.500000e-01> : tensor<f32>
+    %zpX    = onnx.Constant dense<0> : tensor<i8>
+
+    %Wf = onnx.Constant dense<[
+      [[ [1.0] ], [ [2.0] ]],
+      [[ [3.0] ], [ [4.0] ]],
+      [[ [5.0] ], [ [6.0] ]],
+      [[ [7.0] ], [ [8.0] ]]
+    ]> : tensor<4x2x1x1xf32>
+    %scaleW = onnx.Constant dense<7.812500e-03> : tensor<f32>
+    %zpW    = onnx.Constant dense<0> : tensor<i8>
+    %qW = "onnx.QuantizeLinear"(%Wf, %scaleW, %zpW)
+          : (tensor<4x2x1x1xf32>, tensor<f32>, tensor<i8>) -> tensor<4x2x1x1xi8>
+    %dqW = "onnx.DequantizeLinear"(%qW, %scaleW, %zpW)
+           : (tensor<4x2x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<4x2x1x1xf32>
+
+    %bias_i32 = onnx.Constant dense<[10, 20, 30, 40]> : tensor<4xi32>
+    %scaleB   = onnx.Constant dense<6.250000e-02> : tensor<f32>
+    %zpB      = onnx.Constant dense<0> : tensor<i32>
+    %dqB = "onnx.DequantizeLinear"(%bias_i32, %scaleB, %zpB)
+           : (tensor<4xi32>, tensor<f32>, tensor<i32>) -> tensor<4xf32>
+
+    %dqX = "onnx.DequantizeLinear"(%arg0, %scaleX, %zpX)
+           : (tensor<1x2x4x4xi8>, tensor<f32>, tensor<i8>) -> tensor<1x2x4x4xf32>
+
+    %conv = "onnx.Conv"(%dqX, %dqW, %dqB)
+            {kernel_shape = [1, 1], strides = [1, 1], pads = [0, 0, 0, 0]}
+            : (tensor<1x2x4x4xf32>, tensor<4x2x1x1xf32>, tensor<4xf32>) -> tensor<1x4x4x4xf32>
+
+    %scaleY = onnx.Constant dense<2.500000e-01> : tensor<f32>
+    %zpY    = onnx.Constant dense<0> : tensor<i8>
+    %qOut = "onnx.QuantizeLinear"(%conv, %scaleY, %zpY)
+            : (tensor<1x4x4x4xf32>, tensor<f32>, tensor<i8>) -> tensor<1x4x4x4xi8>
+
+    return %qOut : tensor<1x4x4x4xi8>
+  }
+
+
+// CHECK: "onnx.QLinearConv"
+// CHECK-NOT: "onnx.Conv"
+// CHECK-NOT: "onnx.DequantizeLinear"
+// CHECK-NOT: "onnx.QuantizeLinear"
+
+func.func @test_qlinearconv(%arg0: tensor<1x3x16x16xi8>) -> tensor<1x8x14x14xi8> {
+    %scaleX = "onnx.Constant"() {value = dense<0.00784314> : tensor<f32>} : () -> tensor<f32>
+    %zpX    = "onnx.Constant"() {value = dense<0> : tensor<i8>}           : () -> tensor<i8>
+    %w      = "onnx.Constant"() {value = dense<0> : tensor<8x3x3x3xi8>}   : () -> tensor<8x3x3x3xi8>
+    %scaleW = "onnx.Constant"() {value = dense<0.05> : tensor<f32>}       : () -> tensor<f32>
+    %zpW    = "onnx.Constant"() {value = dense<0> : tensor<i8>}           : () -> tensor<i8>
+    %biasF  = "onnx.Constant"() {value = dense<[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]> : tensor<8xf32>} : () -> tensor<8xf32>
+    %biasQ  = "onnx.QuantizeLinear"(%biasF, %scaleW, %zpW)
+                {axis = 1 : si64} : (tensor<8xf32>, tensor<f32>, tensor<i8>) -> tensor<8xi8>
+    %biasDQ = "onnx.DequantizeLinear"(%biasQ, %scaleW, %zpW)
+                {axis = 1 : si64} : (tensor<8xi8>, tensor<f32>, tensor<i8>) -> tensor<8xf32>
+    %dqX    = "onnx.DequantizeLinear"(%arg0, %scaleX, %zpX)
+                {axis = 1 : si64} : (tensor<1x3x16x16xi8>, tensor<f32>, tensor<i8>) -> tensor<1x3x16x16xf32>
+    %dqW    = "onnx.DequantizeLinear"(%w, %scaleW, %zpW)
+                {axis = 1 : si64} : (tensor<8x3x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<8x3x3x3xf32>
+    %conv   = "onnx.Conv"(%dqX, %dqW, %biasDQ) {kernel_shape = [3,3]} :
+                (tensor<1x3x16x16xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x14x14xf32>
+    %scaleY = "onnx.Constant"() {value = dense<0.09> : tensor<f32>} : () -> tensor<f32>
+    %zpY    = "onnx.Constant"() {value = dense<0> : tensor<i8>}     : () -> tensor<i8>
+    %qOut   = "onnx.QuantizeLinear"(%conv, %scaleY, %zpY)
+                {axis = 1 : si64} : (tensor<1x8x14x14xf32>, tensor<f32>, tensor<i8>) -> tensor<1x8x14x14xi8>
+    return %qOut : tensor<1x8x14x14xi8>
+  }
+ 
+// CHECK: "onnx.QLinearConv"
+// CHECK-NOT: "onnx.Conv"
+// CHECK-NOT: "onnx.DequantizeLinear"
+// CHECK-NOT: "onnx.QuantizeLinear"
+
+func.func @test_onnx_conv_without_quantize(%arg0: tensor<1x24x127x127xi8>) -> tensor<1x144x127x127xf32> {
+  %0 = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %1 = onnx.Constant dense<0> : tensor<i8>
+  %2 = onnx.Constant dense_resource<__elided__> : tensor<144x24x1x1xf32>
+  %3 = onnx.Constant dense<7.812500e-03> : tensor<f32>
+  %4 = onnx.Constant dense<0> : tensor<i8>
+  %5 = onnx.Constant dense<7.812500e-03> : tensor<f32>
+  %6 = onnx.Constant dense<0> : tensor<i8>
+  %7 = onnx.Constant dense_resource<__elided__> : tensor<144xf32>
+  %8 = onnx.Constant dense<6.250000e-02> : tensor<f32>
+  %9 = onnx.Constant dense<0> : tensor<i8>
+  %10 = onnx.Constant dense<6.250000e-02> : tensor<f32>
+  %11 = onnx.Constant dense<0> : tensor<i8>
+  %12 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+  %13 = onnx.Constant dense<6.000000e+00> : tensor<f32>
+  %14 = "onnx.DequantizeLinear"(%arg0, %0, %1) {axis = 1 : si64, block_size = 0 : si64, onnx_node_name = "DequantizeLinear_72"} : (tensor<1x24x127x127xi8>, tensor<f32>, tensor<i8>) -> tensor<1x24x127x127xf32>
+  %15 = "onnx.QuantizeLinear"(%2, %3, %4) {axis = 1 : si64, block_size = 0 : si64, onnx_node_name = "QuantizeLinear_75", output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<144x24x1x1xf32>, tensor<f32>, tensor<i8>) -> tensor<144x24x1x1xi8>
+  %16 = "onnx.DequantizeLinear"(%15, %5, %6) {axis = 1 : si64, block_size = 0 : si64, onnx_node_name = "DequantizeLinear_78"} : (tensor<144x24x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<144x24x1x1xf32>
+  %17 = "onnx.QuantizeLinear"(%7, %8, %9) {axis = 1 : si64, block_size = 0 : si64, onnx_node_name = "QuantizeLinear_81", output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<144xf32>, tensor<f32>, tensor<i8>) -> tensor<144xi8>
+  %18 = "onnx.DequantizeLinear"(%17, %10, %11) {axis = 1 : si64, block_size = 0 : si64, onnx_node_name = "DequantizeLinear_84"} : (tensor<144xi8>, tensor<f32>, tensor<i8>) -> tensor<144xf32>
+  %19 = "onnx.Conv"(%14, %16, %18) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], onnx_node_name = "Conv_85", pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x24x127x127xf32>, tensor<144x24x1x1xf32>, tensor<144xf32>) -> tensor<1x144x127x127xf32>
+  %20 = "onnx.Clip"(%19, %12, %13) {onnx_node_name = "Clip_88"} : (tensor<1x144x127x127xf32>, tensor<f32>, tensor<f32>) -> tensor<1x144x127x127xf32>
+  return %20 : tensor<1x144x127x127xf32>
+}
+
+ 
+// CHECK-LABEL:  func.func @test_onnx_conv_without_quantize
+// CHECK-NOT: onnx.QLinearConv


### PR DESCRIPTION
The conv pattern has 3 input DQ nodes (input, weight, bias)
If the bias is int8, compute the int32 quantized bias. 
Create a new int32 onnx constant with the computed bias
Create a [onnx.QLinearConv](https://onnx.ai/onnx/operators/onnx__QLinearConv.html#qlinearconv-10) node
Assumption: The bias is a Constant
