### PR TITLE
fix: Support scenarios that need no Quark quantization

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -57,6 +57,16 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
           opts.enableRecomposeLayernormByTranspose,
           opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose));
     }
+    // If quark quantized legalization is enabled, do a last const prop after it
+    // so that we cover any remaining Cast -> Cast patterns that weren't covered
+    // by the pass.
+    if (opts.enableQuarkQuantizedLegalization) {
+      configureConstPropONNXToONNXPass(/*roundFPToInt=*/false,
+          /*expansionBound=*/-1, /*disabledPatterns=*/{""},
+          /*constantPropIsDisabled=*/false);
+      pm.addNestedPass<func::FuncOp>(
+          onnx_mlir::createConstPropONNXToONNXPass());
+    }
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());

--- a/src/Dialect/ONNX/Transforms/LegalizeQuarkQuantizedOps.cpp
+++ b/src/Dialect/ONNX/Transforms/LegalizeQuarkQuantizedOps.cpp
@@ -294,7 +294,9 @@ public:
     };
 
     // Operands of this new op can be: NoValue's, constants, the operand of an
-    // input cast, or the current op's operand.
+    // input cast, or the current op's operand. We expect at least one input
+    // Cast operator.
+    bool hasAtLeastOneCastInput = false;
     SmallVector<Value> operands;
     llvm::transform(
         op->getOperands(), std::back_inserter(operands), [&](Value operand) {
@@ -305,27 +307,16 @@ public:
           if (onnx_mlir::isNoneValue(operand))
             return operand;
 
-          if (auto constOp = dyn_cast<mlir::ONNXConstantOp>(operandOp)) {
-            auto constValue = createNewConstantOp(rewriter, constOp,
-                constOp->getLoc(), fromFloatType, toFloatType);
-
-            createdOpsTrackerForFailedVerifier.push_back(
-                constValue.getDefiningOp());
-            return constValue;
-          }
-
           if (!isInputCastOp(operandOp, fromFloatType, toFloatType)) {
             return operand;
           }
 
+          hasAtLeastOneCastInput = true;
           newOpLocations.push_back(operandOp->getLoc());
           return cast<mlir::ONNXCastOp>(operandOp).getInput();
         });
 
-    if (llvm::any_of(operands, [&](auto operand) {
-          auto tensorType = dyn_cast<TensorType>(operand.getType());
-          return tensorType && tensorType.getElementType() == fromFloatType;
-        })) {
+    if (!hasAtLeastOneCastInput) {
       // Make sure to erase any additional op that was created so that the
       // rewriter doesn't trigger any changes by this pass.
       removeTrackedOps();

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -165,6 +165,11 @@ struct ONNXHybridTransformPass
 
     if (quarkQuantizedOpsLegalization) {
       getLegalizeQuarkQuantizedOpsPatterns(cumulativePatterns);
+      // Disable CastofConst constant propagation pattern to avoid conflicts
+      // with quark quantized ops legalization which needs to consume Cast ops.
+      configureConstPropONNXToONNXPass(/*roundFPToInt=*/false,
+          /*expansionBound=*/-1, /*disabledPatterns=*/{"CastofConst"},
+          /*constantPropIsDisabled=*/false);
     }
 
     if (canonicalization) {

--- a/test/mlir/onnx/onnx_hybrid_transform_with_quark_legalize_ops.mlir
+++ b/test/mlir/onnx/onnx_hybrid_transform_with_quark_legalize_ops.mlir
@@ -1,0 +1,21 @@
+// RUN: onnx-mlir-opt -onnx-hybrid-transform="canonicalization=true constant-propagation=true decomposition=true enable-convtranspose=false enable-convtranspose-1d-phased=false enable-convtranspose-phased=true enable-instancenorm-decompose=true enable-split-to-slice-decompose=false max-num-rewrites-multiplier=2.000000e-01 max-num-rewrites-offset=20 quark-quantized-ops-legalization=true recompose-layernorm-by-transpose=true recomposition=true shape-inference=true" %s | FileCheck %s
+
+// Illustrates the interaction between 
+
+func.func @resize_test_hybrid_transform(%arg0: tensor<1x256x20x20xf32> {onnx.name = "input"}) -> (tensor<*xbf16> {onnx.name = "output"}) {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = onnx.Constant dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>
+    %2 = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = bf16} : (tensor<1x256x20x20xf32>) -> tensor<*xbf16>
+    %3 = "onnx.Cast"(%2) {saturate = 1 : si64, to = f32} : (tensor<*xbf16>) -> tensor<*xf32>
+    %4 = "onnx.Resize"(%3, %0, %1, %0) {antialias = 0 : si64, coordinate_transformation_mode = "asymmetric", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "floor", onnx_node_name = "/fpn/up/Resize"} : (tensor<*xf32>, none, tensor<4xf32>, none) -> tensor<*xf32>
+    %5 = "onnx.Cast"(%4) {saturate = 1 : si64, to = bf16} : (tensor<*xf32>) -> tensor<*xbf16>
+    onnx.Return %5 : tensor<*xbf16>
+}
+// CHECK-LABEL:  func.func @resize_test_hybrid_transform
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x256x20x20xf32> {onnx.name = "input"}) -> (tensor<1x256x40x40xbf16> {onnx.name = "output"}) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {saturate = 1 : si64, to = bf16} : (tensor<1x256x20x20xf32>) -> tensor<1x256x20x20xbf16>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Resize"([[VAR_2_]], [[VAR_0_]], [[VAR_1_]], [[VAR_0_]]) {antialias = 0 : si64, coordinate_transformation_mode = "asymmetric", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "floor", onnx_node_name = "/fpn/up/Resize"} : (tensor<1x256x20x20xbf16>, none, tensor<4xf32>, none) -> tensor<1x256x40x40xbf16>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<1x256x40x40xbf16>
+// CHECK:         }

--- a/test/mlir/onnx/onnx_legalize_quark_quantized_ops_CastToCastPattern.mlir
+++ b/test/mlir/onnx/onnx_legalize_quark_quantized_ops_CastToCastPattern.mlir
@@ -59,10 +59,11 @@ func.func @test_no_cast_cast_canonicalization(%arg0: tensor<1x1x256x256xbf16>) -
     %2 = "onnx.Add"(%1, %arg0) {onnx_node_name = "/bert/Where_1"} : (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16> loc("add")
     "onnx.Return"(%2) : (tensor<1x1x256x256xbf16>) -> ()
 }
-// CHECK-LABEL:   func.func @test_no_cast_cast_canonicalization(
-// CHECK-SAME:                                                  %[[VAL_0:.*]]: tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16> {
-// CHECK:           %[[VAL_1:.*]] = "onnx.Cast"(%[[VAL_0]]) {saturate = 1 : si64, to = bf16} : (tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16>
-// CHECK:           %[[VAL_2:.*]] = "onnx.Add"(%[[VAL_1]], %[[VAL_0]]) {onnx_node_name = "/bert/Where_1"} : (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16>
-// CHECK:           onnx.Return %[[VAL_2]] : tensor<1x1x256x256xbf16>
+// CHECK-LABEL:  func.func @test_no_cast_cast_canonicalization
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {onnx_node_name = "/bert/Sub_onnx.Cast_39", saturate = 1 : si64, to = f32} : (tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Cast"([[VAR_0_]]) {onnx_node_name = "/bert/Cast_1", saturate = 1 : si64, to = bf16} : (tensor<1x1x256x256xf32>) -> tensor<1x1x256x256xbf16>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Add"([[VAR_1_]], [[PARAM_0_]]) {onnx_node_name = "/bert/Where_1"} : (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x1x256x256xbf16>
 // CHECK:         }
 

--- a/test/mlir/onnx/onnx_legalize_quark_quantized_ops_CastToCastPattern_locations.mlir
+++ b/test/mlir/onnx/onnx_legalize_quark_quantized_ops_CastToCastPattern_locations.mlir
@@ -50,7 +50,7 @@ func.func @test_no_cast_cast_canonicalization(%arg0: tensor<1x1x256x256xbf16>) -
     %0 = "onnx.Cast"(%arg0) {
       onnx_node_name = "/bert/Sub_onnx.Cast_39",
       saturate = 1 : si64,
-      to = f32} : (tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xf32> loc("cast2")
+      to = f32} : (tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xf32> loc("cast1")
     %1 = "onnx.Cast"(%0) {
       onnx_node_name = "/bert/Cast_1",
       saturate = 1 : si64,
@@ -58,9 +58,13 @@ func.func @test_no_cast_cast_canonicalization(%arg0: tensor<1x1x256x256xbf16>) -
     %2 = "onnx.Add"(%1, %arg0) {onnx_node_name = "/bert/Where_1"} : (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16> loc("add")
     "onnx.Return"(%2) : (tensor<1x1x256x256xbf16>) -> ()
 }
-// CHECK-LABEL:   func.func @test_no_cast_cast_canonicalization
-// CHECK:           %[[VAL_1:.*]] = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = bf16} : (tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16>
-// CHECK:           %[[VAL_2:.*]] = "onnx.Add"(%[[VAL_1]], %arg0) {onnx_node_name = "/bert/Where_1"} : (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16>
-// CHECK:           onnx.Return %[[VAL_2]] : tensor<1x1x256x256xbf16>
+// CHECK: test_no_cast_cast_canonicalization
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"(%arg0) {onnx_node_name = "/bert/Sub_onnx.Cast_39", saturate = 1 : si64, to = f32} : (tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xf32> loc(#[[CAST1:.*]])
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Cast"([[VAR_0_]]) {onnx_node_name = "/bert/Cast_1", saturate = 1 : si64, to = bf16} : (tensor<1x1x256x256xf32>) -> tensor<1x1x256x256xbf16> loc(#[[CAST2:.*]])
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Add"([[VAR_1_]], %arg0) {onnx_node_name = "/bert/Where_1"} : (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16> loc(#[[ADD:.*]])
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x1x256x256xbf16>
 // CHECK:         }
 
+// CHECK-DAG: #[[CAST1:.*]] = loc("cast1")
+// CHECK-DAG: #[[CAST2:.*]] = loc("cast2")
+// CHECK-DAG: #[[ADD]] = loc("add")

--- a/test/mlir/onnx/onnx_legalize_quark_quantized_ops_generic_pattern.mlir
+++ b/test/mlir/onnx/onnx_legalize_quark_quantized_ops_generic_pattern.mlir
@@ -347,3 +347,24 @@ func.func @resize(%arg0: tensor<1x256x20x20xf32> {onnx.name = "input"}) -> (tens
 // CHECK:           onnx.Return [[VAR_3_]] : tensor<1x256x40x40xbf16>
 // CHECK:         }
 
+// -----
+
+func.func @resize_not_converted_no_input_cast(%arg0: tensor<1x256x20x20xf32> {onnx.name = "input"}) -> (tensor<1x256x40x40xbf16> {onnx.name = "output"}) {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = onnx.Constant dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>
+    %2 = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = f16} : (tensor<1x256x20x20xf32>) -> tensor<1x256x20x20xf16>
+    %3 = "onnx.Cast"(%2) {saturate = 1 : si64, to = f32} : (tensor<1x256x20x20xf16>) -> tensor<1x256x20x20xf32>
+    %4 = "onnx.Resize"(%3, %0, %1, %0) {antialias = 0 : si64, coordinate_transformation_mode = "asymmetric", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "floor", onnx_node_name = "/fpn/up/Resize"} : (tensor<1x256x20x20xf32>, none, tensor<4xf32>, none) -> tensor<1x256x40x40xf32>
+    %5 = "onnx.Cast"(%4) {saturate = 1 : si64, to = bf16} : (tensor<1x256x40x40xf32>) -> tensor<1x256x40x40xbf16>
+    onnx.Return %5 : tensor<1x256x40x40xbf16>
+}
+// CHECK-LABEL:  func.func @resize_not_converted_no_input_cast
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x256x20x20xf32> {onnx.name = "input"}) -> (tensor<1x256x40x40xbf16> {onnx.name = "output"}) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {saturate = 1 : si64, to = f16} : (tensor<1x256x20x20xf32>) -> tensor<1x256x20x20xf16>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Cast"([[VAR_2_]]) {saturate = 1 : si64, to = f32} : (tensor<1x256x20x20xf16>) -> tensor<1x256x20x20xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Resize"([[VAR_3_]], [[VAR_0_]], [[VAR_1_]], [[VAR_0_]]) {antialias = 0 : si64, coordinate_transformation_mode = "asymmetric", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "floor", onnx_node_name = "/fpn/up/Resize"} : (tensor<1x256x20x20xf32>, none, tensor<4xf32>, none) -> tensor<1x256x40x40xf32>
+// CHECK:           [[VAR_5_:%.+]] = "onnx.Cast"([[VAR_4_]]) {saturate = 1 : si64, to = bf16} : (tensor<1x256x40x40xf32>) -> tensor<1x256x40x40xbf16>
+// CHECK:           onnx.Return [[VAR_5_]] : tensor<1x256x40x40xbf16>
+// CHECK:         }

--- a/test/mlir/onnx/onnx_legalize_quark_quantized_ops_generic_pattern.mlir
+++ b/test/mlir/onnx/onnx_legalize_quark_quantized_ops_generic_pattern.mlir
@@ -326,3 +326,24 @@ func.func @multiple_ops(%arg0: tensor<?x?x?xbf16>, %arg1 : tensor<1x2xi64>, %arg
 // CHECK:           %[[VAL_13:.*]] = "onnx.Add"(%[[VAL_10]], %[[VAL_11]]) : (tensor<?x?x?x?xbf16>, tensor<?x?x?xbf16>) -> tensor<?x?x?x?xbf16>
 // CHECK:           onnx.Return %[[VAL_13]], %[[VAL_10]], %[[VAL_11]], %[[VAL_10]] : tensor<?x?x?x?xbf16>, tensor<?x?x?x?xbf16>, tensor<?x?x?xbf16>, tensor<?x?x?x?xbf16>
 // CHECK:         }
+
+// -----
+
+func.func @resize(%arg0: tensor<1x256x20x20xf32> {onnx.name = "input"}) -> (tensor<1x256x40x40xbf16> {onnx.name = "output"}) {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = onnx.Constant dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>
+    %2 = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = bf16} : (tensor<1x256x20x20xf32>) -> tensor<1x256x20x20xbf16>
+    %3 = "onnx.Cast"(%2) {saturate = 1 : si64, to = f32} : (tensor<1x256x20x20xbf16>) -> tensor<1x256x20x20xf32>
+    %4 = "onnx.Resize"(%3, %0, %1, %0) {antialias = 0 : si64, coordinate_transformation_mode = "asymmetric", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "floor", onnx_node_name = "/fpn/up/Resize"} : (tensor<1x256x20x20xf32>, none, tensor<4xf32>, none) -> tensor<1x256x40x40xf32>
+    %5 = "onnx.Cast"(%4) {saturate = 1 : si64, to = bf16} : (tensor<1x256x40x40xf32>) -> tensor<1x256x40x40xbf16>
+    onnx.Return %5 : tensor<1x256x40x40xbf16>
+}
+// CHECK-LABEL:  func.func @resize
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x256x20x20xf32> {onnx.name = "input"}) -> (tensor<1x256x40x40xbf16> {onnx.name = "output"}) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {saturate = 1 : si64, to = bf16} : (tensor<1x256x20x20xf32>) -> tensor<1x256x20x20xbf16>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Resize"([[VAR_2_]], [[VAR_0_]], [[VAR_1_]], [[VAR_0_]]) {antialias = 0 : si64, coordinate_transformation_mode = "asymmetric", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "floor", onnx_node_name = "/fpn/up/Resize"} : (tensor<1x256x20x20xbf16>, none, tensor<4xf32>, none) -> tensor<1x256x40x40xbf16>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<1x256x40x40xbf16>
+// CHECK:         }
+

--- a/test/mlir/onnx/parse/test_quark_pass_with_conv.json
+++ b/test/mlir/onnx/parse/test_quark_pass_with_conv.json
@@ -2,10 +2,10 @@
 // Json generated with utils/onnx2json.py
 // CHECK-LABEL:   func.func @main_graph(
 // CHECK-SAME:                          %[[VAL_0:.*]]: tensor<1x1x32x32xbf16> {onnx.name = "input"}) -> (tensor<1x1x30x30xbf16> {onnx.name = "cast_out0"}) {
-// CHECK:    %[[VAL_2:.*]] = onnx.Constant dense<1.500000e+00> : tensor<1xbf16>
-// CHECK:    %[[VAL_1:.*]] = onnx.Constant dense<{{\[\[}}{{\[\[}}0.000000e+00, 1.000000e+00, -1.000000e+00], [0.000000e+00, 1.000000e+00, 0.000000e+00], [-1.000000e+00, 1.000000e+00, -1.000000e+00]]]]> : tensor<1x1x3x3xbf16>
-// CHECK:    %[[VAL_3:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], onnx_node_name = "Conv6", pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x32x32xbf16>, tensor<1x1x3x3xbf16>, tensor<1xbf16>) -> tensor<1x1x30x30xbf16>
-// CHECK:    return %[[VAL_3]] : tensor<1x1x30x30xbf16>
+// CHECK-DAG:    %[[VAL_2:.*]] = onnx.Constant dense<1.500000e+00> : tensor<1xbf16>
+// CHECK-DAG:    %[[VAL_1:.*]] = onnx.Constant dense<{{\[\[}}{{\[\[}}0.000000e+00, 1.000000e+00, -1.000000e+00], [0.000000e+00, 1.000000e+00, 0.000000e+00], [-1.000000e+00, 1.000000e+00, -1.000000e+00]]]]> : tensor<1x1x3x3xbf16>
+// CHECK-DAG:    %[[VAL_3:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], onnx_node_name = "Conv6", pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x32x32xbf16>, tensor<1x1x3x3xbf16>, tensor<1xbf16>) -> tensor<1x1x30x30xbf16>
+// CHECK-DAG:    return %[[VAL_3]] : tensor<1x1x30x30xbf16>
 // CHECK:  }
 // CHECK:  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 {
@@ -37,6 +37,24 @@
           "weight"
         ],
         "output": [
+          "cast_weight1"
+        ],
+        "name": "Cast4",
+        "opType": "Cast",
+        "attribute": [
+          {
+            "name": "to",
+            "i": "16",
+            "type": "INT"
+          }
+        ],
+        "domain": ""
+      },
+      {
+        "input": [
+          "cast_weight1"
+        ],
+        "output": [
           "cast_weight"
         ],
         "name": "Cast4",
@@ -53,6 +71,24 @@
       {
         "input": [
           "bias"
+        ],
+        "output": [
+          "cast_bias2"
+        ],
+        "name": "Cast5",
+        "opType": "Cast",
+        "attribute": [
+          {
+            "name": "to",
+            "i": "16",
+            "type": "INT"
+          }
+        ],
+        "domain": ""
+      },
+      {
+        "input": [
+          "cast_bias2"
         ],
         "output": [
           "cast_bias"


### PR DESCRIPTION
Quark legalization pass required that all `f32` operands of an operator needed to be a `Cast(f32) -> bf16`. However, some operations like, `Resize` won't have all operands with a Cast. E.g., the `scales` operands can only be of dtype `F32` or `None`, so it isn't expected that said operand has a Cast. 
This PR makes sure to address this issue by assuming that Quark quantizer uses the correct assumptions in terms of when a Cast needs to be added. Since this pass isn't very often used, such an assumption isn't very much problematic.
Another issue related to having to defer the constant propagation of Cast ops in order for the matching to work properly. This is also fixed and THIS CHANGES WON'T IMPACT THE CURRENT FLOW.