### PR TITLE
AIESW-17979: Legalize dynamic to static switching in ONNXToTOSA

### DIFF
--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -5,7 +5,7 @@
 //====------ ConvertONNXToTOSA.cpp - ONNX dialects to TOSA lowering -------===//
 //
 // Copyright (c) 2022 Arm Limited.
-// Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -120,6 +120,51 @@ public:
       llvm::cl::ZeroOrMore, llvm::cl::init(false)};
 };
 
+Value handleDynamicToStaticShapes(
+    OpBuilder &builder, TensorType type, ValueRange inputs, Location loc) {
+  if (inputs.size() != 1) {
+    // we can only handle inputs of size 1
+    return {};
+  }
+  Value out = inputs.front();
+  auto outType = dyn_cast<ShapedType>(out.getType());
+  if (!outType) {
+    // no operation as input
+    return {};
+  }
+  if (outType.hasStaticShape() || !type.hasStaticShape()) {
+    // we are looking for a dynamic to static "cast"
+    return {};
+  }
+  if (outType.getElementType() != type.getElementType()) {
+    // type is not equal
+    // this should be mostly caught by the operation validation already
+    return {};
+  }
+  if (outType.hasRank()) {
+    if (outType.getRank() != type.getRank()) {
+      // rank does not match
+      // this seems to be caught by the shape inference already
+      return {};
+    } else {
+      auto outShape = outType.getShape();
+      auto tyShape = type.getShape();
+
+      for (int i = 0; i < outType.getRank(); ++i) {
+        if (outType.isDynamicDim(i)) {
+          continue;
+        }
+        if (outShape[i] != tyShape[i]) {
+          // input and output does not match in one dimension
+          return {};
+        }
+      }
+    }
+  }
+  out.setType(type);
+  return out;
+}
+
 void FrontendToTosaLoweringPass::runOnOperation() {
   ModuleOp module = getOperation();
   // Define final conversion target
@@ -142,6 +187,7 @@ void FrontendToTosaLoweringPass::runOnOperation() {
       return type;
     return std::nullopt;
   });
+  typeConverter.addSourceMaterialization(handleDynamicToStaticShapes);
 
   // Define legal dialects and operations
   target.addLegalDialect<mlir::tosa::TosaDialect, func::FuncDialect,

--- a/src/Conversion/ONNXToTOSA/NN/DequantizeLinear.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/DequantizeLinear.cpp
@@ -34,15 +34,7 @@ public:
     Location loc = op->getLoc();
     TosaBuilder tosaBuilder(rewriter, op->getLoc());
     Value x = op.getX();
-    // We check for the type of the x input here to plain reject dynamic input
-    // tensors. This is not necessary for the lowering but prevents later errors
-    // when going back from dynamic to static types, i.e. inputs are dynamic but
-    // outputs not. Adapt this to support dynamic shapes once it becomes
-    // relevant.
-    auto xType = dyn_cast<ShapedType>(x.getType());
-    if (!xType.hasStaticShape()) {
-      return rewriter.notifyMatchFailure(loc, "expected valid tensor x type");
-    }
+
     auto resultType = dyn_cast_if_present<ShapedType>(
         getTypeConverter()->convertType(op.getResult().getType()));
     if (!resultType || !resultType.hasStaticShape()) {

--- a/test/mlir/conversion/onnx_to_tosa/NN/DequantizeLinear.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/DequantizeLinear.mlir
@@ -111,10 +111,61 @@ func.func @all_scalar(%arg0 : tensor<i8>) -> tensor<f32> {
 
 // -----
 
-func.func @dynamic(%arg0 : tensor<?xi8>, %arg1 : tensor<f32>, %arg2 : tensor<i8>) -> tensor<f32> {
-  %0 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<?xi8>, tensor<f32>, tensor<i8>) -> tensor<f32>
-  return %0 : tensor<f32>
+func.func @dynamic(%arg0 : tensor<?xi8>, %arg1 : tensor<f32>, %arg2 : tensor<i8>) -> tensor<1xf32> {
+  %0 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<?xi8>, tensor<f32>, tensor<i8>) -> tensor<1xf32>
+  return %0 : tensor<1xf32>
 }
 
-// CHECK-LABEL: dynamic
+// CHECK-LABEL:  func.func @dynamic
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xi8>, [[PARAM_1_:%.+]]: tensor<f32>, [[PARAM_2_:%.+]]: tensor<i8>) -> tensor<1xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.cast [[PARAM_0_]] : (tensor<?xi8>) -> tensor<?xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1>} : (tensor<i8>) -> tensor<1xi8>
+// CHECK:           [[VAR_2_:%.+]] = tosa.cast [[VAR_1_]] : (tensor<1xi8>) -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.sub [[VAR_0_]], [[VAR_2_]] : (tensor<?xf32>, tensor<1xf32>) -> tensor<?xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1>} : (tensor<f32>) -> tensor<1xf32>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_4_]] {shift = 0 : i8} : (tensor<?xf32>, tensor<1xf32>) -> tensor<1xf32>
+// CHECK:           return [[VAR_5_]] : tensor<1xf32>
+// CHECK:         }
+// -----
+
+func.func @dynamic2(%arg0 : tensor<*xi8>, %arg1 : tensor<f32>, %arg2 : tensor<i8>) -> tensor<1xf32> {
+  %0 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<*xi8>, tensor<f32>, tensor<i8>) -> tensor<1xf32>
+  return %0 : tensor<1xf32>
+}
+
+// CHECK-LABEL:  func.func @dynamic2
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xi8>, [[PARAM_1_:%.+]]: tensor<f32>, [[PARAM_2_:%.+]]: tensor<i8>) -> tensor<1xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.cast [[PARAM_0_]] : (tensor<*xi8>) -> tensor<*xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1>} : (tensor<i8>) -> tensor<1xi8>
+// CHECK:           [[VAR_2_:%.+]] = tosa.cast [[VAR_1_]] : (tensor<1xi8>) -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.sub [[VAR_0_]], [[VAR_2_]] : (tensor<*xf32>, tensor<1xf32>) -> tensor<*xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1>} : (tensor<f32>) -> tensor<1xf32>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_4_]] {shift = 0 : i8} : (tensor<*xf32>, tensor<1xf32>) -> tensor<1xf32>
+// CHECK:           return [[VAR_5_]] : tensor<1xf32>
+// CHECK:         }
+// -----
+
+func.func @dynamic3(%arg0 : tensor<2x?xi8>, %arg1 : tensor<f32>, %arg2 : tensor<i8>) -> tensor<2x1xf32> {
+  %0 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<2x?xi8>, tensor<f32>, tensor<i8>) -> tensor<2x1xf32>
+  return %0 : tensor<2x1xf32>
+}
+
+// CHECK-LABEL:  func.func @dynamic3
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x?xi8>, [[PARAM_1_:%.+]]: tensor<f32>, [[PARAM_2_:%.+]]: tensor<i8>) -> tensor<2x1xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.cast [[PARAM_0_]] : (tensor<2x?xi8>) -> tensor<2x?xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 1, 1>} : (tensor<i8>) -> tensor<1x1xi8>
+// CHECK:           [[VAR_2_:%.+]] = tosa.cast [[VAR_1_]] : (tensor<1x1xi8>) -> tensor<1x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tosa.sub [[VAR_0_]], [[VAR_2_]] : (tensor<2x?xf32>, tensor<1x1xf32>) -> tensor<2x?xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 1, 1>} : (tensor<f32>) -> tensor<1x1xf32>
+// CHECK:           [[VAR_5_:%.+]] = tosa.mul [[VAR_3_]], [[VAR_4_]] {shift = 0 : i8} : (tensor<2x?xf32>, tensor<1x1xf32>) -> tensor<2x1xf32>
+// CHECK:           return [[VAR_5_]] : tensor<2x1xf32>
+// CHECK:         }
+// -----
+
+func.func @dynamic4(%arg0 : tensor<?xi8>, %arg1 : tensor<f32>, %arg2 : tensor<i8>) -> tensor<?xf32> {
+  %0 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<?xi8>, tensor<f32>, tensor<i8>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+// CHECK-LABEL: dynamic4
 // CHECK: onnx.DequantizeLinear


### PR DESCRIPTION
This commit legalizes code where a ONNX operation takes dynamic inputs and outputs static types. It is currently tested only for DequantizeLinear.

It reverts and improves
bd09ba44a8d6ea1f76938c1fbb6ec9e0fabc24c7 and
bdc8b97cda85d0596555cc07f8a21011bc073b59.

This PR is a backport of #485.