### PR TITLE
XCompiler passes to onnx-mlir

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -51,6 +51,7 @@ void addXmcMlirPasses(mlir::PassManager &pm, OnnxToMlirOptions opts) {
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createCombineTransposePairPass());
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createReplaceNDimTransposePass());
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createTransfer5dStridedSliceTo4d());
+  pm.addNestedPass<func::FuncOp>(onnx_mlir::createTransferOpShapeTo4dPass());
   pm.addNestedPass<func::FuncOp>(
   onnx_mlir::createBatchReductionToReshapeReductionPass());
   pm.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -37,6 +37,7 @@ void addXmcMlirPasses(mlir::PassManager &pm, OnnxToMlirOptions opts) {
   onnx_mlir::createMergeStridedSliceConcatConvPass());
   pm.addNestedPass<func::FuncOp>(
   onnx_mlir::createTransferConvSliceToConvPass());
+  pm.addNestedPass<func::FuncOp>(onnx_mlir::createTransferOp1dToOp2dPass());
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvertToChannelLastPass());
   pm.addNestedPass<func::FuncOp>(
   onnx_mlir::createONNXTransposeOptimizationPass());

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -85,6 +85,7 @@ add_onnx_mlir_library(OMONNXRewrite
   xmc/BatchReductionToReshapeReductionPass.cpp
   xmc/RemoveRedundantReluPass.cpp
   xmc/ReplaceNDimTransposePass.cpp
+  xmc/TransferOpShapeTo4dPass.cpp
   xmc/ONNXTransposeOptimizationPass.cpp
   xmc/ONNXTransposeOptimizationAxisChangePatterns.cpp
 

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -86,6 +86,7 @@ add_onnx_mlir_library(OMONNXRewrite
   xmc/RemoveRedundantReluPass.cpp
   xmc/ReplaceNDimTransposePass.cpp
   xmc/TransferOpShapeTo4dPass.cpp
+  xmc/TransferOp1dToOp2dPass.cpp
   xmc/ONNXTransposeOptimizationPass.cpp
   xmc/ONNXTransposeOptimizationAxisChangePatterns.cpp
 

--- a/src/Dialect/ONNX/Transforms/xmc/TransferOp1dToOp2dPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/TransferOp1dToOp2dPass.cpp
@@ -2,7 +2,11 @@
 //
 // This pass converts 1D operations to 2D operations:
 // - Conv1D → Conv2D
+// - ConvTranspose1D → ConvTranspose2D
 // - MaxPool1D → MaxPool2D
+// - AveragePool1D → AveragePool2D
+// - GlobalMaxPool1D → GlobalMaxPool2D
+// - GlobalAveragePool1D → GlobalAveragePool2D
 // - DepthwiseConv1D → DepthwiseConv2D
 //
 // The transformation inserts reshape operations before and after the target
@@ -135,8 +139,9 @@ bool is1DSpatialOp(RankedTensorType inputType) {
   return inputType && inputType.getRank() == 3;
 }
 
-/// Get the group attribute from Conv op, defaults to 1
-int64_t getConvGroup(ONNXConvOp convOp) {
+/// Get the group attribute from Conv/ConvTranspose op, defaults to 1
+template <typename ConvOpType>
+int64_t getConvOpGroup(ConvOpType convOp) {
   auto groupAttr = convOp.getGroupAttr();
   return groupAttr ? groupAttr.getValue().getSExtValue() : 1;
 }
@@ -191,106 +196,18 @@ Value createActivation4D(PatternRewriter &rewriter, Location loc,
 }
 
 //===----------------------------------------------------------------------===//
-// Conv1D/DepthwiseConv1D to Conv2D Transformation
+// Pattern: Conv1D/ConvTranspose1D to Conv2D/ConvTranspose2D
+// (handles Conv, ConvTranspose, regular and depthwise, with/without activation)
 //===----------------------------------------------------------------------===//
 
-/// Unified transformation for Conv1D → Conv2D (handles both regular and
-/// depthwise) For depthwise conv, group == C, which getConvGroup() returns
-LogicalResult transformConv1dToConv2d(ONNXConvOp convOp,
-    PatternRewriter &rewriter, Operation *activationOp) {
-  Location loc = convOp.getLoc();
-  Value input = convOp.getX();
-  Value weight = convOp.getW();
-  Value bias = convOp.getB();
+template <typename ConvOpType>
+struct Conv1dToConv2dPattern : public OpRewritePattern<ConvOpType> {
+  using OpRewritePattern<ConvOpType>::OpRewritePattern;
 
-  auto inputType = cast<RankedTensorType>(input.getType());
-  auto weightType = cast<RankedTensorType>(weight.getType());
-
-  auto outputType =
-      cast<RankedTensorType>(activationOp ? activationOp->getResult(0).getType()
-                                          : convOp.getResult().getType());
-  auto outputShape3D = outputType.getShape();
-
-  // Get kernel size for special case handling
-  auto kernel1d = getArrayAttrValues(convOp.getKernelShape());
-  if (kernel1d.empty())
-    kernel1d = {weightType.getShape()[2]};
-  int64_t kernelSize = kernel1d[0];
-
-  // Reshape input: [N, C, L] → [N, C, 1, L] or [1, N, C, L] for kernel=1
-  Value reshapedInput = reshapeInputTo4D(rewriter, loc, input, kernelSize);
-
-  // Reshape weight: [OC, IC/g, K] → [OC, IC/g, 1, K]
-  Value reshapedWeight = reshapeWeightTo4D(rewriter, loc, weight);
-
-  // Get and extend attributes from 1D to 2D
-  auto stride1d = getArrayAttrValues(convOp.getStrides());
-  auto dilation1d = getArrayAttrValues(convOp.getDilations());
-  auto pads1d = getArrayAttrValues(convOp.getPads());
-
-  if (stride1d.empty())
-    stride1d = {1};
-  if (dilation1d.empty())
-    dilation1d = {1};
-  if (pads1d.empty())
-    pads1d = {0, 0};
-
-  auto kernel2d = extend1DAttrTo2D(kernel1d);
-  auto stride2d = extend1DAttrTo2D(stride1d);
-  auto dilation2d = extend1DAttrTo2D(dilation1d);
-  auto pads2d = extend1DPadsTo2D(pads1d);
-
-  // Use unranked type - let ONNX infer Conv2D output shape
-  auto conv2dOutputType = UnrankedTensorType::get(inputType.getElementType());
-
-  // Handle bias
-  Value conv2dBias = bias;
-  if (!bias || isa<NoneType>(bias.getType())) {
-    onnx_mlir::OnnxBuilder onnxBuilder(rewriter, loc);
-    conv2dBias = onnxBuilder.none();
-  }
-
-  auto si64Type =
-      IntegerType::get(rewriter.getContext(), 64, IntegerType::Signed);
-
-  // Create Conv2D (group from original op - works for both regular and
-  // depthwise)
-  auto conv2dOp = rewriter.create<ONNXConvOp>(loc, conv2dOutputType,
-      reshapedInput, reshapedWeight, conv2dBias,
-      /*auto_pad=*/convOp.getAutoPadAttr(),
-      /*dilations=*/rewriter.getI64ArrayAttr(dilation2d),
-      /*group=*/IntegerAttr::get(si64Type, getConvGroup(convOp)),
-      /*kernel_shape=*/rewriter.getI64ArrayAttr(kernel2d),
-      /*pads=*/rewriter.getI64ArrayAttr(pads2d),
-      /*strides=*/rewriter.getI64ArrayAttr(stride2d));
-
-  Value result = conv2dOp.getResult();
-
-  if (activationOp) {
-    result = createActivation4D(rewriter, loc, activationOp, result);
-  }
-
-  Value finalOutput = reshapeOutputTo3D(rewriter, loc, result, outputShape3D,
-      outputType.getElementType());
-
-  if (activationOp) {
-    rewriter.replaceOp(activationOp, finalOutput);
-  } else {
-    rewriter.replaceOp(convOp, finalOutput);
-  }
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// Pattern: Conv1D to Conv2D (handles both regular and depthwise)
-//===----------------------------------------------------------------------===//
-
-struct Conv1dToConv2dPattern : public OpRewritePattern<ONNXConvOp> {
-  using OpRewritePattern<ONNXConvOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ONNXConvOp convOp,
+  LogicalResult matchAndRewrite(ConvOpType convOp,
       PatternRewriter &rewriter) const override {
+    Location loc = convOp.getLoc();
+
     // Check if this is a 1D convolution (3D input tensor)
     auto inputType = dyn_cast<RankedTensorType>(convOp.getX().getType());
     if (!is1DSpatialOp(inputType))
@@ -301,51 +218,35 @@ struct Conv1dToConv2dPattern : public OpRewritePattern<ONNXConvOp> {
     if (!weightType || weightType.getRank() != 3)
       return failure();
 
-    // Check for following activation (relu, leaky-relu, prelu, relu6)
+    // Check for following activation
     Operation *activationOp = getFollowingActivation(convOp);
 
-    return transformConv1dToConv2d(convOp, rewriter, activationOp);
-  }
-};
+    // Get input/output info
+    Value input = convOp.getX();
+    Value weight = convOp.getW();
+    Value bias = convOp.getB();
 
-//===----------------------------------------------------------------------===//
-// Pattern: MaxPool1D to MaxPool2D
-//===----------------------------------------------------------------------===//
-
-struct MaxPool1dToMaxPool2dPattern
-    : public OpRewritePattern<ONNXMaxPoolSingleOutOp> {
-  using OpRewritePattern<ONNXMaxPoolSingleOutOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ONNXMaxPoolSingleOutOp maxPoolOp,
-      PatternRewriter &rewriter) const override {
-    Location loc = maxPoolOp.getLoc();
-    Value input = maxPoolOp.getX();
-
-    // Check if 1D pooling (3D input)
-    auto inputType = dyn_cast<RankedTensorType>(input.getType());
-    if (!is1DSpatialOp(inputType))
-      return failure();
-
-    auto inputShape = inputType.getShape();
-    auto outputType = cast<RankedTensorType>(maxPoolOp.getResult().getType());
+    auto outputType = cast<RankedTensorType>(
+        activationOp ? activationOp->getResult(0).getType()
+                     : convOp.getResult().getType());
     auto outputShape3D = outputType.getShape();
 
-    // Reshape input: [N, C, L] → [N, C, 1, L] (no special kernel=1 case for
-    // maxpool)
-    llvm::SmallVector<int64_t> input4DShape = {inputShape[0], inputShape[1], 1,
-        inputShape[2]};
-    auto input4DType =
-        RankedTensorType::get(input4DShape, inputType.getElementType());
-    auto inputShapeConst = createShapeConstant(rewriter, loc, input4DShape);
-    Value reshapedInput =
-        rewriter.create<ONNXReshapeOp>(loc, input4DType, input, inputShapeConst)
-            .getReshaped();
+    // Get kernel size for special case handling
+    auto kernel1d = getArrayAttrValues(convOp.getKernelShape());
+    if (kernel1d.empty())
+      kernel1d = {weightType.getShape()[2]};
+    int64_t kernelSize = kernel1d[0];
 
-    // Get and extend attributes
-    auto kernel1d = getArrayAttrValues(maxPoolOp.getKernelShape());
-    auto stride1d = getArrayAttrValues(maxPoolOp.getStrides());
-    auto dilation1d = getArrayAttrValues(maxPoolOp.getDilations());
-    auto pads1d = getArrayAttrValues(maxPoolOp.getPads());
+    // Reshape input: [N, C, L] → [N, C, 1, L] or [1, N, C, L] for kernel=1
+    Value reshapedInput = reshapeInputTo4D(rewriter, loc, input, kernelSize);
+
+    // Reshape weight: [OC, IC/g, K] or [IC, OC/g, K] → [..., 1, K]
+    Value reshapedWeight = reshapeWeightTo4D(rewriter, loc, weight);
+
+    // Get and extend common attributes from 1D to 2D
+    auto stride1d = getArrayAttrValues(convOp.getStrides());
+    auto dilation1d = getArrayAttrValues(convOp.getDilations());
+    auto pads1d = getArrayAttrValues(convOp.getPads());
 
     if (stride1d.empty())
       stride1d = {1};
@@ -359,29 +260,254 @@ struct MaxPool1dToMaxPool2dPattern
     auto dilation2d = extend1DAttrTo2D(dilation1d);
     auto pads2d = extend1DPadsTo2D(pads1d);
 
-    // Use unranked type - let ONNX infer MaxPool2D output shape
-    auto pool2dOutputType = UnrankedTensorType::get(inputType.getElementType());
+    // Handle ConvTranspose-specific attributes
+    llvm::SmallVector<int64_t> outputPadding2d;
+    llvm::SmallVector<int64_t> outputShape2d;
+    if constexpr (std::is_same_v<ConvOpType, ONNXConvTransposeOp>) {
+      auto outputPadding1d = getArrayAttrValues(convOp.getOutputPadding());
+      if (!outputPadding1d.empty()) {
+        outputPadding2d = extend1DAttrTo2D(outputPadding1d);
+      }
+
+      auto outputShape1d = getArrayAttrValues(convOp.getOutputShape());
+      if (!outputShape1d.empty()) {
+        outputShape2d = extend1DAttrTo2D(outputShape1d);
+      }
+    }
+
+    // Use unranked type - let ONNX infer Conv2D output shape
+    auto conv2dOutputType =
+        UnrankedTensorType::get(inputType.getElementType());
+
+    // Handle bias
+    Value conv2dBias = bias;
+    if (!bias || isa<NoneType>(bias.getType())) {
+      onnx_mlir::OnnxBuilder onnxBuilder(rewriter, loc);
+      conv2dBias = onnxBuilder.none();
+    }
 
     auto si64Type =
         IntegerType::get(rewriter.getContext(), 64, IntegerType::Signed);
 
-    // Create MaxPool2D
-    auto maxPool2dOp = rewriter.create<ONNXMaxPoolSingleOutOp>(loc,
-        pool2dOutputType, reshapedInput,
-        /*auto_pad=*/maxPoolOp.getAutoPadAttr(),
-        /*ceil_mode=*/maxPoolOp.getCeilModeAttr(),
-        /*dilations=*/rewriter.getI64ArrayAttr(dilation2d),
-        /*kernel_shape=*/rewriter.getI64ArrayAttr(kernel2d),
-        /*pads=*/rewriter.getI64ArrayAttr(pads2d),
-        /*storage_order=*/IntegerAttr::get(si64Type, 0),
-        /*strides=*/rewriter.getI64ArrayAttr(stride2d));
+    // Create Conv2D or ConvTranspose2D operation
+    Value result;
+    if constexpr (std::is_same_v<ConvOpType, ONNXConvOp>) {
+      // Create Conv2D
+      auto conv2dOp = rewriter.create<ONNXConvOp>(loc, conv2dOutputType,
+          reshapedInput, reshapedWeight, conv2dBias,
+          /*auto_pad=*/convOp.getAutoPadAttr(),
+          /*dilations=*/rewriter.getI64ArrayAttr(dilation2d),
+          /*group=*/IntegerAttr::get(si64Type, getConvOpGroup(convOp)),
+          /*kernel_shape=*/rewriter.getI64ArrayAttr(kernel2d),
+          /*pads=*/rewriter.getI64ArrayAttr(pads2d),
+          /*strides=*/rewriter.getI64ArrayAttr(stride2d));
+      // Infer the output shape
+      if (failed(conv2dOp.inferShapes([](Region &) {})))
+        return failure();
+      result = conv2dOp.getResult();
+    } else if constexpr (std::is_same_v<ConvOpType, ONNXConvTransposeOp>) {
+      // Create ConvTranspose2D
+      auto convTranspose2dOp = rewriter.create<ONNXConvTransposeOp>(loc,
+          conv2dOutputType, reshapedInput, reshapedWeight, conv2dBias,
+          /*auto_pad=*/convOp.getAutoPadAttr(),
+          /*dilations=*/rewriter.getI64ArrayAttr(dilation2d),
+          /*group=*/IntegerAttr::get(si64Type, getConvOpGroup(convOp)),
+          /*kernel_shape=*/rewriter.getI64ArrayAttr(kernel2d),
+          /*output_padding=*/
+          outputPadding2d.empty() ? ArrayAttr{}
+                                  : rewriter.getI64ArrayAttr(outputPadding2d),
+          /*output_shape=*/
+          outputShape2d.empty() ? ArrayAttr{}
+                                : rewriter.getI64ArrayAttr(outputShape2d),
+          /*pads=*/rewriter.getI64ArrayAttr(pads2d),
+          /*strides=*/rewriter.getI64ArrayAttr(stride2d));
+      // Infer the output shape
+      if (failed(convTranspose2dOp.inferShapes([](Region &) {})))
+        return failure();
+      result = convTranspose2dOp.getResult();
+    } else {
+      static_assert(std::is_same_v<ConvOpType, ONNXConvOp> ||
+                    std::is_same_v<ConvOpType, ONNXConvTransposeOp>,
+                    "Unsupported convolution operation type");
+    }
+
+    // Apply activation if present
+    if (activationOp) {
+      result = createActivation4D(rewriter, loc, activationOp, result);
+    }
+
+    // Reshape output back to 3D
+    Value finalOutput = reshapeOutputTo3D(rewriter, loc, result, outputShape3D,
+        outputType.getElementType());
+
+    // Replace operation
+    if (activationOp) {
+      rewriter.replaceOp(activationOp, finalOutput);
+    } else {
+      rewriter.replaceOp(convOp, finalOutput);
+    }
+
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pattern: Pool1D to Pool2D (MaxPool, AveragePool)
+//===----------------------------------------------------------------------===//
+
+template <typename PoolOp>
+struct Pool1dToPool2dPattern : public OpRewritePattern<PoolOp> {
+  using OpRewritePattern<PoolOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(PoolOp poolOp,
+      PatternRewriter &rewriter) const override {
+    Location loc = poolOp.getLoc();
+    Value input = poolOp.getX();
+
+    // Check if 1D pooling (3D input)
+    auto inputType = dyn_cast<RankedTensorType>(input.getType());
+    if (!is1DSpatialOp(inputType))
+      return failure();
+
+    auto inputShape = inputType.getShape();
+    auto outputType = cast<RankedTensorType>(poolOp.getResult().getType());
+    auto outputShape3D = outputType.getShape();
+
+    // Reshape input: [N, C, L] → [N, C, 1, L]
+    llvm::SmallVector<int64_t> input4DShape = {inputShape[0], inputShape[1], 1,
+        inputShape[2]};
+    auto input4DType =
+        RankedTensorType::get(input4DShape, inputType.getElementType());
+    auto inputShapeConst = createShapeConstant(rewriter, loc, input4DShape);
+    Value reshapedInput =
+        rewriter.create<ONNXReshapeOp>(loc, input4DType, input, inputShapeConst)
+            .getReshaped();
+
+    // Get and extend common attributes
+    auto kernel1d = getArrayAttrValues(poolOp.getKernelShape());
+    auto stride1d = getArrayAttrValues(poolOp.getStrides());
+    auto pads1d = getArrayAttrValues(poolOp.getPads());
+
+    if (stride1d.empty())
+      stride1d = {1};
+    if (pads1d.empty())
+      pads1d = {0, 0};
+
+    auto kernel2d = extend1DAttrTo2D(kernel1d);
+    auto stride2d = extend1DAttrTo2D(stride1d);
+    auto pads2d = extend1DPadsTo2D(pads1d);
+
+    // Get and extend dilations (supported by both MaxPool and AveragePool)
+    auto dilation1d = getArrayAttrValues(poolOp.getDilations());
+    if (dilation1d.empty())
+      dilation1d = {1};
+    auto dilation2d = extend1DAttrTo2D(dilation1d);
+
+    // Use unranked type - let ONNX infer Pool2D output shape
+    auto pool2dOutputType = UnrankedTensorType::get(inputType.getElementType());
+
+    Value pool2dResult;
+
+    // Create Pool2D operation based on type
+    if constexpr (std::is_same_v<PoolOp, ONNXMaxPoolSingleOutOp>) {
+      // MaxPool: has storage_order
+      auto si64Type =
+          IntegerType::get(rewriter.getContext(), 64, IntegerType::Signed);
+
+      auto maxPool2dOp = rewriter.create<ONNXMaxPoolSingleOutOp>(loc,
+          pool2dOutputType, reshapedInput,
+          /*auto_pad=*/poolOp.getAutoPadAttr(),
+          /*ceil_mode=*/poolOp.getCeilModeAttr(),
+          /*dilations=*/rewriter.getI64ArrayAttr(dilation2d),
+          /*kernel_shape=*/rewriter.getI64ArrayAttr(kernel2d),
+          /*pads=*/rewriter.getI64ArrayAttr(pads2d),
+          /*storage_order=*/IntegerAttr::get(si64Type, 0),
+          /*strides=*/rewriter.getI64ArrayAttr(stride2d));
+
+      // Infer the output shape
+      if (failed(maxPool2dOp.inferShapes([](Region &) {})))
+        return failure();
+      pool2dResult = maxPool2dOp.getResult();
+    } else if constexpr (std::is_same_v<PoolOp, ONNXAveragePoolOp>) {
+      // AveragePool: has count_include_pad and dilations, NO storage_order
+      auto avgPool2dOp = rewriter.create<ONNXAveragePoolOp>(loc,
+          pool2dOutputType, reshapedInput,
+          /*auto_pad=*/poolOp.getAutoPadAttr(),
+          /*ceil_mode=*/poolOp.getCeilModeAttr(),
+          /*count_include_pad=*/poolOp.getCountIncludePadAttr(),
+          /*dilations=*/rewriter.getI64ArrayAttr(dilation2d),
+          /*kernel_shape=*/rewriter.getI64ArrayAttr(kernel2d),
+          /*pads=*/rewriter.getI64ArrayAttr(pads2d),
+          /*strides=*/rewriter.getI64ArrayAttr(stride2d));
+
+      // Infer the output shape
+      if (failed(avgPool2dOp.inferShapes([](Region &) {})))
+        return failure();
+      pool2dResult = avgPool2dOp.getResult();
+    } else {
+      static_assert(std::is_same_v<PoolOp, ONNXMaxPoolSingleOutOp> ||
+                    std::is_same_v<PoolOp, ONNXAveragePoolOp>,
+                    "Unsupported pooling operation type");
+    }
 
     // Reshape output back to 3D
     Value finalOutput = reshapeOutputTo3D(
-        rewriter, loc, maxPool2dOp.getResult(), outputShape3D,
+        rewriter, loc, pool2dResult, outputShape3D,
         outputType.getElementType());
 
-    rewriter.replaceOp(maxPoolOp, finalOutput);
+    rewriter.replaceOp(poolOp, finalOutput);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pattern: GlobalPool1D to GlobalPool2D (GlobalMaxPool, GlobalAveragePool)
+//===----------------------------------------------------------------------===//
+
+template <typename GlobalPoolOp>
+struct GlobalPool1dToGlobalPool2dPattern : public OpRewritePattern<GlobalPoolOp> {
+  using OpRewritePattern<GlobalPoolOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(GlobalPoolOp globalPoolOp,
+      PatternRewriter &rewriter) const override {
+    Location loc = globalPoolOp.getLoc();
+    Value input = globalPoolOp.getX();
+
+    // Check if 1D pooling (3D input)
+    auto inputType = dyn_cast<RankedTensorType>(input.getType());
+    if (!is1DSpatialOp(inputType))
+      return failure();
+
+    auto inputShape = inputType.getShape();
+    auto outputType =
+        cast<RankedTensorType>(globalPoolOp.getResult().getType());
+    auto outputShape3D = outputType.getShape();
+
+    // Reshape input: [N, C, L] → [N, C, 1, L]
+    llvm::SmallVector<int64_t> input4DShape = {inputShape[0], inputShape[1], 1,
+        inputShape[2]};
+    auto input4DType =
+        RankedTensorType::get(input4DShape, inputType.getElementType());
+    auto inputShapeConst = createShapeConstant(rewriter, loc, input4DShape);
+    Value reshapedInput =
+        rewriter.create<ONNXReshapeOp>(loc, input4DType, input, inputShapeConst)
+            .getReshaped();
+
+    // Create GlobalPool2D - no attributes to extend
+    auto pool2dOutputType = UnrankedTensorType::get(inputType.getElementType());
+    auto globalPool2dOp = rewriter.create<GlobalPoolOp>(
+        loc, pool2dOutputType, reshapedInput);
+
+    // Infer the output shape
+    if (failed(globalPool2dOp.inferShapes([](Region &) {})))
+      return failure();
+
+    // Reshape output back to 3D
+    Value finalOutput = reshapeOutputTo3D(rewriter, loc,
+        globalPool2dOp.getResult(), outputShape3D,
+        outputType.getElementType());
+
+    rewriter.replaceOp(globalPoolOp, finalOutput);
     return success();
   }
 };
@@ -395,13 +521,16 @@ namespace onnx_mlir {
 //===----------------------------------------------------------------------===//
 
 /// Pass to transfer 1D operations to 2D operations.
-/// This converts Conv1D, MaxPool1D, and DepthwiseConv1D to their 2D equivalents
-/// by inserting reshape operations before and after.
+/// This converts Conv1D, ConvTranspose1D, MaxPool1D, AveragePool1D,
+/// GlobalMaxPool1D, GlobalAveragePool1D, and DepthwiseConv1D to their 2D
+/// equivalents by inserting reshape operations before and after.
 struct TransferOp1dToOp2dPass
     : public PassWrapper<TransferOp1dToOp2dPass, OperationPass<func::FuncOp>> {
   StringRef getArgument() const override { return "transfer-op1d-to-op2d"; }
   StringRef getDescription() const override {
-    return "Convert 1D operations (Conv1D, MaxPool1D) to 2D equivalents";
+    return "Convert 1D operations (Conv1D, ConvTranspose1D, MaxPool1D, "
+           "AveragePool1D, GlobalMaxPool1D, GlobalAveragePool1D) to 2D "
+           "equivalents";
   }
 
   void runOnOperation() override {
@@ -409,12 +538,23 @@ struct TransferOp1dToOp2dPass
 
     RewritePatternSet patterns(ctx);
 
-    // Conv1D → Conv2D (handles both regular and depthwise, with or without
-    // activation)
-    patterns.add<Conv1dToConv2dPattern>(ctx);
+    // Conv1D → Conv2D (handles regular and depthwise, with/without activation)
+    patterns.add<Conv1dToConv2dPattern<ONNXConvOp>>(ctx);
+
+    // ConvTranspose1D → ConvTranspose2D (with/without activation)
+    patterns.add<Conv1dToConv2dPattern<ONNXConvTransposeOp>>(ctx);
 
     // MaxPool1D → MaxPool2D
-    patterns.add<MaxPool1dToMaxPool2dPattern>(ctx);
+    patterns.add<Pool1dToPool2dPattern<ONNXMaxPoolSingleOutOp>>(ctx);
+
+    // AveragePool1D → AveragePool2D
+    patterns.add<Pool1dToPool2dPattern<ONNXAveragePoolOp>>(ctx);
+
+    // GlobalMaxPool1D → GlobalMaxPool2D
+    patterns.add<GlobalPool1dToGlobalPool2dPattern<ONNXGlobalMaxPoolOp>>(ctx);
+
+    // GlobalAveragePool1D → GlobalAveragePool2D
+    patterns.add<GlobalPool1dToGlobalPool2dPattern<ONNXGlobalAveragePoolOp>>(ctx);
 
     GreedyRewriteConfig config;
     config.strictMode = GreedyRewriteStrictness::ExistingAndNewOps;

--- a/src/Dialect/ONNX/Transforms/xmc/TransferOp1dToOp2dPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/TransferOp1dToOp2dPass.cpp
@@ -1,0 +1,433 @@
+// Copyright (C) 2022 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// This pass converts 1D operations to 2D operations:
+// - Conv1D → Conv2D
+// - MaxPool1D → MaxPool2D
+// - DepthwiseConv1D → DepthwiseConv2D
+//
+// The transformation inserts reshape operations before and after the target
+// operation to convert 3D tensors [N, C, L] to 4D tensors [N, C, 1, L] and
+// back.
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Pass/Passes.hpp"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Casting.h"
+
+#define DEBUG_TYPE "transfer-op1d-to-op2d"
+
+using namespace mlir;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Helper Functions
+//===----------------------------------------------------------------------===//
+
+/// Extract int64_t value from IntegerAttr
+inline int64_t getIntAttrValue(Attribute attr) {
+  return cast<IntegerAttr>(attr).getValue().getSExtValue();
+}
+
+/// Extract values from ArrayAttr into vector
+llvm::SmallVector<int64_t> getArrayAttrValues(std::optional<ArrayAttr> arr) {
+  llvm::SmallVector<int64_t> result;
+  if (!arr)
+    return result;
+  for (auto attr : arr->getValue()) {
+    result.push_back(getIntAttrValue(attr));
+  }
+  return result;
+}
+
+/// Extend 1D attribute array to 2D by prepending 1
+/// [K] → [1, K] (ONNX format: kH=1, kW=K since conv operates on W dimension)
+llvm::SmallVector<int64_t> extend1DAttrTo2D(llvm::ArrayRef<int64_t> arr1d) {
+  llvm::SmallVector<int64_t> result;
+  result.push_back(1);
+  for (auto val : arr1d) {
+    result.push_back(val);
+  }
+  return result;
+}
+
+/// Extend 1D pad array to 2D pad array
+/// ONNX pads format: [H_begin, W_begin, H_end, W_end]
+/// [pad_begin, pad_end] → [0, pad_begin, 0, pad_end]
+/// H padding=0 (dummy dimension), W padding=original values (conv dimension)
+llvm::SmallVector<int64_t> extend1DPadsTo2D(llvm::ArrayRef<int64_t> pads1d) {
+  // pads1d is guaranteed to be size 2 (defaulted if empty)
+  return {0, pads1d[0], 0, pads1d[1]};
+}
+
+/// Create a shape constant for ONNX Reshape
+Value createShapeConstant(PatternRewriter &rewriter, Location loc,
+    llvm::ArrayRef<int64_t> shape) {
+  onnx_mlir::OnnxBuilder onnxBuilder(rewriter, loc);
+  return onnxBuilder.constantInt64(shape);
+}
+
+/// Reshape 3D tensor [N, C, L] to 4D tensor for ONNX Conv2D
+/// ONNX Conv2D expects input in NCHW format: [N, C, H, W]
+/// Normal case: [N, C, L] → [N, C, 1, L] (H=1, W=L)
+/// Kernel=1 case: [N, C, L] → [1, N, C, L] (special optimization)
+Value reshapeInputTo4D(PatternRewriter &rewriter, Location loc, Value input,
+    int64_t kernelSize) {
+  auto inputType = cast<RankedTensorType>(input.getType());
+  auto inputShape = inputType.getShape();
+
+  llvm::SmallVector<int64_t> newShape;
+  if (kernelSize == 1) {
+    // Special case for kernel=1: [N, C, L] → [1, N, C, L]
+    newShape = {1, inputShape[0], inputShape[1], inputShape[2]};
+  } else {
+    // Normal case: [N, C, L] → [N, C, 1, L] (NCHW with H=1)
+    newShape = {inputShape[0], inputShape[1], 1, inputShape[2]};
+  }
+
+  auto newType = RankedTensorType::get(newShape, inputType.getElementType());
+  auto shapeConst = createShapeConstant(rewriter, loc, newShape);
+
+  return rewriter.create<ONNXReshapeOp>(loc, newType, input, shapeConst)
+      .getReshaped();
+}
+
+/// Reshape 4D tensor back to 3D tensor using original output shape
+/// Note: input may be unranked, so we pass elementType explicitly
+Value reshapeOutputTo3D(PatternRewriter &rewriter, Location loc, Value input,
+    llvm::ArrayRef<int64_t> outputShape3D, Type elementType) {
+  auto newType = RankedTensorType::get(outputShape3D, elementType);
+  auto shapeConst = createShapeConstant(rewriter, loc, outputShape3D);
+
+  return rewriter.create<ONNXReshapeOp>(loc, newType, input, shapeConst)
+      .getReshaped();
+}
+
+/// Reshape 3D weight [OC, IC, K] to 4D for ONNX Conv2D
+/// ONNX Conv2D expects weight in [OC, IC, kH, kW] format
+/// [OC, IC, K] → [OC, IC, 1, K] (kH=1, kW=K)
+Value reshapeWeightTo4D(PatternRewriter &rewriter, Location loc, Value weight) {
+  auto weightType = cast<RankedTensorType>(weight.getType());
+  auto weightShape = weightType.getShape();
+
+  // [OC, IC, K] → [OC, IC, 1, K] (ONNX weight format with kH=1)
+  llvm::SmallVector<int64_t> newShape = {weightShape[0], weightShape[1], 1,
+      weightShape[2]};
+
+  auto newType = RankedTensorType::get(newShape, weightType.getElementType());
+  auto shapeConst = createShapeConstant(rewriter, loc, newShape);
+
+  return rewriter.create<ONNXReshapeOp>(loc, newType, weight, shapeConst)
+      .getReshaped();
+}
+
+/// Check if operation has 1D spatial dimensions (3D tensor)
+bool is1DSpatialOp(RankedTensorType inputType) {
+  return inputType && inputType.getRank() == 3;
+}
+
+/// Get the group attribute from Conv op, defaults to 1
+int64_t getConvGroup(ONNXConvOp convOp) {
+  auto groupAttr = convOp.getGroupAttr();
+  return groupAttr ? groupAttr.getValue().getSExtValue() : 1;
+}
+
+/// Check if operation is a supported activation (relu, leaky-relu, prelu,
+/// relu6)
+bool isActivationOp(Operation *op) {
+  if (!op)
+    return false;
+  return isa<ONNXReluOp, ONNXLeakyReluOp, ONNXPReluOp, ONNXClipOp>(op);
+}
+
+/// Get the single-use activation op following a conv/pool, or nullptr
+Operation *getFollowingActivation(Operation *op) {
+  if (!op->getResult(0).hasOneUse())
+    return nullptr;
+
+  Operation *user = *op->getResult(0).getUsers().begin();
+  if (isActivationOp(user))
+    return user;
+
+  return nullptr;
+}
+
+/// Create activation op with 4D output type
+Value createActivation4D(PatternRewriter &rewriter, Location loc,
+    Operation *originalActivation, Value input4D) {
+  auto outputType = input4D.getType();
+
+  if (auto reluOp = dyn_cast<ONNXReluOp>(originalActivation)) {
+    return rewriter.create<ONNXReluOp>(loc, outputType, input4D).getResult();
+  }
+  if (auto leakyReluOp = dyn_cast<ONNXLeakyReluOp>(originalActivation)) {
+    return rewriter
+        .create<ONNXLeakyReluOp>(loc, outputType, input4D,
+            leakyReluOp.getAlphaAttr())
+        .getResult();
+  }
+  if (auto preluOp = dyn_cast<ONNXPReluOp>(originalActivation)) {
+    Value slope = preluOp.getSlope();
+    return rewriter.create<ONNXPReluOp>(loc, outputType, input4D, slope)
+        .getResult();
+  }
+  if (auto clipOp = dyn_cast<ONNXClipOp>(originalActivation)) {
+    return rewriter
+        .create<ONNXClipOp>(loc, outputType, input4D, clipOp.getMin(),
+            clipOp.getMax())
+        .getResult();
+  }
+
+  llvm_unreachable("Unknown activation type");
+}
+
+//===----------------------------------------------------------------------===//
+// Conv1D/DepthwiseConv1D to Conv2D Transformation
+//===----------------------------------------------------------------------===//
+
+/// Unified transformation for Conv1D → Conv2D (handles both regular and
+/// depthwise) For depthwise conv, group == C, which getConvGroup() returns
+LogicalResult transformConv1dToConv2d(ONNXConvOp convOp,
+    PatternRewriter &rewriter, Operation *activationOp) {
+  Location loc = convOp.getLoc();
+  Value input = convOp.getX();
+  Value weight = convOp.getW();
+  Value bias = convOp.getB();
+
+  auto inputType = cast<RankedTensorType>(input.getType());
+  auto weightType = cast<RankedTensorType>(weight.getType());
+
+  auto outputType =
+      cast<RankedTensorType>(activationOp ? activationOp->getResult(0).getType()
+                                          : convOp.getResult().getType());
+  auto outputShape3D = outputType.getShape();
+
+  // Get kernel size for special case handling
+  auto kernel1d = getArrayAttrValues(convOp.getKernelShape());
+  if (kernel1d.empty())
+    kernel1d = {weightType.getShape()[2]};
+  int64_t kernelSize = kernel1d[0];
+
+  // Reshape input: [N, C, L] → [N, C, 1, L] or [1, N, C, L] for kernel=1
+  Value reshapedInput = reshapeInputTo4D(rewriter, loc, input, kernelSize);
+
+  // Reshape weight: [OC, IC/g, K] → [OC, IC/g, 1, K]
+  Value reshapedWeight = reshapeWeightTo4D(rewriter, loc, weight);
+
+  // Get and extend attributes from 1D to 2D
+  auto stride1d = getArrayAttrValues(convOp.getStrides());
+  auto dilation1d = getArrayAttrValues(convOp.getDilations());
+  auto pads1d = getArrayAttrValues(convOp.getPads());
+
+  if (stride1d.empty())
+    stride1d = {1};
+  if (dilation1d.empty())
+    dilation1d = {1};
+  if (pads1d.empty())
+    pads1d = {0, 0};
+
+  auto kernel2d = extend1DAttrTo2D(kernel1d);
+  auto stride2d = extend1DAttrTo2D(stride1d);
+  auto dilation2d = extend1DAttrTo2D(dilation1d);
+  auto pads2d = extend1DPadsTo2D(pads1d);
+
+  // Use unranked type - let ONNX infer Conv2D output shape
+  auto conv2dOutputType = UnrankedTensorType::get(inputType.getElementType());
+
+  // Handle bias
+  Value conv2dBias = bias;
+  if (!bias || isa<NoneType>(bias.getType())) {
+    onnx_mlir::OnnxBuilder onnxBuilder(rewriter, loc);
+    conv2dBias = onnxBuilder.none();
+  }
+
+  auto si64Type =
+      IntegerType::get(rewriter.getContext(), 64, IntegerType::Signed);
+
+  // Create Conv2D (group from original op - works for both regular and
+  // depthwise)
+  auto conv2dOp = rewriter.create<ONNXConvOp>(loc, conv2dOutputType,
+      reshapedInput, reshapedWeight, conv2dBias,
+      /*auto_pad=*/convOp.getAutoPadAttr(),
+      /*dilations=*/rewriter.getI64ArrayAttr(dilation2d),
+      /*group=*/IntegerAttr::get(si64Type, getConvGroup(convOp)),
+      /*kernel_shape=*/rewriter.getI64ArrayAttr(kernel2d),
+      /*pads=*/rewriter.getI64ArrayAttr(pads2d),
+      /*strides=*/rewriter.getI64ArrayAttr(stride2d));
+
+  Value result = conv2dOp.getResult();
+
+  if (activationOp) {
+    result = createActivation4D(rewriter, loc, activationOp, result);
+  }
+
+  Value finalOutput = reshapeOutputTo3D(rewriter, loc, result, outputShape3D,
+      outputType.getElementType());
+
+  if (activationOp) {
+    rewriter.replaceOp(activationOp, finalOutput);
+  } else {
+    rewriter.replaceOp(convOp, finalOutput);
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Pattern: Conv1D to Conv2D (handles both regular and depthwise)
+//===----------------------------------------------------------------------===//
+
+struct Conv1dToConv2dPattern : public OpRewritePattern<ONNXConvOp> {
+  using OpRewritePattern<ONNXConvOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ONNXConvOp convOp,
+      PatternRewriter &rewriter) const override {
+    // Check if this is a 1D convolution (3D input tensor)
+    auto inputType = dyn_cast<RankedTensorType>(convOp.getX().getType());
+    if (!is1DSpatialOp(inputType))
+      return failure();
+
+    // Verify weight is 3D
+    auto weightType = dyn_cast<RankedTensorType>(convOp.getW().getType());
+    if (!weightType || weightType.getRank() != 3)
+      return failure();
+
+    // Check for following activation (relu, leaky-relu, prelu, relu6)
+    Operation *activationOp = getFollowingActivation(convOp);
+
+    return transformConv1dToConv2d(convOp, rewriter, activationOp);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pattern: MaxPool1D to MaxPool2D
+//===----------------------------------------------------------------------===//
+
+struct MaxPool1dToMaxPool2dPattern
+    : public OpRewritePattern<ONNXMaxPoolSingleOutOp> {
+  using OpRewritePattern<ONNXMaxPoolSingleOutOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ONNXMaxPoolSingleOutOp maxPoolOp,
+      PatternRewriter &rewriter) const override {
+    Location loc = maxPoolOp.getLoc();
+    Value input = maxPoolOp.getX();
+
+    // Check if 1D pooling (3D input)
+    auto inputType = dyn_cast<RankedTensorType>(input.getType());
+    if (!is1DSpatialOp(inputType))
+      return failure();
+
+    auto inputShape = inputType.getShape();
+    auto outputType = cast<RankedTensorType>(maxPoolOp.getResult().getType());
+    auto outputShape3D = outputType.getShape();
+
+    // Reshape input: [N, C, L] → [N, C, 1, L] (no special kernel=1 case for
+    // maxpool)
+    llvm::SmallVector<int64_t> input4DShape = {inputShape[0], inputShape[1], 1,
+        inputShape[2]};
+    auto input4DType =
+        RankedTensorType::get(input4DShape, inputType.getElementType());
+    auto inputShapeConst = createShapeConstant(rewriter, loc, input4DShape);
+    Value reshapedInput =
+        rewriter.create<ONNXReshapeOp>(loc, input4DType, input, inputShapeConst)
+            .getReshaped();
+
+    // Get and extend attributes
+    auto kernel1d = getArrayAttrValues(maxPoolOp.getKernelShape());
+    auto stride1d = getArrayAttrValues(maxPoolOp.getStrides());
+    auto dilation1d = getArrayAttrValues(maxPoolOp.getDilations());
+    auto pads1d = getArrayAttrValues(maxPoolOp.getPads());
+
+    if (stride1d.empty())
+      stride1d = {1};
+    if (dilation1d.empty())
+      dilation1d = {1};
+    if (pads1d.empty())
+      pads1d = {0, 0};
+
+    auto kernel2d = extend1DAttrTo2D(kernel1d);
+    auto stride2d = extend1DAttrTo2D(stride1d);
+    auto dilation2d = extend1DAttrTo2D(dilation1d);
+    auto pads2d = extend1DPadsTo2D(pads1d);
+
+    // Use unranked type - let ONNX infer MaxPool2D output shape
+    auto pool2dOutputType = UnrankedTensorType::get(inputType.getElementType());
+
+    auto si64Type =
+        IntegerType::get(rewriter.getContext(), 64, IntegerType::Signed);
+
+    // Create MaxPool2D
+    auto maxPool2dOp = rewriter.create<ONNXMaxPoolSingleOutOp>(loc,
+        pool2dOutputType, reshapedInput,
+        /*auto_pad=*/maxPoolOp.getAutoPadAttr(),
+        /*ceil_mode=*/maxPoolOp.getCeilModeAttr(),
+        /*dilations=*/rewriter.getI64ArrayAttr(dilation2d),
+        /*kernel_shape=*/rewriter.getI64ArrayAttr(kernel2d),
+        /*pads=*/rewriter.getI64ArrayAttr(pads2d),
+        /*storage_order=*/IntegerAttr::get(si64Type, 0),
+        /*strides=*/rewriter.getI64ArrayAttr(stride2d));
+
+    // Reshape output back to 3D
+    Value finalOutput = reshapeOutputTo3D(
+        rewriter, loc, maxPool2dOp.getResult(), outputShape3D,
+        outputType.getElementType());
+
+    rewriter.replaceOp(maxPoolOp, finalOutput);
+    return success();
+  }
+};
+
+} // namespace
+
+namespace onnx_mlir {
+
+//===----------------------------------------------------------------------===//
+// Pass Definition
+//===----------------------------------------------------------------------===//
+
+/// Pass to transfer 1D operations to 2D operations.
+/// This converts Conv1D, MaxPool1D, and DepthwiseConv1D to their 2D equivalents
+/// by inserting reshape operations before and after.
+struct TransferOp1dToOp2dPass
+    : public PassWrapper<TransferOp1dToOp2dPass, OperationPass<func::FuncOp>> {
+  StringRef getArgument() const override { return "transfer-op1d-to-op2d"; }
+  StringRef getDescription() const override {
+    return "Convert 1D operations (Conv1D, MaxPool1D) to 2D equivalents";
+  }
+
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+
+    RewritePatternSet patterns(ctx);
+
+    // Conv1D → Conv2D (handles both regular and depthwise, with or without
+    // activation)
+    patterns.add<Conv1dToConv2dPattern>(ctx);
+
+    // MaxPool1D → MaxPool2D
+    patterns.add<MaxPool1dToMaxPool2dPattern>(ctx);
+
+    GreedyRewriteConfig config;
+    config.strictMode = GreedyRewriteStrictness::ExistingAndNewOps;
+
+    if (failed(applyPatternsGreedily(
+            getOperation(), std::move(patterns), config))) {
+      signalPassFailure();
+    }
+  }
+};
+
+std::unique_ptr<mlir::Pass> createTransferOp1dToOp2dPass() {
+  return std::make_unique<TransferOp1dToOp2dPass>();
+}
+
+} // namespace onnx_mlir

--- a/src/Dialect/ONNX/Transforms/xmc/TransferOpShapeTo4dPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/TransferOpShapeTo4dPass.cpp
@@ -1,0 +1,336 @@
+// Copyright (C) 2022 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// This pass transfers element-wise operations with non-4D shapes to 4D.
+// Handles broadcasting by computing per-input 4D shapes based on which
+// dimensions differ between inputs and output.
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Pass/Passes.hpp"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+#include <algorithm>
+#include <cmath>
+#include <set>
+
+#define DEBUG_TYPE "transfer-op-shape-to-4d"
+
+using namespace mlir;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Helper Functions
+//===----------------------------------------------------------------------===//
+
+/// Helper to get shape from a ranked tensor type
+SmallVector<int64_t> getShapeFromType(Type type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+    auto shape = tensorType.getShape();
+    return SmallVector<int64_t>(shape.begin(), shape.end());
+  }
+  return {};
+}
+
+/// Helper to get element type from a tensor type
+Type getElementType(Type type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+    return tensorType.getElementType();
+  }
+  return nullptr;
+}
+
+/// Create a constant op with the given int64 values
+Value createConstantI64Array(PatternRewriter &rewriter, Location loc,
+    ArrayRef<int64_t> values) {
+  MLIRContext *ctx = rewriter.getContext();
+  auto tensorType = RankedTensorType::get({static_cast<int64_t>(values.size())},
+      IntegerType::get(ctx, 64));
+  auto denseAttr = DenseIntElementsAttr::get(tensorType, values);
+  return rewriter.create<ONNXConstantOp>(loc, Attribute(), denseAttr);
+}
+
+/// Multiply all dimensions except those specified in excludeDims
+int64_t mulWithoutDims(ArrayRef<int64_t> shape,
+    const std::set<int64_t> &excludeDims) {
+  int64_t result = 1;
+  for (size_t i = 0; i < shape.size(); ++i) {
+    if (excludeDims.find(i) == excludeDims.end()) {
+      result *= shape[i];
+    }
+  }
+  return result;
+}
+
+/// Simple integer decomposition into prime factors
+SmallVector<int64_t> integerDecomposition(int64_t n) {
+  SmallVector<int64_t> factors;
+  for (int64_t d = 2; d * d <= n; ++d) {
+    while (n % d == 0) {
+      factors.push_back(d);
+      n /= d;
+    }
+  }
+  if (n > 1) {
+    factors.push_back(n);
+  }
+  return factors;
+}
+
+/// Check if all inputs are already 4D with batch=1
+bool allInputsAlready4D(ArrayRef<Value> inputs) {
+  return std::all_of(inputs.begin(), inputs.end(), [](Value input) {
+    auto shape = getShapeFromType(input.getType());
+    return shape.size() == 4 && shape.front() == 1;
+  });
+}
+
+/// Detect which dimensions differ between inputs and output (broadcast dims)
+/// Matches original: assumes same rank, uses input's shape.size() for loop
+std::set<int64_t> detectBroadcastDims(ArrayRef<Value> inputs,
+    ArrayRef<int64_t> outputShape) {
+  std::set<int64_t> broadcastDims;
+
+  for (Value input : inputs) {
+    auto inputShape = getShapeFromType(input.getType());
+    if (inputShape.empty())
+      continue;
+
+    // Original assumes same size - use input's size for loop bound
+    for (size_t idx = 0; idx < inputShape.size(); ++idx) {
+      if (inputShape[idx] != outputShape[idx]) {
+        broadcastDims.insert(idx);
+      }
+    }
+  }
+
+  return broadcastDims;
+}
+
+/// Compute broadcast-aware 4D shape for an input tensor
+/// Takes into account which dimensions are broadcast dimensions
+/// Returns empty vector if input should be kept unchanged
+SmallVector<int64_t>
+computeBroadcastAware4DShape(ArrayRef<int64_t> inputShape,
+    const std::set<int64_t> &broadcastDims) {
+  SmallVector<int64_t> shape(inputShape.begin(), inputShape.end());
+
+  // For < 4D: pad with 1s at the front
+  if (shape.size() < 4) {
+    shape.insert(shape.begin(), 4 - shape.size(), 1);
+    return shape;
+  }
+
+  // For >= 4D: compute N, H, W, C based on broadcast dimensions
+  int64_t N = 1, H = 1, W = 1, C = 1;
+
+  int64_t shapeSize = static_cast<int64_t>(shape.size());
+
+  if (broadcastDims.empty() ||
+      (broadcastDims.size() == 1 && *broadcastDims.begin() == shapeSize - 1)) {
+    // No broadcast or broadcast only at last dim
+    // Use sqrt-based H/W decomposition
+    C = shape.back();
+    int64_t remainder =
+        mulWithoutDims(shape, {static_cast<int64_t>(shapeSize - 1)});
+    double hCandidate = std::ceil(std::sqrt(static_cast<double>(remainder)));
+    auto factors = integerDecomposition(remainder);
+    std::sort(factors.begin(), factors.end());
+
+    for (int64_t item : factors) {
+      if (H < hCandidate) {
+        H *= item;
+      } else {
+        W *= item;
+      }
+    }
+  } else {
+    // Broadcast at a specific dimension
+    int64_t curDim = *broadcastDims.begin();
+
+    if (curDim == 0) {
+      // Broadcast at dim 0
+      H = shape[0];
+      W = mulWithoutDims(shape, {0, shapeSize - 1});
+      C = shape.back();
+    } else {
+      // Broadcast at middle dimension
+      for (int64_t idx = 0; idx < shapeSize; ++idx) {
+        if (idx < curDim) {
+          H *= shape[idx];
+        } else if (idx == curDim) {
+          W = shape[idx];
+        } else {
+          C *= shape[idx];
+        }
+      }
+    }
+  }
+
+  return {N, H, W, C};
+}
+
+//===----------------------------------------------------------------------===//
+// Pattern: Transfer element-wise ops with non-4D shapes to 4D
+//===----------------------------------------------------------------------===//
+
+template <typename OpTy>
+class TransferEltwiseTo4DPattern : public OpRewritePattern<OpTy> {
+public:
+  using OpRewritePattern<OpTy>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OpTy op,
+      PatternRewriter &rewriter) const override {
+    auto outputShape = getShapeFromType(op.getResult().getType());
+    Type elementType = getElementType(op.getResult().getType());
+
+    if (outputShape.empty() || !elementType) {
+      return failure();
+    }
+
+    // Gather all inputs
+    SmallVector<Value> inputs(op->getOperands().begin(),
+        op->getOperands().end());
+
+    // Skip if all inputs are already 4D with batch=1 (matches original)
+    if (allInputsAlready4D(inputs)) {
+      return failure();
+    }
+
+    // Detect broadcast dimensions
+    std::set<int64_t> broadcastDims = detectBroadcastDims(inputs, outputShape);
+
+    // Guard: current logic only supports at most one broadcast dimension.
+    if (broadcastDims.size() > 1) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+
+    // Compute output 4D shape using broadcast-aware logic
+    SmallVector<int64_t> outputShape4D =
+        computeBroadcastAware4DShape(outputShape, broadcastDims);
+    if (outputShape4D.empty()) {
+      // Cannot handle this broadcast pattern (>1 broadcast dims)
+      return failure();
+    }
+
+    // If output shape is unchanged, skip
+    if (outputShape4D.size() == outputShape.size() &&
+        std::equal(outputShape4D.begin(), outputShape4D.end(),
+            outputShape.begin())) {
+      return failure();
+    }
+
+    // Reshape all inputs to their respective 4D shapes
+    SmallVector<Value> reshapedInputs;
+    for (Value input : inputs) {
+      auto inputShape = getShapeFromType(input.getType());
+      Type inputElementType = getElementType(input.getType());
+
+      if (inputShape.empty() || !inputElementType) {
+        return failure();
+      }
+
+      SmallVector<int64_t> inputShape4D =
+          computeBroadcastAware4DShape(inputShape, broadcastDims);
+
+      if (inputShape4D.empty()) {
+        // Cannot reshape this input (>1 broadcast dims) - keep unchanged
+        reshapedInputs.push_back(input);
+        continue;
+      }
+
+      // Check if reshape is actually needed
+      if (inputShape4D.size() == inputShape.size() &&
+          std::equal(inputShape4D.begin(), inputShape4D.end(),
+              inputShape.begin())) {
+        reshapedInputs.push_back(input);
+        continue;
+      }
+
+      auto inputReshapeType =
+          RankedTensorType::get(inputShape4D, inputElementType);
+      Value shapeConst = createConstantI64Array(rewriter, loc, inputShape4D);
+      auto reshapeOp = rewriter.create<ONNXReshapeOp>(
+          loc, inputReshapeType, input, shapeConst);
+      reshapedInputs.push_back(reshapeOp.getResult());
+    }
+
+    // Create new element-wise op with 4D inputs
+    auto newOutputType = RankedTensorType::get(outputShape4D, elementType);
+    Operation *newOp =
+        rewriter.create<OpTy>(loc, newOutputType, reshapedInputs);
+
+    // Reshape output back to original shape
+    auto outputReshapeType = RankedTensorType::get(outputShape, elementType);
+    Value outputShapeConst = createConstantI64Array(rewriter, loc, outputShape);
+    auto outputReshapeOp = rewriter.create<ONNXReshapeOp>(
+        loc, outputReshapeType, newOp->getResult(0), outputShapeConst);
+
+    rewriter.replaceOp(op, outputReshapeOp.getResult());
+    return success();
+  }
+};
+
+} // namespace
+
+namespace onnx_mlir {
+
+//===----------------------------------------------------------------------===//
+// Pass Definition
+//===----------------------------------------------------------------------===//
+
+/// Pass to transfer element-wise ops with non-4D shapes to 4D
+struct TransferOpShapeTo4dPass
+    : public PassWrapper<TransferOpShapeTo4dPass,
+          OperationPass<func::FuncOp>> {
+  StringRef getArgument() const override { return "transfer-op-shape-to-4d"; }
+  StringRef getDescription() const override {
+    return "Transfer element-wise operations with non-4D shapes to 4D";
+  }
+
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+
+    // Add element-wise patterns for various ops
+    patterns.add<TransferEltwiseTo4DPattern<ONNXAddOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXMulOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXSubOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXDivOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXMaxOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXMinOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXAbsOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXExpOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXSqrtOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXReluOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXTanhOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXLeakyReluOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXEluOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXNegOp>>(ctx);
+    patterns.add<TransferEltwiseTo4DPattern<ONNXClipOp>>(ctx);
+
+    GreedyRewriteConfig config;
+    config.strictMode = GreedyRewriteStrictness::ExistingAndNewOps;
+
+    if (failed(applyPatternsGreedily(
+            getOperation(), std::move(patterns), config))) {
+      signalPassFailure();
+    }
+  }
+};
+
+std::unique_ptr<mlir::Pass> createTransferOpShapeTo4dPass() {
+  return std::make_unique<TransferOpShapeTo4dPass>();
+}
+
+} // namespace onnx_mlir

--- a/src/Dialect/ONNX/Transforms/xmc/Transform5DTransposeTo4DPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/Transform5DTransposeTo4DPass.cpp
@@ -1,7 +1,9 @@
 // Copyright (C) 2022 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
-// This pass transforms 5D Transpose operations to Reshape + 4D Transpose + Reshape
-// when the perm contains a consecutive pair, enabling more efficient execution.
+// This pass transforms >4D Transpose operations to Reshape + 4D Transpose + Reshape
+// using two strategies:
+// 1. Merging consecutive identity dimensions (where i == order[i])
+// 2. Merging consecutive pairs in perm (where perm[i] + 1 == perm[i+1])
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -26,6 +28,112 @@ namespace {
 
 //===----------------------------------------------------------------------===//
 // Helper Functions
+//===----------------------------------------------------------------------===//
+
+/// Helper to get shape from a ranked tensor type
+SmallVector<int64_t> getShapeFromType(Type type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+    auto shape = tensorType.getShape();
+    return SmallVector<int64_t>(shape.begin(), shape.end());
+  }
+  return {};
+}
+
+/// Helper to get element type from a tensor type
+Type getElementType(Type type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+    return tensorType.getElementType();
+  }
+  return nullptr;
+}
+
+/// Create a constant op with the given int64 values
+Value createConstantI64Array(PatternRewriter &rewriter, Location loc,
+    ArrayRef<int64_t> values) {
+  MLIRContext *ctx = rewriter.getContext();
+  auto tensorType = RankedTensorType::get({static_cast<int64_t>(values.size())},
+      IntegerType::get(ctx, 64));
+  auto denseAttr = DenseIntElementsAttr::get(tensorType, values);
+  return rewriter.create<ONNXConstantOp>(loc, Attribute(), denseAttr);
+}
+
+//===----------------------------------------------------------------------===//
+// Strategy 1: Merge consecutive identity dimensions
+//===----------------------------------------------------------------------===//
+
+/// Check if the transpose order can be reduced to 4D or less
+/// by merging consecutive identity dimensions (where i == order[i])
+bool canReduceTransposeTo4D(ArrayAttr permAttr) {
+  if (!permAttr || permAttr.size() <= 4)
+    return false;
+
+  SmallVector<int64_t> order;
+  for (auto attr : permAttr) {
+    order.push_back(cast<IntegerAttr>(attr).getInt());
+  }
+
+  int reshapedDimLength = 0;
+  bool isPreDimOrg = false;
+  for (size_t i = 0; i < order.size(); ++i) {
+    if (static_cast<int64_t>(i) == order[i]) {
+      if (!isPreDimOrg) {
+        reshapedDimLength++;
+        isPreDimOrg = true;
+      }
+    } else {
+      reshapedDimLength++;
+      isPreDimOrg = false;
+    }
+  }
+  return reshapedDimLength <= 4;
+}
+
+/// Compute reduced transpose order and reshaped input shape
+/// by merging consecutive identity dimensions
+std::pair<SmallVector<int64_t>, SmallVector<int64_t>>
+computeReducedTranspose(ArrayRef<int64_t> inputShape, ArrayAttr permAttr) {
+  SmallVector<int64_t> order;
+  for (auto attr : permAttr) {
+    order.push_back(cast<IntegerAttr>(attr).getInt());
+  }
+
+  SmallVector<int64_t> reshapedOrder;
+  SmallVector<int64_t> reshapedInputShape;
+  int64_t reducedDimNum = 0;
+  bool isPreDimOrg = false;
+
+  for (size_t i = 0; i < order.size(); ++i) {
+    if (static_cast<int64_t>(i) == order[i]) {
+      if (isPreDimOrg) {
+        reshapedInputShape.back() *= inputShape[i];
+        reducedDimNum++;
+      } else {
+        reshapedInputShape.push_back(inputShape[i]);
+        reshapedOrder.push_back(order[i] - reducedDimNum);
+      }
+      isPreDimOrg = true;
+    } else {
+      reshapedInputShape.push_back(inputShape[i]);
+      reshapedOrder.push_back(order[i] - reducedDimNum);
+      isPreDimOrg = false;
+    }
+  }
+
+  return {reshapedOrder, reshapedInputShape};
+}
+
+/// Compute output shape after transpose
+SmallVector<int64_t> computeTransposeOutputShape(ArrayRef<int64_t> inputShape,
+    ArrayRef<int64_t> perm) {
+  SmallVector<int64_t> outputShape;
+  for (int64_t p : perm) {
+    outputShape.push_back(inputShape[p]);
+  }
+  return outputShape;
+}
+
+//===----------------------------------------------------------------------===//
+// Strategy 2: Merge consecutive pairs in perm
 //===----------------------------------------------------------------------===//
 
 /// Find first consecutive pair in perm where perm[i] + 1 == perm[i+1]
@@ -112,7 +220,76 @@ ArrayAttr getI64ArrayAttr(MLIRContext *ctx, ArrayRef<int64_t> values) {
 }
 
 //===----------------------------------------------------------------------===//
-// Pattern: Transform 5D Transpose to Reshape + 4D Transpose + Reshape
+// Pattern 1: Reduce transpose by merging consecutive identity dimensions
+// Transforms: input -> transpose(>4D order with identity dims) -> output
+// Into: input -> reshape -> transpose(<=4D order) -> reshape -> output
+//===----------------------------------------------------------------------===//
+
+class TransferTransposeTo4DPattern
+    : public OpRewritePattern<ONNXTransposeOp> {
+public:
+  using OpRewritePattern<ONNXTransposeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ONNXTransposeOp transposeOp,
+      PatternRewriter &rewriter) const override {
+    auto permAttr = transposeOp.getPermAttr();
+    if (!canReduceTransposeTo4D(permAttr)) {
+      return failure();
+    }
+
+    // Check single use
+    if (!transposeOp.getResult().hasOneUse()) {
+      return failure();
+    }
+
+    Location loc = transposeOp.getLoc();
+    Value input = transposeOp.getData();
+    auto inputShape = getShapeFromType(input.getType());
+    auto outputShape = getShapeFromType(transposeOp.getResult().getType());
+    Type elementType = getElementType(input.getType());
+
+    if (inputShape.empty() || !elementType) {
+      return failure();
+    }
+
+    // Compute reduced transpose parameters
+    auto [reshapedOrder, reshapedInputShape] =
+        computeReducedTranspose(inputShape, permAttr);
+
+    // Create input reshape
+    auto inputReshapeType =
+        RankedTensorType::get(reshapedInputShape, elementType);
+    Value inputReshapeShapeConst =
+        createConstantI64Array(rewriter, loc, reshapedInputShape);
+    auto inputReshapeOp = rewriter.create<ONNXReshapeOp>(
+        loc, inputReshapeType, input, inputReshapeShapeConst);
+
+    // Create new transpose with reduced order
+    auto transposeOutputShape =
+        computeTransposeOutputShape(reshapedInputShape, reshapedOrder);
+    auto newTransposeType =
+        RankedTensorType::get(transposeOutputShape, elementType);
+    auto newTransposeOp = rewriter.create<ONNXTransposeOp>(
+        loc, newTransposeType, inputReshapeOp.getResult(),
+        rewriter.getI64ArrayAttr(reshapedOrder));
+
+    // Create output reshape back to original output shape
+    auto outputReshapeType = RankedTensorType::get(outputShape, elementType);
+    Value outputReshapeShapeConst =
+        createConstantI64Array(rewriter, loc, outputShape);
+    auto outputReshapeOp = rewriter.create<ONNXReshapeOp>(
+        loc, outputReshapeType, newTransposeOp.getResult(),
+        outputReshapeShapeConst);
+
+    rewriter.replaceOp(transposeOp, outputReshapeOp.getResult());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pattern 2: Transform 5D Transpose by merging consecutive pairs in perm
+// Transforms: input -> transpose(5D with consecutive pair) -> output
+// Into: input -> reshape -> transpose(4D) -> reshape -> output
 //===----------------------------------------------------------------------===//
 
 class Transform5DTransposeTo4DPattern
@@ -216,12 +393,16 @@ struct Transform5DTransposeTo4DPass
     return "transform-5d-transpose-to-4d";
   }
   StringRef getDescription() const override {
-    return "Transform 5D Transpose to Reshape + 4D Transpose + Reshape";
+    return "Transform >4D Transpose to Reshape + <=4D Transpose + Reshape";
   }
 
   void runOnOperation() override {
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
+
+    // Pattern 1: Merge consecutive identity dimensions (higher priority)
+    patterns.add<TransferTransposeTo4DPattern>(ctx);
+    // Pattern 2: Merge consecutive pairs in perm (for 5D specifically)
     patterns.add<Transform5DTransposeTo4DPattern>(ctx);
 
     GreedyRewriteConfig config;

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -198,6 +198,9 @@ std::unique_ptr<mlir::Pass> createRemoveRedundantReluPass();
 /// Pass for model-specific transpose decomposition (XMC).
 std::unique_ptr<mlir::Pass> createReplaceNDimTransposePass();
 
+/// Pass for transferring element-wise ops with non-4D shapes to 4D.
+std::unique_ptr<mlir::Pass> createTransferOpShapeTo4dPass();
+
 /// Pass for verifying Onnx ops before lowering to Krnl
 std::unique_ptr<mlir::Pass> createONNXPreKrnlVerifyPass();
 

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -201,6 +201,9 @@ std::unique_ptr<mlir::Pass> createReplaceNDimTransposePass();
 /// Pass for transferring element-wise ops with non-4D shapes to 4D.
 std::unique_ptr<mlir::Pass> createTransferOpShapeTo4dPass();
 
+/// Pass for transferring 1D operations to 2D operations.
+std::unique_ptr<mlir::Pass> createTransferOp1dToOp2dPass();
+
 /// Pass for verifying Onnx ops before lowering to Krnl
 std::unique_ptr<mlir::Pass> createONNXPreKrnlVerifyPass();
 

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -148,6 +148,10 @@ void registerOMPasses(int optLevel) {
   });
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return createTransferOp1dToOp2dPass();
+  });
+
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return createTransferOp3dToOp2dPass();
   });
 

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -144,6 +144,10 @@ void registerOMPasses(int optLevel) {
   });
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return createTransferOpShapeTo4dPass();
+  });
+
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return createTransferOp3dToOp2dPass();
   });
 

--- a/test/mlir/onnx/onnx_convert_to_channel_last.mlir
+++ b/test/mlir/onnx/onnx_convert_to_channel_last.mlir
@@ -296,8 +296,8 @@ func.func @test_resize_scales_to_channel_last(%arg0: tensor<1x3x4x4xf32>) -> ten
   } : (tensor<1x3x4x4xf32>, none, tensor<4xf32>, none) -> tensor<1x3x8x8xf32>
   onnx.Return %0 : tensor<1x3x8x8xf32>
 
+  // CHECK: [[SCALES_PERMUTED:%.+]] = onnx.Constant dense<[1.000000e+00, 2.000000e+00, 2.000000e+00, 1.000000e+00]> : tensor<4xf32>
   // CHECK: [[INPUT_CHANNEL_LAST:%.+]] = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x3x4x4xf32>) -> tensor<1x4x4x3xf32>
-  // CHECK: [[SCALES_PERMUTED:%.+]] = "onnx.Gather"
   // CHECK: [[RESIZE_CHANNEL_LAST:%.+]] = "onnx.XFEResize"([[INPUT_CHANNEL_LAST]], %{{.*}}, [[SCALES_PERMUTED]], %{{.*}}) {{{.*}}coordinate_transformation_mode = "half_pixel"{{.*}}mode = "nearest", nearest_mode = "round_prefer_floor"{{.*}}}
   // CHECK: [[OUTPUT_NCHW:%.+]] = "onnx.Transpose"([[RESIZE_CHANNEL_LAST]]) {perm = [0, 3, 1, 2]}
   // CHECK: onnx.Return [[OUTPUT_NCHW]] : tensor<1x3x8x8xf32>
@@ -316,8 +316,8 @@ func.func @test_resize_sizes_to_channel_last(%arg0: tensor<1x3x4x4xf32>) -> tens
   } : (tensor<1x3x4x4xf32>, none, none, tensor<4xi64>) -> tensor<1x3x8x8xf32>
   onnx.Return %0 : tensor<1x3x8x8xf32>
 
+  // CHECK: [[SIZES_PERMUTED:%.+]] = onnx.Constant dense<[1, 8, 8, 3]> : tensor<4xi64>
   // CHECK: [[INPUT_CHANNEL_LAST:%.+]] = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x3x4x4xf32>) -> tensor<1x4x4x3xf32>
-  // CHECK: [[SIZES_PERMUTED:%.+]] = "onnx.Gather"
   // CHECK: [[RESIZE_CHANNEL_LAST:%.+]] = "onnx.XFEResize"([[INPUT_CHANNEL_LAST]], %{{.*}}, %{{.*}}, [[SIZES_PERMUTED]]) {{{.*}}coordinate_transformation_mode = "half_pixel"{{.*}}mode = "linear"{{.*}}}
   // CHECK: [[OUTPUT_NCHW:%.+]] = "onnx.Transpose"([[RESIZE_CHANNEL_LAST]]) {perm = [0, 3, 1, 2]}
   // CHECK: onnx.Return [[OUTPUT_NCHW]] : tensor<1x3x8x8xf32>
@@ -337,8 +337,8 @@ func.func @test_resize_downsample_to_channel_last(%arg0: tensor<1x64x32x32xf32>)
   } : (tensor<1x64x32x32xf32>, none, tensor<4xf32>, none) -> tensor<1x64x16x16xf32>
   onnx.Return %0 : tensor<1x64x16x16xf32>
 
+  // CHECK: [[SCALES_PERMUTED:%.+]] = onnx.Constant dense<[1.000000e+00, 5.000000e-01, 5.000000e-01, 1.000000e+00]> : tensor<4xf32>
   // CHECK: [[INPUT_CHANNEL_LAST:%.+]] = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x64x32x32xf32>) -> tensor<1x32x32x64xf32>
-  // CHECK: [[SCALES_PERMUTED:%.+]] = "onnx.Gather"
   // CHECK: [[RESIZE_CHANNEL_LAST:%.+]] = "onnx.XFEResize"([[INPUT_CHANNEL_LAST]], %{{.*}}, [[SCALES_PERMUTED]], %{{.*}}) {{{.*}}coordinate_transformation_mode = "asymmetric"{{.*}}mode = "nearest", nearest_mode = "floor"{{.*}}}
   // CHECK: [[OUTPUT_NCHW:%.+]] = "onnx.Transpose"([[RESIZE_CHANNEL_LAST]]) {perm = [0, 3, 1, 2]}
   // CHECK: onnx.Return [[OUTPUT_NCHW]] : tensor<1x64x16x16xf32>

--- a/test/mlir/onnx/xmc/transfer_op1d_to_op2d.mlir
+++ b/test/mlir/onnx/xmc/transfer_op1d_to_op2d.mlir
@@ -1,0 +1,252 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+// RUN: onnx-mlir-opt %s -transfer-op1d-to-op2d -o - | FileCheck %s
+
+module {
+  //===--------------------------------------------------------------------===//
+  // Test 1: Conv1D without activation
+  // Input: [N, C, L] = [1, 16, 64] → [N, C, 1, L] = [1, 16, 1, 64]
+  // Weight: [OC, IC, K] = [32, 16, 3] → [OC, IC, 1, K] = [32, 16, 1, 3]
+  //===--------------------------------------------------------------------===//
+  func.func @test_conv1d(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+                         %arg1: tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>)
+                         -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
+      auto_pad = "NOTSET",
+      dilations = [1],
+      group = 1 : si64,
+      kernel_shape = [3],
+      pads = [0, 0],
+      strides = [1]
+    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+         tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>, none)
+         -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
+    return %1 : tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
+  }
+  // CHECK-LABEL: func.func @test_conv1d
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x1x64x!quant.uniform<i8:f32, 1.000000e-01>>
+  // CHECK: onnx.Reshape{{.*}} -> tensor<32x16x1x3x!quant.uniform<i8:f32, 5.000000e-02>>
+  // CHECK: onnx.Conv{{.*}}kernel_shape = [1, 3]{{.*}}pads = [0, 0, 0, 0]{{.*}}strides = [1, 1]
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x32x62x!quant.uniform<i8:f32, 1.000000e-01>>
+
+  //===--------------------------------------------------------------------===//
+  // Test 2: Conv1D with Relu activation
+  // Tests fusion of Conv1D + Relu
+  //===--------------------------------------------------------------------===//
+  func.func @test_conv1d_relu(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+                              %arg1: tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>)
+                              -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
+      auto_pad = "NOTSET",
+      dilations = [1],
+      group = 1 : si64,
+      kernel_shape = [3],
+      pads = [0, 0],
+      strides = [1]
+    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+         tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>, none)
+         -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
+    %2 = "onnx.Relu"(%1) : (tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>)
+                           -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
+    return %2 : tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
+  }
+  // CHECK-LABEL: func.func @test_conv1d_relu
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x1x64x!quant.uniform<i8:f32, 1.000000e-01>>
+  // CHECK: onnx.Reshape{{.*}} -> tensor<32x16x1x3x!quant.uniform<i8:f32, 5.000000e-02>>
+  // CHECK: onnx.Conv
+  // CHECK: onnx.Relu
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x32x62x!quant.uniform<i8:f32, 1.000000e-01>>
+
+  //===--------------------------------------------------------------------===//
+  // Test 3: Conv1D with kernel=1 (special case)
+  // When kernel=1 and N=C, input [N, C, L] → [1, N, C, L]
+  // Here N=C=8 satisfies the constraint for the kernel=1 optimization
+  //===--------------------------------------------------------------------===//
+  func.func @test_conv1d_kernel1(%arg0: tensor<8x8x64x!quant.uniform<i8:f32, 0.1:0>>,
+                                 %arg1: tensor<32x8x1x!quant.uniform<i8:f32, 0.05:0>>)
+                                 -> tensor<8x32x64x!quant.uniform<i8:f32, 0.1:0>> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
+      auto_pad = "NOTSET",
+      dilations = [1],
+      group = 1 : si64,
+      kernel_shape = [1],
+      pads = [0, 0],
+      strides = [1]
+    } : (tensor<8x8x64x!quant.uniform<i8:f32, 0.1:0>>,
+         tensor<32x8x1x!quant.uniform<i8:f32, 0.05:0>>, none)
+         -> tensor<8x32x64x!quant.uniform<i8:f32, 0.1:0>>
+    return %1 : tensor<8x32x64x!quant.uniform<i8:f32, 0.1:0>>
+  }
+  // CHECK-LABEL: func.func @test_conv1d_kernel1
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x8x8x64x!quant.uniform<i8:f32, 1.000000e-01>>
+  // CHECK: onnx.Reshape{{.*}} -> tensor<32x8x1x1x!quant.uniform<i8:f32, 5.000000e-02>>
+  // CHECK: onnx.Conv{{.*}}kernel_shape = [1, 1]
+  // CHECK: onnx.Reshape{{.*}} -> tensor<8x32x64x!quant.uniform<i8:f32, 1.000000e-01>>
+
+  //===--------------------------------------------------------------------===//
+  // Test 4: Conv1D with bias
+  //===--------------------------------------------------------------------===//
+  func.func @test_conv1d_bias(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+                              %arg1: tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>,
+                              %arg2: tensor<32xf32>)
+                              -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>> {
+    %1 = "onnx.Conv"(%arg0, %arg1, %arg2) {
+      auto_pad = "NOTSET",
+      dilations = [1],
+      group = 1 : si64,
+      kernel_shape = [3],
+      pads = [0, 0],
+      strides = [1]
+    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+         tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>, tensor<32xf32>)
+         -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
+    return %1 : tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
+  }
+  // CHECK-LABEL: func.func @test_conv1d_bias
+  // CHECK: onnx.Reshape
+  // CHECK: onnx.Reshape
+  // CHECK: onnx.Conv
+  // CHECK: onnx.Reshape
+
+  //===--------------------------------------------------------------------===//
+  // Test 5: DepthwiseConv1D without activation
+  // group == input_channels (depthwise)
+  //===--------------------------------------------------------------------===//
+  func.func @test_dwconv1d(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+                           %arg1: tensor<16x1x3x!quant.uniform<i8:f32, 0.05:0>>)
+                           -> tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
+      auto_pad = "NOTSET",
+      dilations = [1],
+      group = 16 : si64,
+      kernel_shape = [3],
+      pads = [0, 0],
+      strides = [1]
+    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+         tensor<16x1x3x!quant.uniform<i8:f32, 0.05:0>>, none)
+         -> tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>
+    return %1 : tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>
+  }
+  // CHECK-LABEL: func.func @test_dwconv1d
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x1x64x!quant.uniform<i8:f32, 1.000000e-01>>
+  // CHECK: onnx.Reshape{{.*}} -> tensor<16x1x1x3x!quant.uniform<i8:f32, 5.000000e-02>>
+  // CHECK: onnx.Conv{{.*}}group = 16{{.*}}kernel_shape = [1, 3]
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x62x!quant.uniform<i8:f32, 1.000000e-01>>
+
+  //===--------------------------------------------------------------------===//
+  // Test 6: DepthwiseConv1D with Relu
+  //===--------------------------------------------------------------------===//
+  func.func @test_dwconv1d_relu(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+                                %arg1: tensor<16x1x3x!quant.uniform<i8:f32, 0.05:0>>)
+                                -> tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
+      auto_pad = "NOTSET",
+      dilations = [1],
+      group = 16 : si64,
+      kernel_shape = [3],
+      pads = [0, 0],
+      strides = [1]
+    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+         tensor<16x1x3x!quant.uniform<i8:f32, 0.05:0>>, none)
+         -> tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>
+    %2 = "onnx.Relu"(%1) : (tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>)
+                           -> tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>
+    return %2 : tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>
+  }
+  // CHECK-LABEL: func.func @test_dwconv1d_relu
+  // CHECK: onnx.Reshape
+  // CHECK: onnx.Reshape
+  // CHECK: onnx.Conv{{.*}}group = 16
+  // CHECK: onnx.Relu
+  // CHECK: onnx.Reshape
+
+  //===--------------------------------------------------------------------===//
+  // Test 7: MaxPool1D without activation
+  // Input: [N, C, L] = [1, 16, 64] → [N, C, 1, L] = [1, 16, 1, 64]
+  //===--------------------------------------------------------------------===//
+  func.func @test_maxpool1d(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>)
+                            -> tensor<1x16x32x!quant.uniform<i8:f32, 0.1:0>> {
+    %0 = "onnx.MaxPoolSingleOut"(%arg0) {
+      auto_pad = "NOTSET",
+      ceil_mode = 0 : si64,
+      kernel_shape = [2],
+      pads = [0, 0],
+      strides = [2]
+    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>)
+        -> tensor<1x16x32x!quant.uniform<i8:f32, 0.1:0>>
+    return %0 : tensor<1x16x32x!quant.uniform<i8:f32, 0.1:0>>
+  }
+  // CHECK-LABEL: func.func @test_maxpool1d
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x1x64x!quant.uniform<i8:f32, 1.000000e-01>>
+  // CHECK: onnx.MaxPoolSingleOut{{.*}}kernel_shape = [1, 2]{{.*}}pads = [0, 0, 0, 0]{{.*}}strides = [1, 2]
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x32x!quant.uniform<i8:f32, 1.000000e-01>>
+
+  //===--------------------------------------------------------------------===//
+  // Test 8: Conv1D with padding and stride
+  //===--------------------------------------------------------------------===//
+  func.func @test_conv1d_pad_stride(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+                                    %arg1: tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>)
+                                    -> tensor<1x32x32x!quant.uniform<i8:f32, 0.1:0>> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
+      auto_pad = "NOTSET",
+      dilations = [1],
+      group = 1 : si64,
+      kernel_shape = [3],
+      pads = [1, 1],
+      strides = [2]
+    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
+         tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>, none)
+         -> tensor<1x32x32x!quant.uniform<i8:f32, 0.1:0>>
+    return %1 : tensor<1x32x32x!quant.uniform<i8:f32, 0.1:0>>
+  }
+  // CHECK-LABEL: func.func @test_conv1d_pad_stride
+  // CHECK: onnx.Reshape
+  // CHECK: onnx.Reshape
+  // CHECK: onnx.Conv{{.*}}pads = [0, 1, 0, 1]{{.*}}strides = [1, 2]
+  // CHECK: onnx.Reshape
+
+  //===--------------------------------------------------------------------===//
+  // Test 9: Should NOT match - 2D convolution (4D input)
+  //===--------------------------------------------------------------------===//
+  func.func @test_conv2d_no_match(%arg0: tensor<1x16x64x64xf32>,
+                                  %arg1: tensor<32x16x3x3xf32>) -> tensor<1x32x62x62xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
+      auto_pad = "NOTSET",
+      dilations = [1, 1],
+      group = 1 : si64,
+      kernel_shape = [3, 3],
+      pads = [0, 0, 0, 0],
+      strides = [1, 1]
+    } : (tensor<1x16x64x64xf32>, tensor<32x16x3x3xf32>, none) -> tensor<1x32x62x62xf32>
+    return %1 : tensor<1x32x62x62xf32>
+  }
+  // CHECK-LABEL: func.func @test_conv2d_no_match
+  // CHECK-NOT: onnx.Reshape
+  // CHECK: onnx.Conv
+  // CHECK-NOT: onnx.Reshape
+
+  //===--------------------------------------------------------------------===//
+  // Test 10: Should NOT match - 2D MaxPool (4D input)
+  //===--------------------------------------------------------------------===//
+  func.func @test_maxpool2d_no_match(%arg0: tensor<1x16x64x64xf32>) -> tensor<1x16x32x32xf32> {
+    %0 = "onnx.MaxPoolSingleOut"(%arg0) {
+      auto_pad = "NOTSET",
+      ceil_mode = 0 : si64,
+      kernel_shape = [2, 2],
+      pads = [0, 0, 0, 0],
+      strides = [2, 2]
+    } : (tensor<1x16x64x64xf32>) -> tensor<1x16x32x32xf32>
+    return %0 : tensor<1x16x32x32xf32>
+  }
+  // CHECK-LABEL: func.func @test_maxpool2d_no_match
+  // CHECK-NOT: onnx.Reshape
+  // CHECK: onnx.MaxPoolSingleOut
+  // CHECK-NOT: onnx.Reshape
+}

--- a/test/mlir/onnx/xmc/transfer_op1d_to_op2d.mlir
+++ b/test/mlir/onnx/xmc/transfer_op1d_to_op2d.mlir
@@ -4,9 +4,7 @@
 
 module {
   //===--------------------------------------------------------------------===//
-  // Test 1: Conv1D without activation
-  // Input: [N, C, L] = [1, 16, 64] → [N, C, 1, L] = [1, 16, 1, 64]
-  // Weight: [OC, IC, K] = [32, 16, 3] → [OC, IC, 1, K] = [32, 16, 1, 3]
+  // Test 1: Conv1D
   //===--------------------------------------------------------------------===//
   func.func @test_conv1d(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
                          %arg1: tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>)
@@ -31,143 +29,33 @@ module {
   // CHECK: onnx.Reshape{{.*}} -> tensor<1x32x62x!quant.uniform<i8:f32, 1.000000e-01>>
 
   //===--------------------------------------------------------------------===//
-  // Test 2: Conv1D with Relu activation
-  // Tests fusion of Conv1D + Relu
+  // Test 2: ConvTranspose1D
+  // Output calculation: (32-1)*2 + 3 = 65
   //===--------------------------------------------------------------------===//
-  func.func @test_conv1d_relu(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
-                              %arg1: tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>)
-                              -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>> {
+  func.func @test_convtranspose1d(%arg0: tensor<1x16x32x!quant.uniform<i8:f32, 0.1:0>>,
+                                  %arg1: tensor<16x32x3x!quant.uniform<i8:f32, 0.05:0>>)
+                                  -> tensor<1x32x65x!quant.uniform<i8:f32, 0.1:0>> {
     %0 = "onnx.NoValue"() {value} : () -> none
-    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
+    %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {
       auto_pad = "NOTSET",
       dilations = [1],
       group = 1 : si64,
       kernel_shape = [3],
       pads = [0, 0],
-      strides = [1]
-    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
-         tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>, none)
-         -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
-    %2 = "onnx.Relu"(%1) : (tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>)
-                           -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
-    return %2 : tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
+      strides = [2]
+    } : (tensor<1x16x32x!quant.uniform<i8:f32, 0.1:0>>,
+         tensor<16x32x3x!quant.uniform<i8:f32, 0.05:0>>, none)
+         -> tensor<1x32x65x!quant.uniform<i8:f32, 0.1:0>>
+    return %1 : tensor<1x32x65x!quant.uniform<i8:f32, 0.1:0>>
   }
-  // CHECK-LABEL: func.func @test_conv1d_relu
-  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x1x64x!quant.uniform<i8:f32, 1.000000e-01>>
-  // CHECK: onnx.Reshape{{.*}} -> tensor<32x16x1x3x!quant.uniform<i8:f32, 5.000000e-02>>
-  // CHECK: onnx.Conv
-  // CHECK: onnx.Relu
-  // CHECK: onnx.Reshape{{.*}} -> tensor<1x32x62x!quant.uniform<i8:f32, 1.000000e-01>>
+  // CHECK-LABEL: func.func @test_convtranspose1d
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x1x32x!quant.uniform<i8:f32, 1.000000e-01>>
+  // CHECK: onnx.Reshape{{.*}} -> tensor<16x32x1x3x!quant.uniform<i8:f32, 5.000000e-02>>
+  // CHECK: onnx.ConvTranspose{{.*}}kernel_shape = [1, 3]{{.*}}pads = [0, 0, 0, 0]{{.*}}strides = [1, 2]
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x32x65x!quant.uniform<i8:f32, 1.000000e-01>>
 
   //===--------------------------------------------------------------------===//
-  // Test 3: Conv1D with kernel=1 (special case)
-  // When kernel=1 and N=C, input [N, C, L] → [1, N, C, L]
-  // Here N=C=8 satisfies the constraint for the kernel=1 optimization
-  //===--------------------------------------------------------------------===//
-  func.func @test_conv1d_kernel1(%arg0: tensor<8x8x64x!quant.uniform<i8:f32, 0.1:0>>,
-                                 %arg1: tensor<32x8x1x!quant.uniform<i8:f32, 0.05:0>>)
-                                 -> tensor<8x32x64x!quant.uniform<i8:f32, 0.1:0>> {
-    %0 = "onnx.NoValue"() {value} : () -> none
-    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
-      auto_pad = "NOTSET",
-      dilations = [1],
-      group = 1 : si64,
-      kernel_shape = [1],
-      pads = [0, 0],
-      strides = [1]
-    } : (tensor<8x8x64x!quant.uniform<i8:f32, 0.1:0>>,
-         tensor<32x8x1x!quant.uniform<i8:f32, 0.05:0>>, none)
-         -> tensor<8x32x64x!quant.uniform<i8:f32, 0.1:0>>
-    return %1 : tensor<8x32x64x!quant.uniform<i8:f32, 0.1:0>>
-  }
-  // CHECK-LABEL: func.func @test_conv1d_kernel1
-  // CHECK: onnx.Reshape{{.*}} -> tensor<1x8x8x64x!quant.uniform<i8:f32, 1.000000e-01>>
-  // CHECK: onnx.Reshape{{.*}} -> tensor<32x8x1x1x!quant.uniform<i8:f32, 5.000000e-02>>
-  // CHECK: onnx.Conv{{.*}}kernel_shape = [1, 1]
-  // CHECK: onnx.Reshape{{.*}} -> tensor<8x32x64x!quant.uniform<i8:f32, 1.000000e-01>>
-
-  //===--------------------------------------------------------------------===//
-  // Test 4: Conv1D with bias
-  //===--------------------------------------------------------------------===//
-  func.func @test_conv1d_bias(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
-                              %arg1: tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>,
-                              %arg2: tensor<32xf32>)
-                              -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>> {
-    %1 = "onnx.Conv"(%arg0, %arg1, %arg2) {
-      auto_pad = "NOTSET",
-      dilations = [1],
-      group = 1 : si64,
-      kernel_shape = [3],
-      pads = [0, 0],
-      strides = [1]
-    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
-         tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>, tensor<32xf32>)
-         -> tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
-    return %1 : tensor<1x32x62x!quant.uniform<i8:f32, 0.1:0>>
-  }
-  // CHECK-LABEL: func.func @test_conv1d_bias
-  // CHECK: onnx.Reshape
-  // CHECK: onnx.Reshape
-  // CHECK: onnx.Conv
-  // CHECK: onnx.Reshape
-
-  //===--------------------------------------------------------------------===//
-  // Test 5: DepthwiseConv1D without activation
-  // group == input_channels (depthwise)
-  //===--------------------------------------------------------------------===//
-  func.func @test_dwconv1d(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
-                           %arg1: tensor<16x1x3x!quant.uniform<i8:f32, 0.05:0>>)
-                           -> tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>> {
-    %0 = "onnx.NoValue"() {value} : () -> none
-    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
-      auto_pad = "NOTSET",
-      dilations = [1],
-      group = 16 : si64,
-      kernel_shape = [3],
-      pads = [0, 0],
-      strides = [1]
-    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
-         tensor<16x1x3x!quant.uniform<i8:f32, 0.05:0>>, none)
-         -> tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>
-    return %1 : tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>
-  }
-  // CHECK-LABEL: func.func @test_dwconv1d
-  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x1x64x!quant.uniform<i8:f32, 1.000000e-01>>
-  // CHECK: onnx.Reshape{{.*}} -> tensor<16x1x1x3x!quant.uniform<i8:f32, 5.000000e-02>>
-  // CHECK: onnx.Conv{{.*}}group = 16{{.*}}kernel_shape = [1, 3]
-  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x62x!quant.uniform<i8:f32, 1.000000e-01>>
-
-  //===--------------------------------------------------------------------===//
-  // Test 6: DepthwiseConv1D with Relu
-  //===--------------------------------------------------------------------===//
-  func.func @test_dwconv1d_relu(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
-                                %arg1: tensor<16x1x3x!quant.uniform<i8:f32, 0.05:0>>)
-                                -> tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>> {
-    %0 = "onnx.NoValue"() {value} : () -> none
-    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
-      auto_pad = "NOTSET",
-      dilations = [1],
-      group = 16 : si64,
-      kernel_shape = [3],
-      pads = [0, 0],
-      strides = [1]
-    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
-         tensor<16x1x3x!quant.uniform<i8:f32, 0.05:0>>, none)
-         -> tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>
-    %2 = "onnx.Relu"(%1) : (tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>)
-                           -> tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>
-    return %2 : tensor<1x16x62x!quant.uniform<i8:f32, 0.1:0>>
-  }
-  // CHECK-LABEL: func.func @test_dwconv1d_relu
-  // CHECK: onnx.Reshape
-  // CHECK: onnx.Reshape
-  // CHECK: onnx.Conv{{.*}}group = 16
-  // CHECK: onnx.Relu
-  // CHECK: onnx.Reshape
-
-  //===--------------------------------------------------------------------===//
-  // Test 7: MaxPool1D without activation
-  // Input: [N, C, L] = [1, 16, 64] → [N, C, 1, L] = [1, 16, 1, 64]
+  // Test 3: MaxPool1D
   //===--------------------------------------------------------------------===//
   func.func @test_maxpool1d(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>)
                             -> tensor<1x16x32x!quant.uniform<i8:f32, 0.1:0>> {
@@ -187,66 +75,50 @@ module {
   // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x32x!quant.uniform<i8:f32, 1.000000e-01>>
 
   //===--------------------------------------------------------------------===//
-  // Test 8: Conv1D with padding and stride
+  // Test 4: AveragePool1D
   //===--------------------------------------------------------------------===//
-  func.func @test_conv1d_pad_stride(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
-                                    %arg1: tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>)
-                                    -> tensor<1x32x32x!quant.uniform<i8:f32, 0.1:0>> {
-    %0 = "onnx.NoValue"() {value} : () -> none
-    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
-      auto_pad = "NOTSET",
-      dilations = [1],
-      group = 1 : si64,
-      kernel_shape = [3],
-      pads = [1, 1],
-      strides = [2]
-    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>,
-         tensor<32x16x3x!quant.uniform<i8:f32, 0.05:0>>, none)
-         -> tensor<1x32x32x!quant.uniform<i8:f32, 0.1:0>>
-    return %1 : tensor<1x32x32x!quant.uniform<i8:f32, 0.1:0>>
-  }
-  // CHECK-LABEL: func.func @test_conv1d_pad_stride
-  // CHECK: onnx.Reshape
-  // CHECK: onnx.Reshape
-  // CHECK: onnx.Conv{{.*}}pads = [0, 1, 0, 1]{{.*}}strides = [1, 2]
-  // CHECK: onnx.Reshape
-
-  //===--------------------------------------------------------------------===//
-  // Test 9: Should NOT match - 2D convolution (4D input)
-  //===--------------------------------------------------------------------===//
-  func.func @test_conv2d_no_match(%arg0: tensor<1x16x64x64xf32>,
-                                  %arg1: tensor<32x16x3x3xf32>) -> tensor<1x32x62x62xf32> {
-    %0 = "onnx.NoValue"() {value} : () -> none
-    %1 = "onnx.Conv"(%arg0, %arg1, %0) {
-      auto_pad = "NOTSET",
-      dilations = [1, 1],
-      group = 1 : si64,
-      kernel_shape = [3, 3],
-      pads = [0, 0, 0, 0],
-      strides = [1, 1]
-    } : (tensor<1x16x64x64xf32>, tensor<32x16x3x3xf32>, none) -> tensor<1x32x62x62xf32>
-    return %1 : tensor<1x32x62x62xf32>
-  }
-  // CHECK-LABEL: func.func @test_conv2d_no_match
-  // CHECK-NOT: onnx.Reshape
-  // CHECK: onnx.Conv
-  // CHECK-NOT: onnx.Reshape
-
-  //===--------------------------------------------------------------------===//
-  // Test 10: Should NOT match - 2D MaxPool (4D input)
-  //===--------------------------------------------------------------------===//
-  func.func @test_maxpool2d_no_match(%arg0: tensor<1x16x64x64xf32>) -> tensor<1x16x32x32xf32> {
-    %0 = "onnx.MaxPoolSingleOut"(%arg0) {
+  func.func @test_avgpool1d(%arg0: tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>)
+                            -> tensor<1x16x32x!quant.uniform<i8:f32, 0.1:0>> {
+    %0 = "onnx.AveragePool"(%arg0) {
       auto_pad = "NOTSET",
       ceil_mode = 0 : si64,
-      kernel_shape = [2, 2],
-      pads = [0, 0, 0, 0],
-      strides = [2, 2]
-    } : (tensor<1x16x64x64xf32>) -> tensor<1x16x32x32xf32>
-    return %0 : tensor<1x16x32x32xf32>
+      kernel_shape = [2],
+      pads = [0, 0],
+      strides = [2]
+    } : (tensor<1x16x64x!quant.uniform<i8:f32, 0.1:0>>)
+        -> tensor<1x16x32x!quant.uniform<i8:f32, 0.1:0>>
+    return %0 : tensor<1x16x32x!quant.uniform<i8:f32, 0.1:0>>
   }
-  // CHECK-LABEL: func.func @test_maxpool2d_no_match
-  // CHECK-NOT: onnx.Reshape
-  // CHECK: onnx.MaxPoolSingleOut
-  // CHECK-NOT: onnx.Reshape
+  // CHECK-LABEL: func.func @test_avgpool1d
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x1x64x!quant.uniform<i8:f32, 1.000000e-01>>
+  // CHECK: onnx.AveragePool{{.*}}kernel_shape = [1, 2]{{.*}}pads = [0, 0, 0, 0]{{.*}}strides = [1, 2]
+  // CHECK: onnx.Reshape{{.*}} -> tensor<1x16x32x!quant.uniform<i8:f32, 1.000000e-01>>
+
+  //===--------------------------------------------------------------------===//
+  // Test 5: GlobalMaxPool1D
+  //===--------------------------------------------------------------------===//
+  func.func @test_globalmaxpool1d(%arg0: tensor<2x64x256x!quant.uniform<i8:f32, 0.1:0>>)
+                                  -> tensor<2x64x1x!quant.uniform<i8:f32, 0.1:0>> {
+    %0 = "onnx.GlobalMaxPool"(%arg0) : (tensor<2x64x256x!quant.uniform<i8:f32, 0.1:0>>)
+                                       -> tensor<2x64x1x!quant.uniform<i8:f32, 0.1:0>>
+    return %0 : tensor<2x64x1x!quant.uniform<i8:f32, 0.1:0>>
+  }
+  // CHECK-LABEL: func.func @test_globalmaxpool1d
+  // CHECK: onnx.Reshape{{.*}} -> tensor<2x64x1x256x!quant.uniform<i8:f32, 1.000000e-01>>
+  // CHECK: onnx.GlobalMaxPool
+  // CHECK: onnx.Reshape{{.*}} -> tensor<2x64x1x!quant.uniform<i8:f32, 1.000000e-01>>
+
+  //===--------------------------------------------------------------------===//
+  // Test 6: GlobalAveragePool1D
+  //===--------------------------------------------------------------------===//
+  func.func @test_globalavgpool1d(%arg0: tensor<4x128x512x!quant.uniform<i8:f32, 0.05:0>>)
+                                  -> tensor<4x128x1x!quant.uniform<i8:f32, 0.05:0>> {
+    %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<4x128x512x!quant.uniform<i8:f32, 0.05:0>>)
+                                           -> tensor<4x128x1x!quant.uniform<i8:f32, 0.05:0>>
+    return %0 : tensor<4x128x1x!quant.uniform<i8:f32, 0.05:0>>
+  }
+  // CHECK-LABEL: func.func @test_globalavgpool1d
+  // CHECK: onnx.Reshape{{.*}} -> tensor<4x128x1x512x!quant.uniform<i8:f32, 5.000000e-02>>
+  // CHECK: onnx.GlobalAveragePool
+  // CHECK: onnx.Reshape{{.*}} -> tensor<4x128x1x!quant.uniform<i8:f32, 5.000000e-02>>
 }

--- a/test/mlir/onnx/xmc/transfer_op_shape_to_4d.mlir
+++ b/test/mlir/onnx/xmc/transfer_op_shape_to_4d.mlir
@@ -1,0 +1,76 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+// RUN: onnx-mlir-opt --split-input-file --transfer-op-shape-to-4d %s | FileCheck %s
+
+// Define quantization types for testing
+!qtype1 = !quant.uniform<i8:f32, 0.5:10>
+!qtype2 = !quant.uniform<i8:f32, 0.25:5>
+!qtype3 = !quant.uniform<i16:f32, 0.125:0>
+
+// ============================================================================
+// Test 1: Element-wise Add with 3D inputs (same shape) -> convert to 4D
+// [2,3,4] -> pad with 1 at front -> [1,2,3,4]
+// Verifies quant type is preserved through reshape and add
+// ============================================================================
+func.func @test_add_3d_same_shape(%arg0: tensor<2x3x4x!qtype1>, %arg1: tensor<2x3x4x!qtype1>) -> tensor<2x3x4x!qtype1> {
+  %0 = "onnx.Add"(%arg0, %arg1) : (tensor<2x3x4x!qtype1>, tensor<2x3x4x!qtype1>) -> tensor<2x3x4x!qtype1>
+  return %0 : tensor<2x3x4x!qtype1>
+}
+// CHECK-LABEL: func.func @test_add_3d_same_shape
+// CHECK-DAG: %[[OUT_SHAPE:.*]] = onnx.Constant dense<[2, 3, 4]> : tensor<3xi64>
+// CHECK-DAG: %[[SHAPE4D:.*]] = onnx.Constant dense<[1, 2, 3, 4]> : tensor<4xi64>
+// CHECK: %[[R1:.*]] = "onnx.Reshape"(%arg0, %[[SHAPE4D]]) {{.*}} : (tensor<2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>, tensor<4xi64>) -> tensor<1x2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>
+// CHECK: %[[R2:.*]] = "onnx.Reshape"(%arg1, %[[SHAPE4D]]) {{.*}} : (tensor<2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>, tensor<4xi64>) -> tensor<1x2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>
+// CHECK: %[[ADD:.*]] = "onnx.Add"(%[[R1]], %[[R2]]) : (tensor<1x2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>, tensor<1x2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>) -> tensor<1x2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>
+// CHECK: %[[OUT:.*]] = "onnx.Reshape"(%[[ADD]], %[[OUT_SHAPE]]) {{.*}} : (tensor<1x2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>, tensor<3xi64>) -> tensor<2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>
+// CHECK: return %[[OUT]]
+
+// ============================================================================
+// Test 2: Element-wise Mul with broadcasting - 3D x scalar broadcast
+// Input1: [2,3,4], Input2: [1] (scalar broadcast)
+// Output: [2,3,4] -> [1,2,3,4]
+// Input1 reshaped to [1,2,3,4], Input2 reshaped to [1,1,1,1]
+// Verifies quant type is preserved through reshape and mul with broadcast
+// ============================================================================
+func.func @test_mul_broadcast_scalar(%arg0: tensor<2x3x4x!qtype3>, %arg1: tensor<1x!qtype3>) -> tensor<2x3x4x!qtype3> {
+  %0 = "onnx.Mul"(%arg0, %arg1) : (tensor<2x3x4x!qtype3>, tensor<1x!qtype3>) -> tensor<2x3x4x!qtype3>
+  return %0 : tensor<2x3x4x!qtype3>
+}
+// CHECK-LABEL: func.func @test_mul_broadcast_scalar
+// CHECK-DAG: %[[OUT_SHAPE:.*]] = onnx.Constant dense<[2, 3, 4]> : tensor<3xi64>
+// CHECK-DAG: %[[SHAPE4D:.*]] = onnx.Constant dense<[1, 2, 3, 4]> : tensor<4xi64>
+// CHECK-DAG: %[[SCALAR_SHAPE:.*]] = onnx.Constant dense<1> : tensor<4xi64>
+// CHECK: %[[R1:.*]] = "onnx.Reshape"(%arg0, %[[SHAPE4D]]) {{.*}} : (tensor<2x3x4x!quant.uniform<i16:f32, 1.250000e-01>>, tensor<4xi64>) -> tensor<1x2x3x4x!quant.uniform<i16:f32, 1.250000e-01>>
+// CHECK: %[[R2:.*]] = "onnx.Reshape"(%arg1, %[[SCALAR_SHAPE]]) {{.*}} : (tensor<1x!quant.uniform<i16:f32, 1.250000e-01>>, tensor<4xi64>) -> tensor<1x1x1x1x!quant.uniform<i16:f32, 1.250000e-01>>
+// CHECK: %[[MUL:.*]] = "onnx.Mul"(%[[R1]], %[[R2]]) : (tensor<1x2x3x4x!quant.uniform<i16:f32, 1.250000e-01>>, tensor<1x1x1x1x!quant.uniform<i16:f32, 1.250000e-01>>) -> tensor<1x2x3x4x!quant.uniform<i16:f32, 1.250000e-01>>
+// CHECK: %[[OUT:.*]] = "onnx.Reshape"(%[[MUL]], %[[OUT_SHAPE]]) {{.*}} : (tensor<1x2x3x4x!quant.uniform<i16:f32, 1.250000e-01>>, tensor<3xi64>) -> tensor<2x3x4x!quant.uniform<i16:f32, 1.250000e-01>>
+// CHECK: return %[[OUT]]
+
+// ============================================================================
+// Test 3: Element-wise Add with 5D inputs (same shape) -> convert to 4D
+// [2,3,4,5,6] with batch != 1 -> needs reshaping
+// Verifies quant type is preserved through 5D to 4D conversion
+// ============================================================================
+func.func @test_add_5d_same_shape(%arg0: tensor<2x3x4x5x6x!qtype2>, %arg1: tensor<2x3x4x5x6x!qtype2>) -> tensor<2x3x4x5x6x!qtype2> {
+  %0 = "onnx.Add"(%arg0, %arg1) : (tensor<2x3x4x5x6x!qtype2>, tensor<2x3x4x5x6x!qtype2>) -> tensor<2x3x4x5x6x!qtype2>
+  return %0 : tensor<2x3x4x5x6x!qtype2>
+}
+// CHECK-LABEL: func.func @test_add_5d_same_shape
+// CHECK: "onnx.Reshape"{{.*}}-> tensor<{{.*}}x!quant.uniform<i8:f32, 2.500000e-01:5>>
+// CHECK: "onnx.Reshape"{{.*}}-> tensor<{{.*}}x!quant.uniform<i8:f32, 2.500000e-01:5>>
+// CHECK: "onnx.Add"{{.*}}-> tensor<{{.*}}x!quant.uniform<i8:f32, 2.500000e-01:5>>
+// CHECK: "onnx.Reshape"{{.*}}-> tensor<2x3x4x5x6x!quant.uniform<i8:f32, 2.500000e-01:5>>
+// CHECK: return
+
+// ============================================================================
+// Test 4: 4D inputs with batch=1 should NOT be transformed (early return)
+// Verifies quant type is preserved when no transformation occurs
+// ============================================================================
+func.func @test_add_4d_already_valid(%arg0: tensor<1x2x3x4x!qtype1>, %arg1: tensor<1x2x3x4x!qtype1>) -> tensor<1x2x3x4x!qtype1> {
+  %0 = "onnx.Add"(%arg0, %arg1) : (tensor<1x2x3x4x!qtype1>, tensor<1x2x3x4x!qtype1>) -> tensor<1x2x3x4x!qtype1>
+  return %0 : tensor<1x2x3x4x!qtype1>
+}
+// CHECK-LABEL: func.func @test_add_4d_already_valid
+// CHECK-NOT: "onnx.Reshape"
+// CHECK: %[[ADD:.*]] = "onnx.Add"(%arg0, %arg1) : (tensor<1x2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>, tensor<1x2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>) -> tensor<1x2x3x4x!quant.uniform<i8:f32, 5.000000e-01:10>>
+// CHECK: return %[[ADD]]

--- a/test/mlir/onnx/xmc/transform_5d_transpose_to_4d.mlir
+++ b/test/mlir/onnx/xmc/transform_5d_transpose_to_4d.mlir
@@ -25,15 +25,15 @@ module {
   // CHECK: "onnx.Transpose"{{.*}}{perm = [0, 3, 2, 1]}{{.*}}tensor<1x24x32x64xf32>{{.*}}tensor<1x64x32x24xf32>
   // CHECK: onnx.Reshape
 
-  // Test 3: perm = [0, 1, 2, 4, 3] - consecutive pair at positions 0,1 (values 0,1)
-  // Merge dims 0,1 -> 4D perm [0, 1, 3, 2]
+  // Test 3: perm = [0, 1, 2, 4, 3] - dims 0,1,2 are identity
+  // Merge dims 0,1,2 -> 3D perm [0, 2, 1]
   func.func @test_perm_01243(%arg0: tensor<1x3x4x16x32xf32>) -> tensor<1x3x4x32x16xf32> {
     %0 = "onnx.Transpose"(%arg0) {perm = [0, 1, 2, 4, 3]} : (tensor<1x3x4x16x32xf32>) -> tensor<1x3x4x32x16xf32>
     return %0 : tensor<1x3x4x32x16xf32>
   }
   // CHECK-LABEL: func.func @test_perm_01243
   // CHECK: onnx.Reshape
-  // CHECK: "onnx.Transpose"{{.*}}{perm = [0, 1, 3, 2]}{{.*}}tensor<3x4x16x32xf32>{{.*}}tensor<3x4x32x16xf32>
+  // CHECK: "onnx.Transpose"{{.*}}{perm = [0, 2, 1]}{{.*}}tensor<12x16x32xf32>{{.*}}tensor<12x32x16xf32>
   // CHECK: onnx.Reshape
 
   // Test 4: perm = [0, 1, 4, 3, 2] - consecutive pair at positions 0,1 (values 0,1)
@@ -77,5 +77,41 @@ module {
   // CHECK: onnx.Reshape
   // CHECK: "onnx.Transpose"{{.*}}{perm = [0, 3, 2, 1]}
   // CHECK: onnx.Reshape
+
+  //===----------------------------------------------------------------------===//
+  // Tests for Pattern: Merge consecutive identity dimensions (from TransferOpShapeTo4dPass)
+  //===----------------------------------------------------------------------===//
+
+  // Test 8: 5D transpose with consecutive identity dims at [0,1]
+  // Input: [1,2,3,4,5], Order: [0,1,3,2,4]
+  // Dims 0,1 are consecutive identity -> merge: [1*2,3,4,5] = [2,3,4,5]
+  // New order: [0,2,1,3]
+  func.func @test_transpose_5d_to_4d_identity(%arg0: tensor<1x2x3x4x5x!quant.uniform<i8:f32, 0.5:10>>) -> tensor<1x2x4x3x5x!quant.uniform<i8:f32, 0.5:10>> {
+    %0 = "onnx.Transpose"(%arg0) {perm = [0, 1, 3, 2, 4]} : (tensor<1x2x3x4x5x!quant.uniform<i8:f32, 0.5:10>>) -> tensor<1x2x4x3x5x!quant.uniform<i8:f32, 0.5:10>>
+    return %0 : tensor<1x2x4x3x5x!quant.uniform<i8:f32, 0.5:10>>
+  }
+  // CHECK-LABEL: func.func @test_transpose_5d_to_4d_identity
+  // CHECK-DAG: %[[OUT_SHAPE:.*]] = onnx.Constant dense<[1, 2, 4, 3, 5]> : tensor<5xi64>
+  // CHECK-DAG: %[[IN_SHAPE:.*]] = onnx.Constant dense<[2, 3, 4, 5]> : tensor<4xi64>
+  // CHECK: %[[RESHAPE1:.*]] = "onnx.Reshape"(%arg0, %[[IN_SHAPE]]) {{.*}} : (tensor<1x2x3x4x5x!quant.uniform<i8:f32, 5.000000e-01:10>>, tensor<4xi64>) -> tensor<2x3x4x5x!quant.uniform<i8:f32, 5.000000e-01:10>>
+  // CHECK: %[[TRANSPOSE:.*]] = "onnx.Transpose"(%[[RESHAPE1]]) {perm = [0, 2, 1, 3]} : (tensor<2x3x4x5x!quant.uniform<i8:f32, 5.000000e-01:10>>) -> tensor<2x4x3x5x!quant.uniform<i8:f32, 5.000000e-01:10>>
+  // CHECK: %[[RESHAPE2:.*]] = "onnx.Reshape"(%[[TRANSPOSE]], %[[OUT_SHAPE]]) {{.*}} : (tensor<2x4x3x5x!quant.uniform<i8:f32, 5.000000e-01:10>>, tensor<5xi64>) -> tensor<1x2x4x3x5x!quant.uniform<i8:f32, 5.000000e-01:10>>
+  // CHECK: return %[[RESHAPE2]]
+
+  // Test 9: 6D transpose reduced to 4D
+  // Input: [1,2,3,4,3,5], Order: [0,1,2,4,3,5]
+  // Dims 0,1,2 are consecutive identity -> merge: [1*2*3,4,3,5] = [6,4,3,5]
+  // New order: [0,2,1,3]
+  func.func @test_transpose_6d_to_4d(%arg0: tensor<1x2x3x4x3x5x!quant.uniform<i8:f32, 0.25:5>>) -> tensor<1x2x3x3x4x5x!quant.uniform<i8:f32, 0.25:5>> {
+    %0 = "onnx.Transpose"(%arg0) {perm = [0, 1, 2, 4, 3, 5]} : (tensor<1x2x3x4x3x5x!quant.uniform<i8:f32, 0.25:5>>) -> tensor<1x2x3x3x4x5x!quant.uniform<i8:f32, 0.25:5>>
+    return %0 : tensor<1x2x3x3x4x5x!quant.uniform<i8:f32, 0.25:5>>
+  }
+  // CHECK-LABEL: func.func @test_transpose_6d_to_4d
+  // CHECK-DAG: %[[OUT_SHAPE:.*]] = onnx.Constant dense<[1, 2, 3, 3, 4, 5]> : tensor<6xi64>
+  // CHECK-DAG: %[[IN_SHAPE:.*]] = onnx.Constant dense<[6, 4, 3, 5]> : tensor<4xi64>
+  // CHECK: %[[RESHAPE1:.*]] = "onnx.Reshape"(%arg0, %[[IN_SHAPE]]) {{.*}} : (tensor<1x2x3x4x3x5x!quant.uniform<i8:f32, 2.500000e-01:5>>, tensor<4xi64>) -> tensor<6x4x3x5x!quant.uniform<i8:f32, 2.500000e-01:5>>
+  // CHECK: %[[TRANSPOSE:.*]] = "onnx.Transpose"(%[[RESHAPE1]]) {perm = [0, 2, 1, 3]} : (tensor<6x4x3x5x!quant.uniform<i8:f32, 2.500000e-01:5>>) -> tensor<6x3x4x5x!quant.uniform<i8:f32, 2.500000e-01:5>>
+  // CHECK: %[[RESHAPE2:.*]] = "onnx.Reshape"(%[[TRANSPOSE]], %[[OUT_SHAPE]]) {{.*}} : (tensor<6x3x4x5x!quant.uniform<i8:f32, 2.500000e-01:5>>, tensor<6xi64>) -> tensor<1x2x3x3x4x5x!quant.uniform<i8:f32, 2.500000e-01:5>>
+  // CHECK: return %[[RESHAPE2]]
 }
 


### PR DESCRIPTION
moved the pass

1. transferop1Dto2D
2. transferopto4d
3. transfer Transpose >4D


for transferop1Dto2D
- Refactor pooling patterns to use generic templates (similar to TransferOpShapeTo4d)
- Add support for AveragePool1D → AveragePool2D transformation
- Add support for ConvTranspose1D → ConvTranspose2D transformation
- Add support for GlobalMaxPool1D → GlobalMaxPool2D transformation
- Add support for GlobalAveragePool1D → GlobalAveragePool2D transformation
- Add test cases for all new operations