### PR TITLE
Do not emit error in shape inference if this error only means that the shape could not be computed.

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
@@ -47,7 +47,7 @@ bool isAbsent(Value input) {
 LogicalResult ONNXResizeOpShapeHelper::computeShape() {
   ONNXResizeOpAdaptor operandAdaptor(operands, cast<ONNXResizeOp>(op));
   if (operandAdaptor.getAxes().has_value())
-    return op->emitOpError("axes are unsupported");
+    return failure();
   const auto x = operandAdaptor.getX();
   if (!hasShapeAndRank(x)) {
     return failure();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
@@ -43,7 +43,7 @@ LogicalResult ONNXSliceOpShapeHelper::computeShape() {
     createIE->getIntFromArrayAsSymbols(axes, axesSymbol);
     for (IndexExpr val : axesSymbol) {
       if (!val.isLiteral())
-        return op->emitError("Axes must be known at compile time");
+        return success();
       int64_t axis = val.getLiteral();
       if (axis < 0)
         axis += dataRank;


### PR DESCRIPTION

Currently some ops mix canonicalization, shape inference, and validation in their inferShapes method, which can lead to confusing error messages and can generally be difficult to understand. In the future I would like to split them up, so that inferShapes does only shape inference, and canonicalization becomes its own method/pattern.