### PR TITLE
[AIESW-19089] Added flag to disable ScatterND decomposition optimization

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -50,15 +50,15 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
           opts.enableSimdDataLayout && !opts.disableSimdOption));
-      pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
-          !opts.disableRecomposeOption,
-          /*enableQuarkQuantizedOpsLegalization=*/false,
-          opts.enableConvTransposeDecompose,
-          opts.enableConvTransposeDecomposeToPhasedConv,
-          opts.enableConvTranspose1dDecomposeToPhasedConv,
-          opts.enableRecomposeLayernormByTranspose,
-          opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose,
-          opts.enableScatterNDDecompose));
+      pm.addNestedPass<func::FuncOp>(
+          onnx_mlir::createONNXHybridTransformPass(!opts.disableRecomposeOption,
+              /*enableQuarkQuantizedOpsLegalization=*/false,
+              opts.enableConvTransposeDecompose,
+              opts.enableConvTransposeDecomposeToPhasedConv,
+              opts.enableConvTranspose1dDecomposeToPhasedConv,
+              opts.enableRecomposeLayernormByTranspose,
+              opts.enableInstanceNormDecompose,
+              opts.enableSplitToSliceDecompose, opts.enableScatterNDDecompose));
     }
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -31,7 +31,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
       /*target=*/"", opts.enableConvTransposeDecompose,
       opts.enableConvTransposeDecomposeToPhasedConv,
       opts.enableConvTranspose1dDecomposeToPhasedConv,
-      opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose));
+      opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose,
+      opts.enableScatterNDDecompose));
   if (!opts.disableRecomposeOption)
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass(
         /*target=*/"", opts.enableRecomposeLayernormByTranspose));
@@ -43,7 +44,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTransposeDecomposeToPhasedConv,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
         opts.enableRecomposeLayernormByTranspose,
-        opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose));
+        opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose,
+        opts.enableScatterNDDecompose));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
@@ -55,7 +57,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
           opts.enableConvTransposeDecomposeToPhasedConv,
           opts.enableConvTranspose1dDecomposeToPhasedConv,
           opts.enableRecomposeLayernormByTranspose,
-          opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose));
+          opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose,
+          opts.enableScatterNDDecompose));
     }
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
@@ -113,7 +116,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTransposeDecomposeToPhasedConv,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
         opts.enableRecomposeLayernormByTranspose,
-        opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose));
+        opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose,
+        opts.enableScatterNDDecompose));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -22,6 +22,7 @@ struct OnnxToMlirOptions {
   bool enableRemoveBinary = false;
   bool enableRecomposeLayernormByTranspose = false;
   bool enableSplitToSliceDecompose = false;
+  bool enableScatterNDDecompose = true;
 
   bool disableRecomposeOption = false;
   bool enableONNXHybridPass = true;

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -3783,8 +3783,7 @@ struct DecomposeONNXToONNXPass
         pass.enableInstanceNormDecompose.getValue();
     this->enableSplitToSliceDecompose =
         pass.enableSplitToSliceDecompose.getValue();
-    this->enableScatterNDDecompose =
-        pass.enableScatterNDDecompose.getValue();
+    this->enableScatterNDDecompose = pass.enableScatterNDDecompose.getValue();
   }
 
   StringRef getArgument() const override { return "decompose-onnx"; }
@@ -3824,8 +3823,7 @@ struct DecomposeONNXToONNXPass
       llvm::cl::desc("Enable decomposition of Split to Slice operations"),
       ::llvm::cl::init(false)};
 
-  Option<bool> enableScatterNDDecompose{*this,
-      "enable-scatternd-decompose",
+  Option<bool> enableScatterNDDecompose{*this, "enable-scatternd-decompose",
       llvm::cl::desc("Enable decomposition of ScatterND"),
       ::llvm::cl::init(true)};
 

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -3758,7 +3758,8 @@ struct DecomposeONNXToONNXPass
       bool enableConvTransposeDecomposeToPhasedConv = false,
       bool enableConvTranspose1dDecomposeToPhasedConv = false,
       bool enableInstanceNormDecompose = true,
-      bool enableSplitToSliceDecompose = false) {
+      bool enableSplitToSliceDecompose = false,
+      bool enableScatterNDDecompose = true) {
     this->target = target;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
     this->enableConvTransposeDecomposeToPhasedConv =
@@ -3767,6 +3768,7 @@ struct DecomposeONNXToONNXPass
         enableConvTranspose1dDecomposeToPhasedConv;
     this->enableInstanceNormDecompose = enableInstanceNormDecompose;
     this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
+    this->enableScatterNDDecompose = enableScatterNDDecompose;
   }
 
   DecomposeONNXToONNXPass(const DecomposeONNXToONNXPass &pass)
@@ -3781,6 +3783,8 @@ struct DecomposeONNXToONNXPass
         pass.enableInstanceNormDecompose.getValue();
     this->enableSplitToSliceDecompose =
         pass.enableSplitToSliceDecompose.getValue();
+    this->enableScatterNDDecompose =
+        pass.enableScatterNDDecompose.getValue();
   }
 
   StringRef getArgument() const override { return "decompose-onnx"; }
@@ -3820,6 +3824,11 @@ struct DecomposeONNXToONNXPass
       llvm::cl::desc("Enable decomposition of Split to Slice operations"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableScatterNDDecompose{*this,
+      "enable-scatternd-decompose",
+      llvm::cl::desc("Enable decomposition of ScatterND"),
+      ::llvm::cl::init(true)};
+
   void runOnOperation() final;
 
   typedef PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>>
@@ -3833,7 +3842,7 @@ void DecomposeONNXToONNXPass::runOnOperation() {
   onnx_mlir::getDecomposeONNXToONNXPatterns(patterns,
       enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
-      enableSplitToSliceDecompose);
+      enableSplitToSliceDecompose, enableScatterNDDecompose);
   patterns.insert<ReplaceCastLikeByCastPattern>(context);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
@@ -3852,7 +3861,8 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     mlir::RewritePatternSet &patterns, bool enableConvTransposeDecompose,
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
-    bool enableInstanceNormDecompose, bool enableSplitToSliceDecompose) {
+    bool enableInstanceNormDecompose, bool enableSplitToSliceDecompose,
+    bool enableScatterNDDecompose) {
   MLIRContext *context = patterns.getContext();
   populateWithGenerated(patterns);
   if (enableConvTransposeDecompose)
@@ -3882,7 +3892,8 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
   patterns.insert<SimplifiedLayerNorm>(context);
   patterns.insert<MicrosoftSkipSimplifiedLayerNorm>(context);
   patterns.insert<DecomposeSlicePadPattern>(context);
-  patterns.insert<DecomposeScatterNDPattern>(context);
+  if (enableScatterNDDecompose)
+    patterns.insert<DecomposeScatterNDPattern>(context);
   patterns.insert<SoftmaxCrossEntropyPattern>(context);
   patterns.insert<SumToAddPattern>(context);
   if (enableSplitToSliceDecompose)
@@ -3905,9 +3916,10 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createDecomposeONNXToONNXPass(
     const std::string &target, bool enableConvTransposeDecompose,
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
-    bool enableInstanceNormDecompose, bool enableSplitToSliceDecompose) {
+    bool enableInstanceNormDecompose, bool enableSplitToSliceDecompose,
+    bool enableScatterNDDecompose) {
   return std::make_unique<DecomposeONNXToONNXPass>(target,
       enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
-      enableSplitToSliceDecompose);
+      enableSplitToSliceDecompose, enableScatterNDDecompose);
 }

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -30,7 +30,8 @@ void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableConvTransposeDecompose,
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
-    bool enableInstanceNormDecompose, bool enableSplitToSliceDecompose = false);
+    bool enableInstanceNormDecompose, bool enableSplitToSliceDecompose = false,
+    bool enableScatterNDDecompose = true);
 
 } // namespace onnx_mlir
 #endif

--- a/src/Dialect/ONNX/Transforms/Decompose.td
+++ b/src/Dialect/ONNX/Transforms/Decompose.td
@@ -35,16 +35,15 @@ def KeepdimsIsTrue
     : Constraint<CPred<"mlir::cast<IntegerAttr>($_self).getSInt() == 1">,
           "keepdims attribute is true">;
 
-def ONNXConstantOpNormalize
-    : NativeCodeCall<"onnx_mlir::normalizeConstantOp($_builder, $0, $1)">;
+def ONNXConstantOpNormalize: NativeCodeCall<
+  "onnx_mlir::normalizeConstantOp($_builder, $0, $1)">;
 
 def AttributeIsNull : Constraint<CPred<"! ($_self)">, "Attribute is null">;
 
 def AttributeIsNotNull : Constraint<CPred<"($_self)">, "Attribute is not null">;
 
-def HasFloatType
-    : Constraint<CPred<"(mlir::dyn_cast<ShapedType>(($_self).getType())"
-                       ".getElementType().isF32())">>;
+def HasFloatType : Constraint<CPred<"(mlir::dyn_cast<ShapedType>(($_self).getType())"
+                                    ".getElementType().isF32())">>;
 
 def IsNoneType : Constraint<CPred<"mlir::isa<NoneType>(($_self).getType())">>;
 
@@ -52,14 +51,14 @@ def GetNullAttr : NativeCodeCall<"Attribute()">;
 
 def GetNullFloatAttr : NativeCodeCall<"FloatAttr()">;
 
-def GetZeroFloatAttr
-    : NativeCodeCall<"$_builder.getFloatAttr($_builder.getF32Type(), 0)">;
+def GetZeroFloatAttr :
+	NativeCodeCall<"$_builder.getFloatAttr($_builder.getF32Type(), 0)">;
 
 def GetNullIntegerAttr : NativeCodeCall<"IntegerAttr()">;
 
 def GetNullStringAttr : NativeCodeCall<"StringAttr()">;
 
-def GetNullArrayAttr : NativeCodeCall<"ArrayAttr()">;
+def GetNullArrayAttr :  NativeCodeCall<"ArrayAttr()">;
 
 // Create a unit constant that will be used as none input.
 def CreateNoneValue : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc)">;
@@ -72,24 +71,21 @@ def createScalarDenseAttrRank0
 // Create a scalar DenseElementsAttr of tensor<dtype> from an ElementsAttr.
 // The input ElementsAttr must have only one element. Otherwise only the first
 // element is used to create the scalar DenseElementsAttr
-def ReshapeElementsAttrToRank0
-    : NativeCodeCall<"onnx_mlir::OnnxElementsAttrBuilder($0.getContext())."
-                     "reshape(cast<ElementsAttr>($0), {})">;
+def ReshapeElementsAttrToRank0 : NativeCodeCall<
+    "onnx_mlir::OnnxElementsAttrBuilder($0.getContext()).reshape(cast<ElementsAttr>($0), {})">;
 
-def ReplaceSequenceAt
-    : NativeCodeCall<"onnx_mlir::replaceSequenceAt($_builder, $_loc, $0)">;
+def ReplaceSequenceAt :  NativeCodeCall<
+    "onnx_mlir::replaceSequenceAt($_builder, $_loc, $0)">;
 
-def UpgradeGridSampleV16Mode
-    : NativeCodeCall<"onnx_mlir::upgradeGridSampleV16Mode($_builder, $0)">;
-
-def CanSequenceAtBeReplaced
-    : Constraint<CPred<"::onnx_mlir::canSequenceAtBeReplaced($_self)">,
-          "check whether the SequenceAt can be replaced with split">;
+def UpgradeGridSampleV16Mode :  NativeCodeCall<
+    "onnx_mlir::upgradeGridSampleV16Mode($_builder, $0)">;
+    
+def CanSequenceAtBeReplaced :
+   Constraint<CPred<"::onnx_mlir::canSequenceAtBeReplaced($_self)">, "check whether the SequenceAt can be replaced with split">;
 
 // Create a DenseElementsAttr from a single attribute.
 def createDenseArrayAttrFromSingleAttr
-    : NativeCodeCall<"::onnx_mlir::createDenseArrayAttr($_builder, "
-                     "$_builder.getArrayAttr($0))">;
+    : NativeCodeCall<"::onnx_mlir::createDenseArrayAttr($_builder, $_builder.getArrayAttr($0))">;
 
 // Create a DenseElementsAttr from an ArrayAttr.
 def createDenseArrayAttr
@@ -105,27 +101,24 @@ def noop_with_empty_axes
                      "/*isSigned=*/true), APInt(64, 0, /*isSigned=*/true))">;
 
 // Check if value is a dense constant
-def IsDenseONNXConstant
-    : Constraint<CPred<"::onnx_mlir::isDenseONNXConstant($_self)">,
-          "not a dense constant">;
+def IsDenseONNXConstant:
+   Constraint<CPred<"::onnx_mlir::isDenseONNXConstant($_self)">, "not a dense constant">;
 
-def createSequenceConstructOp
-    : NativeCodeCall<
-          "::onnx_mlir::createSequenceConstructOp($_builder, $0, $1)">;
+def createSequenceConstructOp : NativeCodeCall<
+  "::onnx_mlir::createSequenceConstructOp($_builder, $0, $1)">;
 
-def ONNXDataType
-    : NativeCodeCall<
-          "IntegerAttr::get($_builder.getIntegerType(64, /*isSigned=*/true), "
-          "::onnx_mlir::mlirTypeToOnnxType(mlir::cast<ShapedType>($0.getType()."
-          "front()).getElementType()))">;
+def ONNXDataType : NativeCodeCall<
+  "IntegerAttr::get($_builder.getIntegerType(64, /*isSigned=*/true), "
+  "::onnx_mlir::mlirTypeToOnnxType(mlir::cast<ShapedType>($0.getType().front()).getElementType()))">;
 
 // Check if value has a type that is ranked with a shape.
-def HasRankAndShape
-    : Constraint<CPred<"::onnx_mlir::isRankedShapedType($_self.getType())">,
-          "A value has rank and shape">;
+def HasRankAndShape:
+  Constraint<CPred<"::onnx_mlir::isRankedShapedType($_self.getType())">,
+  "A value has rank and shape">;
 
-def IntOne : AttrConstraint<CPred<"::mlir::matchPattern($_self, m_One())">,
-                 "is integer one">;
+def IntOne : AttrConstraint<
+    CPred<"::mlir::matchPattern($_self, m_One())">,
+    "is integer one">;
 
 //===----------------------------------------------------------------------===//
 // ONNXReduceL1Op %X = ONNXReduceSumOp (ONNXAbsOp %X)
@@ -160,8 +153,8 @@ def ReduceLogSumExpOpPattern1
                $axes, $keepdims, $noop),
               $max),
           [(KeepdimsIsTrue
-              : $keepdims)],
-          [], (addBenefit 1)>;
+              : $keepdims)], [],
+          (addBenefit 1)>;
 
 // keepdims is false
 def ReduceLogSumExpOpPattern2
@@ -178,7 +171,7 @@ def ReduceLogSumExpOpPattern2
 //===----------------------------------------------------------------------===//
 def ReduceSumSquareOpPattern
     : Pat<(ONNXReduceSumSquareOp $oprd, $axes, $keepdims, $noop),
-          (ONNXReduceSumOp(ONNXMulOp $oprd, $oprd), $axes, $keepdims, $noop)>;
+          (ONNXReduceSumOp (ONNXMulOp $oprd, $oprd), $axes, $keepdims, $noop)>;
 
 //===----------------------------------------------------------------------===//
 // ONNXScalerOp %X, %Offest, %Scale
@@ -187,65 +180,46 @@ def ReduceSumSquareOpPattern
 // No attribute
 def ScalerNullPattern
     : Pat<(ONNXScalerOp $x, $offset, $scale), (replaceWithValue $x),
-          [
-            (HasFloatType
-                : $x),
-            (AttributeIsNull
-                : $offset),
-            (AttributeIsNull
-                : $scale)
-          ],
-          [], (addBenefit 5)>;
+          [(HasFloatType:$x), (AttributeIsNull:$offset), (AttributeIsNull:$scale)], [],
+          (addBenefit 5)>;
 
 // No attribute, input x not float type
 def ScalerNullPattern2
-    : Pat<(ONNXScalerOp $x, $offset, $scale),
-          (ONNXCastOp $x, (GetNullIntegerAttr), (ScalerT)),
-          [(AttributeIsNull
-               : $offset),
-            (AttributeIsNull
-                : $scale)],
-          [], (addBenefit 4)>;
+    : Pat<(ONNXScalerOp $x, $offset, $scale), (ONNXCastOp $x, (GetNullIntegerAttr), (ScalerT)),
+          [(AttributeIsNull:$offset), (AttributeIsNull:$scale)], [],
+          (addBenefit 4)>;
 
 // No scale
 def ScalerNoScalePattern
     : Pat<(ONNXScalerOp $x, $offset, $scale),
           (ONNXSubOp $x,
               (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $offset))),
-          [(HasFloatType
-               : $x),
-            (AttributeIsNull
-                : $scale)],
-          [], (addBenefit 3)>;
+          [(HasFloatType:$x), (AttributeIsNull:$scale)], [],
+          (addBenefit 3)>;
 
 // No scale, input x not float type
 def ScalerNoScalePattern2
     : Pat<(ONNXScalerOp $x, $offset, $scale),
           (ONNXSubOp(ONNXCastOp $x, (GetNullIntegerAttr), (ScalerT)),
               (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $offset))),
-          [(AttributeIsNull
-              : $scale)],
-          [], (addBenefit 2)>;
+          [(AttributeIsNull:$scale)], [],
+          (addBenefit 2)>;
 
 // No offset
 def ScalerNoOffsetPattern
     : Pat<(ONNXScalerOp $x, $offset, $scale),
           (ONNXMulOp $x,
               (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scale))),
-          [(HasFloatType
-               : $x),
-            (AttributeIsNull
-                : $offset)],
-          [], (addBenefit 3)>;
+          [(HasFloatType:$x), (AttributeIsNull:$offset)], [],
+          (addBenefit 3)>;
 
 // No offset, input x not float type
 def ScalerNoOffsetPattern2
     : Pat<(ONNXScalerOp $x, $offset, $scale),
           (ONNXMulOp(ONNXCastOp $x, (GetNullIntegerAttr), (ScalerT)),
               (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scale))),
-          [(AttributeIsNull
-              : $offset)],
-          [], (addBenefit 2)>;
+          [(AttributeIsNull:$offset)], [],
+          (addBenefit 2)>;
 
 // Normal ONNXScalerOp
 def ScalerPattern
@@ -253,9 +227,8 @@ def ScalerPattern
           (ONNXMulOp(ONNXSubOp $x,
                (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $offset))),
               (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scale))),
-          [(HasFloatType
-              : $x)],
-          [], (addBenefit 1)>;
+          [(HasFloatType:$x)], [],
+          (addBenefit 1)>;
 
 // Normal ONNXScalerOp, input x not float type
 def ScalerPattern2
@@ -270,189 +243,203 @@ def LogSoftmaxPattern
     : Pat<(ONNXLogSoftmaxOp $x, $axis), (ONNXLogOp(ONNXSoftmaxOp $x, $axis))>;
 
 // Express Upsample using Resize.
-def UpsamplePattern
-    : Pat<(ONNXUpsampleOp $x, $scales, $mode),
-          (ONNXResizeOp $x, (CreateNoneValue), $scales, (CreateNoneValue),
-              (GetNullIntegerAttr), (GetNullArrayAttr),
-              (NativeCodeCall<"$_builder.getStringAttr(\"asymmetric\")">),
-              (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr),
-              (GetNullStringAttr), $mode, (GetNullFloatAttr))>;
+def UpsamplePattern : Pat<
+  (ONNXUpsampleOp $x, $scales, $mode),
+  (ONNXResizeOp $x, (CreateNoneValue), $scales, (CreateNoneValue),
+     (GetNullIntegerAttr), (GetNullArrayAttr), (NativeCodeCall<"$_builder.getStringAttr(\"asymmetric\")">),
+     (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr), (GetNullStringAttr),
+     $mode, (GetNullFloatAttr))
+>;
 
-def UpsampleV7Pattern
-    : Pat<(ONNXUpsampleV7Op $x, $mode, $scales),
-          (ONNXResizeOp $x, (CreateNoneValue),
-              (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scales)),
-              (CreateNoneValue), (GetNullIntegerAttr), (GetNullArrayAttr),
-              (NativeCodeCall<"$_builder.getStringAttr(\"asymmetric\")">),
-              (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr),
-              (GetNullStringAttr), $mode, (GetNullFloatAttr))>;
+def UpsampleV7Pattern : Pat<
+  (ONNXUpsampleV7Op $x, $mode, $scales),
+  (ONNXResizeOp $x, (CreateNoneValue),
+     (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scales)),
+     (CreateNoneValue), (GetNullIntegerAttr), (GetNullArrayAttr), (NativeCodeCall<"$_builder.getStringAttr(\"asymmetric\")">),
+     (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr), (GetNullStringAttr),
+     $mode, (GetNullFloatAttr))
+>;
 
 // Express PadV2 using the latest Pad version.
-def PadV2Pattern
-    : Pat<(ONNXPadV2Op $x, $modeAttr, $padsAttr, $valueAttr),
-          (ONNXPadOp $x,
-              (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $padsAttr)),
-              (ONNXConstantOpFromDenseAttr(
-                  createDenseArrayAttrFromSingleAttr $valueAttr)),
-              (CreateNoneValue), $modeAttr)>;
+def PadV2Pattern : Pat<
+  (ONNXPadV2Op $x, $modeAttr, $padsAttr, $valueAttr),
+  (ONNXPadOp $x, (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $padsAttr)),
+     (ONNXConstantOpFromDenseAttr(createDenseArrayAttrFromSingleAttr $valueAttr)),
+     (CreateNoneValue),
+     $modeAttr)
+>;
 
 // Express PadV11 using the latest Pad version.
-def PadV11Pattern
-    : Pat<(ONNXPadV11Op $x, $pads, $mode, $value),
-          (ONNXPadOp $x, $pads, $mode, (CreateNoneValue), $value)>;
+def PadV11Pattern : Pat<
+  (ONNXPadV11Op $x, $pads, $mode, $value),
+  (ONNXPadOp $x, $pads, $mode, (CreateNoneValue), $value)
+>;
 
-def PadV13Pattern
-    : Pat<(ONNXPadV13Op $x, $pads, $value, $mode),
-          (ONNXPadOp $x, $pads, $value, (CreateNoneValue), $mode)>;
+def PadV13Pattern : Pat<
+  (ONNXPadV13Op $x, $pads, $value, $mode),
+  (ONNXPadOp $x, $pads, $value, (CreateNoneValue), $mode)
+>;
 
-def PadV18Pattern : Pat<(ONNXPadV18Op $x, $pads, $value, $axes, $mode),
-                        (ONNXPadOp $x, $pads, $value, $axes, $mode)>;
+def PadV18Pattern : Pat<
+  (ONNXPadV18Op $x, $pads, $value, $axes, $mode),
+  (ONNXPadOp $x, $pads, $value, $axes, $mode)
+>;
 
-def ReduceMaxV18Pattern
-    : Pat<(ONNXReduceMaxV18Op $data, $axes, $keepdims, $noop_with_empty_axes),
-          (ONNXReduceMaxOp $data, $axes, $keepdims, $noop_with_empty_axes)>;
+def ReduceMaxV18Pattern : Pat<
+  (ONNXReduceMaxV18Op $data, $axes, $keepdims, $noop_with_empty_axes),
+  (ONNXReduceMaxOp $data, $axes, $keepdims, $noop_with_empty_axes)
+>;
 
-def ReduceMinV18Pattern
-    : Pat<(ONNXReduceMinV18Op $data, $axes, $keepdims, $noop_with_empty_axes),
-          (ONNXReduceMinOp $data, $axes, $keepdims, $noop_with_empty_axes)>;
+def ReduceMinV18Pattern : Pat<
+  (ONNXReduceMinV18Op $data, $axes, $keepdims, $noop_with_empty_axes),
+  (ONNXReduceMinOp $data, $axes, $keepdims, $noop_with_empty_axes)
+>;
 
-def ResizeV10Pattern
-    : Pat<(ONNXResizeV10Op
-              : $res $x, $scales, $mode),
-          (ONNXResizeOp $x, (CreateNoneValue), $scales, (CreateNoneValue),
-              /*antialias*/ (GetNullIntegerAttr),
-              /*axes*/ (GetNullArrayAttr),
-              /*coordinate_transformation_mode*/ (GetNullStringAttr),
-              /*cubic_coeff_a*/ (GetNullFloatAttr),
-              /*exclude_outside*/ (GetNullIntegerAttr),
-              /*extrapolation_value*/ (GetNullFloatAttr),
-              /*keep_aspect_ratio_policy*/ (GetNullStringAttr),
-              /*mode*/ $mode,
-              /*nearest_mode*/ (GetNullStringAttr))>;
+def ResizeV10Pattern: Pat<
+   (ONNXResizeV10Op:$res $x, $scales, $mode),
+   (ONNXResizeOp $x, (CreateNoneValue),
+        $scales, (CreateNoneValue),
+       /*antialias*/(GetNullIntegerAttr),
+       /*axes*/(GetNullArrayAttr),
+       /*coordinate_transformation_mode*/(GetNullStringAttr),
+       /*cubic_coeff_a*/(GetNullFloatAttr),
+       /*exclude_outside*/(GetNullIntegerAttr),
+       /*extrapolation_value*/(GetNullFloatAttr),
+       /*keep_aspect_ratio_policy*/(GetNullStringAttr),
+       /*mode*/$mode,
+       /*nearest_mode*/(GetNullStringAttr))
+>;
 
-def ResizeV11Pattern
-    : Pat<(ONNXResizeV11Op
-              : $res $x, $roi, $scales, $size, $coordinate_transformation_node,
-              $cubic_coeff_a, $exclude_outside, $extrapolation_value, $mode,
-              $nearest_mode),
-          (ONNXResizeOp $x, $roi, $scales, $size,
-              /*antialias*/ (GetNullIntegerAttr),
-              /*axes*/ (GetNullArrayAttr), $coordinate_transformation_node,
-              $cubic_coeff_a, $exclude_outside, $extrapolation_value,
-              /*keep_aspect_ratio_policy*/ (GetNullStringAttr), $mode,
-              $nearest_mode)>;
+def ResizeV11Pattern: Pat<
+   (ONNXResizeV11Op:$res $x, $roi, $scales, $size,
+                    $coordinate_transformation_node, $cubic_coeff_a,
+                    $exclude_outside, $extrapolation_value, $mode,
+                    $nearest_mode),
+   (ONNXResizeOp    $x, $roi, $scales, $size,
+                    /*antialias*/(GetNullIntegerAttr),
+                    /*axes*/(GetNullArrayAttr),
+                    $coordinate_transformation_node, $cubic_coeff_a,
+                    $exclude_outside, $extrapolation_value,
+                    /*keep_aspect_ratio_policy*/(GetNullStringAttr),
+                    $mode, $nearest_mode)
+>;
 
-def ResizeV13Pattern
-    : Pat<(ONNXResizeV13Op
-              : $res $x, $roi, $scales, $size, $coordinate_transformation_node,
-              $cubic_coeff_a, $exclude_outside, $extrapolation_value, $mode,
-              $nearest_mode),
-          (ONNXResizeOp $x, $roi, $scales, $size,
-              /*antialias*/ (GetNullIntegerAttr),
-              /*axes*/ (GetNullArrayAttr), $coordinate_transformation_node,
-              $cubic_coeff_a, $exclude_outside, $extrapolation_value,
-              /*keep_aspect_ratio_policy*/ (GetNullStringAttr), $mode,
-              $nearest_mode)>;
+def ResizeV13Pattern: Pat<
+   (ONNXResizeV13Op:$res $x, $roi, $scales, $size,
+                    $coordinate_transformation_node, $cubic_coeff_a,
+                    $exclude_outside, $extrapolation_value, $mode,
+                    $nearest_mode),
+   (ONNXResizeOp    $x, $roi, $scales, $size,
+                    /*antialias*/(GetNullIntegerAttr),
+                    /*axes*/(GetNullArrayAttr),
+                    $coordinate_transformation_node, $cubic_coeff_a,
+                    $exclude_outside, $extrapolation_value,
+                    /*keep_aspect_ratio_policy*/(GetNullStringAttr),
+                    $mode, $nearest_mode)
+>;
 
-def ResizeV18Pattern
-    : Pat<(ONNXResizeV18Op
-              : $res $x, $roi, $scales, $size, $antialias, $axes,
-              $coordinate_transformation_node, $cubic_coeff_a, $exclude_outside,
-              $extrapolation_value, $keep_aspect_ratio_policy, $mode,
-              $nearest_mode),
-          (ONNXResizeOp $x, $roi, $scales, $size, $antialias, $axes,
-              $coordinate_transformation_node, $cubic_coeff_a, $exclude_outside,
-              $extrapolation_value, $keep_aspect_ratio_policy, $mode,
-              $nearest_mode)>;
+def ResizeV18Pattern: Pat<
+   (ONNXResizeV18Op:$res $x, $roi, $scales, $size, $antialias, $axes,
+                    $coordinate_transformation_node, $cubic_coeff_a,
+                    $exclude_outside, $extrapolation_value,
+                    $keep_aspect_ratio_policy, $mode, $nearest_mode),
+   (ONNXResizeOp    $x, $roi, $scales, $size, $antialias, $axes,
+                    $coordinate_transformation_node, $cubic_coeff_a,
+                    $exclude_outside, $extrapolation_value,
+                    $keep_aspect_ratio_policy, $mode, $nearest_mode)
+>;
 
-def SequenceConstructPattern1
-    : Pat<(ONNXSequenceConstructOp
-              : $res $x1),
-          (createSequenceConstructOp(
-               ONNXSequenceEmptyOp(ONNXDataType $x1), (returnType $res)),
-              $x1)>;
+def SequenceConstructPattern1: Pat<
+    (ONNXSequenceConstructOp:$res $x1),
+    (createSequenceConstructOp
+        (ONNXSequenceEmptyOp (ONNXDataType $x1), (returnType $res)),
+        $x1)
+>;
 
 // Express Clip V6 using Clip V11.
-def ClipV6Pattern : Pat<(ONNXClipV6Op $x, $maxAttr, $minAttr),
-                        (ONNXClipV11Op $x,
-                            (ONNXConstantOpFromDenseAttr(
-                                createScalarDenseAttrRank0 $minAttr)),
-                            (ONNXConstantOpFromDenseAttr(
-                                createScalarDenseAttrRank0 $maxAttr)))>;
+def ClipV6Pattern : Pat<
+  (ONNXClipV6Op $x, $maxAttr, $minAttr),
+  (ONNXClipV11Op $x, (ONNXConstantOpFromDenseAttr(createScalarDenseAttrRank0 $minAttr)),
+     (ONNXConstantOpFromDenseAttr(createScalarDenseAttrRank0 $maxAttr)))
+>;
 
 // Express Clip V11 using Clip V12.
-def ClipV11Pattern
-    : Pat<(ONNXClipV11Op $x, $min, $max), (ONNXClipV12Op $x, $min, $max)>;
+def ClipV11Pattern : Pat<
+  (ONNXClipV11Op $x, $min, $max),
+  (ONNXClipV12Op $x, $min, $max)
+>;
 
 // Express Clip V12 using Clip V13 (the lastest).
-def ClipV12Pattern
-    : Pat<(ONNXClipV12Op $x, $min, $max), (ONNXClipOp $x, $min, $max)>;
+def ClipV12Pattern : Pat<
+  (ONNXClipV12Op $x, $min, $max),
+  (ONNXClipOp $x, $min, $max)
+>;
 
 // Rewrite GridSample 20 to GridSample 22
-def GridSampleV20Pattern
-    : Pat<(ONNXGridSampleV20Op $x, $grid, $align_corners, $mode, $padding_mode),
-          (ONNXGridSampleOp $x, $grid, $align_corners, $mode, $padding_mode)>;
+def GridSampleV20Pattern : Pat<
+  (ONNXGridSampleV20Op $x, $grid, $align_corners, $mode, $padding_mode),
+  (ONNXGridSampleOp $x, $grid, $align_corners, $mode, $padding_mode)
+>;
 
 // Rewrite GridSample 16 to GridSample 20
-def GridSampleV16Pattern
-    : Pat<(ONNXGridSampleV16Op $x, $grid, $align_corners, $mode, $padding_mode),
-          (ONNXGridSampleV20Op $x, $grid, $align_corners,
-              (UpgradeGridSampleV16Mode $mode), $padding_mode)>;
+def GridSampleV16Pattern : Pat<
+  (ONNXGridSampleV16Op $x, $grid, $align_corners, $mode, $padding_mode),
+  (ONNXGridSampleV20Op $x, $grid, $align_corners, (UpgradeGridSampleV16Mode $mode), $padding_mode)
+>;
 
-def DFTV17Pattern
-    : Pat<(ONNXDFTV17Op $x, $dft_length, $axis, $inverse, $onesided),
-          (ONNXDFTOp $x, $dft_length,
-              (ONNXConstantOpFromDenseAttr(createScalarDenseAttrRank0 $axis)),
-              $inverse, $onesided)>;
+def DFTV17Pattern : Pat<
+  (ONNXDFTV17Op $x, $dft_length, $axis, $inverse, $onesided),
+  (ONNXDFTOp $x, $dft_length, (ONNXConstantOpFromDenseAttr(createScalarDenseAttrRank0 $axis)), $inverse, $onesided)
+>;
 
-def SplitV11PatternNoAttr
-    : Pat<(ONNXSplitV11Op $x, $axis, $split),
-          (ONNXSplitV13Op $x, (CreateNoneValue), $axis), [(AttributeIsNull
-                                                             : $split)],
-          [], (addBenefit 1)>;
+def SplitV11PatternNoAttr : Pat<
+  (ONNXSplitV11Op $x, $axis, $split),
+  (ONNXSplitV13Op $x, (CreateNoneValue), $axis),
+  [(AttributeIsNull:$split)], [], (addBenefit 1)
+>;
 
-def SplitV11Pattern
-    : Pat<(ONNXSplitV11Op $x, $axis, $split),
-          (ONNXSplitV13Op $x,
-              (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $split)),
-              $axis),
-          [], [], (addBenefit 0)>;
+def SplitV11Pattern : Pat<
+  (ONNXSplitV11Op $x, $axis, $split),
+  (ONNXSplitV13Op $x, (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $split)), $axis),
+  [], [], (addBenefit 0)
+>;
 
-def SplitV13Pattern
-    : Pat<(ONNXSplitV13Op $x, $split, $axis),
-          (ONNXSplitOp $x, $split, $axis, (GetNullIntegerAttr))>;
+def SplitV13Pattern : Pat<
+  (ONNXSplitV13Op $x, $split, $axis),
+  (ONNXSplitOp $x, $split, $axis, (GetNullIntegerAttr))
+>;
 
-def SqueezeV11PatternNoAttr
-    : Pat<(ONNXSqueezeV11Op $x, $axes), (ONNXSqueezeOp $x, (CreateNoneValue)),
-          [(AttributeIsNull
-              : $axes)],
-          [], (addBenefit 1)>;
+def SqueezeV11PatternNoAttr : Pat<
+  (ONNXSqueezeV11Op $x, $axes),
+  (ONNXSqueezeOp $x, (CreateNoneValue)),
+  [(AttributeIsNull:$axes)], [], (addBenefit 1)
+>;
 
-def SqueezeV11Pattern
-    : Pat<(ONNXSqueezeV11Op $x, $axes),
-          (ONNXSqueezeOp $x,
-              (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $axes))),
-          [], [], (addBenefit 0)>;
+def SqueezeV11Pattern : Pat<
+  (ONNXSqueezeV11Op $x, $axes),
+  (ONNXSqueezeOp $x, (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $axes))),
+  [], [], (addBenefit 0)
+>;
 
-def UnsqueezeV11Pattern
-    : Pat<(ONNXUnsqueezeV11Op $x, $axes),
-          (ONNXUnsqueezeOp $x,
-              (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $axes)))>;
+def UnsqueezeV11Pattern : Pat<
+  (ONNXUnsqueezeV11Op $x, $axes),
+  (ONNXUnsqueezeOp $x, (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $axes)))
+>;
 
 // Express Scatter (deprecated) using ScatterElements.
-def ScatterPattern : Pat<(ONNXScatterOp $data, $indices, $updates, $axis),
-                         (ONNXScatterElementsOp $data, $indices, $updates,
-                             $axis, (GetNullStringAttr))>;
+def ScatterPattern : Pat<
+  (ONNXScatterOp $data, $indices, $updates, $axis),
+  (ONNXScatterElementsOp $data, $indices, $updates, $axis, (GetNullStringAttr))
+>;
 
 //===----------------------------------------------------------------------===//
 // ONNXReduceL1V13Op %X -> ONNXReduceL1Op %X =
 //===----------------------------------------------------------------------===//
-def ReduceL1V13OpPattern1 : Pat<(ONNXReduceL1V13Op $oprd, $axes, $keepdims),
-                                (ONNXReduceL1Op $oprd, (CreateNoneValue),
-                                    $keepdims, (noop_with_empty_axes)),
-                                [(AttributeIsNull
-                                    : $axes)],
-                                [], (addBenefit 1)>;
+def ReduceL1V13OpPattern1
+    : Pat<(ONNXReduceL1V13Op $oprd, $axes, $keepdims),
+          (ONNXReduceL1Op $oprd,
+              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
+          [(AttributeIsNull:$axes)], [], (addBenefit 1)>;
 
 def ReduceL1V13OpPattern2
     : Pat<(ONNXReduceL1V13Op $oprd, $axes, $keepdims),
@@ -464,12 +451,11 @@ def ReduceL1V13OpPattern2
 //===----------------------------------------------------------------------===//
 // ONNXReduceL2V13Op %X -> ONNXReduceL2Op %X =
 //===----------------------------------------------------------------------===//
-def ReduceL2V13OpPattern1 : Pat<(ONNXReduceL2V13Op $oprd, $axes, $keepdims),
-                                (ONNXReduceL2Op $oprd, (CreateNoneValue),
-                                    $keepdims, (noop_with_empty_axes)),
-                                [(AttributeIsNull
-                                    : $axes)],
-                                [], (addBenefit 1)>;
+def ReduceL2V13OpPattern1
+    : Pat<(ONNXReduceL2V13Op $oprd, $axes, $keepdims),
+          (ONNXReduceL2Op $oprd,
+              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
+          [(AttributeIsNull:$axes)], [], (addBenefit 1)>;
 
 def ReduceL2V13OpPattern2
     : Pat<(ONNXReduceL2V13Op $oprd, $axes, $keepdims),
@@ -483,11 +469,9 @@ def ReduceL2V13OpPattern2
 //===----------------------------------------------------------------------===//
 def ReduceLogSumV13OpPattern1
     : Pat<(ONNXReduceLogSumV13Op $oprd, $axes, $keepdims),
-          (ONNXReduceLogSumOp $oprd, (CreateNoneValue), $keepdims,
-              (noop_with_empty_axes)),
-          [(AttributeIsNull
-              : $axes)],
-          [], (addBenefit 1)>;
+          (ONNXReduceLogSumOp $oprd,
+              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
+          [(AttributeIsNull:$axes)], [], (addBenefit 1)>;
 
 def ReduceLogSumV13OpPattern2
     : Pat<(ONNXReduceLogSumV13Op $oprd, $axes, $keepdims),
@@ -501,11 +485,9 @@ def ReduceLogSumV13OpPattern2
 //===----------------------------------------------------------------------===//
 def ReduceLogSumExpV13OpPattern1
     : Pat<(ONNXReduceLogSumExpV13Op $oprd, $axes, $keepdims),
-          (ONNXReduceLogSumExpOp $oprd, (CreateNoneValue), $keepdims,
-              (noop_with_empty_axes)),
-          [(AttributeIsNull
-              : $axes)],
-          [], (addBenefit 1)>;
+          (ONNXReduceLogSumExpOp $oprd,
+              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
+          [(AttributeIsNull:$axes)], [], (addBenefit 1)>;
 
 def ReduceLogSumExpV13OpPattern2
     : Pat<(ONNXReduceLogSumExpV13Op $oprd, $axes, $keepdims),
@@ -519,11 +501,9 @@ def ReduceLogSumExpV13OpPattern2
 //===----------------------------------------------------------------------===//
 def ReduceSumSquareV13OpPattern1
     : Pat<(ONNXReduceSumSquareV13Op $oprd, $axes, $keepdims),
-          (ONNXReduceSumSquareOp $oprd, (CreateNoneValue), $keepdims,
-              (noop_with_empty_axes)),
-          [(AttributeIsNull
-              : $axes)],
-          [], (addBenefit 1)>;
+          (ONNXReduceSumSquareOp $oprd,
+              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
+          [(AttributeIsNull:$axes)], [], (addBenefit 1)>;
 
 def ReduceSumSquareV13OpPattern2
     : Pat<(ONNXReduceSumSquareV13Op $oprd, $axes, $keepdims),
@@ -537,82 +517,76 @@ def ReduceSumSquareV13OpPattern2
 //         `ONNXExpandOp(ONNXConstantOp {value}, %shape)
 //===----------------------------------------------------------------------===//
 
-def ConstantOfShapePattern1 : Pat<(ONNXConstantOfShapeOp
-                                      : $res $shape, $value),
-                                  (ONNXExpandOp(ONNXConstantOpFromDenseAttr(
-                                       ReshapeElementsAttrToRank0 $value)),
-                                      $shape),
-                                  [(AttributeIsNotNull
-                                      : $value)]>;
+def ConstantOfShapePattern1: Pat<
+  (ONNXConstantOfShapeOp:$res $shape, $value),
+  (ONNXExpandOp (ONNXConstantOpFromDenseAttr (ReshapeElementsAttrToRank0 $value)),
+                $shape),
+  [(AttributeIsNotNull:$value)]
+>;
 
-def ConstantOfShapePattern2
-    : Pat<(ONNXConstantOfShapeOp
-              : $res $shape, $value),
-          (ONNXExpandOp(ONNXConstantOpFromDenseAttr(ReshapeElementsAttrToRank0(
-               createDenseArrayAttrFromSingleAttr(GetZeroFloatAttr)))),
-              $shape),
-          [(AttributeIsNull
-              : $value)]>;
+def ConstantOfShapePattern2: Pat<
+  (ONNXConstantOfShapeOp:$res $shape, $value),
+  (ONNXExpandOp (ONNXConstantOpFromDenseAttr (ReshapeElementsAttrToRank0 (createDenseArrayAttrFromSingleAttr (GetZeroFloatAttr)))),
+                $shape),
+  [(AttributeIsNull:$value)]
+>;
 
 //===----------------------------------------------------------------------===//
 // Normalize ONNXConstantOp to use ElementAttrs
 //===----------------------------------------------------------------------===//
 
-def ConstantOpNormalizationPattern1
-    : Pat<(ONNXConstantOp
-              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-              $intsAttr, $stringAttr, $stringsAttr),
-          (ONNXConstantOpNormalize $res, $floatAttr), [(AttributeIsNotNull
-                                                          : $floatAttr)]>;
+def ConstantOpNormalizationPattern1: Pat<
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+       $intsAttr, $stringAttr, $stringsAttr),
+   (ONNXConstantOpNormalize $res, $floatAttr),
+   [(AttributeIsNotNull:$floatAttr)]
+>;
 
-def ConstantOpNormalizationPattern2
-    : Pat<(ONNXConstantOp
-              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-              $intsAttr, $stringAttr, $stringsAttr),
-          (ONNXConstantOpNormalize $res, $intAttr), [(AttributeIsNotNull
-                                                        : $intAttr)]>;
+def ConstantOpNormalizationPattern2: Pat<
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+       $intsAttr, $stringAttr, $stringsAttr),
+   (ONNXConstantOpNormalize $res, $intAttr),
+   [(AttributeIsNotNull:$intAttr)]
+>;
 
-def ConstantOpNormalizationPattern3
-    : Pat<(ONNXConstantOp
-              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-              $intsAttr, $stringAttr, $stringsAttr),
-          (ONNXConstantOpNormalize $res, $stringAttr), [(AttributeIsNotNull
-                                                           : $stringAttr)]>;
+def ConstantOpNormalizationPattern3: Pat<
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+       $intsAttr, $stringAttr, $stringsAttr),
+   (ONNXConstantOpNormalize $res, $stringAttr),
+   [(AttributeIsNotNull:$stringAttr)]
+>;
 
-def ConstantOpNormalizationPattern4
-    : Pat<(ONNXConstantOp
-              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-              $intsAttr, $stringAttr, $stringsAttr),
-          (ONNXConstantOpNormalize $res, $floatsAttr), [(AttributeIsNotNull
-                                                           : $floatsAttr)]>;
+def ConstantOpNormalizationPattern4: Pat<
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+       $intsAttr, $stringAttr, $stringsAttr),
+   (ONNXConstantOpNormalize $res, $floatsAttr),
+   [(AttributeIsNotNull:$floatsAttr)]
+>;
 
-def ConstantOpNormalizationPattern5
-    : Pat<(ONNXConstantOp
-              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-              $intsAttr, $stringAttr, $stringsAttr),
-          (ONNXConstantOpNormalize $res, $intsAttr), [(AttributeIsNotNull
-                                                         : $intsAttr)]>;
+def ConstantOpNormalizationPattern5: Pat<
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+       $intsAttr, $stringAttr, $stringsAttr),
+   (ONNXConstantOpNormalize $res, $intsAttr),
+   [(AttributeIsNotNull:$intsAttr)]
+>;
 
-def ConstantOpNormalizationPattern6
-    : Pat<(ONNXConstantOp
-              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-              $intsAttr, $stringAttr, $stringsAttr),
-          (ONNXConstantOpNormalize $res, $stringsAttr), [(AttributeIsNotNull
-                                                            : $stringsAttr)]>;
+def ConstantOpNormalizationPattern6: Pat<
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+       $intsAttr, $stringAttr, $stringsAttr),
+   (ONNXConstantOpNormalize $res, $stringsAttr),
+   [(AttributeIsNotNull:$stringsAttr)]
+>;
 
 // Optimize for the pattern coming from torch.nn.LSTM exported from pytorch
-//     %32 = "onnx.SplitToSequence"(%30, %27) {axis = 0 : si64, keepdims = 0 :
-//     si64, onnx_node_name = "n1"} : (tensor<1x1x100xf32>, tensor<i64>) ->
-//     !onnx.Seq<tensor<1x1x100xf32>>
-//    %33 = "onnx.SequenceAt"(%32, %26) {onnx_node_name = "n0"} :
-//    (!onnx.Seq<tensor<1x1x100xf32>>, tensor<i64>) -> tensor<1x100xf32>
+//     %32 = "onnx.SplitToSequence"(%30, %27) {axis = 0 : si64, keepdims = 0 : si64, onnx_node_name = "n1"} : (tensor<1x1x100xf32>, tensor<i64>) -> !onnx.Seq<tensor<1x1x100xf32>>
+//    %33 = "onnx.SequenceAt"(%32, %26) {onnx_node_name = "n0"} : (!onnx.Seq<tensor<1x1x100xf32>>, tensor<i64>) -> tensor<1x100xf32>
 // When shape and size/axis related value are constant, this sequence of code
 // can be translated into onnx.slice
 
-def ReplaceSequenceAtPattern
-    : Pat<(ONNXSequenceAtOp
-              : $res $seq, $position),
-          (ReplaceSequenceAt $res), [(CanSequenceAtBeReplaced
-                                        : $res)]>;
+def ReplaceSequenceAtPattern: Pat<
+   (ONNXSequenceAtOp:$res $seq, $position),
+   (ReplaceSequenceAt $res),
+   [(CanSequenceAtBeReplaced:$res)]
+>;
 
 #endif // ONNX_DECOMPOSE

--- a/src/Dialect/ONNX/Transforms/Decompose.td
+++ b/src/Dialect/ONNX/Transforms/Decompose.td
@@ -35,15 +35,16 @@ def KeepdimsIsTrue
     : Constraint<CPred<"mlir::cast<IntegerAttr>($_self).getSInt() == 1">,
           "keepdims attribute is true">;
 
-def ONNXConstantOpNormalize: NativeCodeCall<
-  "onnx_mlir::normalizeConstantOp($_builder, $0, $1)">;
+def ONNXConstantOpNormalize
+    : NativeCodeCall<"onnx_mlir::normalizeConstantOp($_builder, $0, $1)">;
 
 def AttributeIsNull : Constraint<CPred<"! ($_self)">, "Attribute is null">;
 
 def AttributeIsNotNull : Constraint<CPred<"($_self)">, "Attribute is not null">;
 
-def HasFloatType : Constraint<CPred<"(mlir::dyn_cast<ShapedType>(($_self).getType())"
-                                    ".getElementType().isF32())">>;
+def HasFloatType
+    : Constraint<CPred<"(mlir::dyn_cast<ShapedType>(($_self).getType())"
+                       ".getElementType().isF32())">>;
 
 def IsNoneType : Constraint<CPred<"mlir::isa<NoneType>(($_self).getType())">>;
 
@@ -51,14 +52,14 @@ def GetNullAttr : NativeCodeCall<"Attribute()">;
 
 def GetNullFloatAttr : NativeCodeCall<"FloatAttr()">;
 
-def GetZeroFloatAttr :
-	NativeCodeCall<"$_builder.getFloatAttr($_builder.getF32Type(), 0)">;
+def GetZeroFloatAttr
+    : NativeCodeCall<"$_builder.getFloatAttr($_builder.getF32Type(), 0)">;
 
 def GetNullIntegerAttr : NativeCodeCall<"IntegerAttr()">;
 
 def GetNullStringAttr : NativeCodeCall<"StringAttr()">;
 
-def GetNullArrayAttr :  NativeCodeCall<"ArrayAttr()">;
+def GetNullArrayAttr : NativeCodeCall<"ArrayAttr()">;
 
 // Create a unit constant that will be used as none input.
 def CreateNoneValue : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc)">;
@@ -71,21 +72,24 @@ def createScalarDenseAttrRank0
 // Create a scalar DenseElementsAttr of tensor<dtype> from an ElementsAttr.
 // The input ElementsAttr must have only one element. Otherwise only the first
 // element is used to create the scalar DenseElementsAttr
-def ReshapeElementsAttrToRank0 : NativeCodeCall<
-    "onnx_mlir::OnnxElementsAttrBuilder($0.getContext()).reshape(cast<ElementsAttr>($0), {})">;
+def ReshapeElementsAttrToRank0
+    : NativeCodeCall<"onnx_mlir::OnnxElementsAttrBuilder($0.getContext())."
+                     "reshape(cast<ElementsAttr>($0), {})">;
 
-def ReplaceSequenceAt :  NativeCodeCall<
-    "onnx_mlir::replaceSequenceAt($_builder, $_loc, $0)">;
+def ReplaceSequenceAt
+    : NativeCodeCall<"onnx_mlir::replaceSequenceAt($_builder, $_loc, $0)">;
 
-def UpgradeGridSampleV16Mode :  NativeCodeCall<
-    "onnx_mlir::upgradeGridSampleV16Mode($_builder, $0)">;
-    
-def CanSequenceAtBeReplaced :
-   Constraint<CPred<"::onnx_mlir::canSequenceAtBeReplaced($_self)">, "check whether the SequenceAt can be replaced with split">;
+def UpgradeGridSampleV16Mode
+    : NativeCodeCall<"onnx_mlir::upgradeGridSampleV16Mode($_builder, $0)">;
+
+def CanSequenceAtBeReplaced
+    : Constraint<CPred<"::onnx_mlir::canSequenceAtBeReplaced($_self)">,
+          "check whether the SequenceAt can be replaced with split">;
 
 // Create a DenseElementsAttr from a single attribute.
 def createDenseArrayAttrFromSingleAttr
-    : NativeCodeCall<"::onnx_mlir::createDenseArrayAttr($_builder, $_builder.getArrayAttr($0))">;
+    : NativeCodeCall<"::onnx_mlir::createDenseArrayAttr($_builder, "
+                     "$_builder.getArrayAttr($0))">;
 
 // Create a DenseElementsAttr from an ArrayAttr.
 def createDenseArrayAttr
@@ -101,24 +105,27 @@ def noop_with_empty_axes
                      "/*isSigned=*/true), APInt(64, 0, /*isSigned=*/true))">;
 
 // Check if value is a dense constant
-def IsDenseONNXConstant:
-   Constraint<CPred<"::onnx_mlir::isDenseONNXConstant($_self)">, "not a dense constant">;
+def IsDenseONNXConstant
+    : Constraint<CPred<"::onnx_mlir::isDenseONNXConstant($_self)">,
+          "not a dense constant">;
 
-def createSequenceConstructOp : NativeCodeCall<
-  "::onnx_mlir::createSequenceConstructOp($_builder, $0, $1)">;
+def createSequenceConstructOp
+    : NativeCodeCall<
+          "::onnx_mlir::createSequenceConstructOp($_builder, $0, $1)">;
 
-def ONNXDataType : NativeCodeCall<
-  "IntegerAttr::get($_builder.getIntegerType(64, /*isSigned=*/true), "
-  "::onnx_mlir::mlirTypeToOnnxType(mlir::cast<ShapedType>($0.getType().front()).getElementType()))">;
+def ONNXDataType
+    : NativeCodeCall<
+          "IntegerAttr::get($_builder.getIntegerType(64, /*isSigned=*/true), "
+          "::onnx_mlir::mlirTypeToOnnxType(mlir::cast<ShapedType>($0.getType()."
+          "front()).getElementType()))">;
 
 // Check if value has a type that is ranked with a shape.
-def HasRankAndShape:
-  Constraint<CPred<"::onnx_mlir::isRankedShapedType($_self.getType())">,
-  "A value has rank and shape">;
+def HasRankAndShape
+    : Constraint<CPred<"::onnx_mlir::isRankedShapedType($_self.getType())">,
+          "A value has rank and shape">;
 
-def IntOne : AttrConstraint<
-    CPred<"::mlir::matchPattern($_self, m_One())">,
-    "is integer one">;
+def IntOne : AttrConstraint<CPred<"::mlir::matchPattern($_self, m_One())">,
+                 "is integer one">;
 
 //===----------------------------------------------------------------------===//
 // ONNXReduceL1Op %X = ONNXReduceSumOp (ONNXAbsOp %X)
@@ -153,8 +160,8 @@ def ReduceLogSumExpOpPattern1
                $axes, $keepdims, $noop),
               $max),
           [(KeepdimsIsTrue
-              : $keepdims)], [],
-          (addBenefit 1)>;
+              : $keepdims)],
+          [], (addBenefit 1)>;
 
 // keepdims is false
 def ReduceLogSumExpOpPattern2
@@ -171,7 +178,7 @@ def ReduceLogSumExpOpPattern2
 //===----------------------------------------------------------------------===//
 def ReduceSumSquareOpPattern
     : Pat<(ONNXReduceSumSquareOp $oprd, $axes, $keepdims, $noop),
-          (ONNXReduceSumOp (ONNXMulOp $oprd, $oprd), $axes, $keepdims, $noop)>;
+          (ONNXReduceSumOp(ONNXMulOp $oprd, $oprd), $axes, $keepdims, $noop)>;
 
 //===----------------------------------------------------------------------===//
 // ONNXScalerOp %X, %Offest, %Scale
@@ -180,46 +187,65 @@ def ReduceSumSquareOpPattern
 // No attribute
 def ScalerNullPattern
     : Pat<(ONNXScalerOp $x, $offset, $scale), (replaceWithValue $x),
-          [(HasFloatType:$x), (AttributeIsNull:$offset), (AttributeIsNull:$scale)], [],
-          (addBenefit 5)>;
+          [
+            (HasFloatType
+                : $x),
+            (AttributeIsNull
+                : $offset),
+            (AttributeIsNull
+                : $scale)
+          ],
+          [], (addBenefit 5)>;
 
 // No attribute, input x not float type
 def ScalerNullPattern2
-    : Pat<(ONNXScalerOp $x, $offset, $scale), (ONNXCastOp $x, (GetNullIntegerAttr), (ScalerT)),
-          [(AttributeIsNull:$offset), (AttributeIsNull:$scale)], [],
-          (addBenefit 4)>;
+    : Pat<(ONNXScalerOp $x, $offset, $scale),
+          (ONNXCastOp $x, (GetNullIntegerAttr), (ScalerT)),
+          [(AttributeIsNull
+               : $offset),
+            (AttributeIsNull
+                : $scale)],
+          [], (addBenefit 4)>;
 
 // No scale
 def ScalerNoScalePattern
     : Pat<(ONNXScalerOp $x, $offset, $scale),
           (ONNXSubOp $x,
               (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $offset))),
-          [(HasFloatType:$x), (AttributeIsNull:$scale)], [],
-          (addBenefit 3)>;
+          [(HasFloatType
+               : $x),
+            (AttributeIsNull
+                : $scale)],
+          [], (addBenefit 3)>;
 
 // No scale, input x not float type
 def ScalerNoScalePattern2
     : Pat<(ONNXScalerOp $x, $offset, $scale),
           (ONNXSubOp(ONNXCastOp $x, (GetNullIntegerAttr), (ScalerT)),
               (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $offset))),
-          [(AttributeIsNull:$scale)], [],
-          (addBenefit 2)>;
+          [(AttributeIsNull
+              : $scale)],
+          [], (addBenefit 2)>;
 
 // No offset
 def ScalerNoOffsetPattern
     : Pat<(ONNXScalerOp $x, $offset, $scale),
           (ONNXMulOp $x,
               (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scale))),
-          [(HasFloatType:$x), (AttributeIsNull:$offset)], [],
-          (addBenefit 3)>;
+          [(HasFloatType
+               : $x),
+            (AttributeIsNull
+                : $offset)],
+          [], (addBenefit 3)>;
 
 // No offset, input x not float type
 def ScalerNoOffsetPattern2
     : Pat<(ONNXScalerOp $x, $offset, $scale),
           (ONNXMulOp(ONNXCastOp $x, (GetNullIntegerAttr), (ScalerT)),
               (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scale))),
-          [(AttributeIsNull:$offset)], [],
-          (addBenefit 2)>;
+          [(AttributeIsNull
+              : $offset)],
+          [], (addBenefit 2)>;
 
 // Normal ONNXScalerOp
 def ScalerPattern
@@ -227,8 +253,9 @@ def ScalerPattern
           (ONNXMulOp(ONNXSubOp $x,
                (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $offset))),
               (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scale))),
-          [(HasFloatType:$x)], [],
-          (addBenefit 1)>;
+          [(HasFloatType
+              : $x)],
+          [], (addBenefit 1)>;
 
 // Normal ONNXScalerOp, input x not float type
 def ScalerPattern2
@@ -243,203 +270,189 @@ def LogSoftmaxPattern
     : Pat<(ONNXLogSoftmaxOp $x, $axis), (ONNXLogOp(ONNXSoftmaxOp $x, $axis))>;
 
 // Express Upsample using Resize.
-def UpsamplePattern : Pat<
-  (ONNXUpsampleOp $x, $scales, $mode),
-  (ONNXResizeOp $x, (CreateNoneValue), $scales, (CreateNoneValue),
-     (GetNullIntegerAttr), (GetNullArrayAttr), (NativeCodeCall<"$_builder.getStringAttr(\"asymmetric\")">),
-     (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr), (GetNullStringAttr),
-     $mode, (GetNullFloatAttr))
->;
+def UpsamplePattern
+    : Pat<(ONNXUpsampleOp $x, $scales, $mode),
+          (ONNXResizeOp $x, (CreateNoneValue), $scales, (CreateNoneValue),
+              (GetNullIntegerAttr), (GetNullArrayAttr),
+              (NativeCodeCall<"$_builder.getStringAttr(\"asymmetric\")">),
+              (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr),
+              (GetNullStringAttr), $mode, (GetNullFloatAttr))>;
 
-def UpsampleV7Pattern : Pat<
-  (ONNXUpsampleV7Op $x, $mode, $scales),
-  (ONNXResizeOp $x, (CreateNoneValue),
-     (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scales)),
-     (CreateNoneValue), (GetNullIntegerAttr), (GetNullArrayAttr), (NativeCodeCall<"$_builder.getStringAttr(\"asymmetric\")">),
-     (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr), (GetNullStringAttr),
-     $mode, (GetNullFloatAttr))
->;
+def UpsampleV7Pattern
+    : Pat<(ONNXUpsampleV7Op $x, $mode, $scales),
+          (ONNXResizeOp $x, (CreateNoneValue),
+              (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scales)),
+              (CreateNoneValue), (GetNullIntegerAttr), (GetNullArrayAttr),
+              (NativeCodeCall<"$_builder.getStringAttr(\"asymmetric\")">),
+              (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr),
+              (GetNullStringAttr), $mode, (GetNullFloatAttr))>;
 
 // Express PadV2 using the latest Pad version.
-def PadV2Pattern : Pat<
-  (ONNXPadV2Op $x, $modeAttr, $padsAttr, $valueAttr),
-  (ONNXPadOp $x, (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $padsAttr)),
-     (ONNXConstantOpFromDenseAttr(createDenseArrayAttrFromSingleAttr $valueAttr)),
-     (CreateNoneValue),
-     $modeAttr)
->;
+def PadV2Pattern
+    : Pat<(ONNXPadV2Op $x, $modeAttr, $padsAttr, $valueAttr),
+          (ONNXPadOp $x,
+              (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $padsAttr)),
+              (ONNXConstantOpFromDenseAttr(
+                  createDenseArrayAttrFromSingleAttr $valueAttr)),
+              (CreateNoneValue), $modeAttr)>;
 
 // Express PadV11 using the latest Pad version.
-def PadV11Pattern : Pat<
-  (ONNXPadV11Op $x, $pads, $mode, $value),
-  (ONNXPadOp $x, $pads, $mode, (CreateNoneValue), $value)
->;
+def PadV11Pattern
+    : Pat<(ONNXPadV11Op $x, $pads, $mode, $value),
+          (ONNXPadOp $x, $pads, $mode, (CreateNoneValue), $value)>;
 
-def PadV13Pattern : Pat<
-  (ONNXPadV13Op $x, $pads, $value, $mode),
-  (ONNXPadOp $x, $pads, $value, (CreateNoneValue), $mode)
->;
+def PadV13Pattern
+    : Pat<(ONNXPadV13Op $x, $pads, $value, $mode),
+          (ONNXPadOp $x, $pads, $value, (CreateNoneValue), $mode)>;
 
-def PadV18Pattern : Pat<
-  (ONNXPadV18Op $x, $pads, $value, $axes, $mode),
-  (ONNXPadOp $x, $pads, $value, $axes, $mode)
->;
+def PadV18Pattern : Pat<(ONNXPadV18Op $x, $pads, $value, $axes, $mode),
+                        (ONNXPadOp $x, $pads, $value, $axes, $mode)>;
 
-def ReduceMaxV18Pattern : Pat<
-  (ONNXReduceMaxV18Op $data, $axes, $keepdims, $noop_with_empty_axes),
-  (ONNXReduceMaxOp $data, $axes, $keepdims, $noop_with_empty_axes)
->;
+def ReduceMaxV18Pattern
+    : Pat<(ONNXReduceMaxV18Op $data, $axes, $keepdims, $noop_with_empty_axes),
+          (ONNXReduceMaxOp $data, $axes, $keepdims, $noop_with_empty_axes)>;
 
-def ReduceMinV18Pattern : Pat<
-  (ONNXReduceMinV18Op $data, $axes, $keepdims, $noop_with_empty_axes),
-  (ONNXReduceMinOp $data, $axes, $keepdims, $noop_with_empty_axes)
->;
+def ReduceMinV18Pattern
+    : Pat<(ONNXReduceMinV18Op $data, $axes, $keepdims, $noop_with_empty_axes),
+          (ONNXReduceMinOp $data, $axes, $keepdims, $noop_with_empty_axes)>;
 
-def ResizeV10Pattern: Pat<
-   (ONNXResizeV10Op:$res $x, $scales, $mode),
-   (ONNXResizeOp $x, (CreateNoneValue),
-        $scales, (CreateNoneValue),
-       /*antialias*/(GetNullIntegerAttr),
-       /*axes*/(GetNullArrayAttr),
-       /*coordinate_transformation_mode*/(GetNullStringAttr),
-       /*cubic_coeff_a*/(GetNullFloatAttr),
-       /*exclude_outside*/(GetNullIntegerAttr),
-       /*extrapolation_value*/(GetNullFloatAttr),
-       /*keep_aspect_ratio_policy*/(GetNullStringAttr),
-       /*mode*/$mode,
-       /*nearest_mode*/(GetNullStringAttr))
->;
+def ResizeV10Pattern
+    : Pat<(ONNXResizeV10Op
+              : $res $x, $scales, $mode),
+          (ONNXResizeOp $x, (CreateNoneValue), $scales, (CreateNoneValue),
+              /*antialias*/ (GetNullIntegerAttr),
+              /*axes*/ (GetNullArrayAttr),
+              /*coordinate_transformation_mode*/ (GetNullStringAttr),
+              /*cubic_coeff_a*/ (GetNullFloatAttr),
+              /*exclude_outside*/ (GetNullIntegerAttr),
+              /*extrapolation_value*/ (GetNullFloatAttr),
+              /*keep_aspect_ratio_policy*/ (GetNullStringAttr),
+              /*mode*/ $mode,
+              /*nearest_mode*/ (GetNullStringAttr))>;
 
-def ResizeV11Pattern: Pat<
-   (ONNXResizeV11Op:$res $x, $roi, $scales, $size,
-                    $coordinate_transformation_node, $cubic_coeff_a,
-                    $exclude_outside, $extrapolation_value, $mode,
-                    $nearest_mode),
-   (ONNXResizeOp    $x, $roi, $scales, $size,
-                    /*antialias*/(GetNullIntegerAttr),
-                    /*axes*/(GetNullArrayAttr),
-                    $coordinate_transformation_node, $cubic_coeff_a,
-                    $exclude_outside, $extrapolation_value,
-                    /*keep_aspect_ratio_policy*/(GetNullStringAttr),
-                    $mode, $nearest_mode)
->;
+def ResizeV11Pattern
+    : Pat<(ONNXResizeV11Op
+              : $res $x, $roi, $scales, $size, $coordinate_transformation_node,
+              $cubic_coeff_a, $exclude_outside, $extrapolation_value, $mode,
+              $nearest_mode),
+          (ONNXResizeOp $x, $roi, $scales, $size,
+              /*antialias*/ (GetNullIntegerAttr),
+              /*axes*/ (GetNullArrayAttr), $coordinate_transformation_node,
+              $cubic_coeff_a, $exclude_outside, $extrapolation_value,
+              /*keep_aspect_ratio_policy*/ (GetNullStringAttr), $mode,
+              $nearest_mode)>;
 
-def ResizeV13Pattern: Pat<
-   (ONNXResizeV13Op:$res $x, $roi, $scales, $size,
-                    $coordinate_transformation_node, $cubic_coeff_a,
-                    $exclude_outside, $extrapolation_value, $mode,
-                    $nearest_mode),
-   (ONNXResizeOp    $x, $roi, $scales, $size,
-                    /*antialias*/(GetNullIntegerAttr),
-                    /*axes*/(GetNullArrayAttr),
-                    $coordinate_transformation_node, $cubic_coeff_a,
-                    $exclude_outside, $extrapolation_value,
-                    /*keep_aspect_ratio_policy*/(GetNullStringAttr),
-                    $mode, $nearest_mode)
->;
+def ResizeV13Pattern
+    : Pat<(ONNXResizeV13Op
+              : $res $x, $roi, $scales, $size, $coordinate_transformation_node,
+              $cubic_coeff_a, $exclude_outside, $extrapolation_value, $mode,
+              $nearest_mode),
+          (ONNXResizeOp $x, $roi, $scales, $size,
+              /*antialias*/ (GetNullIntegerAttr),
+              /*axes*/ (GetNullArrayAttr), $coordinate_transformation_node,
+              $cubic_coeff_a, $exclude_outside, $extrapolation_value,
+              /*keep_aspect_ratio_policy*/ (GetNullStringAttr), $mode,
+              $nearest_mode)>;
 
-def ResizeV18Pattern: Pat<
-   (ONNXResizeV18Op:$res $x, $roi, $scales, $size, $antialias, $axes,
-                    $coordinate_transformation_node, $cubic_coeff_a,
-                    $exclude_outside, $extrapolation_value,
-                    $keep_aspect_ratio_policy, $mode, $nearest_mode),
-   (ONNXResizeOp    $x, $roi, $scales, $size, $antialias, $axes,
-                    $coordinate_transformation_node, $cubic_coeff_a,
-                    $exclude_outside, $extrapolation_value,
-                    $keep_aspect_ratio_policy, $mode, $nearest_mode)
->;
+def ResizeV18Pattern
+    : Pat<(ONNXResizeV18Op
+              : $res $x, $roi, $scales, $size, $antialias, $axes,
+              $coordinate_transformation_node, $cubic_coeff_a, $exclude_outside,
+              $extrapolation_value, $keep_aspect_ratio_policy, $mode,
+              $nearest_mode),
+          (ONNXResizeOp $x, $roi, $scales, $size, $antialias, $axes,
+              $coordinate_transformation_node, $cubic_coeff_a, $exclude_outside,
+              $extrapolation_value, $keep_aspect_ratio_policy, $mode,
+              $nearest_mode)>;
 
-def SequenceConstructPattern1: Pat<
-    (ONNXSequenceConstructOp:$res $x1),
-    (createSequenceConstructOp
-        (ONNXSequenceEmptyOp (ONNXDataType $x1), (returnType $res)),
-        $x1)
->;
+def SequenceConstructPattern1
+    : Pat<(ONNXSequenceConstructOp
+              : $res $x1),
+          (createSequenceConstructOp(
+               ONNXSequenceEmptyOp(ONNXDataType $x1), (returnType $res)),
+              $x1)>;
 
 // Express Clip V6 using Clip V11.
-def ClipV6Pattern : Pat<
-  (ONNXClipV6Op $x, $maxAttr, $minAttr),
-  (ONNXClipV11Op $x, (ONNXConstantOpFromDenseAttr(createScalarDenseAttrRank0 $minAttr)),
-     (ONNXConstantOpFromDenseAttr(createScalarDenseAttrRank0 $maxAttr)))
->;
+def ClipV6Pattern : Pat<(ONNXClipV6Op $x, $maxAttr, $minAttr),
+                        (ONNXClipV11Op $x,
+                            (ONNXConstantOpFromDenseAttr(
+                                createScalarDenseAttrRank0 $minAttr)),
+                            (ONNXConstantOpFromDenseAttr(
+                                createScalarDenseAttrRank0 $maxAttr)))>;
 
 // Express Clip V11 using Clip V12.
-def ClipV11Pattern : Pat<
-  (ONNXClipV11Op $x, $min, $max),
-  (ONNXClipV12Op $x, $min, $max)
->;
+def ClipV11Pattern
+    : Pat<(ONNXClipV11Op $x, $min, $max), (ONNXClipV12Op $x, $min, $max)>;
 
 // Express Clip V12 using Clip V13 (the lastest).
-def ClipV12Pattern : Pat<
-  (ONNXClipV12Op $x, $min, $max),
-  (ONNXClipOp $x, $min, $max)
->;
+def ClipV12Pattern
+    : Pat<(ONNXClipV12Op $x, $min, $max), (ONNXClipOp $x, $min, $max)>;
 
 // Rewrite GridSample 20 to GridSample 22
-def GridSampleV20Pattern : Pat<
-  (ONNXGridSampleV20Op $x, $grid, $align_corners, $mode, $padding_mode),
-  (ONNXGridSampleOp $x, $grid, $align_corners, $mode, $padding_mode)
->;
+def GridSampleV20Pattern
+    : Pat<(ONNXGridSampleV20Op $x, $grid, $align_corners, $mode, $padding_mode),
+          (ONNXGridSampleOp $x, $grid, $align_corners, $mode, $padding_mode)>;
 
 // Rewrite GridSample 16 to GridSample 20
-def GridSampleV16Pattern : Pat<
-  (ONNXGridSampleV16Op $x, $grid, $align_corners, $mode, $padding_mode),
-  (ONNXGridSampleV20Op $x, $grid, $align_corners, (UpgradeGridSampleV16Mode $mode), $padding_mode)
->;
+def GridSampleV16Pattern
+    : Pat<(ONNXGridSampleV16Op $x, $grid, $align_corners, $mode, $padding_mode),
+          (ONNXGridSampleV20Op $x, $grid, $align_corners,
+              (UpgradeGridSampleV16Mode $mode), $padding_mode)>;
 
-def DFTV17Pattern : Pat<
-  (ONNXDFTV17Op $x, $dft_length, $axis, $inverse, $onesided),
-  (ONNXDFTOp $x, $dft_length, (ONNXConstantOpFromDenseAttr(createScalarDenseAttrRank0 $axis)), $inverse, $onesided)
->;
+def DFTV17Pattern
+    : Pat<(ONNXDFTV17Op $x, $dft_length, $axis, $inverse, $onesided),
+          (ONNXDFTOp $x, $dft_length,
+              (ONNXConstantOpFromDenseAttr(createScalarDenseAttrRank0 $axis)),
+              $inverse, $onesided)>;
 
-def SplitV11PatternNoAttr : Pat<
-  (ONNXSplitV11Op $x, $axis, $split),
-  (ONNXSplitV13Op $x, (CreateNoneValue), $axis),
-  [(AttributeIsNull:$split)], [], (addBenefit 1)
->;
+def SplitV11PatternNoAttr
+    : Pat<(ONNXSplitV11Op $x, $axis, $split),
+          (ONNXSplitV13Op $x, (CreateNoneValue), $axis), [(AttributeIsNull
+                                                             : $split)],
+          [], (addBenefit 1)>;
 
-def SplitV11Pattern : Pat<
-  (ONNXSplitV11Op $x, $axis, $split),
-  (ONNXSplitV13Op $x, (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $split)), $axis),
-  [], [], (addBenefit 0)
->;
+def SplitV11Pattern
+    : Pat<(ONNXSplitV11Op $x, $axis, $split),
+          (ONNXSplitV13Op $x,
+              (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $split)),
+              $axis),
+          [], [], (addBenefit 0)>;
 
-def SplitV13Pattern : Pat<
-  (ONNXSplitV13Op $x, $split, $axis),
-  (ONNXSplitOp $x, $split, $axis, (GetNullIntegerAttr))
->;
+def SplitV13Pattern
+    : Pat<(ONNXSplitV13Op $x, $split, $axis),
+          (ONNXSplitOp $x, $split, $axis, (GetNullIntegerAttr))>;
 
-def SqueezeV11PatternNoAttr : Pat<
-  (ONNXSqueezeV11Op $x, $axes),
-  (ONNXSqueezeOp $x, (CreateNoneValue)),
-  [(AttributeIsNull:$axes)], [], (addBenefit 1)
->;
+def SqueezeV11PatternNoAttr
+    : Pat<(ONNXSqueezeV11Op $x, $axes), (ONNXSqueezeOp $x, (CreateNoneValue)),
+          [(AttributeIsNull
+              : $axes)],
+          [], (addBenefit 1)>;
 
-def SqueezeV11Pattern : Pat<
-  (ONNXSqueezeV11Op $x, $axes),
-  (ONNXSqueezeOp $x, (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $axes))),
-  [], [], (addBenefit 0)
->;
+def SqueezeV11Pattern
+    : Pat<(ONNXSqueezeV11Op $x, $axes),
+          (ONNXSqueezeOp $x,
+              (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $axes))),
+          [], [], (addBenefit 0)>;
 
-def UnsqueezeV11Pattern : Pat<
-  (ONNXUnsqueezeV11Op $x, $axes),
-  (ONNXUnsqueezeOp $x, (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $axes)))
->;
+def UnsqueezeV11Pattern
+    : Pat<(ONNXUnsqueezeV11Op $x, $axes),
+          (ONNXUnsqueezeOp $x,
+              (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $axes)))>;
 
 // Express Scatter (deprecated) using ScatterElements.
-def ScatterPattern : Pat<
-  (ONNXScatterOp $data, $indices, $updates, $axis),
-  (ONNXScatterElementsOp $data, $indices, $updates, $axis, (GetNullStringAttr))
->;
+def ScatterPattern : Pat<(ONNXScatterOp $data, $indices, $updates, $axis),
+                         (ONNXScatterElementsOp $data, $indices, $updates,
+                             $axis, (GetNullStringAttr))>;
 
 //===----------------------------------------------------------------------===//
 // ONNXReduceL1V13Op %X -> ONNXReduceL1Op %X =
 //===----------------------------------------------------------------------===//
-def ReduceL1V13OpPattern1
-    : Pat<(ONNXReduceL1V13Op $oprd, $axes, $keepdims),
-          (ONNXReduceL1Op $oprd,
-              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
-          [(AttributeIsNull:$axes)], [], (addBenefit 1)>;
+def ReduceL1V13OpPattern1 : Pat<(ONNXReduceL1V13Op $oprd, $axes, $keepdims),
+                                (ONNXReduceL1Op $oprd, (CreateNoneValue),
+                                    $keepdims, (noop_with_empty_axes)),
+                                [(AttributeIsNull
+                                    : $axes)],
+                                [], (addBenefit 1)>;
 
 def ReduceL1V13OpPattern2
     : Pat<(ONNXReduceL1V13Op $oprd, $axes, $keepdims),
@@ -451,11 +464,12 @@ def ReduceL1V13OpPattern2
 //===----------------------------------------------------------------------===//
 // ONNXReduceL2V13Op %X -> ONNXReduceL2Op %X =
 //===----------------------------------------------------------------------===//
-def ReduceL2V13OpPattern1
-    : Pat<(ONNXReduceL2V13Op $oprd, $axes, $keepdims),
-          (ONNXReduceL2Op $oprd,
-              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
-          [(AttributeIsNull:$axes)], [], (addBenefit 1)>;
+def ReduceL2V13OpPattern1 : Pat<(ONNXReduceL2V13Op $oprd, $axes, $keepdims),
+                                (ONNXReduceL2Op $oprd, (CreateNoneValue),
+                                    $keepdims, (noop_with_empty_axes)),
+                                [(AttributeIsNull
+                                    : $axes)],
+                                [], (addBenefit 1)>;
 
 def ReduceL2V13OpPattern2
     : Pat<(ONNXReduceL2V13Op $oprd, $axes, $keepdims),
@@ -469,9 +483,11 @@ def ReduceL2V13OpPattern2
 //===----------------------------------------------------------------------===//
 def ReduceLogSumV13OpPattern1
     : Pat<(ONNXReduceLogSumV13Op $oprd, $axes, $keepdims),
-          (ONNXReduceLogSumOp $oprd,
-              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
-          [(AttributeIsNull:$axes)], [], (addBenefit 1)>;
+          (ONNXReduceLogSumOp $oprd, (CreateNoneValue), $keepdims,
+              (noop_with_empty_axes)),
+          [(AttributeIsNull
+              : $axes)],
+          [], (addBenefit 1)>;
 
 def ReduceLogSumV13OpPattern2
     : Pat<(ONNXReduceLogSumV13Op $oprd, $axes, $keepdims),
@@ -485,9 +501,11 @@ def ReduceLogSumV13OpPattern2
 //===----------------------------------------------------------------------===//
 def ReduceLogSumExpV13OpPattern1
     : Pat<(ONNXReduceLogSumExpV13Op $oprd, $axes, $keepdims),
-          (ONNXReduceLogSumExpOp $oprd,
-              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
-          [(AttributeIsNull:$axes)], [], (addBenefit 1)>;
+          (ONNXReduceLogSumExpOp $oprd, (CreateNoneValue), $keepdims,
+              (noop_with_empty_axes)),
+          [(AttributeIsNull
+              : $axes)],
+          [], (addBenefit 1)>;
 
 def ReduceLogSumExpV13OpPattern2
     : Pat<(ONNXReduceLogSumExpV13Op $oprd, $axes, $keepdims),
@@ -501,9 +519,11 @@ def ReduceLogSumExpV13OpPattern2
 //===----------------------------------------------------------------------===//
 def ReduceSumSquareV13OpPattern1
     : Pat<(ONNXReduceSumSquareV13Op $oprd, $axes, $keepdims),
-          (ONNXReduceSumSquareOp $oprd,
-              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
-          [(AttributeIsNull:$axes)], [], (addBenefit 1)>;
+          (ONNXReduceSumSquareOp $oprd, (CreateNoneValue), $keepdims,
+              (noop_with_empty_axes)),
+          [(AttributeIsNull
+              : $axes)],
+          [], (addBenefit 1)>;
 
 def ReduceSumSquareV13OpPattern2
     : Pat<(ONNXReduceSumSquareV13Op $oprd, $axes, $keepdims),
@@ -517,76 +537,82 @@ def ReduceSumSquareV13OpPattern2
 //         `ONNXExpandOp(ONNXConstantOp {value}, %shape)
 //===----------------------------------------------------------------------===//
 
-def ConstantOfShapePattern1: Pat<
-  (ONNXConstantOfShapeOp:$res $shape, $value),
-  (ONNXExpandOp (ONNXConstantOpFromDenseAttr (ReshapeElementsAttrToRank0 $value)),
-                $shape),
-  [(AttributeIsNotNull:$value)]
->;
+def ConstantOfShapePattern1 : Pat<(ONNXConstantOfShapeOp
+                                      : $res $shape, $value),
+                                  (ONNXExpandOp(ONNXConstantOpFromDenseAttr(
+                                       ReshapeElementsAttrToRank0 $value)),
+                                      $shape),
+                                  [(AttributeIsNotNull
+                                      : $value)]>;
 
-def ConstantOfShapePattern2: Pat<
-  (ONNXConstantOfShapeOp:$res $shape, $value),
-  (ONNXExpandOp (ONNXConstantOpFromDenseAttr (ReshapeElementsAttrToRank0 (createDenseArrayAttrFromSingleAttr (GetZeroFloatAttr)))),
-                $shape),
-  [(AttributeIsNull:$value)]
->;
+def ConstantOfShapePattern2
+    : Pat<(ONNXConstantOfShapeOp
+              : $res $shape, $value),
+          (ONNXExpandOp(ONNXConstantOpFromDenseAttr(ReshapeElementsAttrToRank0(
+               createDenseArrayAttrFromSingleAttr(GetZeroFloatAttr)))),
+              $shape),
+          [(AttributeIsNull
+              : $value)]>;
 
 //===----------------------------------------------------------------------===//
 // Normalize ONNXConstantOp to use ElementAttrs
 //===----------------------------------------------------------------------===//
 
-def ConstantOpNormalizationPattern1: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-       $intsAttr, $stringAttr, $stringsAttr),
-   (ONNXConstantOpNormalize $res, $floatAttr),
-   [(AttributeIsNotNull:$floatAttr)]
->;
+def ConstantOpNormalizationPattern1
+    : Pat<(ONNXConstantOp
+              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+              $intsAttr, $stringAttr, $stringsAttr),
+          (ONNXConstantOpNormalize $res, $floatAttr), [(AttributeIsNotNull
+                                                          : $floatAttr)]>;
 
-def ConstantOpNormalizationPattern2: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-       $intsAttr, $stringAttr, $stringsAttr),
-   (ONNXConstantOpNormalize $res, $intAttr),
-   [(AttributeIsNotNull:$intAttr)]
->;
+def ConstantOpNormalizationPattern2
+    : Pat<(ONNXConstantOp
+              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+              $intsAttr, $stringAttr, $stringsAttr),
+          (ONNXConstantOpNormalize $res, $intAttr), [(AttributeIsNotNull
+                                                        : $intAttr)]>;
 
-def ConstantOpNormalizationPattern3: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-       $intsAttr, $stringAttr, $stringsAttr),
-   (ONNXConstantOpNormalize $res, $stringAttr),
-   [(AttributeIsNotNull:$stringAttr)]
->;
+def ConstantOpNormalizationPattern3
+    : Pat<(ONNXConstantOp
+              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+              $intsAttr, $stringAttr, $stringsAttr),
+          (ONNXConstantOpNormalize $res, $stringAttr), [(AttributeIsNotNull
+                                                           : $stringAttr)]>;
 
-def ConstantOpNormalizationPattern4: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-       $intsAttr, $stringAttr, $stringsAttr),
-   (ONNXConstantOpNormalize $res, $floatsAttr),
-   [(AttributeIsNotNull:$floatsAttr)]
->;
+def ConstantOpNormalizationPattern4
+    : Pat<(ONNXConstantOp
+              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+              $intsAttr, $stringAttr, $stringsAttr),
+          (ONNXConstantOpNormalize $res, $floatsAttr), [(AttributeIsNotNull
+                                                           : $floatsAttr)]>;
 
-def ConstantOpNormalizationPattern5: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-       $intsAttr, $stringAttr, $stringsAttr),
-   (ONNXConstantOpNormalize $res, $intsAttr),
-   [(AttributeIsNotNull:$intsAttr)]
->;
+def ConstantOpNormalizationPattern5
+    : Pat<(ONNXConstantOp
+              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+              $intsAttr, $stringAttr, $stringsAttr),
+          (ONNXConstantOpNormalize $res, $intsAttr), [(AttributeIsNotNull
+                                                         : $intsAttr)]>;
 
-def ConstantOpNormalizationPattern6: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
-       $intsAttr, $stringAttr, $stringsAttr),
-   (ONNXConstantOpNormalize $res, $stringsAttr),
-   [(AttributeIsNotNull:$stringsAttr)]
->;
+def ConstantOpNormalizationPattern6
+    : Pat<(ONNXConstantOp
+              : $res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
+              $intsAttr, $stringAttr, $stringsAttr),
+          (ONNXConstantOpNormalize $res, $stringsAttr), [(AttributeIsNotNull
+                                                            : $stringsAttr)]>;
 
 // Optimize for the pattern coming from torch.nn.LSTM exported from pytorch
-//     %32 = "onnx.SplitToSequence"(%30, %27) {axis = 0 : si64, keepdims = 0 : si64, onnx_node_name = "n1"} : (tensor<1x1x100xf32>, tensor<i64>) -> !onnx.Seq<tensor<1x1x100xf32>>
-//    %33 = "onnx.SequenceAt"(%32, %26) {onnx_node_name = "n0"} : (!onnx.Seq<tensor<1x1x100xf32>>, tensor<i64>) -> tensor<1x100xf32>
+//     %32 = "onnx.SplitToSequence"(%30, %27) {axis = 0 : si64, keepdims = 0 :
+//     si64, onnx_node_name = "n1"} : (tensor<1x1x100xf32>, tensor<i64>) ->
+//     !onnx.Seq<tensor<1x1x100xf32>>
+//    %33 = "onnx.SequenceAt"(%32, %26) {onnx_node_name = "n0"} :
+//    (!onnx.Seq<tensor<1x1x100xf32>>, tensor<i64>) -> tensor<1x100xf32>
 // When shape and size/axis related value are constant, this sequence of code
 // can be translated into onnx.slice
 
-def ReplaceSequenceAtPattern: Pat<
-   (ONNXSequenceAtOp:$res $seq, $position),
-   (ReplaceSequenceAt $res),
-   [(CanSequenceAtBeReplaced:$res)]
->;
+def ReplaceSequenceAtPattern
+    : Pat<(ONNXSequenceAtOp
+              : $res $seq, $position),
+          (ReplaceSequenceAt $res), [(CanSequenceAtBeReplaced
+                                        : $res)]>;
 
 #endif // ONNX_DECOMPOSE

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -128,6 +128,11 @@ struct ONNXHybridTransformPass
       llvm::cl::desc("Enable decomposition of Split to Slice"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableScatterNDDecompose{*this,
+      "enable-scatternd-decompose",
+      llvm::cl::desc("Enable decomposition of ScatterND"),
+      ::llvm::cl::init(true)};
+
   FrozenRewritePatternSet patterns;
 
   ONNXHybridTransformPass(bool enableRecomposition,
@@ -136,7 +141,7 @@ struct ONNXHybridTransformPass
       bool enableConvTransposeDecomposeToPhasedConv,
       bool enableConvTranspose1dDecomposeToPhasedConv,
       bool recomposeLayernormByTranspose, bool enableInstanceNormDecompose,
-      bool enableSplitToSliceDecompose) {
+      bool enableSplitToSliceDecompose, bool enableScatterNDDecompose) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
@@ -147,6 +152,7 @@ struct ONNXHybridTransformPass
     this->recomposeLayernormByTranspose = recomposeLayernormByTranspose;
     this->enableInstanceNormDecompose = enableInstanceNormDecompose;
     this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
+    this->enableScatterNDDecompose = enableScatterNDDecompose;
   }
 
   ONNXHybridTransformPass(const ONNXHybridTransformPass &pass)
@@ -190,7 +196,8 @@ struct ONNXHybridTransformPass
           enableConvTransposeDecompose,
           enableConvTransposeDecomposeToPhasedConv,
           enableConvTranspose1dDecomposeToPhasedConv,
-          enableInstanceNormDecompose, enableSplitToSliceDecompose);
+          enableInstanceNormDecompose, enableSplitToSliceDecompose,
+          enableScatterNDDecompose);
     }
 
     if (recomposition) {
@@ -236,11 +243,11 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableRecomposeLayernormByTranspose, bool enableInstanceNormDecompose,
-    bool enableSplitToSliceDecompose) {
+    bool enableSplitToSliceDecompose, bool enableScatterNDDecompose) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv,
       enableRecomposeLayernormByTranspose, enableInstanceNormDecompose,
-      enableSplitToSliceDecompose);
+      enableSplitToSliceDecompose, enableScatterNDDecompose);
 }

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -128,8 +128,7 @@ struct ONNXHybridTransformPass
       llvm::cl::desc("Enable decomposition of Split to Slice"),
       ::llvm::cl::init(false)};
 
-  Option<bool> enableScatterNDDecompose{*this,
-      "enable-scatternd-decompose",
+  Option<bool> enableScatterNDDecompose{*this, "enable-scatternd-decompose",
       llvm::cl::desc("Enable decomposition of ScatterND"),
       ::llvm::cl::init(true)};
 

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -42,7 +42,8 @@ std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
     bool enableConvTransposeDecomposeToPhasedConv = false,
     bool enableConvTranspose1dDecomposeToPhasedConv = false,
     bool enableInstanceNormDecompose = true,
-    bool enableSplitToSliceDecompose = false);
+    bool enableSplitToSliceDecompose = false,
+    bool enableScatterNDDecompose = true);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "",
     const bool &recomposeLayernormByTranspose = false);
@@ -90,7 +91,8 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableConvTranspose1dDecomposeToPhasedConv = false,
     bool enableRecomposeLayernormByTranspose = false,
     bool enableInstanceNormDecompose = true,
-    bool enableSplitToSliceDecompose = false);
+    bool enableSplitToSliceDecompose = false,
+    bool enableScatterNDDecompose = true);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();


### PR DESCRIPTION
 
 
Introduces enableScatterNDDecompose flag to optionally enable/disable ScatterND operation decomposition pattern in ONNX-to-MLIR transformation passes, providing better control over optimization strategies.
 