### PR TITLE
[AIESW-18974] Do not include the scale in LayerNorm recomposing but fuse it later

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -22,6 +22,7 @@
 
 #include "mlir/Dialect/Traits.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -2437,7 +2438,6 @@ struct PushTransposeDownScalePattern : public OpRewritePattern<ONNXMulOp> {
       return rewriter.notifyMatchFailure(mulOp, "no preceding transpose found");
     }
     auto oldTranspose = cast<ONNXTransposeOp>(transposeOp);
-    auto transposePerm = oldTranspose.getPerm();
 
     MultiDialectBuilder<OnnxBuilder> create(rewriter, oldTranspose->getLoc());
 
@@ -2446,15 +2446,15 @@ struct PushTransposeDownScalePattern : public OpRewritePattern<ONNXMulOp> {
       return rewriter.notifyMatchFailure(
           mulOp, "more than one use for transpose");
     // push transpose after mul
+    auto transposePerm = oldTranspose.getPerm();
     if (!transposePerm.has_value())
       return rewriter.notifyMatchFailure(
-          mulOp, "transpose need a fixed permutation");
-    SmallVector<int64_t> perm;
-    ArrayAttrIntVals(*transposePerm, perm);
+          mulOp, "transpose need a constant permutation");
 
     scale = create.onnx.upRank(scale, getRank(Y.getType()));
-    auto transposedMulInput =
-        create.onnx.transposeInt64(scale, invertPermutationVector(perm));
+    auto transposedMulInput = create.onnx.transposeInt64(
+        scale, invertPermutationVector(
+                   extractFromIntegerArrayAttr<int64_t>(*transposePerm)));
     auto newMulOp = create.onnx.mul(Y, transposedMulInput);
     newMulOp.setLoc(mulOp->getLoc());
     rewriter.replaceOpWithNewOp<ONNXTransposeOp>(mulOp,

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2445,21 +2445,25 @@ struct PushTransposeDownScalePattern : public OpRewritePattern<ONNXMulOp> {
     if (!oldTranspose->hasOneUse())
       return rewriter.notifyMatchFailure(
           mulOp, "more than one use for transpose");
-    // push transpose after mul
-    auto transposePerm = oldTranspose.getPerm();
-    if (!transposePerm.has_value())
+
+    // use shape helper to get perm (handles default transpose case)
+    IndexExprBuilderForAnalysis createIE(oldTranspose->getLoc());
+    ONNXTransposeOpShapeHelper shapeHelper(
+        oldTranspose.getOperation(), {oldTranspose.getData()}, &createIE);
+    if (shapeHelper.computeShape().failed())
       return rewriter.notifyMatchFailure(
-          mulOp, "transpose need a constant permutation");
+          mulOp, "could not compute transpose shape");
+    ArrayAttr transposePerm = oldTranspose.getPermAttr();
 
     scale = create.onnx.upRank(scale, getRank(Y.getType()));
     auto transposedMulInput = create.onnx.transposeInt64(
         scale, invertPermutationVector(
-                   extractFromIntegerArrayAttr<int64_t>(*transposePerm)));
+                   extractFromIntegerArrayAttr<int64_t>(transposePerm)));
     auto newMulOp = create.onnx.mul(Y, transposedMulInput);
     newMulOp.setLoc(mulOp->getLoc());
     rewriter.replaceOpWithNewOp<ONNXTransposeOp>(mulOp,
         {oldTranspose->getLoc()}, transposedY.getType(), newMulOp,
-        *transposePerm);
+        transposePerm);
     return llvm::success();
   }
 };

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2397,7 +2397,7 @@ struct PullReluLikeOpsThroughSplitPattern
  * Layernorm.
  *
  * This means going from:
- *   input       layernorm
+ *  constant     layernorm
  *     |             |
  *     |         transpose (loc1)
  *     *---------.   /
@@ -2406,7 +2406,7 @@ struct PullReluLikeOpsThroughSplitPattern
  *
  * to:
  *
- *   input        layernorm
+ *  constant      layernorm
  *     |              |
  *  transpose (loc1)  /
  *     *---------.   /
@@ -2433,6 +2433,11 @@ struct PushTransposeDownScalePattern : public OpRewritePattern<ONNXMulOp> {
               layerOp, transposeOp, Y, 0)) {
         return rewriter.notifyMatchFailure(
             mulOp, "transpose without preceding layernorm");
+      }
+      auto *op = scale.getDefiningOp();
+      if (op == nullptr || !isa<ONNXConstantOp>(op)) {
+        return rewriter.notifyMatchFailure(
+            mulOp, "transpose without preceding constant");
       }
     } else {
       return rewriter.notifyMatchFailure(mulOp, "no preceding transpose found");

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -5,6 +5,7 @@
 //===----------- ONNXRewrite.cpp - ONNX High Level Optimizer --------------===//
 //
 // Copyright 2019-2024 The IBM Research Authors.
+// Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 //
 // =============================================================================
 //
@@ -2390,6 +2391,79 @@ struct PullReluLikeOpsThroughSplitPattern
   }
 };
 
+/*
+ * Push down the transpose after scale (mul op), so the scale can be fused to
+ * Layernorm.
+ *
+ * This means going from:
+ *   input       layernorm
+ *     |             |
+ *     |         transpose (loc1)
+ *     *---------.   /
+ *                mul (loc2)
+ *                 |
+ *
+ * to:
+ *
+ *   input        layernorm
+ *     |              |
+ *  transpose (loc1)  /
+ *     *---------.   /
+ *                mul (loc2)
+ *                 |
+ *             transpose (loc1)
+ *                 |
+ */
+struct PushTransposeDownScalePattern : public OpRewritePattern<ONNXMulOp> {
+  using OpRewritePattern<ONNXMulOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(
+      ONNXMulOp mulOp, PatternRewriter &rewriter) const final {
+    using namespace onnx_mlir;
+    Operation *transposeOp = nullptr;
+    Operation *layerOp = nullptr;
+    Value Y;
+    Value scale;
+    Value transposedY;
+    if (operandOfOpDefinedBy<ONNXTransposeOp>(
+            transposeOp, mulOp, transposedY, scale, 0) ||
+        operandOfOpDefinedBy<ONNXTransposeOp>(
+            transposeOp, mulOp, scale, transposedY, 1)) {
+      if (!operandOfOpDefinedBy<ONNXLayerNormalizationOp>(
+              layerOp, transposeOp, Y, 0)) {
+        return rewriter.notifyMatchFailure(
+            mulOp, "transpose without preceding layernorm");
+      }
+    } else {
+      return rewriter.notifyMatchFailure(mulOp, "no preceding transpose found");
+    }
+    auto oldTranspose = cast<ONNXTransposeOp>(transposeOp);
+    auto transposePerm = oldTranspose.getPerm();
+
+    MultiDialectBuilder<OnnxBuilder> create(rewriter, oldTranspose->getLoc());
+
+    // we have a transpose that we need to move behind the multiplication
+    if (!oldTranspose->hasOneUse())
+      return rewriter.notifyMatchFailure(
+          mulOp, "more than one use for transpose");
+    // push transpose after mul
+    if (!transposePerm.has_value())
+      return rewriter.notifyMatchFailure(
+          mulOp, "transpose need a fixed permutation");
+    SmallVector<int64_t> perm;
+    ArrayAttrIntVals(*transposePerm, perm);
+
+    scale = create.onnx.upRank(scale, getRank(Y.getType()));
+    auto transposedMulInput =
+        create.onnx.transposeInt64(scale, invertPermutationVector(perm));
+    auto newMulOp = create.onnx.mul(Y, transposedMulInput);
+    newMulOp.setLoc(mulOp->getLoc());
+    rewriter.replaceOpWithNewOp<ONNXTransposeOp>(mulOp,
+        {oldTranspose->getLoc()}, transposedY.getType(), newMulOp,
+        *transposePerm);
+    return llvm::success();
+  }
+};
+
 // =============================================================================
 /// Register optimization patterns as "canonicalization" patterns.
 /// Add op to OpsWithCanonicalizer in gen_onnx_mlir.py to activate.
@@ -2595,6 +2669,7 @@ void ONNXMulOp::getCanonicalizationPatterns(
   results.insert<PropagateReshapeThroughBinaryOpPattern<ONNXMulOp>>(context);
   results.insert<PropagateConstantScalingInAttentionLayerPattern<ONNXMulOp>>(
       context);
+  results.insert<PushTransposeDownScalePattern>(context);
 }
 
 /// on the ONNXOrOp.

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -750,6 +750,29 @@ private:
   }
 };
 
+/*
+ * Push down the transpose after scale (mul op), so the scale can be fused to
+ * Layernorm.
+ *
+ * This means going from:
+ *   input       layernorm
+ *     |             |
+ *     |         transpose (loc1)
+ *     *---------.   /
+ *                mul (loc2)
+ *                 |
+ *
+ * to:
+ *
+ *   input        layernorm
+ *     |              |
+ *  transpose (loc1)  /
+ *     *---------.   /
+ *                mul (loc2)
+ *                 |
+ *             transpose (loc1)
+ *                 |
+ */
 struct PushTransposeDownScalePattern : public OpRewritePattern<ONNXMulOp> {
   using OpRewritePattern<ONNXMulOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -750,79 +750,6 @@ private:
   }
 };
 
-/*
- * Push down the transpose after scale (mul op), so the scale can be fused to
- * Layernorm.
- *
- * This means going from:
- *   input       layernorm
- *     |             |
- *     |         transpose (loc1)
- *     *---------.   /
- *                mul (loc2)
- *                 |
- *
- * to:
- *
- *   input        layernorm
- *     |              |
- *  transpose (loc1)  /
- *     *---------.   /
- *                mul (loc2)
- *                 |
- *             transpose (loc1)
- *                 |
- */
-struct PushTransposeDownScalePattern : public OpRewritePattern<ONNXMulOp> {
-  using OpRewritePattern<ONNXMulOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(
-      ONNXMulOp mulOp, PatternRewriter &rewriter) const final {
-    using namespace onnx_mlir;
-    Operation *transposeOp = nullptr;
-    Operation *layerOp = nullptr;
-    Value Y;
-    Value scale;
-    Value transposedY;
-    if (operandOfOpDefinedBy<ONNXTransposeOp>(
-            transposeOp, mulOp, transposedY, scale, 0) ||
-        operandOfOpDefinedBy<ONNXTransposeOp>(
-            transposeOp, mulOp, scale, transposedY, 1)) {
-      if (!operandOfOpDefinedBy<ONNXLayerNormalizationOp>(
-              layerOp, transposeOp, Y, 0)) {
-        return rewriter.notifyMatchFailure(
-            mulOp, "transpose without preceding layernorm");
-      }
-    } else {
-      return rewriter.notifyMatchFailure(mulOp, "no preceding transpose found");
-    }
-    auto oldTranspose = cast<ONNXTransposeOp>(transposeOp);
-    auto transposePerm = oldTranspose.getPerm();
-
-    MultiDialectBuilder<OnnxBuilder> create(rewriter, oldTranspose->getLoc());
-
-    // we have a transpose that we need to move behind the multiplication
-    if (!oldTranspose->hasOneUse())
-      return rewriter.notifyMatchFailure(
-          mulOp, "more than one use for transpose");
-    // push transpose after mul
-    if (!transposePerm.has_value())
-      return rewriter.notifyMatchFailure(
-          mulOp, "transpose need a fixed permutation");
-    SmallVector<int64_t> perm;
-    ArrayAttrIntVals(*transposePerm, perm);
-
-    scale = create.onnx.upRank(scale, getRank(Y.getType()));
-    auto transposedMulInput =
-        create.onnx.transposeInt64(scale, invertPermutationVector(perm));
-    auto newMulOp = create.onnx.mul(Y, transposedMulInput);
-    newMulOp.setLoc(mulOp->getLoc());
-    rewriter.replaceOpWithNewOp<ONNXTransposeOp>(mulOp,
-        {oldTranspose->getLoc()}, transposedY.getType(), newMulOp,
-        *transposePerm);
-    return llvm::success();
-  }
-};
-
 struct RecomposeGeluFromMulPattern : public OpRewritePattern<ONNXMulOp> {
   using OpRewritePattern<ONNXMulOp>::OpRewritePattern;
 
@@ -1613,7 +1540,6 @@ void onnx_mlir::getRecomposeONNXToONNXPatterns(
     patterns.insert<RecomposeLayerNormFromDivPattern<ONNXMulOp, true>>(context);
     patterns.insert<RecomposeLayerNormFromDivPattern<ONNXPowOp, true>>(context);
   }
-  patterns.insert<PushTransposeDownScalePattern>(context);
   patterns.insert<RecomposeDepthToSpaceCRD>(context);
   patterns.insert<RecomposeDepthToSpaceDCR>(context);
   // AMD Disabled as downstream has no special support for it

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -772,16 +772,16 @@ struct PushTransposeDownScalePattern : public OpRewritePattern<ONNXMulOp> {
     } else {
       return rewriter.notifyMatchFailure(mulOp, "no preceding transpose found");
     }
-    MultiDialectBuilder<OnnxBuilder> create(rewriter, mulOp->getLoc());
+    auto oldTranspose = cast<ONNXTransposeOp>(transposeOp);
+    auto transposePerm = oldTranspose.getPerm();
+
+    MultiDialectBuilder<OnnxBuilder> create(rewriter, oldTranspose->getLoc());
 
     // we have a transpose that we need to move behind the multiplication
-    if (!transposeOp->hasOneUse())
+    if (!oldTranspose->hasOneUse())
       return rewriter.notifyMatchFailure(
           mulOp, "more than one use for transpose");
     // push transpose after mul
-    auto oldTranspose = cast<ONNXTransposeOp>(transposeOp);
-
-    auto transposePerm = oldTranspose.getPerm();
     if (!transposePerm.has_value())
       return rewriter.notifyMatchFailure(
           mulOp, "transpose need a fixed permutation");
@@ -792,9 +792,10 @@ struct PushTransposeDownScalePattern : public OpRewritePattern<ONNXMulOp> {
     auto transposedMulInput =
         create.onnx.transposeInt64(scale, invertPermutationVector(perm));
     auto newMulOp = create.onnx.mul(Y, transposedMulInput);
-    // fuseScaleInLayernorm(rewriter, newMulOp, layerNorm)
-    rewriter.replaceOpWithNewOp<ONNXTransposeOp>(
-        mulOp, transposedY.getType(), newMulOp, *transposePerm);
+    newMulOp.setLoc(mulOp->getLoc());
+    rewriter.replaceOpWithNewOp<ONNXTransposeOp>(mulOp,
+        {oldTranspose->getLoc()}, transposedY.getType(), newMulOp,
+        *transposePerm);
     return llvm::success();
   }
 };

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -5,6 +5,7 @@
 //===----------- ONNXRecompose.cpp - ONNX High Level Rewriting ------------===//
 //
 // Copyright 2023 The IBM Research Authors.
+// Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 //
 // =============================================================================
 //
@@ -24,10 +25,12 @@
 
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
 
 #include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
@@ -117,9 +120,9 @@ namespace {
 // %10 = "onnx.Transpose"(%Y)
 //      {perm = [0, 3, 1, 2]} : (<1x128x128x4xf32>) -> <1x4x128x128xf32>
 
-template <bool RecomposeLayernormByTranspose = false>
-struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
-  using OpRewritePattern<ONNXMulOp>::OpRewritePattern;
+template <typename DivOperator, bool RecomposeLayernormByTranspose = false>
+struct RecomposeLayerNormFromDivPattern : public OpRewritePattern<DivOperator> {
+  using OpRewritePattern<DivOperator>::OpRewritePattern;
 
   FailureOr<mlir::Value> createScaleConstOp(const Type &xType,
       const onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> &builder)
@@ -152,10 +155,10 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
   }
 
   LogicalResult matchAndRewrite(
-      ONNXMulOp mulOp, PatternRewriter &rewriter) const final {
+      DivOperator mulOp, PatternRewriter &rewriter) const final {
     using namespace onnx_mlir;
     // Match
-    Value x, scale;
+    Value x;
     FloatAttr epsilon;
     int64_t axis;
     bool isRMSLayerNorm;
@@ -165,8 +168,8 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     // the original tensor and adapting the axis, we make unsuitable axis for
     // layer suitable.
     SmallVector<int64_t> permutation;
-    if (!matchLayerNormPattern(mulOp, x, scale, axis, epsilon,
-            layerNormLocations, isRMSLayerNorm, permutation))
+    if (!matchLayerNormPattern(mulOp, x, axis, epsilon, layerNormLocations,
+            isRMSLayerNorm, permutation))
       return failure();
 
     // Replace
@@ -176,41 +179,31 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     Value res;
 
     if constexpr (RecomposeLayernormByTranspose) {
-      if (!hasShapeAndRank(scale))
-        return rewriter.notifyMatchFailure(
-            mulOp, "the scale doesn't have shape or rank");
       // if the permutation is empty, nothing is needed to be permuted.
       // Otherwise, both input and scale must be transposed.
       if (!permutation.empty()) {
-        if (scale) {
-          // Layernorm supports broadcasting and in order to transpose, the rank
-          // should be equalized.
-          scale = create.onnx.upRank(scale, getRank(x.getType()));
-          scale = create.onnx.transposeInt64(scale, permutation);
-        }
         x = create.onnx.transposeInt64(x, permutation);
       }
     }
 
-    if (isRMSLayerNorm) {
-      if (!scale) {
-        // set scale to unity if there is no scale value present in the pattern
-        // This is required because RMSLayerNorm mandates passing a scale value
+    // set scale to unity if there is no scale value present in the pattern
+    // This is required because RMSLayerNorm and LayerNorm mandates passing a
+    // scale value
 
-        // NOTE: The scale is being passed as a tensor instead of a scalar
-        // because the pass that generates RMSNormAdf templated graph requires
-        // the scale to be a tensor of dimension same as the inner most
-        // dimension of input tensor
-        auto result = this->createScaleConstOp(x.getType(), create);
-        if (failed(result))
-          return failure();
-        scale = result.value();
-      }
+    // NOTE: The scale is being passed as a tensor instead of a scalar
+    // because the pass that generates RMSNormAdf templated graph requires
+    // the scale to be a tensor of dimension same as the inner most
+    // dimension of input tensor
+    auto scale = this->createScaleConstOp(x.getType(), create);
+    if (failed(scale))
+      return failure();
+
+    if (isRMSLayerNorm) {
       res = create.onnx.RMSLayerNorm(
-          x.getType(), x, scale, noneVal, axis, epsilon);
+          x.getType(), x, scale.value(), noneVal, axis, epsilon);
     } else {
-      res =
-          create.onnx.layerNorm(x.getType(), x, scale, noneVal, axis, epsilon);
+      res = create.onnx.layerNorm(
+          x.getType(), x, scale.value(), noneVal, axis, epsilon);
     }
 
     if constexpr (RecomposeLayernormByTranspose) {
@@ -226,6 +219,173 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     return success();
   }
 
+  struct MatchDivArgs {
+    Operation **isdRecipOp;
+    Operation **nDivOp;
+    Operation **nMulOp;
+    Operation **powOp;
+    Operation **sdSqrtOp;
+    Operation **veAddOp;
+    Value &d;
+    Value &invStdDev;
+    Value &stdDev;
+    Value &varEps;
+  };
+  /*
+  * Implement the variations around the div (see matchLayerNormPattern):
+    Since this is the last operation in the layernorm block (we match the scale
+  later and fuse it), we use templates to match all different variants.
+  */
+  template <typename InnerDivOp>
+  static bool matchLastOperator([[maybe_unused]] InnerDivOp layernormOp,
+      [[maybe_unused]] MatchDivArgs &&m) {
+    return reportFailure("RMS missing norm, div, reciprocal or pow op");
+  }
+  template <>
+  bool matchLastOperator<ONNXDivOp>(ONNXDivOp divOp, MatchDivArgs &&m) {
+    // Matched norm = d / stdDev.
+    // %norm = "onnx.Div"(%d, %stdDev)
+    // %normScaled = "onnx.Mul"(%norm, %scale)
+
+    // Now search for the sqrt.
+    // %stdDev = "onnx.Sqrt"(%varEps)
+    // %norm = "onnx.Div"(%d, %stdDev)
+    *m.nDivOp = divOp;
+    if (!onnx_mlir::operandOfOpDefinedBy<ONNXSqrtOp>(
+            *m.sdSqrtOp, divOp, m.d, m.stdDev, 1))
+      return reportFailure("RMS missing std dev (via div), sqrt op");
+    return true;
+  }
+  template <>
+  bool matchLastOperator<ONNXMulOp>(ONNXMulOp mulOp, MatchDivArgs &&m) {
+    using namespace onnx_mlir;
+    // Matched norm = d * (invStdDev).
+    // %Norm = "onnx.Mul"(%d, %InvStdDev)
+    // %NormScaled = "onnx.Mul"(%Norm, %scale)
+    *m.nMulOp = mulOp;
+
+    if (operandOfOpDefinedBy<ONNXReciprocalOp>(
+            *m.isdRecipOp, *m.nMulOp, m.invStdDev, m.d, 0) ||
+        operandOfOpDefinedBy<ONNXReciprocalOp>(
+            *m.isdRecipOp, *m.nMulOp, m.d, m.invStdDev, 1)) {
+      // Now matched the reciprocal.
+      // %InvStdDev = "onnx.Reciprocal"(%StdDev)
+      // %Norm = "onnx.Mul"(%d, %InvStdDev)
+
+      // Now search for the sqrt.
+      // %StdDev = "onnx.Sqrt"(%varEps)
+      // %InvStdDev = "onnx.Reciprocal"(%StdDev)
+      if (!operandOfOpDefinedBy<ONNXSqrtOp>(
+              *m.sdSqrtOp, *m.isdRecipOp, m.stdDev)) {
+        return reportFailure("RMS missing std dev (via reciprocal), sqrt op");
+      }
+    } else if (operandOfOpDefinedBy<ONNXDivOp>(
+                   *m.isdRecipOp, *m.nMulOp, m.invStdDev, m.d, 0) ||
+               operandOfOpDefinedBy<ONNXDivOp>(
+                   *m.isdRecipOp, *m.nMulOp, m.d, m.invStdDev, 1)) {
+      // Now matched the div(1/stddev).
+      // %InvStdDev = "onnx.Div"(%one, %StdDev)
+      // %Norm = "onnx.Mul"(%d, %InvStdDev)
+
+      // Now search for the sqrt.
+      // %StdDev = "onnx.Sqrt"(%varEps)
+      // %InvStdDev = "onnx.Reciprocal"(%StdDev)
+      Value one;
+      if (operandOfOpDefinedBy<ONNXSqrtOp>(
+              *m.sdSqrtOp, *m.isdRecipOp, one, m.stdDev, 1)) {
+        // Has a match, check that the value one is a scalar/tensor of size
+        // one with value 1.
+        Location loc = mulOp.getLoc();
+        IndexExprScope scope(nullptr, loc);
+        IndexExprBuilderForAnalysis createIE(loc);
+        // we can be on a false path here and the div input is not a 1 tensor
+        // but D this should be matched by matchLastOperator<ONNXDivOp> however
+        if (one.getDefiningOp<ONNXSubOp>()) {
+          return reportFailure("false path for matching");
+        }
+        if (createIE.hasShapeAndRank(one) &&
+            createIE.getShapedTypeRank(one) < 2 &&
+            createIE.getArraySize(one, /*static only*/ true) == 1) {
+          IndexExpr floatVal = createIE.getFloatAsNonAffine(one);
+          if (!floatVal.isLiteral() || (floatVal.getFloatLiteral() != 1.0))
+            return reportFailure(
+                "RMS missing std dev (via 1/x), not div of 1.0");
+        } else {
+          return reportFailure("missing std dev (via 1/x), not div of scalar");
+        }
+      } else {
+        return reportFailure("RMS missing std dev (via 1/x), sqrt op");
+      }
+    } else if (operandOfOpDefinedBy<ONNXPowOp>(
+                   *m.powOp, mulOp, m.invStdDev, m.d, 0) ||
+               operandOfOpDefinedBy<ONNXPowOp>(
+                   *m.powOp, mulOp, m.d, m.invStdDev, 1)) {
+      // The following pattern is now matched
+      // %invStdDev = "onnx.Pow"(%varEps, %negHalf)
+      // %norm = "onnx.Mul"(%d, %invStdDev)
+
+      // Now verify the value of exponent for pow op
+      mlir::Value negHalf;
+      if (operandOfOpDefinedBy<ONNXAddOp>(
+              *m.veAddOp, *m.powOp, m.varEps, negHalf, 0)) {
+        // Verify if the exponent is floating point scalar with value -0.5
+        Location loc = (*m.powOp)->getLoc();
+        IndexExprScope scope(nullptr, loc);
+        IndexExprBuilderForAnalysis createIE(loc);
+        if (createIE.hasShapeAndRank(negHalf) &&
+            createIE.getArraySize(negHalf, /*static only*/ true) == 1) {
+          IndexExpr floatVal = createIE.getFloatAsNonAffine(negHalf);
+          if (!floatVal.isLiteral() || (floatVal.getFloatLiteral() != -0.5)) {
+            return reportFailure("RMS missing std dev (via pow(var + eps, "
+                                 "-0.5)), exp is not -0.5");
+          }
+        } else {
+          return reportFailure(
+              "missing std dev (via pow(var + eps, -0.5)), not exp of scalar");
+        }
+      } else {
+        return reportFailure("RMS missing std dev (via pow(var + eps, -0.5)), "
+                             "input to pow is not an Add");
+      }
+    } else {
+      return reportFailure("RMS missing inv std dev, reciprocal op");
+    }
+    return true;
+  }
+  template <>
+  bool matchLastOperator<ONNXPowOp>(ONNXPowOp powInputOp, MatchDivArgs &&m) {
+    using namespace onnx_mlir;
+    // The following pattern is now matched
+    // %invStdDev = "onnx.Pow"(%varEps, %negHalf)
+    // %norm = "onnx.Mul"(%d, %invStdDev)
+    *m.powOp = powInputOp;
+
+    // Now verify the value of exponent for pow op
+    mlir::Value negHalf;
+    if (operandOfOpDefinedBy<ONNXAddOp>(
+            *m.veAddOp, *m.powOp, m.varEps, negHalf, 0)) {
+      // Verify if the exponent is floating point scalar with value -0.5
+      Location loc = (*m.powOp)->getLoc();
+      IndexExprScope scope(nullptr, loc);
+      IndexExprBuilderForAnalysis createIE(loc);
+      if (createIE.hasShapeAndRank(negHalf) &&
+          createIE.getArraySize(negHalf, /*static only*/ true) == 1) {
+        IndexExpr floatVal = createIE.getFloatAsNonAffine(negHalf);
+        if (!floatVal.isLiteral() || (floatVal.getFloatLiteral() != -0.5)) {
+          return reportFailure("RMS missing std dev (via pow(var + eps, "
+                               "-0.5)), exp is not -0.5");
+        }
+      } else {
+        return reportFailure(
+            "missing std dev (via pow(var + eps, -0.5)), not exp of scalar");
+      }
+    } else {
+      return reportFailure("RMS missing std dev (via pow(var + eps, -0.5)), "
+                           "input to pow is not an Add");
+    }
+    return true;
+  }
+
   /*
    * Primary LayerNormalization pattern being matched:
 
@@ -233,14 +393,18 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
      D = X - mean
      var = reduceMean(D*D)
      stdDev = sqrt(var + eps)
-     y = mul(scale, D / stdDev)
+     normalized = D / stdDev
+
+     y = mul(scale, normalized) (not matched anymore but fused later)
 
 
   * Second pattern associated with RMSLayerNormalization:
 
     var = reduceMean(X * X)
     stdDev = sqrt(var + eps)
-    Y = mul(scale, X / stdDev)
+    normalized = X / stdDev
+
+    Y = mul(scale, normalized) (not matched anymore but fused later)
 
   * Third pattern associated with RMSLayerNormalization
 
@@ -262,8 +426,8 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
   replaced by a single Pow op with exponent as -0.5. Everything other than the
   last two lines follows a logic common to primary and secondary pattern.
   */
-  static bool matchLayerNormPattern(ONNXMulOp LayerNormOp, Value &x,
-      Value &scale, int64_t &axis, FloatAttr &epsilonAttr,
+  static bool matchLayerNormPattern(DivOperator LayerNormOp, Value &x,
+      int64_t &axis, FloatAttr &epsilonAttr,
       SmallVectorImpl<Location> &layerNormLocations, bool &isRMSLayerNorm,
       SmallVectorImpl<int64_t> &perm) {
     using namespace onnx_mlir;
@@ -272,11 +436,10 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
 
     // 1: Start first to detect if we have the common layer norm pattern.
     // Values that will be gathered and only kept locally.
-    Value norm, invStdDev, stdDev, varEps, var, epsilon, dd, d, mean, x1;
+    Value invStdDev, stdDev, varEps, var, epsilon, dd, d, mean, x1;
     // Replicate of values, check that they are identical to originals.
     Value d1, d2;
     // Operations that will be gathered and kept locally.
-    Operation *nsMulOp = LayerNormOp.getOperation();
     Operation *ddMulOp = nullptr;
     Operation *nDivOp = nullptr;
     Operation *nMulOp = nullptr;
@@ -287,105 +450,19 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     Operation *mReduceOp = nullptr;
     Operation *dSubOp = nullptr;
     Operation *powOp = nullptr;
-    // after this group, we have defined norm, scale, d, and sdSqrtOp.
-    if (operandOfOpDefinedBy<ONNXDivOp>(nDivOp, nsMulOp, norm, scale, 0) ||
-        operandOfOpDefinedBy<ONNXDivOp>(nDivOp, nsMulOp, scale, norm, 1)) {
-      // Matched norm = d / stdDev.
-      // %norm = "onnx.Div"(%d, %stdDev)
-      // %normScaled = "onnx.Mul"(%norm, %scale)
 
-      // Now search for the sqrt.
-      // %stdDev = "onnx.Sqrt"(%varEps)
-      // %norm = "onnx.Div"(%d, %stdDev)
-      if (!operandOfOpDefinedBy<ONNXSqrtOp>(sdSqrtOp, nDivOp, d, stdDev, 1))
-        return reportFailure("RMS missing std dev (via div), sqrt op");
-    } else if (operandOfOpDefinedBy<ONNXMulOp>(
-                   nMulOp, nsMulOp, norm, scale, 0) ||
-               operandOfOpDefinedBy<ONNXMulOp>(
-                   nMulOp, nsMulOp, scale, norm, 1)) {
-      // Matched norm = d * (invStdDev).
-      // %Norm = "onnx.Mul"(%d, %InvStdDev)
-      // %NormScaled = "onnx.Mul"(%Norm, %scale)
-
-      if (operandOfOpDefinedBy<ONNXReciprocalOp>(
-              isdRecipOp, nMulOp, invStdDev, d, 0) ||
-          operandOfOpDefinedBy<ONNXReciprocalOp>(
-              isdRecipOp, nMulOp, d, invStdDev, 1)) {
-        // Now matched the reciprocal.
-        // %InvStdDev = "onnx.Reciprocal"(%StdDev)
-        // %Norm = "onnx.Mul"(%d, %InvStdDev)
-
-        // Now search for the sqrt.
-        // %StdDev = "onnx.Sqrt"(%varEps)
-        // %InvStdDev = "onnx.Reciprocal"(%StdDev)
-        if (!operandOfOpDefinedBy<ONNXSqrtOp>(sdSqrtOp, isdRecipOp, stdDev)) {
-          return reportFailure("RMS missing std dev (via reciprocal), sqrt op");
-        }
-      } else if (operandOfOpDefinedBy<ONNXDivOp>(
-                     isdRecipOp, nMulOp, invStdDev, d, 0) ||
-                 operandOfOpDefinedBy<ONNXDivOp>(
-                     isdRecipOp, nMulOp, d, invStdDev, 1)) {
-        // Now matched the div(1/stddev).
-        // %InvStdDev = "onnx.Div"(%one, %StdDev)
-        // %Norm = "onnx.Mul"(%d, %InvStdDev)
-
-        // Now search for the sqrt.
-        // %StdDev = "onnx.Sqrt"(%varEps)
-        // %InvStdDev = "onnx.Reciprocal"(%StdDev)
-        Value one;
-        if (operandOfOpDefinedBy<ONNXSqrtOp>(
-                sdSqrtOp, isdRecipOp, one, stdDev, 1)) {
-          // Has a match, check that the value one is a scalar/tensor of size
-          // one with value 1.
-          IndexExprScope scope(nullptr, loc);
-          IndexExprBuilderForAnalysis createIE(loc);
-          if (createIE.hasShapeAndRank(one) &&
-              createIE.getArraySize(one, /*static only*/ true) == 1) {
-            IndexExpr floatVal = createIE.getFloatAsNonAffine(one);
-            if (!floatVal.isLiteral() || (floatVal.getFloatLiteral() != 1.0))
-              return reportFailure(
-                  "RMS missing std dev (via 1/x), not div of 1.0");
-          } else {
-            return reportFailure(
-                "missing std dev (via 1/x), not div of scalar");
-          }
-        } else {
-          return reportFailure("RMS missing std dev (via 1/x), sqrt op");
-        }
-      } else {
-        return reportFailure("RMS missing inv std dev, reciprocal op");
-      }
-    } else if (operandOfOpDefinedBy<ONNXPowOp>(
-                   powOp, nsMulOp, invStdDev, d, 0) ||
-               operandOfOpDefinedBy<ONNXPowOp>(
-                   powOp, nsMulOp, d, invStdDev, 1)) {
-      // The following pattern is now matched
-      // %invStdDev = "onnx.Pow"(%varEps, %negHalf)
-      // %norm = "onnx.Mul"(%d, %invStdDev)
-
-      // Now verify the value of exponent for pow op
-      mlir::Value negHalf;
-      if (operandOfOpDefinedBy<ONNXAddOp>(veAddOp, powOp, varEps, negHalf, 0)) {
-        // Verify if the exponent is floating point scalar with value -0.5
-        IndexExprScope scope(nullptr, loc);
-        IndexExprBuilderForAnalysis createIE(loc);
-        if (createIE.hasShapeAndRank(negHalf) &&
-            createIE.getArraySize(negHalf, /*static only*/ true) == 1) {
-          IndexExpr floatVal = createIE.getFloatAsNonAffine(negHalf);
-          if (!floatVal.isLiteral() || (floatVal.getFloatLiteral() != -0.5)) {
-            return reportFailure("RMS missing std dev (via pow(var + eps, "
-                                 "-0.5)), exp is not -0.5");
-          }
-        } else {
-          return reportFailure(
-              "missing std dev (via pow(var + eps, -0.5)), not exp of scalar");
-        }
-      } else {
-        return reportFailure("RMS missing std dev (via pow(var + eps, -0.5)), "
-                             "input to pow is not an Add");
-      }
-    } else {
-      return reportFailure("RMS missing norm, div, reciprocal or pow op");
+    if (!matchLastOperator<DivOperator>(
+            LayerNormOp, MatchDivArgs{.isdRecipOp = &isdRecipOp,
+                             .nDivOp = &nDivOp,
+                             .nMulOp = &nMulOp,
+                             .powOp = &powOp,
+                             .sdSqrtOp = &sdSqrtOp,
+                             .veAddOp = &veAddOp,
+                             .d = d,
+                             .invStdDev = invStdDev,
+                             .stdDev = stdDev,
+                             .varEps = varEps})) {
+      return reportFailure("First operator could not be matched");
     }
 
     // extract veAddOp and varEps if sqrt pattern is present instead of pow.
@@ -393,6 +470,8 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     if (!powOp) {
       // %varEps = "onnx.Add"(%var, %eps)
       // %stdDev = "onnx.Sqrt"(%varEps)
+      if (!sdSqrtOp)
+        return reportFailure("Sqrt not defined, wrong path.");
       if (!operandOfOpDefinedBy<ONNXAddOp>(veAddOp, sdSqrtOp, varEps))
         return reportFailure("RMS missing var + eps, add op");
     }
@@ -427,13 +506,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
       return reportFailure("RMS var eps add has too many uses");
     if (sdSqrtOp && !sdSqrtOp->hasOneUse())
       return reportFailure("RMS std dev sqrt has too many uses");
-    if (powOp && !powOp->hasOneUse())
-      return reportFailure("RMS std dev pow has too many uses");
     // Gate the next 3 ops by being nonnull, as there are multiple paths.
-    if (nDivOp && !nDivOp->hasOneUse())
-      return reportFailure("RMS norm div has too many uses");
-    if (nMulOp && !nMulOp->hasOneUse())
-      return reportFailure("RMS norm mul has too many uses");
     if (isdRecipOp && !isdRecipOp->hasOneUse())
       return reportFailure("RMS norm recip has too many uses");
     // Now check values epsilon.
@@ -677,6 +750,55 @@ private:
   }
 };
 
+struct PushTransposeDownScalePattern : public OpRewritePattern<ONNXMulOp> {
+  using OpRewritePattern<ONNXMulOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(
+      ONNXMulOp mulOp, PatternRewriter &rewriter) const final {
+    using namespace onnx_mlir;
+    Operation *transposeOp = nullptr;
+    Operation *layerOp = nullptr;
+    Value Y;
+    Value scale;
+    Value transposedY;
+    if (operandOfOpDefinedBy<ONNXTransposeOp>(
+            transposeOp, mulOp, transposedY, scale, 0) ||
+        operandOfOpDefinedBy<ONNXTransposeOp>(
+            transposeOp, mulOp, scale, transposedY, 1)) {
+      if (!operandOfOpDefinedBy<ONNXLayerNormalizationOp>(
+              layerOp, transposeOp, Y, 0)) {
+        return rewriter.notifyMatchFailure(
+            mulOp, "transpose without preceding layernorm");
+      }
+    } else {
+      return rewriter.notifyMatchFailure(mulOp, "no preceding transpose found");
+    }
+    MultiDialectBuilder<OnnxBuilder> create(rewriter, mulOp->getLoc());
+
+    // we have a transpose that we need to move behind the multiplication
+    if (!transposeOp->hasOneUse())
+      return rewriter.notifyMatchFailure(
+          mulOp, "more than one use for transpose");
+    // push transpose after mul
+    auto oldTranspose = cast<ONNXTransposeOp>(transposeOp);
+
+    auto transposePerm = oldTranspose.getPerm();
+    if (!transposePerm.has_value())
+      return rewriter.notifyMatchFailure(
+          mulOp, "transpose need a fixed permutation");
+    SmallVector<int64_t> perm;
+    ArrayAttrIntVals(*transposePerm, perm);
+
+    scale = create.onnx.upRank(scale, getRank(Y.getType()));
+    auto transposedMulInput =
+        create.onnx.transposeInt64(scale, invertPermutationVector(perm));
+    auto newMulOp = create.onnx.mul(Y, transposedMulInput);
+    // fuseScaleInLayernorm(rewriter, newMulOp, layerNorm)
+    rewriter.replaceOpWithNewOp<ONNXTransposeOp>(
+        mulOp, transposedY.getType(), newMulOp, *transposePerm);
+    return llvm::success();
+  }
+};
+
 struct RecomposeGeluFromMulPattern : public OpRewritePattern<ONNXMulOp> {
   using OpRewritePattern<ONNXMulOp>::OpRewritePattern;
 
@@ -733,8 +855,8 @@ struct RecomposeGeluFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     // Two associative cases depending on which Mul 0.5 belongs to:
     // - 0.5 * (a * b)
     // - (0.5 * a) * b
-    // For each case, we have four communitive cases: 2 for the outer Mul and 2
-    // for the inner Mul. In total, we handle 8 cases.
+    // For each case, we have four communitive cases: 2 for the outer Mul and
+    // 2 for the inner Mul. In total, we handle 8 cases.
     Value lhs = mulOp.getOperand(0);
     Value rhs = mulOp.getOperand(1);
 
@@ -985,8 +1107,8 @@ struct RecomposeDepthToSpace : public OpRewritePattern<ONNXReshapeOp> {
     if (!transposePred(perms))
       return std::nullopt;
 
-    // Check for concrete reshape pattern. This pattern applies to both DCR and
-    // CRD modes:
+    // Check for concrete reshape pattern. This pattern applies to both DCR
+    // and CRD modes:
     //   reshape NxC//(B*B)xHxBxWxB -> NxC//(B*B)x(HxB)x(WxB)
     auto sndReshapeInTy = cast<ShapedType>(t.getType());
     ArrayRef<int64_t> sndReshapeInShape = sndReshapeInTy.getShape();
@@ -1264,8 +1386,8 @@ struct CombineParallelConv2DPattern : public OpRewritePattern<ONNXConvOp> {
       }
       return false;
     };
-    // Ensure all convolutions are really parallel, none of then can be part of
-    // the input of another convolution
+    // Ensure all convolutions are really parallel, none of then can be part
+    // of the input of another convolution
     if (llvm::any_of(parallelConvs, checkIfOtherConvsReachable)) {
       return rewriter.notifyMatchFailure(
           convOp1, "conv ops are not parallel (reachable from each other)");
@@ -1364,8 +1486,8 @@ struct CombineParallelConv2DPattern : public OpRewritePattern<ONNXConvOp> {
       for (size_t i = 0; i < parallelConvs.size(); ++i) {
         rewriter.replaceAllOpUsesWith(parallelConvs[i], splitResults[i]);
       }
-      // Sort the block topological, as the operations after the split may be in
-      // the wrong place otherwise
+      // Sort the block topological, as the operations after the split may be
+      // in the wrong place otherwise
       mlir::sortTopologically(newConv->getBlock());
     }
     for (auto conv : parallelConvs) {
@@ -1459,9 +1581,15 @@ void onnx_mlir::getRecomposeONNXToONNXPatterns(
     mlir::RewritePatternSet &patterns, bool recomposeLayernormByTranspose) {
   MLIRContext *context = patterns.getContext();
   patterns.insert<RecomposeGeluFromMulPattern>(context);
-  patterns.insert<RecomposeLayerNormFromMulPattern<false>>(context);
-  if (recomposeLayernormByTranspose)
-    patterns.insert<RecomposeLayerNormFromMulPattern<true>>(context);
+  patterns.insert<RecomposeLayerNormFromDivPattern<ONNXDivOp, false>>(context);
+  patterns.insert<RecomposeLayerNormFromDivPattern<ONNXMulOp, false>>(context);
+  patterns.insert<RecomposeLayerNormFromDivPattern<ONNXPowOp, false>>(context);
+  if (recomposeLayernormByTranspose) {
+    patterns.insert<RecomposeLayerNormFromDivPattern<ONNXDivOp, true>>(context);
+    patterns.insert<RecomposeLayerNormFromDivPattern<ONNXMulOp, true>>(context);
+    patterns.insert<RecomposeLayerNormFromDivPattern<ONNXPowOp, true>>(context);
+  }
+  patterns.insert<PushTransposeDownScalePattern>(context);
   patterns.insert<RecomposeDepthToSpaceCRD>(context);
   patterns.insert<RecomposeDepthToSpaceDCR>(context);
   // AMD Disabled as downstream has no special support for it

--- a/test/mlir/onnx/onnx_recompose.mlir
+++ b/test/mlir/onnx/onnx_recompose.mlir
@@ -1,3 +1,4 @@
+// Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 // RUN: onnx-mlir-opt --recompose-onnx --canonicalize %s -split-input-file | FileCheck %s
 
 // -----
@@ -393,6 +394,33 @@ func.func @not_a_layer_norm_with_div_by_two(%input: tensor<1x384x768xf32>, %scal
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @not_a_layer_norm_with_div_by_two
 // CHECK-NOT:       "onnx.LayerNormalization"
+// CHECK:         }
+}
+
+// -----
+
+func.func @layernorm_with_double_mul(%arg0: tensor<1x1370x384xf32>, %arg1: tensor<1x1370x384xf32>, %arg2: tensor<384xf32>, %arg3: tensor<384xf32>) -> (tensor<1x1370x384xf32>, tensor<1x1370x384xf32>) {
+  %0 = onnx.Constant dense<3.0> : tensor<f32>
+  %1 = "onnx.Add"(%arg0, %arg1) : (tensor<1x1370x384xf32>, tensor<1x1370x384xf32>) -> tensor<1x1370x384xf32>
+  %2 = "onnx.ReduceMeanV13"(%1) {axes = [-1], keepdims = 1 : si64} : (tensor<1x1370x384xf32>) -> tensor<1x1370x1xf32>
+  %3 = "onnx.Sub"(%1, %2) : (tensor<1x1370x384xf32>, tensor<1x1370x1xf32>) -> tensor<1x1370x384xf32>
+  %4 = "onnx.Mul"(%3, %3) : (tensor<1x1370x384xf32>, tensor<1x1370x384xf32>) -> tensor<1x1370x384xf32>
+  %5 = "onnx.ReduceMeanV13"(%4) {axes = [-1], keepdims = 1 : si64} : (tensor<1x1370x384xf32>) -> tensor<1x1370x1xf32>
+  %6 = "onnx.Add"(%5, %0) : (tensor<1x1370x1xf32>, tensor<f32>) -> tensor<1x1370x1xf32>
+  %7 = "onnx.Sqrt"(%6) : (tensor<1x1370x1xf32>) -> tensor<1x1370x1xf32>
+  %8 = "onnx.Div"(%3, %7) : (tensor<1x1370x384xf32>, tensor<1x1370x1xf32>) -> tensor<1x1370x384xf32>
+  %9 = "onnx.Mul"(%8, %arg2) : (tensor<1x1370x384xf32>, tensor<384xf32>) -> tensor<1x1370x384xf32>
+  %10 = "onnx.Mul"(%8, %arg3) : (tensor<1x1370x384xf32>, tensor<384xf32>) -> tensor<1x1370x384xf32>
+  return %9, %10: tensor<1x1370x384xf32>, tensor<1x1370x384xf32>
+// CHECK-LABEL:  func.func @layernorm_with_double_mul
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1370x384xf32>, [[PARAM_1_:%.+]]: tensor<1x1370x384xf32>, [[PARAM_2_:%.+]]: tensor<384xf32>, [[PARAM_3_:%.+]]: tensor<384xf32>) -> (tensor<1x1370x384xf32>, tensor<1x1370x384xf32>) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<384xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<1x1370x384xf32>, tensor<1x1370x384xf32>) -> tensor<1x1370x384xf32>
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_2_]], [[VAR_0_]], [[VAR_1_]]) {axis = 2 : si64, epsilon = 3.000000e+00 : f32, stash_type = 1 : si64} : (tensor<1x1370x384xf32>, tensor<384xf32>, none) -> (tensor<1x1370x384xf32>, none, none)
+// CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Mul"([[VAR_Y_]], [[PARAM_2_]]) : (tensor<1x1370x384xf32>, tensor<384xf32>) -> tensor<1x1370x384xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Mul"([[VAR_Y_]], [[PARAM_3_]]) : (tensor<1x1370x384xf32>, tensor<384xf32>) -> tensor<1x1370x384xf32>
+// CHECK:           return [[VAR_3_]], [[VAR_4_]] : tensor<1x1370x384xf32>, tensor<1x1370x384xf32>
 // CHECK:         }
 }
 

--- a/test/mlir/onnx/onnx_recompose_layernorm_with_transpose.mlir
+++ b/test/mlir/onnx/onnx_recompose_layernorm_with_transpose.mlir
@@ -1,3 +1,4 @@
+// Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 // RUN: onnx-mlir-opt -split-input-file --recompose-onnx="recompose-layernorm-by-transpose" --canonicalize %s | FileCheck %s
 
 func.func @decomposition_to_layernorm_axis_1(%arg0: tensor<1x4x128x128xf32>) -> tensor<1x4x128x128xf32> {
@@ -21,13 +22,13 @@ func.func @decomposition_to_layernorm_axis_1(%arg0: tensor<1x4x128x128xf32>) -> 
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.0970484465]{{.}}, {{.}}[0.0882187337]{{.}}, {{.}}[0.135120019]{{.}}, {{.}}[0.14907673]{{.}}{{.}}> : tensor<4x1x1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.191972837]{{.}}, {{.}}[0.286264896]{{.}}, {{.}}[0.180535644]{{.}}, {{.}}[0.166878015]{{.}}{{.}}> : tensor<4x1x1xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 4, 1, 1]> : tensor<4xi64>
-// CHECK:           [[VAR_3_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x1x4xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x128x128xf32>) -> tensor<1x128x128x4xf32>
 // CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.Reshape"([[VAR_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
-// CHECK:           [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_6_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x1x4xf32>
-// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_5_]], [[VAR_4_]], [[VAR_7_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, tensor<1x1x1x4xf32>) -> (tensor<1x128x128x4xf32>, none, none)
-// CHECK:           [[VAR_8_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_6_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x1x4xf32>
+// CHECK-DAG:       [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_5_]], [[VAR_4_]], [[VAR_7_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, tensor<1x1x1x4xf32>) -> (tensor<1x128x128x4xf32>, none, none)
+// CHECK-DAG:       [[VAR_8_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
 // CHECK:           return [[VAR_8_]] : tensor<1x4x128x128xf32>
 // CHECK:         }
 
@@ -52,13 +53,13 @@ func.func @decomposition_to_layernorm_axis_2(%arg0: tensor<1x128x4x128xf32> {onn
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x128x4x128xf32> {onnx.name = "in0"}) -> (tensor<1x128x4x128xf32> {onnx.name = "out"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.976699769], [0.380195737], [0.923246204], [0.261692435]{{.}}{{.}}> : tensor<1x4x1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 1, 4, 1]> : tensor<4xi64>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x4x1xf32>, tensor<4xi64>) -> tensor<1x1x4x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x4x1xf32>, tensor<4xi64>) -> tensor<1x1x4x1xf32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Transpose"([[VAR_2_]]) {perm = [0, 1, 3, 2]} : (tensor<1x1x4x1xf32>) -> tensor<1x1x1x4xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 1, 3, 2]} : (tensor<1x128x4x128xf32>) -> tensor<1x128x128x4xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x4x1xf32>, tensor<4xi64>) -> tensor<1x1x4x1xf32>
-// CHECK:           [[VAR_6_:%.+]] = "onnx.Transpose"([[VAR_5_]]) {perm = [0, 1, 3, 2]} : (tensor<1x1x4x1xf32>) -> tensor<1x1x1x4xf32>
-// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_4_]], [[VAR_3_]], [[VAR_6_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, tensor<1x1x1x4xf32>) -> (tensor<1x128x128x4xf32>, none, none)
-// CHECK:           [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 1, 3, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x128x4x128xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.Transpose"([[VAR_5_]]) {perm = [0, 1, 3, 2]} : (tensor<1x1x4x1xf32>) -> tensor<1x1x1x4xf32>
+// CHECK-DAG:       [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_4_]], [[VAR_3_]], [[VAR_6_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, tensor<1x1x1x4xf32>) -> (tensor<1x128x128x4xf32>, none, none)
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 1, 3, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x128x4x128xf32>
 // CHECK:           onnx.Return [[VAR_7_]] : tensor<1x128x4x128xf32>
 // CHECK:         }
 
@@ -83,13 +84,13 @@ func.func @decomposition_to_layernorm_axis_1_and_2(%arg0: tensor<1x4x128x128xf32
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x128x128xf32> {onnx.name = "in0"}) -> (tensor<1x4x128x128xf32> {onnx.name = "out"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.976699769]{{.}}, {{.}}[0.380195737]{{.}}, {{.}}[0.923246204]{{.}}, {{.}}[0.261692435]{{.}}{{.}}> : tensor<4x1x1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 4, 1, 1]> : tensor<4xi64>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Transpose"([[VAR_2_]]) {perm = [0, 3, 1, 2]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x4x1xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 3, 1, 2]} : (tensor<1x4x128x128xf32>) -> tensor<1x128x4x128xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
-// CHECK:           [[VAR_6_:%.+]] = "onnx.Transpose"([[VAR_5_]]) {perm = [0, 3, 1, 2]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x4x1xf32>
-// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_4_]], [[VAR_3_]], [[VAR_6_]]) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x4x128xf32>, tensor<1x1x4x1xf32>, tensor<1x1x4x1xf32>) -> (tensor<1x128x4x128xf32>, none, none)
-// CHECK:           [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 2, 3, 1]} : (tensor<1x128x4x128xf32>) -> tensor<1x4x128x128xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.Transpose"([[VAR_5_]]) {perm = [0, 3, 1, 2]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x4x1xf32>
+// CHECK-DAG:       [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_4_]], [[VAR_3_]], [[VAR_6_]]) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x4x128xf32>, tensor<1x1x4x1xf32>, tensor<1x1x4x1xf32>) -> (tensor<1x128x4x128xf32>, none, none)
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 2, 3, 1]} : (tensor<1x128x4x128xf32>) -> tensor<1x4x128x128xf32>
 // CHECK:           onnx.Return [[VAR_7_]] : tensor<1x4x128x128xf32>
 // CHECK:         }
 
@@ -114,12 +115,12 @@ func.func @decomposition_to_layernorm_axis_1_and_3(%arg0: tensor<1x4x128x128xf32
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x128x128xf32> {onnx.name = "in0"}) -> (tensor<1x4x128x128xf32> {onnx.name = "out"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.976699769]{{.}}, {{.}}[0.380195737]{{.}}, {{.}}[0.923246204]{{.}}, {{.}}[0.261692435]{{.}}{{.}}> : tensor<4x1x1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 4, 1, 1]> : tensor<4xi64>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Transpose"([[VAR_2_]]) {perm = [0, 2, 1, 3]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x4x1xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 1, 3]} : (tensor<1x4x128x128xf32>) -> tensor<1x128x4x128xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
-// CHECK:           [[VAR_6_:%.+]] = "onnx.Transpose"([[VAR_5_]]) {perm = [0, 2, 1, 3]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x4x1xf32>
-// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_4_]], [[VAR_3_]], [[VAR_6_]]) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x4x128xf32>, tensor<1x1x4x1xf32>, tensor<1x1x4x1xf32>) -> (tensor<1x128x4x128xf32>, none, none)
-// CHECK:           [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 2, 1, 3]} : (tensor<1x128x4x128xf32>) -> tensor<1x4x128x128xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.Transpose"([[VAR_5_]]) {perm = [0, 2, 1, 3]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x4x1xf32>
+// CHECK-DAG:       [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_4_]], [[VAR_3_]], [[VAR_6_]]) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x4x128xf32>, tensor<1x1x4x1xf32>, tensor<1x1x4x1xf32>) -> (tensor<1x128x4x128xf32>, none, none)
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 2, 1, 3]} : (tensor<1x128x4x128xf32>) -> tensor<1x4x128x128xf32>
 // CHECK:           onnx.Return [[VAR_7_]] : tensor<1x4x128x128xf32>
 // CHECK:         }

--- a/test/mlir/onnx/onnx_recompose_layernorm_with_transpose.mlir
+++ b/test/mlir/onnx/onnx_recompose_layernorm_with_transpose.mlir
@@ -235,3 +235,22 @@ func.func @partly_decomposition_to_layernorm_axis_1_and_3(%arg0: tensor<1x4x128x
 // CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 2, 1, 3]} : (tensor<1x128x4x128xf32>) -> tensor<1x4x128x128xf32>
 // CHECK:           onnx.Return [[VAR_7_]] : tensor<1x4x128x128xf32>
 // CHECK:         }
+
+// -----
+
+func.func @partly_decomposition_to_layernorm_non_constant_mul(%arg0: tensor<1x4x128x128xf32> {onnx.name = "in0"}, %arg1: tensor<4x1x1xf32>) -> (tensor<1x4x128x128xf32> {onnx.name = "out"}) {
+  %0 = onnx.Constant dense<1.000000e+00> : tensor<128xf32>
+  %1 = onnx.Constant dense<[[[0.976699769]], [[0.380195737]], [[0.923246204]], [[0.261692435]]]> : tensor<4x1x1xf32>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.Transpose"(%arg0) {perm = [0, 2, 1, 3]} : (tensor<1x4x128x128xf32>) -> tensor<1x128x4x128xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%3, %0, %2) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x4x128xf32>, tensor<128xf32>, none) -> (tensor<1x128x4x128xf32>, none, none)
+  %4 = "onnx.Transpose"(%Y) {perm = [0, 2, 1, 3]} : (tensor<1x128x4x128xf32>) -> tensor<1x4x128x128xf32>
+  %5 = "onnx.Mul"(%4, %arg1) : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  %6 = "onnx.Add"(%5, %1) {onnx_node_name = "Add12"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  onnx.Return %6 : tensor<1x4x128x128xf32>
+}
+// CHECK-LABEL:  func.func @partly_decomposition_to_layernorm_non_constant_mul
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x128x128xf32> {{.*}}, [[PARAM_1_:%.+]]: tensor<4x1x1xf32>)
+// CHECK:           "onnx.LayerNormalization"
+// CHECK:           [[VAR_T_:%.+]] = "onnx.Transpose"
+// CHECK:           "onnx.Mul"([[VAR_T_]], [[PARAM_1_]]) : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>)

--- a/test/mlir/onnx/onnx_recompose_layernorm_with_transpose.mlir
+++ b/test/mlir/onnx/onnx_recompose_layernorm_with_transpose.mlir
@@ -124,3 +124,114 @@ func.func @decomposition_to_layernorm_axis_1_and_3(%arg0: tensor<1x4x128x128xf32
 // CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 2, 1, 3]} : (tensor<1x128x4x128xf32>) -> tensor<1x4x128x128xf32>
 // CHECK:           onnx.Return [[VAR_7_]] : tensor<1x4x128x128xf32>
 // CHECK:         }
+
+// -----
+// these are the exact same test cases as above but already partly recomposed to test the transpose pushing
+
+func.func @partly_decomposition_to_layernorm_axis_1(%arg0: tensor<1x4x128x128xf32>) -> tensor<1x4x128x128xf32> {
+  %0 = onnx.Constant dense<1.000000e+00> : tensor<4xf32>
+  %1 = onnx.Constant dense<[[[0.0970484465]], [[0.0882187337]], [[0.135120019]], [[0.14907673]]]> : tensor<4x1x1xf32>
+  %2 = onnx.Constant dense<[[[0.191972837]], [[0.286264896]], [[0.180535644]], [[0.166878015]]]> : tensor<4x1x1xf32>
+  %3 = "onnx.NoValue"() {value} : () -> none
+  %4 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x4x128x128xf32>) -> tensor<1x128x128x4xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%4, %0, %3) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<4xf32>, none) -> (tensor<1x128x128x4xf32>, none, none)
+  %5 = "onnx.Transpose"(%Y) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+  %6 = "onnx.Mul"(%5, %1) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Mul_2"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  %7 = "onnx.Add"(%6, %2) {onnx_node_name = "/mask_downscaling/mask_downscaling.1/Add_1"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  return %7 : tensor<1x4x128x128xf32>
+}
+// CHECK-LABEL:  func.func @partly_decomposition_to_layernorm_axis_1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x128x128xf32>) -> tensor<1x4x128x128xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.0970484465]{{.}}, {{.}}[0.0882187337]{{.}}, {{.}}[0.135120019]{{.}}, {{.}}[0.14907673]{{.}}{{.}}> : tensor<4x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.191972837]{{.}}, {{.}}[0.286264896]{{.}}, {{.}}[0.180535644]{{.}}, {{.}}[0.166878015]{{.}}{{.}}> : tensor<4x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 4, 1, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x1x4xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x128x128xf32>) -> tensor<1x128x128x4xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.Reshape"([[VAR_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_6_]]) {perm = [0, 2, 3, 1]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x1x4xf32>
+// CHECK-DAG:       [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_5_]], [[VAR_4_]], [[VAR_7_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, tensor<1x1x1x4xf32>) -> (tensor<1x128x128x4xf32>, none, none)
+// CHECK-DAG:       [[VAR_8_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 3, 1, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           return [[VAR_8_]] : tensor<1x4x128x128xf32>
+// CHECK:         }
+
+// -----
+
+func.func @partly_decomposition_to_layernorm_axis_2(%arg0: tensor<1x128x4x128xf32> {onnx.name = "in0"}) -> (tensor<1x128x4x128xf32> {onnx.name = "out"}) {
+  %0 = onnx.Constant dense<1.000000e+00> : tensor<4xf32>
+  %1 = onnx.Constant dense<[[[0.976699769], [0.380195737], [0.923246204], [0.261692435]]]> : tensor<1x4x1xf32>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.Transpose"(%arg0) {perm = [0, 1, 3, 2]} : (tensor<1x128x4x128xf32>) -> tensor<1x128x128x4xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%3, %0, %2) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<4xf32>, none) -> (tensor<1x128x128x4xf32>, none, none)
+  %4 = "onnx.Transpose"(%Y) {perm = [0, 1, 3, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x128x4x128xf32>
+  %5 = "onnx.Mul"(%4, %1) : (tensor<1x128x4x128xf32>, tensor<1x4x1xf32>) -> tensor<1x128x4x128xf32>
+  %6 = "onnx.Add"(%5, %1) {onnx_node_name = "Add12"} : (tensor<1x128x4x128xf32>, tensor<1x4x1xf32>) -> tensor<1x128x4x128xf32>
+  onnx.Return %6 : tensor<1x128x4x128xf32>
+}
+// CHECK-LABEL:  func.func @partly_decomposition_to_layernorm_axis_2
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x128x4x128xf32> {onnx.name = "in0"}) -> (tensor<1x128x4x128xf32> {onnx.name = "out"}) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.976699769], [0.380195737], [0.923246204], [0.261692435]{{.}}{{.}}> : tensor<1x4x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 1, 4, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x4x1xf32>, tensor<4xi64>) -> tensor<1x1x4x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Transpose"([[VAR_2_]]) {perm = [0, 1, 3, 2]} : (tensor<1x1x4x1xf32>) -> tensor<1x1x1x4xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 1, 3, 2]} : (tensor<1x128x4x128xf32>) -> tensor<1x128x128x4xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x4x1xf32>, tensor<4xi64>) -> tensor<1x1x4x1xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.Transpose"([[VAR_5_]]) {perm = [0, 1, 3, 2]} : (tensor<1x1x4x1xf32>) -> tensor<1x1x1x4xf32>
+// CHECK-DAG:       [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_4_]], [[VAR_3_]], [[VAR_6_]]) {axis = 3 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x128x4xf32>, tensor<1x1x1x4xf32>, tensor<1x1x1x4xf32>) -> (tensor<1x128x128x4xf32>, none, none)
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 1, 3, 2]} : (tensor<1x128x128x4xf32>) -> tensor<1x128x4x128xf32>
+// CHECK:           onnx.Return [[VAR_7_]] : tensor<1x128x4x128xf32>
+// CHECK:         }
+
+// -----
+
+func.func @partly_decomposition_to_layernorm_axis_1_and_2(%arg0: tensor<1x4x128x128xf32> {onnx.name = "in0"}) -> (tensor<1x4x128x128xf32> {onnx.name = "out"}) {
+  %0 = onnx.Constant dense<1.000000e+00> : tensor<128xf32>
+  %1 = onnx.Constant dense<[[[0.976699769]], [[0.380195737]], [[0.923246204]], [[0.261692435]]]> : tensor<4x1x1xf32>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.Transpose"(%arg0) {perm = [0, 3, 1, 2]} : (tensor<1x4x128x128xf32>) -> tensor<1x128x4x128xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%3, %0, %2) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x4x128xf32>, tensor<128xf32>, none) -> (tensor<1x128x4x128xf32>, none, none)
+  %4 = "onnx.Transpose"(%Y) {perm = [0, 2, 3, 1]} : (tensor<1x128x4x128xf32>) -> tensor<1x4x128x128xf32>
+  %5 = "onnx.Mul"(%4, %1) : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  %6 = "onnx.Add"(%5, %1) {onnx_node_name = "Add12"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  onnx.Return %6 : tensor<1x4x128x128xf32>
+}
+// CHECK-LABEL:  func.func @partly_decomposition_to_layernorm_axis_1_and_2
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x128x128xf32> {onnx.name = "in0"}) -> (tensor<1x4x128x128xf32> {onnx.name = "out"}) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.976699769]{{.}}, {{.}}[0.380195737]{{.}}, {{.}}[0.923246204]{{.}}, {{.}}[0.261692435]{{.}}{{.}}> : tensor<4x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 4, 1, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Transpose"([[VAR_2_]]) {perm = [0, 3, 1, 2]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x4x1xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 3, 1, 2]} : (tensor<1x4x128x128xf32>) -> tensor<1x128x4x128xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.Transpose"([[VAR_5_]]) {perm = [0, 3, 1, 2]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x4x1xf32>
+// CHECK-DAG:       [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_4_]], [[VAR_3_]], [[VAR_6_]]) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x4x128xf32>, tensor<1x1x4x1xf32>, tensor<1x1x4x1xf32>) -> (tensor<1x128x4x128xf32>, none, none)
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 2, 3, 1]} : (tensor<1x128x4x128xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           onnx.Return [[VAR_7_]] : tensor<1x4x128x128xf32>
+// CHECK:         }
+
+// -----
+
+func.func @partly_decomposition_to_layernorm_axis_1_and_3(%arg0: tensor<1x4x128x128xf32> {onnx.name = "in0"}) -> (tensor<1x4x128x128xf32> {onnx.name = "out"}) {
+  %0 = onnx.Constant dense<1.000000e+00> : tensor<128xf32>
+  %1 = onnx.Constant dense<[[[0.976699769]], [[0.380195737]], [[0.923246204]], [[0.261692435]]]> : tensor<4x1x1xf32>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.Transpose"(%arg0) {perm = [0, 2, 1, 3]} : (tensor<1x4x128x128xf32>) -> tensor<1x128x4x128xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%3, %0, %2) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x4x128xf32>, tensor<128xf32>, none) -> (tensor<1x128x4x128xf32>, none, none)
+  %4 = "onnx.Transpose"(%Y) {perm = [0, 2, 1, 3]} : (tensor<1x128x4x128xf32>) -> tensor<1x4x128x128xf32>
+  %5 = "onnx.Mul"(%4, %1) : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  %6 = "onnx.Add"(%5, %1) {onnx_node_name = "Add12"} : (tensor<1x4x128x128xf32>, tensor<4x1x1xf32>) -> tensor<1x4x128x128xf32>
+  onnx.Return %6 : tensor<1x4x128x128xf32>
+}
+// CHECK-LABEL:  func.func @partly_decomposition_to_layernorm_axis_1_and_3
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x128x128xf32> {onnx.name = "in0"}) -> (tensor<1x4x128x128xf32> {onnx.name = "out"}) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[0.976699769]{{.}}, {{.}}[0.380195737]{{.}}, {{.}}[0.923246204]{{.}}, {{.}}[0.261692435]{{.}}{{.}}> : tensor<4x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 4, 1, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Transpose"([[VAR_2_]]) {perm = [0, 2, 1, 3]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x4x1xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 1, 3]} : (tensor<1x4x128x128xf32>) -> tensor<1x128x4x128xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[VAR_0_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<4x1x1xf32>, tensor<4xi64>) -> tensor<1x4x1x1xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.Transpose"([[VAR_5_]]) {perm = [0, 2, 1, 3]} : (tensor<1x4x1x1xf32>) -> tensor<1x1x4x1xf32>
+// CHECK-DAG:       [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_4_]], [[VAR_3_]], [[VAR_6_]]) {axis = 2 : si64, epsilon = 9.99999997E-7 : f32, stash_type = 1 : si64} : (tensor<1x128x4x128xf32>, tensor<1x1x4x1xf32>, tensor<1x1x4x1xf32>) -> (tensor<1x128x4x128xf32>, none, none)
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_Y_]]) {perm = [0, 2, 1, 3]} : (tensor<1x128x4x128xf32>) -> tensor<1x4x128x128xf32>
+// CHECK:           onnx.Return [[VAR_7_]] : tensor<1x4x128x128xf32>
+// CHECK:         }


### PR DESCRIPTION
When models have multiple scales, we can match them anyway by providing a scale of 1.
For the normal case, we can fuse it together afterwards.

- The fusing was already in place (just in connection with transpose it needed adaption).
- The operation order after transforming with transpose was different. I adapted the LIT tests accordingly.

## High-Level Explanation:

Previously, only the mul operation was matched that multiplied the scale of the LayerNorm operation. Then, it were matched in three different branches for all possibilities of operations coming before that, so basically:
```c++
struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp>{
    LogicalResult matchAndRewrite(ONNXMulOp mulOp, PatternRewriter &rewriter) const final {
        // do the matching
        if (ONNXDivOp precedes mulOp) {
            match_further1();
        } else if(ONNXPowOp precedes mulOp) {
            match_further2();
        } else if(ONNXMulOp precedes mulOp) {
            match_further3();
        } else {
            fail();
        }
        // do the rewrite
    }
};
```
To split out the mulOp (the scale), I converted this to a template with three specializations:
```c++
template<typename DivOperator>
matchOp(DivOperator divOp, remainingParams) {
    fail();
}
template<>
matchOp(ONNXDivOp divOp, remainingParams) {
    match_further1();
}
template<>
matchOp(ONNXPowOp powOp, remainingParams) {
    match_further2();
}
template<>
matchOp(ONNXMulOp mulOp, remainingParams) {
    match_further3();
}

template<typename DivOperator>
struct RecomposeLayerNormFromDivPattern : public OpRewritePattern<DivOperator>{
    LogicalResult matchAndRewrite(DivOperator divOp, PatternRewriter &rewriter) const final {
        matchOp<DivOperator>(divOp, remainingParams);
        // do the rewrite
    }
};

patterns.add<RecomposeLayerNormFromDivPattern<ONNXDivOp>>();
patterns.add<RecomposeLayerNormFromDivPattern<ONNXPowOp>>();
patterns.add<RecomposeLayerNormFromDivPattern<ONNXMulOp>>();
```
The code inside the template specializations is just copied from the previous branches.