### PR TITLE
Refactor: Move InstanceNorm→LayerNorm from Canonicalize to Decompose

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -42,8 +42,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTransposeDecompose,
         opts.enableConvTransposeDecomposeToPhasedConv,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
-        opts.enableInstanceNormDecompose,
-        opts.enableRecomposeLayernormByTranspose));
+        opts.enableRecomposeLayernormByTranspose,
+        opts.enableInstanceNormDecompose));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
@@ -54,8 +54,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
               opts.enableConvTransposeDecompose,
               opts.enableConvTransposeDecomposeToPhasedConv,
               opts.enableConvTranspose1dDecomposeToPhasedConv,
-              opts.enableInstanceNormDecompose,
-              opts.enableRecomposeLayernormByTranspose));
+              opts.enableRecomposeLayernormByTranspose,
+              opts.enableInstanceNormDecompose));
     }
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
@@ -112,8 +112,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTransposeDecompose,
         opts.enableConvTransposeDecomposeToPhasedConv,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
-        opts.enableInstanceNormDecompose,
-        opts.enableRecomposeLayernormByTranspose));
+        opts.enableRecomposeLayernormByTranspose,
+        opts.enableInstanceNormDecompose));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -30,7 +30,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createDecomposeONNXToONNXPass(
       /*target=*/"", opts.enableConvTransposeDecompose,
       opts.enableConvTransposeDecomposeToPhasedConv,
-      opts.enableConvTranspose1dDecomposeToPhasedConv));
+      opts.enableConvTranspose1dDecomposeToPhasedConv,
+      opts.enableInstanceNormDecompose));
   if (!opts.disableRecomposeOption)
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass(
         /*target=*/"", opts.enableRecomposeLayernormByTranspose));
@@ -41,6 +42,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTransposeDecompose,
         opts.enableConvTransposeDecomposeToPhasedConv,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
+        opts.enableInstanceNormDecompose,
         opts.enableRecomposeLayernormByTranspose));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
@@ -52,6 +54,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
               opts.enableConvTransposeDecompose,
               opts.enableConvTransposeDecomposeToPhasedConv,
               opts.enableConvTranspose1dDecomposeToPhasedConv,
+              opts.enableInstanceNormDecompose,
               opts.enableRecomposeLayernormByTranspose));
     }
   } else {
@@ -109,6 +112,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTransposeDecompose,
         opts.enableConvTransposeDecomposeToPhasedConv,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
+        opts.enableInstanceNormDecompose,
         opts.enableRecomposeLayernormByTranspose));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -16,6 +16,7 @@ struct OnnxToMlirOptions {
   bool enableConvTransposeDecompose = false;
   bool enableConvTransposeDecomposeToPhasedConv = false;
   bool enableConvTranspose1dDecomposeToPhasedConv = false;
+  bool enableInstanceNormDecompose = true;
   bool enableRemoveDqQOp = true;
   bool enableRemoveDqQAroundOp = true;
   bool enableRemoveBinary = false;

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -3643,7 +3643,6 @@ def ONNXIfOp:ONNX_Op<"If",
 
 def ONNXInstanceNormalizationOp:ONNX_Op<"InstanceNormalization",
   [Pure, OpVersionTrait<22>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
-  let hasCanonicalizer = 1;
   let summary = "ONNX InstanceNormalization operation";
   let description = [{
   Carries out instance normalization as described in the paper

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -29,7 +29,8 @@ namespace onnx_mlir {
 void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableConvTransposeDecompose,
     bool enableConvTransposeDecomposeToPhasedConv,
-    bool enableConvTranspose1dDecomposeToPhasedConv);
+    bool enableConvTranspose1dDecomposeToPhasedConv,
+    bool enableInstanceNormDecompose);
 
 } // namespace onnx_mlir
 #endif

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -130,7 +130,7 @@ struct ONNXHybridTransformPass
       bool enableConvTransposeDecompose,
       bool enableConvTransposeDecomposeToPhasedConv,
       bool enableConvTranspose1dDecomposeToPhasedConv,
-      bool enableInstanceNormDecompose, bool recomposeLayernormByTranspose) {
+      bool recomposeLayernormByTranspose, bool enableInstanceNormDecompose) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
@@ -138,8 +138,8 @@ struct ONNXHybridTransformPass
         enableConvTransposeDecomposeToPhasedConv;
     this->enableConvTranspose1dDecomposeToPhasedConv =
         enableConvTranspose1dDecomposeToPhasedConv;
-    this->enableInstanceNormDecompose = enableInstanceNormDecompose;
     this->recomposeLayernormByTranspose = recomposeLayernormByTranspose;
+    this->enableInstanceNormDecompose = enableInstanceNormDecompose;
   }
 
   ONNXHybridTransformPass(const ONNXHybridTransformPass &pass)
@@ -228,11 +228,11 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableConvTransposeDecompose,
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
-    bool enableInstanceNormDecompose,
-    bool enableRecomposeLayernormByTranspose) {
+    bool enableRecomposeLayernormByTranspose,
+    bool enableInstanceNormDecompose) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,
-      enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
-      enableRecomposeLayernormByTranspose);
+      enableConvTranspose1dDecomposeToPhasedConv,
+      enableRecomposeLayernormByTranspose, enableInstanceNormDecompose);
 }

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -111,6 +111,12 @@ struct ONNXHybridTransformPass
           "phased Conv"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableInstanceNormDecompose{*this,
+      "enable-instancenorm-decompose",
+      llvm::cl::desc("Enable decomposition of InstanceNormalization to "
+                     "LayerNormalization"),
+      ::llvm::cl::init(true)};
+
   Option<bool> recomposeLayernormByTranspose{*this,
       "recompose-layernorm-by-transpose",
       llvm::cl::desc("Use transpose operator to make unsuitable axes suitable "
@@ -124,7 +130,7 @@ struct ONNXHybridTransformPass
       bool enableConvTransposeDecompose,
       bool enableConvTransposeDecomposeToPhasedConv,
       bool enableConvTranspose1dDecomposeToPhasedConv,
-      bool recomposeLayernormByTranspose) {
+      bool enableInstanceNormDecompose, bool recomposeLayernormByTranspose) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
@@ -132,6 +138,7 @@ struct ONNXHybridTransformPass
         enableConvTransposeDecomposeToPhasedConv;
     this->enableConvTranspose1dDecomposeToPhasedConv =
         enableConvTranspose1dDecomposeToPhasedConv;
+    this->enableInstanceNormDecompose = enableInstanceNormDecompose;
     this->recomposeLayernormByTranspose = recomposeLayernormByTranspose;
   }
 
@@ -175,7 +182,8 @@ struct ONNXHybridTransformPass
       getDecomposeONNXToONNXPatterns(cumulativePatterns,
           enableConvTransposeDecompose,
           enableConvTransposeDecomposeToPhasedConv,
-          enableConvTranspose1dDecomposeToPhasedConv);
+          enableConvTranspose1dDecomposeToPhasedConv,
+          enableInstanceNormDecompose);
     }
 
     if (recomposition) {
@@ -220,10 +228,11 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableConvTransposeDecompose,
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
+    bool enableInstanceNormDecompose,
     bool enableRecomposeLayernormByTranspose) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,
-      enableConvTranspose1dDecomposeToPhasedConv,
+      enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableRecomposeLayernormByTranspose);
 }

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -87,8 +87,8 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableConvTransposeDecompose = false,
     bool enableConvTransposeDecomposeToPhasedConv = false,
     bool enableConvTranspose1dDecomposeToPhasedConv = false,
-    bool enableInstanceNormDecompose = true,
-    bool enableRecomposeLayernormByTranspose = false);
+    bool enableRecomposeLayernormByTranspose = false,
+    bool enableInstanceNormDecompose = true);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -40,7 +40,8 @@ std::unique_ptr<mlir::Pass> createONNXOpTransformPass(int threshold,
 std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
     const std::string &target = "", bool enableConvTransposeDecompose = false,
     bool enableConvTransposeDecomposeToPhasedConv = false,
-    bool enableConvTranspose1dDecomposeToPhasedConv = false);
+    bool enableConvTranspose1dDecomposeToPhasedConv = false,
+    bool enableInstanceNormDecompose = true);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "",
     const bool &recomposeLayernormByTranspose = false);
@@ -86,6 +87,7 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableConvTransposeDecompose = false,
     bool enableConvTransposeDecomposeToPhasedConv = false,
     bool enableConvTranspose1dDecomposeToPhasedConv = false,
+    bool enableInstanceNormDecompose = true,
     bool enableRecomposeLayernormByTranspose = false);
 
 /// Pass for analyzing unknown dimension in ONNX operations.

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -2133,22 +2133,6 @@ func.func @test_reorder_relu_maxpool(%arg0: tensor<1x64x32x32xf32>) -> tensor<1x
 
 // -----
 
-func.func @test_instancenorm(%arg0: tensor<2x3x4x5x6xf32>, %arg1: tensor<3xf32>, %arg2: tensor<3xf32>) -> tensor<2x3x4x5x6xf32> {
-  %0 = "onnx.InstanceNormalization"(%arg0, %arg1, %arg2) {epsilon = 0.00999999977 : f32} : (tensor<2x3x4x5x6xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<2x3x4x5x6xf32>
-  onnx.Return %0 : tensor<2x3x4x5x6xf32>
-// mlir2FileCheck.py
-// CHECK-LABEL:  func.func @test_instancenorm
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5x6xf32>, [[PARAM_1_:%.+]]: tensor<3xf32>, [[PARAM_2_:%.+]]: tensor<3xf32>) -> tensor<2x3x4x5x6xf32> {
-// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Unsqueeze"([[PARAM_1_]], [[VAR_0_]]) : (tensor<3xf32>, tensor<3xi64>) -> tensor<3x1x1x1xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Unsqueeze"([[PARAM_2_]], [[VAR_0_]]) : (tensor<3xf32>, tensor<3xi64>) -> tensor<3x1x1x1xf32>
-// CHECK:           [[Y_:%.+]], [[Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[VAR_1_]], [[VAR_2_]]) {axis = 2 : si64, epsilon = 0.00999999977 : f32, stash_type = 1 : si64} : (tensor<2x3x4x5x6xf32>, tensor<3x1x1x1xf32>, tensor<3x1x1x1xf32>) -> (tensor<2x3x4x5x6xf32>, none, none)
-// CHECK:           onnx.Return [[Y_]] : tensor<2x3x4x5x6xf32>
-// CHECK:         }
-}
-
-// -----
-
 func.func @test_groupnorm_v18(%arg0: tensor<3x4x2x2xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>) -> tensor<3x4x2x2xf32> {
   %0 = "onnx.GroupNormalizationV18"(%arg0, %arg1, %arg2) {epsilon = 0.00999999977 : f32, num_groups = 2 : si64} : (tensor<3x4x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<3x4x2x2xf32>
   onnx.Return %0 : tensor<3x4x2x2xf32>

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -1109,3 +1109,19 @@ func.func @sce_none(%arg0: tensor<64x10x2x3xf32>, %arg1: tensor<64x2x3xi64>) -> 
   // CHECK-NEXT:     %[[LOSS:.*]] = "onnx.Neg"(%[[SQUEEZE]])
   // CHECK-NEXT:     onnx.Return %[[LOSS]] : tensor<64x2x3xf32>
 }
+
+// -----
+
+func.func @test_instancenorm(%arg0: tensor<2x3x4x5x6xf32>, %arg1: tensor<3xf32>, %arg2: tensor<3xf32>) -> tensor<2x3x4x5x6xf32> {
+  %0 = "onnx.InstanceNormalization"(%arg0, %arg1, %arg2) {epsilon = 0.00999999977 : f32} : (tensor<2x3x4x5x6xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<2x3x4x5x6xf32>
+  onnx.Return %0 : tensor<2x3x4x5x6xf32>
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @test_instancenorm
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5x6xf32>, [[PARAM_1_:%.+]]: tensor<3xf32>, [[PARAM_2_:%.+]]: tensor<3xf32>) -> tensor<2x3x4x5x6xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Unsqueeze"([[PARAM_1_]], [[VAR_0_]]) : (tensor<3xf32>, tensor<3xi64>) -> tensor<3x1x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Unsqueeze"([[PARAM_2_]], [[VAR_0_]]) : (tensor<3xf32>, tensor<3xi64>) -> tensor<3x1x1x1xf32>
+// CHECK:           [[Y_:%.+]], [[Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[VAR_1_]], [[VAR_2_]]) {axis = 2 : si64, epsilon = 0.00999999977 : f32, stash_type = 1 : si64} : (tensor<2x3x4x5x6xf32>, tensor<3x1x1x1xf32>, tensor<3x1x1x1xf32>) -> (tensor<2x3x4x5x6xf32>, none, none)
+// CHECK:           onnx.Return [[Y_]] : tensor<2x3x4x5x6xf32>
+// CHECK:         }
+}

--- a/test/mlir/onnx/parse/instancenorm_to_layernorm.onnxtext
+++ b/test/mlir/onnx/parse/instancenorm_to_layernorm.onnxtext
@@ -1,0 +1,19 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+<
+   ir_version: 8,
+   opset_import: ["" : 6]
+>
+test_instancenorm_e2e (float[2,3,4,5] input, float[3] scale, float[3] bias) => (float[2,3,4,5] output) {
+   output = InstanceNormalization <epsilon: float = 0.01> (input, scale, bias)
+}
+
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[INPUT:%.+]]: tensor<2x3x4x5xf32> {onnx.name = "input"}, [[SCALE:%.+]]: tensor<3xf32> {onnx.name = "scale"}, [[BIAS:%.+]]: tensor<3xf32> {onnx.name = "bias"}) -> (tensor<2x3x4x5xf32> {onnx.name = "output"}) {
+// CHECK-DAG:       [[AXES:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[UNSQUEEZE_SCALE:%.+]] = "onnx.Unsqueeze"([[SCALE]], [[AXES]]) : (tensor<3xf32>, tensor<2xi64>) -> tensor<3x1x1xf32>
+// CHECK-DAG:       [[UNSQUEEZE_BIAS:%.+]] = "onnx.Unsqueeze"([[BIAS]], [[AXES]]) : (tensor<3xf32>, tensor<2xi64>) -> tensor<3x1x1xf32>
+// CHECK:           [[OUTPUT:%.+]], [[MEAN:%.+]], [[INV_STD_DEV:%.+]] = "onnx.LayerNormalization"([[INPUT]], [[UNSQUEEZE_SCALE]], [[UNSQUEEZE_BIAS]]) {axis = 2 : si64, epsilon = 1.000000e-02 : f32, stash_type = 1 : si64} : (tensor<2x3x4x5xf32>, tensor<3x1x1xf32>, tensor<3x1x1xf32>) -> (tensor<2x3x4x5xf32>, none, none)
+// CHECK:           onnx.Return [[OUTPUT]] : tensor<2x3x4x5xf32>
+// CHECK:         }
+

--- a/test/mlir/onnx/parse/instancenorm_to_layernorm.onnxtext
+++ b/test/mlir/onnx/parse/instancenorm_to_layernorm.onnxtext
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+// RUN: onnx-mlir --EmitONNXIR --printIR %s | FileCheck %s
 <
    ir_version: 8,
    opset_import: ["" : 6]
@@ -11,9 +11,9 @@ test_instancenorm_e2e (float[2,3,4,5] input, float[3] scale, float[3] bias) => (
 // CHECK-LABEL:  func.func @main_graph
 // CHECK-SAME:   ([[INPUT:%.+]]: tensor<2x3x4x5xf32> {onnx.name = "input"}, [[SCALE:%.+]]: tensor<3xf32> {onnx.name = "scale"}, [[BIAS:%.+]]: tensor<3xf32> {onnx.name = "bias"}) -> (tensor<2x3x4x5xf32> {onnx.name = "output"}) {
 // CHECK-DAG:       [[AXES:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-// CHECK-DAG:       [[UNSQUEEZE_SCALE:%.+]] = "onnx.Unsqueeze"([[SCALE]], [[AXES]]) : (tensor<3xf32>, tensor<2xi64>) -> tensor<3x1x1xf32>
-// CHECK-DAG:       [[UNSQUEEZE_BIAS:%.+]] = "onnx.Unsqueeze"([[BIAS]], [[AXES]]) : (tensor<3xf32>, tensor<2xi64>) -> tensor<3x1x1xf32>
-// CHECK:           [[OUTPUT:%.+]], [[MEAN:%.+]], [[INV_STD_DEV:%.+]] = "onnx.LayerNormalization"([[INPUT]], [[UNSQUEEZE_SCALE]], [[UNSQUEEZE_BIAS]]) {axis = 2 : si64, epsilon = 1.000000e-02 : f32, stash_type = 1 : si64} : (tensor<2x3x4x5xf32>, tensor<3x1x1xf32>, tensor<3x1x1xf32>) -> (tensor<2x3x4x5xf32>, none, none)
-// CHECK:           onnx.Return [[OUTPUT]] : tensor<2x3x4x5xf32>
+// CHECK-DAG:       [[UNSQUEEZE_SCALE:%.+]] = "onnx.Unsqueeze"([[SCALE]], [[AXES]]) {{.*}} : (tensor<3xf32>, tensor<2xi64>) -> tensor<3x1x1xf32>
+// CHECK-DAG:       [[UNSQUEEZE_BIAS:%.+]] = "onnx.Unsqueeze"([[BIAS]], [[AXES]]) {{.*}} : (tensor<3xf32>, tensor<2xi64>) -> tensor<3x1x1xf32>
+// CHECK:           [[OUTPUT:%.+]], {{.*}}, {{.*}} = "onnx.LayerNormalization"([[INPUT]], [[UNSQUEEZE_SCALE]], [[UNSQUEEZE_BIAS]]) {axis = 2 : si64, epsilon = {{.*}} : f32{{.*}}} : (tensor<2x3x4x5xf32>, tensor<3x1x1xf32>, tensor<3x1x1xf32>) -> (tensor<2x3x4x5xf32>, none, none)
+// CHECK:           return [[OUTPUT]] : tensor<2x3x4x5xf32>
 // CHECK:         }
 

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -347,7 +347,6 @@ OpsWithCanonicalizer = [
     "GroupNormalizationV18",
     "GRU",
     "Identity",
-    "InstanceNormalization",
     "Less",
     "Loop",
     "LSTM",


### PR DESCRIPTION
Move the InstanceNormalization to LayerNormalization transformation pattern from Canonicalize to Decompose to allow enabling/disabling via flag.

Changes:
- Move RemoveInstanceNormPattern → DecomposeInstanceNormPattern
- Add --enable-instancenorm-decompose flag (default: true)
- Pattern location: src/Dialect/ONNX/Transforms/Decompose.cpp
- Removed from: src/Dialect/ONNX/ONNXOps/Canonicalize.cpp

Test Migration:
- Moved test_instancenorm from onnx_canonicalization.mlir to onnx_decompose.mlir
- Test now uses --decompose-onnx flag instead of --canonicalize

API Changes:
- Updated createDecomposeONNXToONNXPass() to accept enableInstanceNormDecompose
- Updated createONNXHybridTransformPass() to accept enableInstanceNormDecompose
- Added enableInstanceNormDecompose to OnnxToMlirOptions (default: true)