### PR TITLE
[AIESW-23180] Duplicate onnx.DequantizeLinear if it has multiple consumers while removing binary op

### DIFF
--- a/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/DQBinaryQOpt.cpp
@@ -858,19 +858,88 @@ public:
       if (!state.dstNode)
         return rewriter.notifyMatchFailure(op, "dstNode not set");
 
-      if constexpr (std::is_same_v<BinOp, ONNXAddOp> ||
-                    std::is_same_v<BinOp, ONNXSubOp>) {
-        // Update zero-point (for Add/Sub)
-        updateInitializer(rewriter, state.dstNode, state.dstZeroPointValue,
-            static_cast<double>(state.newZp));
-      } else if constexpr (std::is_same_v<BinOp, ONNXMulOp> ||
-                           std::is_same_v<BinOp, ONNXDivOp>) {
-        // Update scale (for Mul/Div)
-        updateInitializer(
-            rewriter, state.dstNode, state.dstScaleValue, state.newScale);
+      // Check if we're folding into a DQ that has multiple users
+      // If so, we need to duplicate the DQ before updating its scale
+      bool needDqDuplication = false;
+      ONNXDequantizeLinearOp dqToDuplicate = nullptr;
+      if (auto dstDq = llvm::dyn_cast<ONNXDequantizeLinearOp>(state.dstNode)) {
+        // Check if the DQ output has multiple users (excluding the binary op)
+        auto dqResult = dstDq.getY();
+        int userCount = 0;
+        for (auto *user : dqResult.getUsers()) {
+          if (user != op.getOperation()) {
+            userCount++;
+          }
+        }
+        if (userCount > 0) {
+          needDqDuplication = true;
+          dqToDuplicate = dstDq;
+        }
+      }
+
+      if (needDqDuplication && dqToDuplicate) {
+        // Duplicate the DQ operation with updated scale/zero-point
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointAfter(dqToDuplicate);
+
+        // Create new scale/zero-point constants with updated values
+        mlir::Value newScaleValue = state.dstScaleValue;
+        mlir::Value newZpValue = state.dstZeroPointValue;
+
+        if constexpr (std::is_same_v<BinOp, ONNXAddOp> ||
+                      std::is_same_v<BinOp, ONNXSubOp>) {
+          // Create new zero-point constant
+          auto zpLikeTy = mlir::dyn_cast<ShapedType>(state.dstZeroPointValue.getType());
+          if (zpLikeTy) {
+            auto zpPayload = makeScalarDEA(zpLikeTy, static_cast<double>(state.newZp));
+            if (zpPayload) {
+              auto newZpCst = rewriter.create<ONNXConstantOp>(
+                  dqToDuplicate.getLoc(), mlir::Attribute(), zpPayload);
+              newZpValue = newZpCst.getOutput();
+            }
+          }
+        } else if constexpr (std::is_same_v<BinOp, ONNXMulOp> ||
+                             std::is_same_v<BinOp, ONNXDivOp>) {
+          // Create new scale constant
+          auto scaleLikeTy = mlir::dyn_cast<ShapedType>(state.dstScaleValue.getType());
+          if (scaleLikeTy) {
+            auto scalePayload = makeScalarDEA(scaleLikeTy, state.newScale);
+            if (scalePayload) {
+              auto newScaleCst = rewriter.create<ONNXConstantOp>(
+                  dqToDuplicate.getLoc(), mlir::Attribute(), scalePayload);
+              newScaleValue = newScaleCst.getOutput();
+            }
+          }
+        }
+
+        // Create the duplicated DQ with updated parameters
+        auto newDq = rewriter.create<ONNXDequantizeLinearOp>(
+            dqToDuplicate.getLoc(),
+            dqToDuplicate.getY().getType(),
+            dqToDuplicate.getX(),
+            newScaleValue,
+            newZpValue,
+            dqToDuplicate.getAxisAttr(),
+            dqToDuplicate.getBlockSizeAttr());
+
+        // Update state to use the duplicated DQ for the binary op replacement
+        state.dequantActivationOfBinOp = newDq;
+      } else {
+        // No duplication needed, update in place
+        if constexpr (std::is_same_v<BinOp, ONNXAddOp> ||
+                      std::is_same_v<BinOp, ONNXSubOp>) {
+          // Update zero-point (for Add/Sub)
+          updateInitializer(rewriter, state.dstNode, state.dstZeroPointValue,
+              static_cast<double>(state.newZp));
+        } else if constexpr (std::is_same_v<BinOp, ONNXMulOp> ||
+                             std::is_same_v<BinOp, ONNXDivOp>) {
+          // Update scale (for Mul/Div)
+          updateInitializer(
+              rewriter, state.dstNode, state.dstScaleValue, state.newScale);
+        }
       }
     }
-
+    
     // STEP 7: Remove binary op
     rewriter.replaceOp(op, state.dequantActivationOfBinOp.getResult());
 

--- a/test/mlir/onnx/onnx_remove_binary.mlir
+++ b/test/mlir/onnx/onnx_remove_binary.mlir
@@ -924,3 +924,57 @@ func.func @div_by_zero_fold_into_dq(%arg0: tensor<1x4xf32>) -> tensor<1x4xf32> {
 // CHECK: "onnx.Div"
 // CHECK: "onnx.QuantizeLinear"
 
+// -----
+
+// ============================================================================
+// DQ DUPLICATION: DQ with multiple users (Sigmoid + Mul)
+// When Mul is folded into DQ, DQ must be duplicated to preserve correctness
+// Original DQ keeps original scale for Sigmoid, duplicated DQ gets updated scale for Mul
+// ============================================================================
+
+func.func @dq_duplication_multiple_users(%arg0: tensor<1x4xf32>) -> (tensor<1x4xf32>, tensor<1x4xf32>) {
+  // Setup: Q->DQ for activation (this DQ will have multiple users)
+  %s_act = onnx.Constant dense<2.000000e+00> : tensor<f32>
+  %zp_act = onnx.Constant dense<0> : tensor<i8>
+  %q_act = "onnx.QuantizeLinear"(%arg0, %s_act, %zp_act) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x4xf32>, tensor<f32>, tensor<i8>) -> tensor<1x4xi8>
+  %dq_shared = "onnx.DequantizeLinear"(%q_act, %s_act, %zp_act) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x4xi8>, tensor<f32>, tensor<i8>) -> tensor<1x4xf32>
+  
+  // Sigmoid uses dq_shared (first user - should keep original DQ)
+  %sigmoid = "onnx.Sigmoid"(%dq_shared) : (tensor<1x4xf32>) -> tensor<1x4xf32>
+  
+  // Constant DQ for Mul (k_value = (5 - 0) * 1.0 = 5.0)
+  %const_q = onnx.Constant dense<5> : tensor<i8>
+  %s_const = onnx.Constant dense<1.000000e+00> : tensor<f32>
+  %zp_const = onnx.Constant dense<0> : tensor<i8>
+  %dq_const = "onnx.DequantizeLinear"(%const_q, %s_const, %zp_const) {axis = 1 : si64, block_size = 0 : si64} : (tensor<i8>, tensor<f32>, tensor<i8>) -> tensor<f32>
+  
+  // Mul uses dq_shared (second user - should trigger DQ duplication)
+  // When folded: new_scale = original_scale * k_value = 2.0 * 5.0 = 10.0
+  %mul = "onnx.Mul"(%dq_shared, %dq_const) : (tensor<1x4xf32>, tensor<f32>) -> tensor<1x4xf32>
+  
+  // Output Q->DQ
+  %s_out = onnx.Constant dense<1.000000e+00> : tensor<f32>
+  %zp_out = onnx.Constant dense<0> : tensor<i8>
+  %q_out = "onnx.QuantizeLinear"(%mul, %s_out, %zp_out) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x4xf32>, tensor<f32>, tensor<i8>) -> tensor<1x4xi8>
+  %dq_out = "onnx.DequantizeLinear"(%q_out, %s_out, %zp_out) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x4xi8>, tensor<f32>, tensor<i8>) -> tensor<1x4xf32>
+  
+  // Return both outputs to ensure both DQ operations are preserved
+  return %sigmoid, %dq_out : tensor<1x4xf32>, tensor<1x4xf32>
+}
+
+// CHECK-LABEL: func.func @dq_duplication_multiple_users
+// CHECK-SAME: (%arg0: tensor<1x4xf32>) -> (tensor<1x4xf32>, tensor<1x4xf32>)
+// CHECK: %[[NEW_SCALE:.*]] = onnx.Constant dense<1.000000e+01> : tensor<f32>
+// CHECK: %[[ORIG_SCALE:.*]] = onnx.Constant dense<2.000000e+00> : tensor<f32>
+// CHECK: %[[ZP:.*]] = onnx.Constant dense<0> : tensor<i8>
+// CHECK: %[[Q_ACT:.*]] = "onnx.QuantizeLinear"(%arg0, %[[ORIG_SCALE]], %[[ZP]])
+// CHECK-SAME: : (tensor<1x4xf32>, tensor<f32>, tensor<i8>) -> tensor<1x4xi8>
+// CHECK: %[[ORIG_DQ:.*]] = "onnx.DequantizeLinear"(%[[Q_ACT]], %[[ORIG_SCALE]], %[[ZP]])
+// CHECK-SAME: : (tensor<1x4xi8>, tensor<f32>, tensor<i8>) -> tensor<1x4xf32>
+// CHECK: %[[NEW_DQ:.*]] = "onnx.DequantizeLinear"(%[[Q_ACT]], %[[NEW_SCALE]], %[[ZP]])
+// CHECK-SAME: : (tensor<1x4xi8>, tensor<f32>, tensor<i8>) -> tensor<1x4xf32>
+// CHECK: %[[SIGMOID:.*]] = "onnx.Sigmoid"(%[[ORIG_DQ]])
+// CHECK-SAME: : (tensor<1x4xf32>) -> tensor<1x4xf32>
+// CHECK-NOT: "onnx.Mul"
+// CHECK: return %[[SIGMOID]], %[[NEW_DQ]] : tensor<1x4xf32>, tensor<1x4xf32>
+


### PR DESCRIPTION
**Issue**: When a dequantize node feeds multiple operations (e.g., Sigmoid and Mul), folding a binary operation into it updated the scale for all users, causing incorrect results.

**Fix**: Detect when a dequantize node has multiple users and duplicate it before updating the scale, so only the binary operation path uses the new scale while other users remain unchanged.

**Impact**: Ensures correctness when optimizing quantized models with shared dequantize nodes, preventing incorrect quantization scale propagation.