### PR TITLE
chore: remove recomposeLayernormWithTranspose toggle

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -33,8 +33,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
       opts.enableConvTranspose1dDecomposeToPhasedConv,
       opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose));
   if (!opts.disableRecomposeOption)
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass(
-        /*target=*/"", opts.enableRecomposeLayernormByTranspose));
+    pm.addNestedPass<func::FuncOp>(
+        onnx_mlir::createRecomposeONNXToONNXPass(/*target=*/""));
 
   if (opts.enableONNXHybridPass) {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
@@ -42,7 +42,6 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTransposeDecompose,
         opts.enableConvTransposeDecomposeToPhasedConv,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
-        opts.enableRecomposeLayernormByTranspose,
         opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
@@ -54,7 +53,6 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
           opts.enableConvTransposeDecompose,
           opts.enableConvTransposeDecomposeToPhasedConv,
           opts.enableConvTranspose1dDecomposeToPhasedConv,
-          opts.enableRecomposeLayernormByTranspose,
           opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose));
     }
     // If quark quantized legalization is enabled, do a last const prop after it
@@ -113,7 +111,6 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTransposeDecompose,
         opts.enableConvTransposeDecomposeToPhasedConv,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
-        opts.enableRecomposeLayernormByTranspose,
         opts.enableInstanceNormDecompose, opts.enableSplitToSliceDecompose));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -20,7 +20,6 @@ struct OnnxToMlirOptions {
   bool enableRemoveDqQAroundOp = false;
   bool enableRemoveBinary = false;
   bool enableFusePadIntoAvgpool = false;
-  bool enableRecomposeLayernormByTranspose = false;
   bool enableSplitToSliceDecompose = false;
 
   bool disableRecomposeOption = false;

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -118,12 +118,6 @@ struct ONNXHybridTransformPass
                      "LayerNormalization"),
       ::llvm::cl::init(true)};
 
-  Option<bool> recomposeLayernormByTranspose{*this,
-      "recompose-layernorm-by-transpose",
-      llvm::cl::desc("Use transpose operator to make unsuitable axes suitable "
-                     "for matching layernorm"),
-      ::llvm::cl::init(false)};
-
   Option<bool> enableSplitToSliceDecompose{*this,
       "enable-split-to-slice-decompose",
       llvm::cl::desc("Enable decomposition of Split to Slice"),
@@ -136,8 +130,7 @@ struct ONNXHybridTransformPass
       bool enableConvTransposeDecompose,
       bool enableConvTransposeDecomposeToPhasedConv,
       bool enableConvTranspose1dDecomposeToPhasedConv,
-      bool recomposeLayernormByTranspose, bool enableInstanceNormDecompose,
-      bool enableSplitToSliceDecompose) {
+      bool enableInstanceNormDecompose, bool enableSplitToSliceDecompose) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
@@ -145,7 +138,6 @@ struct ONNXHybridTransformPass
         enableConvTransposeDecomposeToPhasedConv;
     this->enableConvTranspose1dDecomposeToPhasedConv =
         enableConvTranspose1dDecomposeToPhasedConv;
-    this->recomposeLayernormByTranspose = recomposeLayernormByTranspose;
     this->enableInstanceNormDecompose = enableInstanceNormDecompose;
     this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
   }
@@ -200,8 +192,7 @@ struct ONNXHybridTransformPass
     }
 
     if (recomposition) {
-      getRecomposeONNXToONNXPatterns(
-          cumulativePatterns, recomposeLayernormByTranspose);
+      getRecomposeONNXToONNXPatterns(cumulativePatterns);
     }
 
     patterns = FrozenRewritePatternSet(std::move(cumulativePatterns));
@@ -243,12 +234,10 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableConvTransposeDecompose,
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
-    bool enableRecomposeLayernormByTranspose, bool enableInstanceNormDecompose,
-    bool enableSplitToSliceDecompose) {
+    bool enableInstanceNormDecompose, bool enableSplitToSliceDecompose) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,
-      enableConvTranspose1dDecomposeToPhasedConv,
-      enableRecomposeLayernormByTranspose, enableInstanceNormDecompose,
+      enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableSplitToSliceDecompose);
 }

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -1480,17 +1480,11 @@ struct RecomposeONNXToONNXPass
     : public PassWrapper<RecomposeONNXToONNXPass, OperationPass<func::FuncOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RecomposeONNXToONNXPass)
 
-  RecomposeONNXToONNXPass(
-      const std::string &target, const bool &recomposeLayernormByTranspose) {
-    this->target = target;
-    this->recomposeLayernormByTranspose = recomposeLayernormByTranspose;
-  }
+  RecomposeONNXToONNXPass(const std::string &target) { this->target = target; }
   RecomposeONNXToONNXPass(const RecomposeONNXToONNXPass &pass)
       : mlir::PassWrapper<RecomposeONNXToONNXPass,
             OperationPass<func::FuncOp>>() {
     this->target = pass.target.getValue();
-    this->recomposeLayernormByTranspose =
-        pass.recomposeLayernormByTranspose.getValue();
   }
 
   StringRef getArgument() const override { return "recompose-onnx"; }
@@ -1503,12 +1497,6 @@ struct RecomposeONNXToONNXPass
   Option<std::string> target{*this, "target",
       llvm::cl::desc("Target Dialect to Recompose into"), ::llvm::cl::init("")};
 
-  Option<bool> recomposeLayernormByTranspose{*this,
-      "recompose-layernorm-by-transpose",
-      llvm::cl::desc("Use transpose operator to make unsuitable axes suitable "
-                     "for matching layernorm"),
-      ::llvm::cl::init(false)};
-
   void runOnOperation() final;
 
   typedef PassWrapper<RecomposeONNXToONNXPass, OperationPass<func::FuncOp>>
@@ -1520,8 +1508,7 @@ void RecomposeONNXToONNXPass::runOnOperation() {
   MLIRContext *context = &getContext();
 
   RewritePatternSet patterns(context);
-  onnx_mlir::getRecomposeONNXToONNXPatterns(
-      patterns, recomposeLayernormByTranspose);
+  onnx_mlir::getRecomposeONNXToONNXPatterns(patterns);
 
   onnx_mlir::ResultNamesUpdater rnUpdater;
   if (failed(applyPatternsGreedily(function, std::move(patterns),
@@ -1532,17 +1519,15 @@ void RecomposeONNXToONNXPass::runOnOperation() {
 } // namespace
 
 void onnx_mlir::getRecomposeONNXToONNXPatterns(
-    mlir::RewritePatternSet &patterns, bool recomposeLayernormByTranspose) {
+    mlir::RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
   patterns.insert<RecomposeGeluFromMulPattern>(context);
   patterns.insert<RecomposeLayerNormFromDivPattern<ONNXDivOp, false>>(context);
   patterns.insert<RecomposeLayerNormFromDivPattern<ONNXMulOp, false>>(context);
   patterns.insert<RecomposeLayerNormFromDivPattern<ONNXPowOp, false>>(context);
-  if (recomposeLayernormByTranspose) {
-    patterns.insert<RecomposeLayerNormFromDivPattern<ONNXDivOp, true>>(context);
-    patterns.insert<RecomposeLayerNormFromDivPattern<ONNXMulOp, true>>(context);
-    patterns.insert<RecomposeLayerNormFromDivPattern<ONNXPowOp, true>>(context);
-  }
+  patterns.insert<RecomposeLayerNormFromDivPattern<ONNXDivOp, true>>(context);
+  patterns.insert<RecomposeLayerNormFromDivPattern<ONNXMulOp, true>>(context);
+  patterns.insert<RecomposeLayerNormFromDivPattern<ONNXPowOp, true>>(context);
   patterns.insert<RecomposeDepthToSpaceCRD>(context);
   patterns.insert<RecomposeDepthToSpaceDCR>(context);
   // AMD Disabled as downstream has no special support for it
@@ -1554,7 +1539,6 @@ void onnx_mlir::getRecomposeONNXToONNXPatterns(
  * Create a RecomposeONNX pass.
  */
 std::unique_ptr<mlir::Pass> onnx_mlir::createRecomposeONNXToONNXPass(
-    const std::string &target, const bool &recomposeLayernormByTranspose) {
-  return std::make_unique<RecomposeONNXToONNXPass>(
-      target, recomposeLayernormByTranspose);
+    const std::string &target) {
+  return std::make_unique<RecomposeONNXToONNXPass>(target);
 }

--- a/src/Dialect/ONNX/Transforms/Recompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.hpp
@@ -26,10 +26,9 @@ namespace onnx_mlir {
 
 // Exports the RecomposeONNXToONNXPass patterns. They are all plain rewrite
 // patterns that can be used with any PatternRewriter, not conversion patterns.
-// recomposeLayernormByTranspose is the flag for using transpose operator to
-// make unsuitable axes suitable for matching layernorm.
-void getRecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
-    bool recomposeLayernormByTranspose = false);
+// Always include patterns that use transpose to make unsuitable axes suitable
+// for matching layernorm.
+void getRecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns);
 
 } // namespace onnx_mlir
 #endif

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -44,8 +44,7 @@ std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
     bool enableInstanceNormDecompose = true,
     bool enableSplitToSliceDecompose = false);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
-    const std::string &target = "",
-    const bool &recomposeLayernormByTranspose = false);
+    const std::string &target = "");
 
 std::unique_ptr<mlir::Pass> createConvOptONNXToONNXPass(
     bool enableSimdDataLayoutOpt = false);
@@ -89,7 +88,6 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableConvTransposeDecompose = false,
     bool enableConvTransposeDecomposeToPhasedConv = false,
     bool enableConvTranspose1dDecomposeToPhasedConv = false,
-    bool enableRecomposeLayernormByTranspose = false,
     bool enableInstanceNormDecompose = true,
     bool enableSplitToSliceDecompose = false);
 

--- a/test/mlir/onnx/onnx_hybrid_transform_with_quark_legalize_ops.mlir
+++ b/test/mlir/onnx/onnx_hybrid_transform_with_quark_legalize_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt -onnx-hybrid-transform="canonicalization=true constant-propagation=true decomposition=true enable-convtranspose=false enable-convtranspose-1d-phased=false enable-convtranspose-phased=true enable-instancenorm-decompose=true enable-split-to-slice-decompose=false max-num-rewrites-multiplier=2.000000e-01 max-num-rewrites-offset=20 quark-quantized-ops-legalization=true recompose-layernorm-by-transpose=true recomposition=true shape-inference=true" %s | FileCheck %s
+// RUN: onnx-mlir-opt -onnx-hybrid-transform="canonicalization=true constant-propagation=true decomposition=true enable-convtranspose=false enable-convtranspose-1d-phased=false enable-convtranspose-phased=true enable-instancenorm-decompose=true enable-split-to-slice-decompose=false max-num-rewrites-multiplier=2.000000e-01 max-num-rewrites-offset=20 quark-quantized-ops-legalization=true recomposition=true shape-inference=true" %s | FileCheck %s
 
 // Illustrates the interaction between 
 

--- a/test/mlir/onnx/onnx_recompose.mlir
+++ b/test/mlir/onnx/onnx_recompose.mlir
@@ -93,16 +93,9 @@ func.func @layernorm_without_bias_second_reduce_unsuitable_axis(%x: tensor<1x384
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @layernorm_without_bias_second_reduce_unsuitable_axis
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x384x768xf32>, [[PARAM_1_:%.+]]: tensor<768xf32>, [[PARAM_2_:%.+]]: tensor<768xf32>) -> tensor<1x384x768xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.200000e+00> : tensor<f32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.ReduceMeanV13"([[PARAM_0_]]) {axes = [-1], keepdims = 1 : si64} : (tensor<1x384x768xf32>) -> tensor<1x384x1xf32>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Sub"([[PARAM_0_]], [[VAR_1_]]) : (tensor<1x384x768xf32>, tensor<1x384x1xf32>) -> tensor<1x384x768xf32>
-// CHECK:           [[VAR_3_:%.+]] = "onnx.Mul"([[VAR_2_]], [[VAR_2_]]) : (tensor<1x384x768xf32>, tensor<1x384x768xf32>) -> tensor<1x384x768xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.ReduceMeanV13"([[VAR_3_]]) {axes = [-2], keepdims = 1 : si64} : (tensor<1x384x768xf32>) -> tensor<1x384x1xf32>
-// CHECK:           [[VAR_5_:%.+]] = "onnx.Add"([[VAR_4_]], [[VAR_0_]]) : (tensor<1x384x1xf32>, tensor<f32>) -> tensor<1x384x1xf32>
-// CHECK:           [[VAR_6_:%.+]] = "onnx.Sqrt"([[VAR_5_]]) : (tensor<1x384x1xf32>) -> tensor<1x384x1xf32>
-// CHECK:           [[VAR_7_:%.+]] = "onnx.Div"([[VAR_2_]], [[VAR_6_]]) : (tensor<1x384x768xf32>, tensor<1x384x1xf32>) -> tensor<1x384x768xf32>
-// CHECK:           [[VAR_8_:%.+]] = "onnx.Mul"([[VAR_7_]], [[PARAM_1_]]) : (tensor<1x384x768xf32>, tensor<768xf32>) -> tensor<1x384x768xf32>
-// CHECK:           return [[VAR_8_]] : tensor<1x384x768xf32>
+// CHECK:           [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]]) {axis = 2 : si64, epsilon = 1.200000e+00 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<768xf32>, none) -> (tensor<1x384x768xf32>, none, none)
+// CHECK:           return [[VAR_Y_]] : tensor<1x384x768xf32>
 // CHECK:         }
 }
 
@@ -203,18 +196,9 @@ func.func @layernorm_without_bias_second_reduce_unsuitable_axis_v18(%x: tensor<1
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @layernorm_without_bias_second_reduce_unsuitable_axis_v18
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x384x768xf32>, [[PARAM_1_:%.+]]: tensor<768xf32>, [[PARAM_2_:%.+]]: tensor<768xf32>) -> tensor<1x384x768xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.200000e+00> : tensor<f32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<-1> : tensor<1xi64>
-// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<-2> : tensor<1xi64>
-// CHECK:           [[VAR_3_:%.+]] = "onnx.ReduceMean"([[PARAM_0_]], [[VAR_1_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x384x768xf32>, tensor<1xi64>) -> tensor<1x384x1xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Sub"([[PARAM_0_]], [[VAR_3_]]) : (tensor<1x384x768xf32>, tensor<1x384x1xf32>) -> tensor<1x384x768xf32>
-// CHECK:           [[VAR_5_:%.+]] = "onnx.Mul"([[VAR_4_]], [[VAR_4_]]) : (tensor<1x384x768xf32>, tensor<1x384x768xf32>) -> tensor<1x384x768xf32>
-// CHECK:           [[VAR_6_:%.+]] = "onnx.ReduceMean"([[VAR_5_]], [[VAR_2_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x384x768xf32>, tensor<1xi64>) -> tensor<1x384x1xf32>
-// CHECK:           [[VAR_7_:%.+]] = "onnx.Add"([[VAR_6_]], [[VAR_0_]]) : (tensor<1x384x1xf32>, tensor<f32>) -> tensor<1x384x1xf32>
-// CHECK:           [[VAR_8_:%.+]] = "onnx.Sqrt"([[VAR_7_]]) : (tensor<1x384x1xf32>) -> tensor<1x384x1xf32>
-// CHECK:           [[VAR_9_:%.+]] = "onnx.Div"([[VAR_4_]], [[VAR_8_]]) : (tensor<1x384x768xf32>, tensor<1x384x1xf32>) -> tensor<1x384x768xf32>
-// CHECK:           [[VAR_10_:%.+]] = "onnx.Mul"([[VAR_9_]], [[PARAM_1_]]) : (tensor<1x384x768xf32>, tensor<768xf32>) -> tensor<1x384x768xf32>
-// CHECK:           return [[VAR_10_]] : tensor<1x384x768xf32>
+// CHECK:           [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]]) {axis = 2 : si64, epsilon = 1.200000e+00 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<768xf32>, none) -> (tensor<1x384x768xf32>, none, none)
+// CHECK:           return [[VAR_Y_]] : tensor<1x384x768xf32>
 // CHECK:         }
 }
 

--- a/test/mlir/onnx/onnx_recompose_layernorm_with_transpose.mlir
+++ b/test/mlir/onnx/onnx_recompose_layernorm_with_transpose.mlir
@@ -1,5 +1,5 @@
 // Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
-// RUN: onnx-mlir-opt -split-input-file --recompose-onnx="recompose-layernorm-by-transpose" --canonicalize %s | FileCheck %s
+// RUN: onnx-mlir-opt -split-input-file --recompose-onnx --canonicalize %s | FileCheck %s
 
 func.func @decomposition_to_layernorm_axis_1(%arg0: tensor<1x4x128x128xf32>) -> tensor<1x4x128x128xf32> {
   %2 = onnx.Constant dense<1.000000e+00> : tensor<f32>


### PR DESCRIPTION
Removing toggle for the Layernorm recomposition as it is enabled by default.