### PR TITLE
FronendDialectHelper: fix data length checking

### DIFF
--- a/src/Builder/FrontendDialectHelper.cpp
+++ b/src/Builder/FrontendDialectHelper.cpp
@@ -76,7 +76,8 @@ std::unique_ptr<llvm::MemoryBuffer> readExternalData_LE(
   }
 
   const uint64_t requiredSize = offset + length;
-  if (requiredSize > fileSize) {
+  if (offset > fileSize ||
+      (length != uint64_t(-1) && requiredSize > fileSize)) {
     llvm::errs() << "Error: External data file " << pathStr
                  << " is too small.\n"
                  << "  File size: " << fileSize << " bytes\n"


### PR DESCRIPTION
A length value of -1 is a valid value and makes the MemoryBuffer find out the file length by itself.