### PR TITLE
Feat: Match LayerNorm decomposition pattern with transposing original input and axis

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -40,7 +40,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         !opts.disableRecomposeOption, opts.enableQuarkQuantizedLegalization,
         opts.enableConvTransposeDecompose,
         opts.enableConvTransposeDecomposeToPhasedConv,
-        opts.enableConvTranspose1dDecomposeToPhasedConv, opts.enableRecomposeLayernormByTranspose));
+        opts.enableConvTranspose1dDecomposeToPhasedConv,
+        opts.enableRecomposeLayernormByTranspose));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -51,7 +51,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
               /*enableQuarkQuantizedOpsLegalization=*/false,
               opts.enableConvTransposeDecompose,
               opts.enableConvTransposeDecomposeToPhasedConv,
-              opts.enableConvTranspose1dDecomposeToPhasedConv));
+              opts.enableConvTranspose1dDecomposeToPhasedConv,
+              opts.enableRecomposeLayernormByTranspose));
     }
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
@@ -107,7 +108,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         !opts.disableRecomposeOption, opts.enableQuarkQuantizedLegalization,
         opts.enableConvTransposeDecompose,
         opts.enableConvTransposeDecomposeToPhasedConv,
-        opts.enableConvTranspose1dDecomposeToPhasedConv));
+        opts.enableConvTranspose1dDecomposeToPhasedConv,
+        opts.enableRecomposeLayernormByTranspose));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -32,13 +32,15 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
       opts.enableConvTransposeDecomposeToPhasedConv,
       opts.enableConvTranspose1dDecomposeToPhasedConv));
   if (!opts.disableRecomposeOption)
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass());
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass(
+        /*target=*/"", opts.enableRecomposeLayernormByTranspose));
+
   if (opts.enableONNXHybridPass) {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
         !opts.disableRecomposeOption, opts.enableQuarkQuantizedLegalization,
         opts.enableConvTransposeDecompose,
         opts.enableConvTransposeDecomposeToPhasedConv,
-        opts.enableConvTranspose1dDecomposeToPhasedConv));
+        opts.enableConvTranspose1dDecomposeToPhasedConv, opts.enableRecomposeLayernormByTranspose));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -19,6 +19,7 @@ struct OnnxToMlirOptions {
   bool enableRemoveDqQOp = true;
   bool enableRemoveDqQAroundOp = true;
   bool enableRemoveBinary = false;
+  bool enableRecomposeLayernormByTranspose = false;
 
   bool disableRecomposeOption = false;
   bool enableONNXHybridPass = true;

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -246,6 +246,11 @@ struct OnnxBuilder : DialectBuilder {
   mlir::Value unsqueeze(
       mlir::Type outputType, mlir::Value data, mlir::Value axes) const;
 
+  // Up ranking of the data tensor with reshape operator. The trailing is the
+  // option to choose to add the dimension with size 1 as leading or trailing.
+  mlir::Value upRank(
+      mlir::Value data, int64_t toRank, bool trailing = false) const;
+
   // ONNXWhereOp
   mlir::Value where(mlir::Type outputType, mlir::Value condition, mlir::Value X,
       mlir::Value Y) const;

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -587,22 +587,23 @@ public:
 
 // This pattern bubbles up AddOp through transpose to keep the bias Add
 // operation right after LN_type op. This will helps the other patterns fold the
-// add into the operands of LayerNorm.
+// add into the operands of a Norm operator.
 //
-// From: LayerNorm
+// From:
+// Norm operator
 //    |
 // Transpose
 //    |
 //   Add
 //
 // To:
-// LayerNorm
+// Norm operator
 //    |
 //   Add
 //    |
 // Transpose
 template <typename LN_TYPE>
-class BubbleUpBiasForLayerNormPattern : public OpRewritePattern<ONNXAddOp> {
+class BubbleUpBiasForNormOpPattern : public OpRewritePattern<ONNXAddOp> {
 public:
   using OpRewritePattern<ONNXAddOp>::OpRewritePattern;
 
@@ -2468,9 +2469,9 @@ void ONNXAddOp::getCanonicalizationPatterns(
       PropagateBiasIntoLayerNormRewritePattern<ONNXRMSLayerNormalizationOp>>(
       context);
   results.insert<PropagateReshapeThroughBinaryOpPattern<ONNXAddOp>>(context);
-  results.insert<BubbleUpBiasForLayerNormPattern<ONNXLayerNormalizationOp>>(
+  results.insert<BubbleUpBiasForNormOpPattern<ONNXLayerNormalizationOp>>(
       context);
-  results.insert<BubbleUpBiasForLayerNormPattern<ONNXRMSLayerNormalizationOp>>(
+  results.insert<BubbleUpBiasForNormOpPattern<ONNXRMSLayerNormalizationOp>>(
       context);
 }
 

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -20,6 +20,7 @@
 #include <numeric>
 
 #include "mlir/Dialect/Traits.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -580,6 +581,66 @@ public:
     Value res = create.onnx.reshape(outputType, x, reshapeShape, reshapeAZ);
 
     rewriter.replaceOp(op, res);
+    return success();
+  };
+};
+
+// This pattern bubbles up AddOp through transpose to keep the bias Add
+// operation right after LN_type op. This will helps the other patterns fold the
+// add into the operands of LayerNorm.
+//
+// From: LayerNorm
+//    |
+// Transpose
+//    |
+//   Add
+//
+// To:
+// LayerNorm
+//    |
+//   Add
+//    |
+// Transpose
+template <typename LN_TYPE>
+class BubbleUpBiasForLayerNormPattern : public OpRewritePattern<ONNXAddOp> {
+public:
+  using OpRewritePattern<ONNXAddOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXAddOp addOp, PatternRewriter &r) const override {
+    if (!isConstLikeValue(addOp.getB()))
+      return r.notifyMatchFailure(addOp, "not a constant rhs operand");
+
+    auto transposeOp =
+        llvm::dyn_cast_or_null<ONNXTransposeOp>(addOp.getA().getDefiningOp());
+    if (!transposeOp)
+      return r.notifyMatchFailure(addOp, "the producer is not a transpose");
+
+    if (!transposeOp->hasOneUse())
+      return r.notifyMatchFailure(
+          addOp, "cannot bubble up because transpose has other user");
+
+    auto layernormResult = transposeOp.getData();
+    auto layerNorm =
+        llvm::dyn_cast_or_null<LN_TYPE>(layernormResult.getDefiningOp());
+    if (!layerNorm)
+      return r.notifyMatchFailure(
+          transposeOp, "the producer is not a layernorm");
+
+    if (!isNoneValue(layerNorm.getB()))
+      return r.notifyMatchFailure(layerNorm, "layernorm already has a bias");
+
+    OnnxBuilder create(r, addOp.getLoc());
+
+    auto perm = extractFromIntegerArrayAttr<int64_t>(transposeOp.getPermAttr());
+    auto invertedPerm = invertPermutationVector(perm);
+    auto cstReshaped = create.upRank(addOp.getB(), getRank(addOp.getType()));
+    auto cstTranposed = create.transposeInt64(cstReshaped, invertedPerm);
+    auto newAddOp = create.add(layernormResult, cstTranposed);
+    auto transposedBack = create.transposeInt64(newAddOp, perm);
+
+    r.replaceOp(addOp, transposedBack);
+
     return success();
   };
 };
@@ -2407,6 +2468,10 @@ void ONNXAddOp::getCanonicalizationPatterns(
       PropagateBiasIntoLayerNormRewritePattern<ONNXRMSLayerNormalizationOp>>(
       context);
   results.insert<PropagateReshapeThroughBinaryOpPattern<ONNXAddOp>>(context);
+  results.insert<BubbleUpBiasForLayerNormPattern<ONNXLayerNormalizationOp>>(
+      context);
+  results.insert<BubbleUpBiasForLayerNormPattern<ONNXRMSLayerNormalizationOp>>(
+      context);
 }
 
 /// on the ONNXAndOp.

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -176,6 +176,9 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     Value res;
 
     if constexpr (RecomposeLayernormByTranspose) {
+      if (!hasShapeAndRank(scale))
+        return rewriter.notifyMatchFailure(
+            mulOp, "the scale doesn't have shape or rank");
       // if the permutation is empty, nothing is needed to be permuted.
       // Otherwise, both input and scale must be transposed.
       if (!permutation.empty()) {

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -23,6 +23,7 @@
 #include <numeric>
 
 #include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -89,6 +90,34 @@ namespace {
 /// Include the patterns defined in the Declarative Rewrite framework.
 // #include "src/Dialect/ONNX/Transforms/ONNXRecompose.inc"
 
+// There could be scenarios that the pattern can be matched as layernorm but the
+// axis is not suitable. However, there is a possibility to make the axis
+// suitable by transposing the original input tensor and axis. In the following
+// example, since the second dimension is being reduced, it's not a layernorm
+// but if that dimension is transposed to the last dimension and and change the
+// axis of layernorm to 3 and transpose the result back, the transform IR is
+// semantically and mathematically correct and legal.
+//
+// Before:
+// %9 = "onnx.ReduceMeanV13"(%8) {axes = [1]} : (<1x4x128xf32>) -> <1x1x128xf32>
+// %10 = "onnx.Sub"(%8, %9) (<1x4x128xf32>, <1x1x128xf32>) -> <1x4x128xf32>
+// %11 = "onnx.Mul"(%10, %10) (<1x4x128xf32>, <1x4x128xf32>) -> <1x4x128xf32>
+// %12 = "onnx.ReduceMeanV13"(%11) {axes = [1]} : (<1x4x128xf32>) ->
+// <1x1x128xf32> %13 = "onnx.Add"(%12, %4) : (<1x1x128xf32>, <f32>) ->
+// <1x1x128xf32> %14 = "onnx.Sqrt"(%13): (<1x1x128xf32>) -> <1x1x128xf32> %15 =
+// "onnx.Div"(%10, %14) : (<1x4x128xf32>, <1x1x128xf32>) -> <1x4x128xf32> %16 =
+// "onnx.Mul"(%15, %5) : (<1x4x128xf32>, <4x1x1xf32>) -> <1x4x128xf32>
+//
+// After:
+// %9 = "onnx.Transpose"(%6)
+//      {perm = [0, 2, 3, 1]} : (<1x4x128x128xf32>) -> <1x128x128x4xf32>
+// %Y = "onnx.LayerNormalization"(%9, %8, %1)
+//      {axis = 3 : si64} : (<1x128x128x4xf32>, <1x1x1x4xf32>, none) ->
+//      (<1x128x128x4xf32>)
+// %10 = "onnx.Transpose"(%Y)
+//      {perm = [0, 3, 1, 2]} : (<1x128x128x4xf32>) -> <1x4x128x128xf32>
+
+template <bool RecomposeLayernormByTranspose = false>
 struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
   using OpRewritePattern<ONNXMulOp>::OpRewritePattern;
 
@@ -131,16 +160,35 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     int64_t axis;
     bool isRMSLayerNorm;
     SmallVector<Location> layerNormLocations;
-    if (!matchLayerNormPattern(
-            mulOp, x, scale, axis, epsilon, layerNormLocations, isRMSLayerNorm))
+
+    // This will be filled up with the permutation that helps us by transposing
+    // the original tensor and adapting the axis, we make unsuitable axis for
+    // layer suitable.
+    SmallVector<int64_t> permutation;
+    if (!matchLayerNormPattern(mulOp, x, scale, axis, epsilon,
+            layerNormLocations, isRMSLayerNorm, permutation))
       return failure();
 
     // Replace
     MultiDialectBuilder<OnnxBuilder> create(
         rewriter, rewriter.getFusedLoc(layerNormLocations));
-    Type xType = x.getType();
     Value noneVal = create.onnx.none();
     Value res;
+
+    if constexpr (RecomposeLayernormByTranspose) {
+      // if the permutation is empty, nothing is needed to be permuted.
+      // Otherwise, both input and scale must be transposed.
+      if (!permutation.empty()) {
+        if (scale) {
+          // Layernorm supports broadcasting and in order to transpose, the rank
+          // should be equalized.
+          scale = create.onnx.upRank(scale, getRank(x.getType()));
+          scale = create.onnx.transposeInt64(scale, permutation);
+        }
+        x = create.onnx.transposeInt64(x, permutation);
+      }
+    }
+
     if (isRMSLayerNorm) {
       if (!scale) {
         // set scale to unity if there is no scale value present in the pattern
@@ -150,15 +198,26 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
         // because the pass that generates RMSNormAdf templated graph requires
         // the scale to be a tensor of dimension same as the inner most
         // dimension of input tensor
-        auto result = this->createScaleConstOp(xType, create);
+        auto result = this->createScaleConstOp(x.getType(), create);
         if (failed(result))
           return failure();
         scale = result.value();
       }
-      res = create.onnx.RMSLayerNorm(xType, x, scale, noneVal, axis, epsilon);
+      res = create.onnx.RMSLayerNorm(
+          x.getType(), x, scale, noneVal, axis, epsilon);
     } else {
-      res = create.onnx.layerNorm(xType, x, scale, noneVal, axis, epsilon);
+      res =
+          create.onnx.layerNorm(x.getType(), x, scale, noneVal, axis, epsilon);
     }
+
+    if constexpr (RecomposeLayernormByTranspose) {
+      // Transpose back the result if the input and scale got transposed.
+      if (!permutation.empty()) {
+        res = create.onnx.transposeInt64(
+            res, invertPermutationVector(permutation));
+      }
+    }
+
     copySingleResultType(mulOp, res);
     rewriter.replaceOp(mulOp, res);
     return success();
@@ -202,7 +261,8 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
   */
   static bool matchLayerNormPattern(ONNXMulOp LayerNormOp, Value &x,
       Value &scale, int64_t &axis, FloatAttr &epsilonAttr,
-      SmallVectorImpl<Location> &layerNormLocations, bool &isRMSLayerNorm) {
+      SmallVectorImpl<Location> &layerNormLocations, bool &isRMSLayerNorm,
+      SmallVectorImpl<int64_t> &perm) {
     using namespace onnx_mlir;
     Location loc = LayerNormOp.getLoc();
     isRMSLayerNorm = false;
@@ -388,8 +448,14 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
       return reportFailure("RMS need rank and shape for input dd");
     int64_t ddRank = mlir::cast<ShapedType>(dd.getType()).getRank();
     int64_t varAxis;
-    if (!suitableAxis(vReduceOp, ddRank, varAxis))
-      return reportFailure("RMS unsuitable var reduce axes");
+    if constexpr (!RecomposeLayernormByTranspose) {
+      if (!suitableAxis(vReduceOp, ddRank, varAxis))
+        return reportFailure("RMS unsuitable var reduce axes");
+    } else {
+      if (failed(isAxisSuitableWithTranspose(vReduceOp, ddRank, varAxis)))
+        return reportFailure("RMS unsuitable var reduce axes that cannot be "
+                             "handled even with transposition");
+    }
 
     // 3: All the conditions are now correct for having an RMS pattern.
     // Now check if we can extend the pattern to a full LM pattern.
@@ -438,10 +504,24 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
         return reportFailure("LN need rank and shape for input x");
       int64_t x1Rank = mlir::cast<ShapedType>(x1.getType()).getRank();
       int64_t meanAxis;
-      if (!suitableAxis(mReduceOp, x1Rank, meanAxis))
-        hasFullPattern = reportFailure("LN unsuitable mean reduce axes");
-      else if (meanAxis != varAxis)
-        hasFullPattern = reportFailure("LN mean and var axes must be the same");
+      if constexpr (!RecomposeLayernormByTranspose) {
+        if (!suitableAxis(mReduceOp, x1Rank, meanAxis))
+          hasFullPattern = reportFailure("LN unsuitable mean reduce axes");
+        else if (meanAxis != varAxis)
+          hasFullPattern =
+              reportFailure("LN mean and var axes must be the same");
+      } else {
+        auto permutation =
+            isAxisSuitableWithTranspose(mReduceOp, x1Rank, meanAxis);
+        if (failed(permutation))
+          hasFullPattern =
+              reportFailure("LN unsuitable mean reduce axes that cannot be "
+                            "handled even with transposition");
+        else if (meanAxis != varAxis)
+          hasFullPattern =
+              reportFailure("LN mean and var axes must be the same");
+        perm = permutation.value();
+      }
     }
 
     // We have now success, either with the shorter RMS LN pattern or the
@@ -450,13 +530,27 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     if (hasFullPattern) {
       isRMSLayerNorm = false;
       x = x1;
-      LLVM_DEBUG(llvm::dbgs() << "LayerNorm from mult, axis " << axis << "\n");
+
     } else {
       isRMSLayerNorm = true;
       x = d;
-      LLVM_DEBUG(
-          llvm::dbgs() << "RMSLayerNorm from mult, axis " << axis << "\n");
     }
+
+    static const std::string layerNormKind =
+        isRMSLayerNorm ? "RMSLayerNorm" : "LayerNorm";
+    if (perm.empty()) {
+      LLVM_DEBUG(llvm::dbgs() << llvm::formatv(
+                     "{0} from mult, axis {1}", layerNormKind, axis));
+    } else {
+      std::string msg;
+      llvm::raw_string_ostream rso(msg);
+      llvm::interleaveComma(perm, rso);
+      LLVM_DEBUG(llvm::dbgs()
+                 << llvm::formatv("{0} from mult with transpose {1} of the "
+                                  "original input and new axis {2} \n",
+                        layerNormKind, msg, axis));
+    }
+
     // Collect the locations of the recomposed ops
     if (mReduceOp)
       layerNormLocations.push_back(mReduceOp->getLoc());
@@ -481,31 +575,34 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
   }
 
 private:
-  static bool suitableAxis(Operation *op, int64_t xRank, int64_t &axis) {
+  // Return the reduced dimensions as bit vector.
+  static FailureOr<llvm::SmallBitVector> getReducedAxis(
+      Operation *op, int64_t xRank, int64_t &axis) {
     SmallVector<int64_t> axes; // The axes attribute/operand of the ReduceMeanOp
     if (auto reduceOpV13 = mlir::dyn_cast<ONNXReduceMeanV13Op>(op)) {
       if (reduceOpV13.getKeepdims() != 1)
-        return reportFailure("need keepdims = 1");
+        return success(reportFailure("need keepdims = 1"));
       ArrayAttr axesAttr = reduceOpV13.getAxesAttr();
       for (size_t i = 0; i < axesAttr.size(); ++i) {
         axes.emplace_back(onnx_mlir::ArrayAttrIntVal(axesAttr, i));
       }
     } else if (auto reduceOp = mlir::dyn_cast<ONNXReduceMeanOp>(op)) {
       if (reduceOp.getKeepdims() != 1)
-        return reportFailure("need keepdims = 1");
+        return success(reportFailure("need keepdims = 1"));
       Value axesValue = reduceOp.getAxes();
       if (isa<NoneType>(axesValue.getType())) {
         if (reduceOp.getNoopWithEmptyAxes()) {
           // No reduction
-          return reportFailure("needs a reduction on at least one dimension");
+          return success(
+              reportFailure("needs a reduction on at least one dimension"));
         } else {
           // Reduction on all dimensions
           axis = 0;
-          return true;
+          return llvm::SmallBitVector(xRank, true);
         }
       }
       if (!onnx_mlir::getI64ValuesFromONNXConstantOp(axesValue, axes)) {
-        return reportFailure("only static axes are supported");
+        return success(reportFailure("only static axes are supported"));
       }
     } else {
       llvm_unreachable("ReduceMean is the only supported op");
@@ -517,21 +614,57 @@ private:
       int64_t a = onnx_mlir::getAxisInRange(axe, xRank);
       reduceAxes[a] = true;
     }
+    return reduceAxes;
+  }
+
+  // Check if the axis is suitable for Layernorm.
+  static bool suitableAxis(Operation *op, int64_t xRank, int64_t &axis) {
+    auto reduceAxes = getReducedAxis(op, xRank, axis);
+    if (failed(reduceAxes))
+      return false;
+
     // Check that we have a "false"* "true"+ pattern.
     bool foundFirstAxis = false;
     for (int64_t i = 0; i < xRank; ++i) {
       if (!foundFirstAxis) {
-        if (reduceAxes[i]) {
+        if (reduceAxes.value()[i]) {
           foundFirstAxis = true;
           axis = i;
         }
-      } else if (!reduceAxes[i]) {
+      } else if (!reduceAxes.value()[i]) {
         // Once we found an axis, we must reduce all subsequent dimensions.
         return false;
       }
     }
     // Ensure we had at least one reduction.
     return foundFirstAxis;
+  }
+
+  // Checks if the axes with transpose op could be suitable for Layernorm.
+  // normalized_axes is [axis, ..., rank of X - 1] in layernorm but the
+  // reduce_mean ops in the decomposition have axes = [1,3] in the 4d tensor,
+  // that's not suitable for layernorm. However, we transpose the dimensions 1
+  // and 3 to the innermost dimension with perm = [0,2,1,3], this can be
+  // represented as Layernorm with axis = 2.
+  static FailureOr<SmallVector<int64_t>> isAxisSuitableWithTranspose(
+      Operation *op, int64_t xRank, int64_t &axis) {
+    auto reduceAxes = getReducedAxis(op, xRank, axis);
+    if (failed(reduceAxes))
+      return failure();
+
+    SmallVector<int64_t> reducedIdx;
+    SmallVector<int64_t> nonReducedIdx;
+    for (int64_t i = 0; i < xRank; ++i) {
+      auto &array = reduceAxes.value()[i] ? reducedIdx : nonReducedIdx;
+      array.push_back(i);
+    }
+
+    SmallVector<int64_t> perm;
+    perm.append(nonReducedIdx);
+    perm.append(reducedIdx);
+    axis = nonReducedIdx.size();
+
+    return perm;
   }
 
   static bool reportFailure(std::string msg) {
@@ -1270,11 +1403,17 @@ struct RecomposeONNXToONNXPass
     : public PassWrapper<RecomposeONNXToONNXPass, OperationPass<func::FuncOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RecomposeONNXToONNXPass)
 
-  RecomposeONNXToONNXPass(const std::string &target) { this->target = target; }
+  RecomposeONNXToONNXPass(
+      const std::string &target, const bool &recomposeLayernormByTranspose) {
+    this->target = target;
+    this->recomposeLayernormByTranspose = recomposeLayernormByTranspose;
+  }
   RecomposeONNXToONNXPass(const RecomposeONNXToONNXPass &pass)
       : mlir::PassWrapper<RecomposeONNXToONNXPass,
             OperationPass<func::FuncOp>>() {
     this->target = pass.target.getValue();
+    this->recomposeLayernormByTranspose =
+        pass.recomposeLayernormByTranspose.getValue();
   }
 
   StringRef getArgument() const override { return "recompose-onnx"; }
@@ -1287,6 +1426,12 @@ struct RecomposeONNXToONNXPass
   Option<std::string> target{*this, "target",
       llvm::cl::desc("Target Dialect to Recompose into"), ::llvm::cl::init("")};
 
+  Option<bool> recomposeLayernormByTranspose{*this,
+      "recompose-layernorm-by-transpose",
+      llvm::cl::desc("Use transpose operator to make unsuitable axes suitable "
+                     "for matching layernorm"),
+      ::llvm::cl::init(false)};
+
   void runOnOperation() final;
 
   typedef PassWrapper<RecomposeONNXToONNXPass, OperationPass<func::FuncOp>>
@@ -1298,7 +1443,8 @@ void RecomposeONNXToONNXPass::runOnOperation() {
   MLIRContext *context = &getContext();
 
   RewritePatternSet patterns(context);
-  onnx_mlir::getRecomposeONNXToONNXPatterns(patterns);
+  onnx_mlir::getRecomposeONNXToONNXPatterns(
+      patterns, recomposeLayernormByTranspose);
 
   if (failed(applyPatternsGreedily(function, std::move(patterns))))
     signalPassFailure();
@@ -1307,10 +1453,12 @@ void RecomposeONNXToONNXPass::runOnOperation() {
 } // namespace
 
 void onnx_mlir::getRecomposeONNXToONNXPatterns(
-    mlir::RewritePatternSet &patterns) {
+    mlir::RewritePatternSet &patterns, bool recomposeLayernormByTranspose) {
   MLIRContext *context = patterns.getContext();
   patterns.insert<RecomposeGeluFromMulPattern>(context);
-  patterns.insert<RecomposeLayerNormFromMulPattern>(context);
+  patterns.insert<RecomposeLayerNormFromMulPattern<false>>(context);
+  if (recomposeLayernormByTranspose)
+    patterns.insert<RecomposeLayerNormFromMulPattern<true>>(context);
   patterns.insert<RecomposeDepthToSpaceCRD>(context);
   patterns.insert<RecomposeDepthToSpaceDCR>(context);
   // AMD Disabled as downstream has no special support for it
@@ -1322,6 +1470,7 @@ void onnx_mlir::getRecomposeONNXToONNXPatterns(
  * Create a RecomposeONNX pass.
  */
 std::unique_ptr<mlir::Pass> onnx_mlir::createRecomposeONNXToONNXPass(
-    const std::string &target) {
-  return std::make_unique<RecomposeONNXToONNXPass>(target);
+    const std::string &target, const bool &recomposeLayernormByTranspose) {
+  return std::make_unique<RecomposeONNXToONNXPass>(
+      target, recomposeLayernormByTranspose);
 }

--- a/src/Dialect/ONNX/Transforms/Recompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.hpp
@@ -26,7 +26,10 @@ namespace onnx_mlir {
 
 // Exports the RecomposeONNXToONNXPass patterns. They are all plain rewrite
 // patterns that can be used with any PatternRewriter, not conversion patterns.
-void getRecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns);
+// recomposeLayernormByTranspose is the flag for using transpose operator to
+// make unsuitable axes suitable for matching layernorm.
+void getRecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
+    bool recomposeLayernormByTranspose = false);
 
 } // namespace onnx_mlir
 #endif

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -42,7 +42,8 @@ std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
     bool enableConvTransposeDecomposeToPhasedConv = false,
     bool enableConvTranspose1dDecomposeToPhasedConv = false);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
-    const std::string &target = "");
+    const std::string &target = "",
+    const bool &recomposeLayernormByTranspose = false);
 
 std::unique_ptr<mlir::Pass> createConvOptONNXToONNXPass(
     bool enableSimdDataLayoutOpt = false);
@@ -84,7 +85,8 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableRecomposition, bool enableQuarkQuantizedOpsLegalization = false,
     bool enableConvTransposeDecompose = false,
     bool enableConvTransposeDecomposeToPhasedConv = false,
-    bool enableConvTranspose1dDecomposeToPhasedConv = false);
+    bool enableConvTranspose1dDecomposeToPhasedConv = false,
+    bool enableRecomposeLayernormByTranspose = false);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -2648,6 +2648,179 @@ func.func @layernorm_with_reshape_with_neutral_scale(%arg0: tensor<1x384x768xf32
 // CHECK:         }
 }
 
+func.func @layernorm_transpose_bias_fusable(%arg0: tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32> {
+  %0 = "onnx.NoValue"() {value} : () -> none
+  %1 = onnx.Constant dense<2.000000e-01> : tensor<4x1x1xf32>
+  %2 = onnx.Constant dense<1.000000e-01> : tensor<1x1x1x4xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%arg0, %2, %0) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, none) -> (tensor<1x128x128x4xf32>, none, none)
+  %3 = "onnx.Transpose"(%Y) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+  %4 = "onnx.Add"(%3, %1) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  return %4 : tensor<1x4x128x128xf32>
+}
+// CHECK-LABEL:  func.func @layernorm_transpose_bias_fusable
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2.000000e-01> : tensor<4x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e-01> : tensor<1x1x1x4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 4, 1, 1]> : tensor<4xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x1x4xf32>
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[VAR_1_]], [[VAR_4_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, tensor<1x1x1x4xf32>) -> (tensor<1x128x128x4xf32>, none, none)
+// CHECK:           [[VAR_5_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           return [[VAR_5_]] : tensor<1x4x128x128xf32>
+// CHECK:         }
+
+// -----
+
+func.func @rms_layernorm_transpose_bias_fusable(%arg0: tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32> {
+  %0 = "onnx.NoValue"() {value} : () -> none
+  %1 = onnx.Constant dense<2.000000e-01> : tensor<4x1x1xf32>
+  %2 = onnx.Constant dense<1.000000e-01> : tensor<1x1x1x4xf32>
+  %Y, %InvStdDev = "onnx.RMSLayerNormalization"(%arg0, %2, %0) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, none) -> (tensor<1x128x128x4xf32>, none)
+  %3 = "onnx.Transpose"(%Y) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+  %4 = "onnx.Add"(%3, %1) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  return %4 : tensor<1x4x128x128xf32>
+}
+// CHECK-LABEL:  func.func @rms_layernorm_transpose_bias_fusable
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2.000000e-01> : tensor<4x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e-01> : tensor<1x1x1x4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 4, 1, 1]> : tensor<4xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x1x4xf32>
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.RMSLayerNormalization"([[PARAM_0_]], [[VAR_1_]], [[VAR_4_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, tensor<1x1x1x4xf32>) -> (tensor<1x128x128x4xf32>, none)
+// CHECK:           [[VAR_5_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           return [[VAR_5_]] : tensor<1x4x128x128xf32>
+// CHECK:         }
+
+// -----
+
+func.func @layernorm_transpose_bias_not_constant(%arg0: tensor<1x128x128x4xf32>, %arg1: tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32> {
+  %0 = "onnx.NoValue"() {value} : () -> none
+  %2 = onnx.Constant dense<1.000000e-01> : tensor<1x1x1x4xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%arg0, %2, %0) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, none) -> (tensor<1x128x128x4xf32>, none, none)
+  %3 = "onnx.Transpose"(%Y) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+  %4 = "onnx.Add"(%3, %arg1) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  return %4 : tensor<1x4x128x128xf32>
+}
+// CHECK-LABEL:  func.func @layernorm_transpose_bias_not_constant
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x128x128x4xf32>, [[PARAM_1_:%.+]]: tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e-01> : tensor<1x1x1x4xf32>
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[VAR_1_]], [[VAR_0_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, none) -> (tensor<1x128x128x4xf32>, none, none)
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[VAR_2_]], [[PARAM_1_]]) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x4x128x128xf32>
+// CHECK:         }
+
+// -----
+
+func.func @layernorm_transpose_bias_transpose_has_more_user(%arg0: tensor<1x128x128x4xf32>, %arg1: tensor<4x1x1xf32>) -> (tensor<1x4x128x128xf32>,tensor<1x4x128x128xf32>) {
+  %0 = "onnx.NoValue"() {value} : () -> none
+  %2 = onnx.Constant dense<1.000000e-01> : tensor<1x1x1x4xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%arg0, %2, %0) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, none) -> (tensor<1x128x128x4xf32>, none, none)
+  %3 = "onnx.Transpose"(%Y) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+  %4 = "onnx.Add"(%3, %arg1) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  return %4, %3 : tensor<1x4x128x128xf32>, tensor<1x4x128x128xf32>
+}
+// CHECK-LABEL:  func.func @layernorm_transpose_bias_transpose_has_more_user
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x128x128x4xf32>, [[PARAM_1_:%.+]]: tensor<4x1x1xf32>) -> (tensor<1x4x128x128xf32>, tensor<1x4x128x128xf32>) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e-01> : tensor<1x1x1x4xf32>
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[VAR_1_]], [[VAR_0_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, none) -> (tensor<1x128x128x4xf32>, none, none)
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[VAR_2_]], [[PARAM_1_]]) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           return [[VAR_3_]], [[VAR_2_]] : tensor<1x4x128x128xf32>, tensor<1x4x128x128xf32>
+// CHECK:         }
+
+// -----
+
+func.func @layernorm_has_already_bias(%arg0: tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32> {
+  %1 = onnx.Constant dense<2.000000e-01> : tensor<4x1x1xf32>
+  %2 = onnx.Constant dense<1.000000e-01> : tensor<1x1x1x4xf32>
+  %bias = onnx.Constant dense<2.000000e-01> : tensor<1x1x1x4xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%arg0, %2, %bias) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, tensor<1x1x1x4xf32>) -> (tensor<1x128x128x4xf32>, none, none)
+  %3 = "onnx.Transpose"(%Y) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+  %4 = "onnx.Add"(%3, %1) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  return %4 : tensor<1x4x128x128xf32>
+}
+// CHECK-LABEL:  func.func @layernorm_has_already_bias
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2.000000e-01> : tensor<4x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e-01> : tensor<1x1x1x4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<2.000000e-01> : tensor<1x1x1x4xf32>
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[VAR_1_]], [[VAR_2_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, tensor<1x1x1x4xf32>) -> (tensor<1x128x128x4xf32>, none, none)
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Add"([[VAR_3_]], [[VAR_0_]]) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x4x128x128xf32>
+// CHECK:         }
+
+// -----
+
+func.func @layernorm_3d_and_with_transpose_other_broadcast_kind(%arg0: tensor<128x128x4xf32>) -> tensor<128x4x128xf32> {
+  %0 = "onnx.NoValue"() {value} : () -> none
+  %1 = onnx.Constant dense<2.000000e-01> : tensor<128xf32>
+  %2 = onnx.Constant dense<1.000000e-01> : tensor<1x128x1xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%arg0, %2, %0) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<128x128x4xf32>, tensor<1x128x1xf32>, none) -> (tensor<128x128x4xf32>, none, none)
+  %3 = "onnx.Transpose"(%Y) {perm = [1, 2, 0]} : (tensor<128x128x4xf32>) -> tensor<128x4x128xf32>
+  %4 = "onnx.Add"(%3, %1) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<128x4x128xf32>, tensor<128xf32>) -> tensor<128x4x128xf32>
+  return %4 : tensor<128x4x128xf32>
+}
+// CHECK-LABEL:  func.func @layernorm_3d_and_with_transpose_other_broadcast_kind
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x128x4xf32>) -> tensor<128x4x128xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2.000000e-01> : tensor<128xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e-01> : tensor<1x128x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 1, 128]> : tensor<3xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<128xf32>, tensor<3xi64>) -> tensor<1x1x128xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [2, 0, 1]} : (tensor<1x1x128xf32>) -> tensor<128x1x1xf32>
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[VAR_1_]], [[VAR_4_]]) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<128x128x4xf32>, tensor<1x128x1xf32>, tensor<128x1x1xf32>) -> (tensor<128x128x4xf32>, none, none)
+// CHECK:           [[VAR_5_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [1, 2, 0]} : (tensor<128x128x4xf32>) -> tensor<128x4x128xf32>
+// CHECK:           return [[VAR_5_]] : tensor<128x4x128xf32>
+// CHECK:         }
+
+// -----
+
+func.func @layernorm_3d_with_transpose_with_no_broadcast(%arg0: tensor<128x128x4xf32>) -> tensor<128x4x128xf32> {
+  %0 = "onnx.NoValue"() {value} : () -> none
+  %1 = onnx.Constant dense<2.000000e-01> : tensor<128x4x128xf32>
+  %2 = onnx.Constant dense<1.000000e-01> : tensor<1x128x1xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%arg0, %2, %0) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<128x128x4xf32>, tensor<1x128x1xf32>, none) -> (tensor<128x128x4xf32>, none, none)
+  %3 = "onnx.Transpose"(%Y) {perm = [1, 2, 0]} : (tensor<128x128x4xf32>) -> tensor<128x4x128xf32>
+  %4 = "onnx.Add"(%3, %1) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<128x4x128xf32>, tensor<128x4x128xf32>) -> tensor<128x4x128xf32>
+  return %4 : tensor<128x4x128xf32>
+}
+// CHECK-LABEL:  func.func @layernorm_3d_with_transpose_with_no_broadcast
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x128x4xf32>) -> tensor<128x4x128xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2.000000e-01> : tensor<128x4x128xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e-01> : tensor<1x128x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Transpose"([[VAR_0_]]) {perm = [2, 0, 1]} : (tensor<128x4x128xf32>) -> tensor<128x128x4xf32>
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[VAR_1_]], [[VAR_2_]]) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<128x128x4xf32>, tensor<1x128x1xf32>, tensor<128x128x4xf32>) -> (tensor<128x128x4xf32>, none, none)
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [1, 2, 0]} : (tensor<128x128x4xf32>) -> tensor<128x4x128xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x4x128xf32>
+// CHECK:         }
+
+// -----
+
+func.func @layernorm_transpose_with_other_type(%arg0: tensor<1x128x128x4xf16>) -> tensor<1x4x128x128xf16> {
+  %0 = "onnx.NoValue"() {value} : () -> none
+  %1 = onnx.Constant dense<2.000000e-01> : tensor<4x1x1xf16>
+  %2 = onnx.Constant dense<1.000000e-01> : tensor<1x1x1x4xf16>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%arg0, %2, %0) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf16>, tensor<1x1x1x4xf16>, none) -> (tensor<1x128x128x4xf16>, none, none)
+  %3 = "onnx.Transpose"(%Y) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf16>) -> tensor<1x4x128x128xf16>
+  %4 = "onnx.Add"(%3, %1) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<1x4x128x128xf16>, tensor<4x1x1xf16>) -> tensor<1x4x128x128xf16>
+  return %4 : tensor<1x4x128x128xf16>
+}
+// CHECK-LABEL:  func.func @layernorm_transpose_with_other_type
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x128x128x4xf16>) -> tensor<1x4x128x128xf16> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.999510e-01> : tensor<4x1x1xf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<9.997550e-02> : tensor<1x1x1x4xf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 4, 1, 1]> : tensor<4xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf16>, tensor<4xi64>) -> tensor<1x4x1x1xf16>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x1x1xf16>) -> tensor<1x1x1x4xf16>
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[VAR_1_]], [[VAR_4_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf16>, tensor<1x1x1x4xf16>, tensor<1x1x1x4xf16>) -> (tensor<1x128x128x4xf16>, none, none)
+// CHECK:           [[VAR_5_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf16>) -> tensor<1x4x128x128xf16>
+// CHECK:           return [[VAR_5_]] : tensor<1x4x128x128xf16>
+// CHECK:         }
+
 // -----
 func.func @decomposed_group_norm(%arg0: tensor<1x16x20x20xf32>, %scale: tensor<16x1x1xf32>, %bias: tensor<16x1x1xf32>) -> tensor<1x16x20x20xf32> {
   %one = onnx.Constant dense<1.000000e+00> : tensor<16x1xf32>

--- a/test/mlir/onnx/onnx_recompose_layernorm_with_transpose.mlir
+++ b/test/mlir/onnx/onnx_recompose_layernorm_with_transpose.mlir
@@ -1,0 +1,36 @@
+// RUN: onnx-mlir-opt --recompose-onnx="recompose-layernorm-by-transpose" --canonicalize %s -split-input-file | FileCheck %s
+
+func.func @main_graph(%arg0: tensor<1x4x128x128xf32>) -> tensor<1x4x128x128xf32> {
+  %2 = onnx.Constant dense<1.000000e+00> : tensor<f32>
+  %4 = onnx.Constant dense<9.99999997E-7> : tensor<f32>
+  %5 = onnx.Constant dense<[[[0.0970484465]], [[0.0882187337]], [[0.135120019]], [[0.14907673]]]> : tensor<4x1x1xf32>
+  %6 = onnx.Constant dense<[[[0.191972837]], [[0.286264896]], [[0.180535644]], [[0.166878015]]]> : tensor<4x1x1xf32>    
+  %9 = "onnx.ReduceMeanV13"(%arg0) {axes = [1], keepdims = 1 : si64, onnx_node_name = "/mask_downscaling/mask_downscaling.1/ReduceMean"} : (tensor<1x4x128x128xf32>) -> tensor<1x1x128x128xf32>
+  %10 = "onnx.Sub"(%arg0, %9) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Sub"} : (tensor<1x4x128x128xf32>, tensor<1x1x128x128xf32>) -> tensor<1x4x128x128xf32>
+  %11 = "onnx.Mul"(%10, %10) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Pow_1"} : (tensor<1x4x128x128xf32>, tensor<1x4x128x128xf32>) -> tensor<1x4x128x128xf32>
+  %12 = "onnx.ReduceMeanV13"(%11) {axes = [1], keepdims = 1 : si64, onnx_node_name = "/mask_downscaling/mask_downscaling.1/ReduceMean_1"} : (tensor<1x4x128x128xf32>) -> tensor<1x1x128x128xf32>
+  %13 = "onnx.Add"(%12, %4) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add"} : (tensor<1x1x128x128xf32>, tensor<f32>) -> tensor<1x1x128x128xf32>
+  %14 = "onnx.Sqrt"(%13) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Sqrt"} : (tensor<1x1x128x128xf32>) -> tensor<1x1x128x128xf32>
+  %15 = "onnx.Div"(%10, %14) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Div"} : (tensor<1x4x128x128xf32>, tensor<1x1x128x128xf32>) -> tensor<1x4x128x128xf32>
+  %16 = "onnx.Mul"(%15, %5) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Mul_2"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  %17 = "onnx.Add"(%16, %6) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  return %17 : tensor<1x4x128x128xf32>
+}
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x128x128xf32>) -> tensor<1x4x128x128xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.0970484465]{{.}}, {{.}}[0.0882187337]{{.}}, {{.}}[0.135120019]{{.}}, {{.}}[0.14907673]{{.}}{{.}}> : tensor<4x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.191972837]{{.}}, {{.}}[0.286264896]{{.}}, {{.}}[0.180535644]{{.}}, {{.}}[0.166878015]{{.}}{{.}}> : tensor<4x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 4, 1, 1]> : tensor<4xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x1x4xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x128x128xf32>) -> tensor<1x128x128x4xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.Reshape"([[VAR_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK:           [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_6_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x1x4xf32>
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_5_]], [[VAR_4_]], [[VAR_7_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, tensor<1x1x1x4xf32>) -> (tensor<1x128x128x4xf32>, none, none)
+// CHECK:           [[VAR_8_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           return [[VAR_8_]] : tensor<1x4x128x128xf32>
+// CHECK:         }
+
+// -----
+
+// TODO: ADD more lit tests here


### PR DESCRIPTION
Todos:
- [x] Add more lit test for matching decomposition to layernorm
- [x] Add lit test for canonicalization part
- [x] **X86 transformation proof: The transformation was tested and passed with x86 onnx rt with rtol=1e-19 atol=1e-5.**

Description:
From:
```
%9 = "onnx.ReduceMeanV13"(%8) {axes = [1]} : (<1x4x128xf32>) -> <1x1x128xf32>
%10 = "onnx.Sub"(%8, %9) (<1x4x128xf32>, <1x1x128xf32>) -> <1x4x128xf32>
%11 = "onnx.Mul"(%10, %10) (<1x4x128xf32>, <1x4x128xf32>) -> <1x4x128xf32>
%12 = "onnx.ReduceMeanV13"(%11) {axes = [1]} : (<1x4x128xf32>) -> <1x1x128xf32> 
%13 = "onnx.Add"(%12, %4) : (<1x1x128xf32>, <f32>) -> <1x1x128xf32>
%14 = "onnx.Sqrt"(%13): (<1x1x128xf32>) -> <1x1x128xf32> 
%15 = "onnx.Div"(%10, %14) : (<1x4x128xf32>, <1x1x128xf32>) -> <1x4x128xf32> 
%16 = "onnx.Mul"(%15, %5) : (<1x4x128xf32>, <4x1x1xf32>) -> <1x4x128xf32>
```

To:
```
%9 = "onnx.Transpose"(%6) {perm = [0, 2, 3, 1]} : (<1x4x128x128xf32>) -> <1x128x128x4xf32>
%Y = "onnx.LayerNormalization"(%9, %8, %1) {axis = 3 : si64} : (<1x128x128x4xf32>, <1x1x1x4xf32>, none) ->(<1x128x128x4xf32>)
%10 = "onnx.Transpose"(%Y) {perm = [0, 3, 1, 2]} : (<1x128x128x4xf32>) -> <1x4x128x128xf32>
```