### PR TITLE
FoldBinaryThroughQDQ: fix invalid read access in step 7

### DIFF
--- a/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
@@ -538,7 +538,10 @@ public:
     rewriter.replaceOp(op, dqAct.getResult());
 
     // STEP 7: Remove Q->DQ chain
-    for (Operation *user : quantOutputOp.getY().getUsers()) {
+
+    // prevent iterating and removing elements
+    auto users = llvm::make_early_inc_range(quantOutputOp.getY().getUsers());
+    for (Operation *user : users) {
       if (auto tailDQ = llvm::dyn_cast<ONNXDequantizeLinearOp>(user)) {
         (void)tryRemoveQThenDQChain(rewriter, tailDQ);
       }


### PR DESCRIPTION
In the step 7 we iterator over a range while removing element from it.
This make the iterator in an invalid state.