### PR TITLE
ONNXConstantOp: Allow extra attributes (parser/printer)

### DIFF
--- a/test/mlir/onnx/onnx_constant.mlir
+++ b/test/mlir/onnx/onnx_constant.mlir
@@ -1,0 +1,34 @@
+// RUN: onnx-mlir-opt %s -mlir-print-op-generic | FileCheck -check-prefix=GENERIC %s
+// RUN: onnx-mlir-opt %s | FileCheck %s
+
+func.func @test() {
+  %generic = "onnx.Constant"() {value = dense<-1> : tensor<1xi64> } : () -> tensor<1xi64>
+  %pretty = onnx.Constant dense<-1> : tensor<1xi64>
+
+  %generic_with_extra_attr = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>, extra_attr = 0 : i32 } : () -> tensor<1xi64>
+  %pretty_with_extra_attr = onnx.Constant {extra_attr = 0 : i32} dense<-1> : tensor<1xi64>
+
+  %generic_dynamic = "onnx.Constant"() {value = dense<-1> : tensor<1xi64> } : () -> tensor<*xi64>
+  %pretty_dynamic = onnx.Constant {value = dense<-1> : tensor<1xi64>} : tensor<*xi64>
+
+  %generic_dynamic_with_extra_attr = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>, extra_attr = 0 : i32 } : () -> tensor<*xi64>
+  %pretty_dynamic_with_extra_attr = onnx.Constant {extra_attr = 0 : i32, value = dense<-1> : tensor<1xi64>} : tensor<*xi64>
+  func.return
+}
+
+// GENERIC: "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
+// GENERIC: "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
+// GENERIC: "onnx.Constant"() {extra_attr = 0 : i32, value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
+// GENERIC: "onnx.Constant"() {extra_attr = 0 : i32, value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
+// GENERIC: "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<*xi64>
+// GENERIC: "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<*xi64>
+// GENERIC: "onnx.Constant"() {extra_attr = 0 : i32, value = dense<-1> : tensor<1xi64>} : () -> tensor<*xi64>
+// GENERIC: "onnx.Constant"() {extra_attr = 0 : i32, value = dense<-1> : tensor<1xi64>} : () -> tensor<*xi64>
+// CHECK: onnx.Constant dense<-1> : tensor<1xi64>
+// CHECK: onnx.Constant dense<-1> : tensor<1xi64>
+// CHECK: onnx.Constant {extra_attr = 0 : i32} dense<-1> : tensor<1xi64>
+// CHECK: onnx.Constant {extra_attr = 0 : i32} dense<-1> : tensor<1xi64>
+// CHECK: onnx.Constant {value = dense<-1> : tensor<1xi64>} : tensor<*xi64>
+// CHECK: onnx.Constant {value = dense<-1> : tensor<1xi64>} : tensor<*xi64>
+// CHECK: onnx.Constant {extra_attr = 0 : i32, value = dense<-1> : tensor<1xi64>} : tensor<*xi64>
+// CHECK: onnx.Constant {extra_attr = 0 : i32, value = dense<-1> : tensor<1xi64>} : tensor<*xi64>

--- a/test/mlir/onnx/parse/com.microsoft.qdq_linear.json
+++ b/test/mlir/onnx/parse/com.microsoft.qdq_linear.json
@@ -1,8 +1,8 @@
 // RUN: onnx-mlir --EmitONNXIR --useOnnxModelTypes=false --printIR %s | FileCheck %s
 // Semi hand-written model.
 // When converted to onnxtext, onnx-mlir didn't like the result.
-// CHECK-DAG:       [[SCALE:%.+]] = onnx.Constant dense<-1.08420217E-19> : tensor<f32>
-// CHECK-DAG:       [[ZERO_P:%.+]] = onnx.Constant dense<0> : tensor<i8>
+// CHECK-DAG:       [[SCALE:%.+]] = onnx.Constant {onnx_node_name = "scale"} dense<-1.08420217E-19> : tensor<f32>
+// CHECK-DAG:       [[ZERO_P:%.+]] = onnx.Constant {onnx_node_name = "zeropoint"} dense<0> : tensor<i8>
 // CHECK:           [[DQ:%.+]] = "onnx.DequantizeLinear"(%arg0, [[SCALE]], [[ZERO_P]]) {axis = 1 : si64, block_size = 0 : si64, onnx_node_name = "myDequantizeLinear"} : (tensor<1x64x112x112xi8>, tensor<f32>, tensor<i8>) -> tensor<1x64x112x112xf32>
 // CHECK:           [[RELU:%.+]] = "onnx.Relu"([[DQ]]) {onnx_node_name = "myrelu1Relu"} : (tensor<1x64x112x112xf32>) -> tensor<1x64x112x112xf32>
 // CHECK:           [[Q:%.+]] = "onnx.QuantizeLinear"([[RELU]], [[SCALE]], [[ZERO_P]]) {axis = 1 : si64, block_size = 0 : si64, onnx_node_name = "myQuantizeLinear_1", output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x64x112x112xf32>, tensor<f32>, tensor<i8>) -> tensor<1x64x112x112xi8>


### PR DESCRIPTION
When attaching extra attributes to a ONNXConstantOp, those are currently not printed (and cannot be parsed) because the custom assembly format doesn't consider them.
This PR adds support for printing/parsing extra attributes, which look like
```
onnx.Constant {extra_attr = 0 : i32} dense<-1> : tensor<1xi64>
```
in the pretty form.