### PR TITLE
Cmake fixes for building with BUILD_SHARED_LIBS

### DIFF
--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -47,8 +47,6 @@ else()
   add_definitions(${LLVM_DEFINITIONS})
 endif()
 
-set(BUILD_SHARED_LIBS ${LLVM_ENABLE_SHARED_LIBS} CACHE BOOL "" FORCE)
-message(STATUS "BUILD_SHARED_LIBS        : " ${BUILD_SHARED_LIBS})
 
 # onnx uses exceptions, so we need to make sure that LLVM_REQUIRES_EH is set to ON, so that
 # the functions from HandleLLVMOptions and AddLLVM don't disable exceptions.

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -104,6 +104,9 @@ add_onnx_mlir_library(OMOnnxToMlirPasses
 
   LINK_LIBS PRIVATE
   OMHybridTransform
+  OMInstrument
+  OMInstrumentONNX
+  OMOpTransform
   OMONNXStandardFuncReturnPass
   OMONNXSimplifyShapeRelatedOps
   OMDisposableGarbageCollector

--- a/src/Tools/onnx-mlir-opt/CMakeLists.txt
+++ b/src/Tools/onnx-mlir-opt/CMakeLists.txt
@@ -12,6 +12,7 @@ add_onnx_mlir_executable(onnx-mlir-opt
   OMCompilerDialects
   OMCompilerOptions
   OMCompilerPasses
+  OMDisposableGarbageCollector
   OMAccelerator
   OMVersion
   MLIRAffineTransforms


### PR DESCRIPTION
This is also needs when selectively linking static libs