### PR TITLE
Quant Types pass convert Q/DQ to StorageCastOps [AIESW-24071]

### DIFF
--- a/src/Dialect/ONNX/Transforms/QuantTypes.cpp
+++ b/src/Dialect/ONNX/Transforms/QuantTypes.cpp
@@ -137,7 +137,7 @@ public:
 
 class QuantTypesPass
     : public PassWrapper<QuantTypesPass, OperationPass<func::FuncOp>> {
-  StringRef getArgument() const override { return "quant-types"; }
+  [[nodiscard]] StringRef getArgument() const override { return "quant-types"; }
 
   void getDependentDialects(::DialectRegistry &registry) const override {
     registry.insert<quant::QuantDialect>();

--- a/src/Dialect/ONNX/Transforms/QuantTypes.cpp
+++ b/src/Dialect/ONNX/Transforms/QuantTypes.cpp
@@ -8,14 +8,13 @@
 #include <mlir/Dialect/Quant/IR/Quant.h>
 #include <mlir/Dialect/Quant/IR/QuantTypes.h>
 #include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/IR/Verifier.h>
+#include <mlir/IR/Value.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Value.h"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 
 using namespace mlir;
@@ -102,15 +101,16 @@ public:
 
     auto qType = std::get<quant::QuantizedType>(qTypeErr);
     auto qTensorType = cast<TensorType>(dqOp.getType()).clone(qType);
-    if (auto constOp = dqOp.getX().getDefiningOp<ONNXConstantOp>()) {
+    if (auto constOp = dqOp.getX().getDefiningOp<ONNXConstantOp>();
+        constOp && constOp.getResult().hasOneUse()) {
       rewriter.modifyOpInPlace(
           constOp, [&]() { constOp.getResult().setType(qTensorType); });
       rewriter.replaceOp(dqOp, constOp);
-    } else {
-      rewriter.replaceOpWithNewOp<quant::StorageCastOp>(
-          dqOp, qTensorType, dqOp.getX());
+      return success();
     }
 
+    rewriter.replaceOpWithNewOp<quant::StorageCastOp>(
+        dqOp, qTensorType, dqOp.getX());
     return success();
   }
 };

--- a/src/Dialect/ONNX/Transforms/QuantTypes.cpp
+++ b/src/Dialect/ONNX/Transforms/QuantTypes.cpp
@@ -60,7 +60,8 @@ std::variant<quant::QuantizedType, StringLiteral> getQuantType(QDQOp op) {
     // Creating a templated lambda and invoking immediately
     []<bool flag = false>() {
       static_assert(flag, "Only defined for DequantizeLinear & QuantizeLinear");
-    }();
+    }
+    ();
   }
 
   if (scale.getNumElements() == 1 && zeropoint.getNumElements() == 1)

--- a/src/Dialect/ONNX/Transforms/QuantTypes.cpp
+++ b/src/Dialect/ONNX/Transforms/QuantTypes.cpp
@@ -102,8 +102,14 @@ public:
 
     auto qType = std::get<quant::QuantizedType>(qTypeErr);
     auto qTensorType = cast<TensorType>(dqOp.getType()).clone(qType);
-    rewriter.replaceOpWithNewOp<quant::StorageCastOp>(
-        dqOp, qTensorType, dqOp.getX());
+    if (auto constOp = dqOp.getX().getDefiningOp<ONNXConstantOp>()) {
+      rewriter.modifyOpInPlace(
+          constOp, [&]() { constOp.getResult().setType(qTensorType); });
+      rewriter.replaceOp(dqOp, constOp);
+    } else {
+      rewriter.replaceOpWithNewOp<quant::StorageCastOp>(
+          dqOp, qTensorType, dqOp.getX());
+    }
 
     return success();
   }

--- a/src/Dialect/ONNX/Transforms/QuantTypes.cpp
+++ b/src/Dialect/ONNX/Transforms/QuantTypes.cpp
@@ -1,6 +1,7 @@
 // (c) Copyright 2022 - 2025 Advanced Micro Devices, Inc. All Rights reserved.
 
 #include <memory>
+#include <variant>
 
 #include <llvm/ADT/STLExtras.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -13,8 +14,11 @@
 #include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
-#include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
+
+using namespace mlir;
 
 namespace onnx_mlir {
 
@@ -25,158 +29,131 @@ namespace onnx_mlir {
  * or vice-versa
  */
 
-template <typename QdqOp>
-class QuantTypesFrom : public mlir::OpRewritePattern<QdqOp> {
-  using mlir::OpRewritePattern<QdqOp>::OpRewritePattern;
+namespace {
+template <typename QDQOp>
+std::variant<quant::QuantizedType, StringLiteral> getQuantType(QDQOp op) {
 
-  mlir::LogicalResult matchAndRewrite(
-      QdqOp op, mlir::PatternRewriter &rewriter) const override {
+  auto scaleOp = op->getOperand(1).template getDefiningOp<ONNXConstantOp>();
+  auto zeropointOp = op->getOperand(2).template getDefiningOp<ONNXConstantOp>();
+  if (!scaleOp || !zeropointOp)
+    return StringLiteral("Scale/Zeropoint not constant");
 
-    // Should not convert when input comes from blockArg or Cast node
-    // TODO: Fix for cast node by either of:
-    //  - Updating the cast to quantized type
-    //  - Add qcast/scast after cast based on types
-    mlir::Value input = op->getOperand(0);
-    mlir::Operation *inputOp = input.getDefiningOp();
-    if (inputOp == nullptr || mlir::isa<mlir::ONNXCastOp>(inputOp))
-      return rewriter.notifyMatchFailure(
-          op, "Not converting blockArg or Cast output");
+  auto scale =
+      dyn_cast_if_present<DenseIntOrFPElementsAttr>(scaleOp.getValueAttr());
+  auto zeropoint =
+      dyn_cast_if_present<DenseIntOrFPElementsAttr>(zeropointOp.getValueAttr());
+  if (!scale || !zeropoint)
+    return StringLiteral("Scale/Zeropoint not DenseElementsAttr");
 
-    // Should not convert types when the output is used by 'return' op
-    // Check both func::ReturnOp and ONNXReturnOp
-    mlir::Value result = op->getResult(0);
-    if (llvm::any_of(result.getUsers(), [](mlir::Operation *op) {
-          return mlir::isa<mlir::func::ReturnOp>(op);
-        }))
-      return rewriter.notifyMatchFailure(
-          op, "Not converting return value from function");
+  Value input = op->getOperand(0);
+  Value result = op->getResult(0);
 
-    auto scaleOp = mlir::dyn_cast_if_present<mlir::ONNXConstantOp>(
-        op->getOperand(1).getDefiningOp());
-    auto zeropointOp = mlir::dyn_cast_if_present<mlir::ONNXConstantOp>(
-        op->getOperand(2).getDefiningOp());
-    if (!scaleOp || !zeropointOp)
-      return rewriter.notifyMatchFailure(op, "Scale/Zeropoint not constant");
+  Type storageType;
+  Type expressedType;
+  if constexpr (std::is_same_v<QDQOp, ONNXDequantizeLinearOp>) {
+    storageType = cast<TensorType>(input.getType()).getElementType();
+    expressedType = cast<TensorType>(result.getType()).getElementType();
+  } else if constexpr (std::is_same_v<QDQOp, ONNXQuantizeLinearOp>) {
+    storageType = cast<TensorType>(result.getType()).getElementType();
+    expressedType = cast<TensorType>(input.getType()).getElementType();
+  } else {
+    // Cannot directly use static_assert(false) before c++23
+    // Creating a templated lambda and invoking immediately
+    []<bool flag = false>() {
+      static_assert(flag, "Only defined for DequantizeLinear & QuantizeLinear");
+    }();
+  }
 
-    auto scale = mlir::dyn_cast_if_present<mlir::DenseIntOrFPElementsAttr>(
-        scaleOp.getValueAttr());
-    auto zeropoint = mlir::dyn_cast_if_present<mlir::DenseIntOrFPElementsAttr>(
-        zeropointOp.getValueAttr());
-    if (!scale || !zeropoint)
-      return rewriter.notifyMatchFailure(
-          op, "Scale/Zeropoint not DenseElementsAttr");
-
-    // TODO: Add support for per-channel quantization
-    if (scale.getNumElements() != 1 || zeropoint.getNumElements() != 1)
-      return rewriter.notifyMatchFailure(op, "Scale/Zeropoint not scalar");
-
-    auto inType = mlir::cast<mlir::TensorType>(input.getType());
-    mlir::Type inElemType = inType.getElementType();
-    auto outType = mlir::cast<mlir::TensorType>(result.getType());
-    mlir::Type outElemType = outType.getElementType();
-    unsigned flags = outElemType.isSignedInteger();
-
-    mlir::Type storageType;
-    mlir::Type expressedType;
-
-    if constexpr (std::is_same_v<QdqOp, mlir::ONNXDequantizeLinearOp>) {
-      storageType = inElemType;
-      expressedType = outElemType;
-    } else if constexpr (std::is_same_v<QdqOp, mlir::ONNXQuantizeLinearOp>) {
-      storageType = outElemType;
-      expressedType = inElemType;
-    } else {
-      // Cannot directly use static_assert(false) before c++23
-      // Creating a templated lambda and invoking immediately
-      []<bool flag = false>() {
-        static_assert(
-            flag, "Only defined for DequantizeLinear & QuantizeLinear");
-      }
-      ();
-    }
-
-    // Get existing quantized type if available
-    mlir::quant::QuantizedType oldQuantType;
-    if (oldQuantType = mlir::dyn_cast<mlir::quant::QuantizedType>(storageType);
-        oldQuantType)
-      storageType = oldQuantType.getStorageType();
-
-    // Create quantized type
-    mlir::Type quantType = mlir::quant::UniformQuantizedType::get(flags,
+  if (scale.getNumElements() == 1 && zeropoint.getNumElements() == 1)
+    return quant::UniformQuantizedType::get(storageType.isSignedInteger(),
         storageType, expressedType,
-        scale.template getSplatValue<mlir::APFloat>().convertToDouble(),
+        scale.template getSplatValue<APFloat>().convertToDouble(),
         storageType.isSignedInteger()
-            ? zeropoint.template getSplatValue<mlir::APInt>().getSExtValue()
-            : zeropoint.template getSplatValue<mlir::APInt>().getZExtValue(),
-        mlir::quant::QuantizedType::getDefaultMinimumForInteger(
+            ? zeropoint.template getSplatValue<APInt>().getSExtValue()
+            : zeropoint.template getSplatValue<APInt>().getZExtValue(),
+        quant::QuantizedType::getDefaultMinimumForInteger(
             storageType.isSignedInteger(), storageType.getIntOrFloatBitWidth()),
-        mlir::quant::QuantizedType::getDefaultMaximumForInteger(
+        quant::QuantizedType::getDefaultMaximumForInteger(
             storageType.isSignedInteger(),
             storageType.getIntOrFloatBitWidth()));
 
-    if (oldQuantType && oldQuantType != quantType)
-      return rewriter.notifyMatchFailure(op, "Unequal quant types");
+  // TODO: Add support for per-channel quantization
+  return StringLiteral("Scale/Zeropoint not scalar");
+}
 
-    // To avoid disrupting other uses of input, create a copy of defining op
-    mlir::Operation *newInputOp = rewriter.clone(*inputOp);
+} // namespace
 
-    // Change input tensor to be quant type
-    auto results = inputOp->getOpResults();
-    unsigned int resultIdx = std::distance(
-        results.begin(), std::find(results.begin(), results.end(), input));
-    mlir::Value newResult = newInputOp->getResult(resultIdx);
-    rewriter.modifyOpInPlace(
-        newInputOp, [&]() { newResult.setType(outType.clone(quantType)); });
-    {
-      onnx_mlir::IgnoreDiagnostic diag(rewriter.getContext()->getDiagEngine());
-      if (mlir::failed(mlir::verify(newInputOp))) {
-        // Roll back the changes
-        rewriter.eraseOp(newInputOp);
-        return rewriter.notifyMatchFailure(
-            op, "Quant type not allowed as result");
-      }
+class DQToSCast : public OpRewritePattern<ONNXDequantizeLinearOp> {
+public:
+  using OpRewritePattern<ONNXDequantizeLinearOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXDequantizeLinearOp dqOp, PatternRewriter &rewriter) const override {
+    if (llvm::any_of(dqOp.getY().getUsers(),
+            [](Operation *op) { return isa<func::ReturnOp>(op); })) {
+      return rewriter.notifyMatchFailure(
+          dqOp, "Cannot convert DQ output to function return");
     }
 
-    // Remove the Q/DQ op
-    rewriter.replaceAllUsesWith(result, newResult);
-    {
-      onnx_mlir::IgnoreDiagnostic diag(rewriter.getContext()->getDiagEngine());
-      for (auto *userOp : newResult.getUsers()) {
-        if (mlir::failed(mlir::verify(userOp))) {
-          // Rollback the changes
-          rewriter.replaceAllUsesWith(newResult, result);
-          rewriter.eraseOp(newInputOp);
-          return rewriter.notifyMatchFailure(
-              op, "Quant type not allowed as operand");
-        }
-      }
-    }
-    rewriter.eraseOp(op);
+    auto qTypeErr = getQuantType(dqOp);
+    if (std::holds_alternative<StringLiteral>(qTypeErr))
+      return rewriter.notifyMatchFailure(
+          dqOp, std::get<StringLiteral>(qTypeErr));
 
-    return mlir::success();
+    auto qType = std::get<quant::QuantizedType>(qTypeErr);
+    auto qTensorType = cast<TensorType>(dqOp.getType()).clone(qType);
+    rewriter.replaceOpWithNewOp<quant::StorageCastOp>(
+        dqOp, qTensorType, dqOp.getX());
+
+    return success();
   }
 };
 
-class QuantTypesPass : public mlir::PassWrapper<QuantTypesPass,
-                           mlir::OperationPass<mlir::func::FuncOp>> {
-  mlir::StringRef getArgument() const override { return "quant-types"; }
+class QToSCast : public OpRewritePattern<ONNXQuantizeLinearOp> {
+public:
+  using OpRewritePattern<ONNXQuantizeLinearOp>::OpRewritePattern;
 
-  void getDependentDialects(::mlir::DialectRegistry &registry) const override {
-    registry.insert<mlir::quant::QuantDialect>();
+  LogicalResult matchAndRewrite(
+      ONNXQuantizeLinearOp qOp, PatternRewriter &rewriter) const override {
+    if (isa<BlockArgument>(qOp.getOperand(0))) {
+      return rewriter.notifyMatchFailure(
+          qOp, "Cannot convert Q input from BlockArg");
+    }
+
+    auto qTypeErr = getQuantType(qOp);
+    if (std::holds_alternative<StringLiteral>(qTypeErr))
+      return rewriter.notifyMatchFailure(
+          qOp, std::get<StringLiteral>(qTypeErr));
+
+    auto qType = std::get<quant::QuantizedType>(qTypeErr);
+    auto qTensorType = cast<TensorType>(qOp.getType()).clone(qType);
+    rewriter.modifyOpInPlace(qOp, [&]() { qOp.getX().setType(qTensorType); });
+    rewriter.replaceOpWithNewOp<quant::StorageCastOp>(
+        qOp, qOp.getY().getType(), qOp.getX());
+
+    return success();
+  }
+};
+
+class QuantTypesPass
+    : public PassWrapper<QuantTypesPass, OperationPass<func::FuncOp>> {
+  StringRef getArgument() const override { return "quant-types"; }
+
+  void getDependentDialects(::DialectRegistry &registry) const override {
+    registry.insert<quant::QuantDialect>();
   }
 
   void runOnOperation() override {
     auto func = getOperation();
     auto *ctx = &getContext();
-    mlir::RewritePatternSet patterns(ctx);
-    patterns.add<QuantTypesFrom<mlir::ONNXDequantizeLinearOp>,
-        QuantTypesFrom<mlir::ONNXQuantizeLinearOp>>(ctx);
-    if (failed(mlir::applyPatternsGreedily(func, std::move(patterns))))
+    RewritePatternSet patterns(ctx);
+    patterns.add<DQToSCast, QToSCast>(ctx);
+    if (failed(applyPatternsGreedily(func, std::move(patterns))))
       signalPassFailure();
   }
 };
 
-std::unique_ptr<mlir::Pass> createQuantTypesPass() {
+std::unique_ptr<Pass> createQuantTypesPass() {
   return std::make_unique<QuantTypesPass>();
 }
 

--- a/test/mlir/onnx/onnx_quanttypes.mlir
+++ b/test/mlir/onnx/onnx_quanttypes.mlir
@@ -24,19 +24,69 @@ func.func @matmul_add(%arg0: tensor<1x128x768xf32>) -> tensor<1x128x768xf32> {
   %20 = "onnx.QuantizeLinear"(%19, %11, %10) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
   %21 = "onnx.DequantizeLinear"(%20, %11, %10) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
   return %21 : tensor<1x128x768xf32>
+}
 
 // CHECK-LABEL: @matmul_add
 // CHECK: onnx.QuantizeLinear
-// CHECK-SAME: (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>)
-// CHECK-SAME: -> tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>
+// CHECK-SAME: (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
+// CHECK-NEXT: quant.scast
+// CHECK-SAME: tensor<1x128x768xui16> to tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>
 // CHECK-NEXT: onnx.MatMul
-// CHECK-SAME: (tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>, tensor<768x768x!quant.uniform<u8:f32, 0.0043040169402956963:137>>)
-// CHECK-SAME: -> tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>>
+// CHECK-SAME: (tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>, tensor<768x768x!quant.uniform<u8:f32, 0.0043040169402956963:137>>) -> tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>>
 // CHECK-NEXT: onnx.Add
-// CHECK-SAME: (tensor<768x!quant.uniform<u16:f32, 6.7978078277519671E-7:41309>>, tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>>)
-// CHECK-SAME: -> tensor<1x128x768x!quant.uniform<u16:f32, 2.0647853671107441E-4:31907>>
+// CHECK-SAME: (tensor<768x!quant.uniform<u16:f32, 6.7978078277519671E-7:41309>>, tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>>) -> tensor<1x128x768x!quant.uniform<u16:f32, 2.0647853671107441E-4:31907>>
+// CHECK-NEXT: quant.scast
+// CHECK-SAME: tensor<1x128x768x!quant.uniform<u16:f32, 2.0647853671107441E-4:31907>> to tensor<1x128x768xui16>
 // CHECK-NEXT: onnx.DequantizeLinear
-// CHECK-SAME: (tensor<1x128x768x!quant.uniform<u16:f32, 2.0647853671107441E-4:31907>>, tensor<f32>, tensor<ui16>)
-// CHECK-SAME: -> tensor<1x128x768xf32>
+// CHECK-SAME: (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
 
+
+func.func @no_boundary_qdq(%arg0: tensor<1x128x768xui16>) -> tensor<1x128x768xui16> {
+  %0 = onnx.Constant dense<35166> : tensor<ui16>
+  %1 = onnx.Constant dense<2.13029256E-4> : tensor<f32>
+  %2 = onnx.Constant dense<137> : tensor<ui8>
+  %3 = onnx.Constant dense<0.00430401694> : tensor<f32>
+  %4 = onnx.Constant dense_resource<__elided__> : tensor<768x768xui8>
+  %5 = onnx.Constant dense<31929> : tensor<ui16>
+  %6 = onnx.Constant dense<2.06352008E-4> : tensor<f32>
+  %7 = onnx.Constant dense<31907> : tensor<ui16>
+  %8 = onnx.Constant dense<2.06478537E-4> : tensor<f32>
+  %9 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
+  %10 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<768x768xui8>, tensor<f32>, tensor<ui8>) -> tensor<768x768xf32>
+  %11 = "onnx.MatMul"(%9, %10) : (tensor<1x128x768xf32>, tensor<768x768xf32>) -> tensor<1x128x768xf32>
+  %12 = "onnx.QuantizeLinear"(%11, %6, %5) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
+  return %12 : tensor<1x128x768xui16>
 }
+
+// CHECK-LABEL: @no_boundary_qdq
+// CHECK: onnx.Constant
+// CHECK-SAME: tensor<768x768x!quant.uniform<u8:f32, 0.0043040169402956963:137>>
+// CHECK-NEXT: quant.scast
+// CHECK-SAME: tensor<1x128x768xui16> to tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>
+// CHECK-NEXT: onnx.MatMul
+// CHECK-SAME: (tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>, tensor<768x768x!quant.uniform<u8:f32, 0.0043040169402956963:137>>) -> tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>>
+// CHECK-NEXT: quant.scast
+// CHECK-SAME: tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>> to tensor<1x128x768xui16>
+
+
+func.func @unequal_qdq(%arg0: tensor<1x128x768xui16>) -> tensor<1x128x768xui16> {
+  %0 = onnx.Constant dense<32768> : tensor<ui16>
+  %1 = onnx.Constant dense<2.52349739E-4> : tensor<f32>
+  %2 = onnx.Constant dense<1474> : tensor<ui16>
+  %3 = onnx.Constant dense<1.15280403E-4> : tensor<f32>
+  %4 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
+  %5 = "onnx.Gelu"(%4) {approximate = "none"} : (tensor<1x128x768xf32>) -> tensor<1x128x768xf32>
+  %6 = "onnx.QuantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
+  %7 = "onnx.DequantizeLinear"(%6, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
+  %8 = "onnx.Gelu"(%7) {approximate = "none"} : (tensor<1x128x768xf32>) -> tensor<1x128x768xf32>
+  %9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
+  return %9 : tensor<1x128x768xui16>
+}
+
+// CHECK-LABEL: @unequal_qdq
+// CHECK: quant.scast
+// CHECK-NEXT: onnx.Gelu
+// CHECK-NEXT: quant.scast
+// CHECK-NEXT: quant.scast
+// CHECK-NEXT: onnx.Gelu
+// CHECK-NEXT: quant.scast

--- a/test/mlir/onnx/onnx_quanttypes.mlir
+++ b/test/mlir/onnx/onnx_quanttypes.mlir
@@ -90,3 +90,35 @@ func.func @unequal_qdq(%arg0: tensor<1x128x768xui16>) -> tensor<1x128x768xui16> 
 // CHECK-NEXT: quant.scast
 // CHECK-NEXT: onnx.Gelu
 // CHECK-NEXT: quant.scast
+
+func.func @multiuse_constant(%arg0: tensor<1x128x128xf32>) -> tensor<1x128x128xf32> {
+  %0 = onnx.Constant dense<35166> : tensor<ui16>
+  %1 = onnx.Constant dense<2.13029256E-4> : tensor<f32>
+  %2 = onnx.Constant dense<137> : tensor<ui8>
+  %3 = onnx.Constant dense<0.00430401694> : tensor<f32>
+  %4 = onnx.Constant dense_resource<__elided__> : tensor<128x128xui8>
+  %5 = onnx.Constant dense<31929> : tensor<ui16>
+  %6 = onnx.Constant dense<2.06352008E-4> : tensor<f32>
+  %7 = onnx.Constant dense<41309> : tensor<ui16>
+  %8 = onnx.Constant dense<6.79780783E-7> : tensor<f32>
+  %9 = onnx.Constant dense<31907> : tensor<ui16>
+  %10 = onnx.Constant dense<2.06478537E-4> : tensor<f32>
+  %11 = "onnx.QuantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xui16>
+  %12 = "onnx.DequantizeLinear"(%11, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xf32>
+  %13 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<128x128xui8>, tensor<f32>, tensor<ui8>) -> tensor<128x128xf32>
+  %14 = "onnx.MatMul"(%12, %13) : (tensor<1x128x128xf32>, tensor<128x128xf32>) -> tensor<1x128x128xf32>
+  %15 = "onnx.QuantizeLinear"(%14, %6, %5) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xui16>
+  %16 = "onnx.DequantizeLinear"(%4, %8, %7) {axis = 1 : si64, block_size = 0 : si64} : (tensor<128x128xui8>, tensor<f32>, tensor<ui16>) -> tensor<128x128xf32>
+  %17 = "onnx.DequantizeLinear"(%15, %6, %5) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xf32>
+  %18 = "onnx.Add"(%16, %17) : (tensor<128x128xf32>, tensor<1x128x128xf32>) -> tensor<1x128x128xf32>
+  %19 = "onnx.QuantizeLinear"(%18, %10, %9) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xui16>
+  %20 = "onnx.DequantizeLinear"(%19, %10, %9) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xf32>
+  return %20 : tensor<1x128x128xf32>
+}
+
+// CHECK-LABEL: @multiuse_constant
+// CHECK: [[CONST:%[0-9]+]] = onnx.Constant dense_resource<__elided__> : tensor<128x128xui8>
+// CHECK: quant.scast [[CONST]]
+// CHECK-SAME: tensor<128x128x!quant.uniform<u8:f32, 0.0043040169402956963:137>>
+// CHECK: quant.scast [[CONST]]
+// CHECK-SAME: tensor<128x128x!quant.uniform<u8:f32, 6.7978078277519671E-7:41309>>

--- a/test/mlir/onnx/onnx_quanttypes.mlir
+++ b/test/mlir/onnx/onnx_quanttypes.mlir
@@ -1,86 +1,86 @@
 // RUN: onnx-mlir-opt %s -quant-types | FileCheck %s
 
 func.func @matmul_add(%arg0: tensor<1x128x768xf32>) -> tensor<1x128x768xf32> {
-  %0 = onnx.Constant dense<35166> : tensor<ui16>
+  %0 = onnx.Constant dense<35166> : tensor<i16>
   %1 = onnx.Constant dense<2.13029256E-4> : tensor<f32>
-  %2 = onnx.Constant dense<137> : tensor<ui8>
+  %2 = onnx.Constant dense<137> : tensor<i8>
   %3 = onnx.Constant dense<0.00430401694> : tensor<f32>
-  %4 = onnx.Constant dense_resource<__elided__> : tensor<768x768xui8>
-  %5 = onnx.Constant dense<31929> : tensor<ui16>
+  %4 = onnx.Constant dense_resource<__elided__> : tensor<768x768xi8>
+  %5 = onnx.Constant dense<31929> : tensor<i16>
   %6 = onnx.Constant dense<2.06352008E-4> : tensor<f32>
-  %7 = onnx.Constant dense<41309> : tensor<ui16>
+  %7 = onnx.Constant dense<41309> : tensor<i16>
   %8 = onnx.Constant dense<6.79780783E-7> : tensor<f32>
-  %9 = onnx.Constant dense_resource<__elided__> : tensor<768xui16>
-  %10 = onnx.Constant dense<31907> : tensor<ui16>
+  %9 = onnx.Constant dense_resource<__elided__> : tensor<768xi16>
+  %10 = onnx.Constant dense<31907> : tensor<i16>
   %11 = onnx.Constant dense<2.06478537E-4> : tensor<f32>
-  %12 = "onnx.QuantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
-  %13 = "onnx.DequantizeLinear"(%12, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
-  %14 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<768x768xui8>, tensor<f32>, tensor<ui8>) -> tensor<768x768xf32>
+  %12 = "onnx.QuantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xi16>
+  %13 = "onnx.DequantizeLinear"(%12, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xf32>
+  %14 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<768x768xi8>, tensor<f32>, tensor<i8>) -> tensor<768x768xf32>
   %15 = "onnx.MatMul"(%13, %14) : (tensor<1x128x768xf32>, tensor<768x768xf32>) -> tensor<1x128x768xf32>
-  %16 = "onnx.QuantizeLinear"(%15, %6, %5) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
-  %17 = "onnx.DequantizeLinear"(%9, %8, %7) {axis = 1 : si64, block_size = 0 : si64} : (tensor<768xui16>, tensor<f32>, tensor<ui16>) -> tensor<768xf32>
-  %18 = "onnx.DequantizeLinear"(%16, %6, %5) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
+  %16 = "onnx.QuantizeLinear"(%15, %6, %5) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xi16>
+  %17 = "onnx.DequantizeLinear"(%9, %8, %7) {axis = 1 : si64, block_size = 0 : si64} : (tensor<768xi16>, tensor<f32>, tensor<i16>) -> tensor<768xf32>
+  %18 = "onnx.DequantizeLinear"(%16, %6, %5) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xf32>
   %19 = "onnx.Add"(%17, %18) : (tensor<768xf32>, tensor<1x128x768xf32>) -> tensor<1x128x768xf32>
-  %20 = "onnx.QuantizeLinear"(%19, %11, %10) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
-  %21 = "onnx.DequantizeLinear"(%20, %11, %10) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
+  %20 = "onnx.QuantizeLinear"(%19, %11, %10) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xi16>
+  %21 = "onnx.DequantizeLinear"(%20, %11, %10) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xf32>
   return %21 : tensor<1x128x768xf32>
 }
 
 // CHECK-LABEL: @matmul_add
 // CHECK: onnx.QuantizeLinear
-// CHECK-SAME: (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
+// CHECK-SAME: (tensor<1x128x768xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xi16>
 // CHECK-NEXT: quant.scast
-// CHECK-SAME: tensor<1x128x768xui16> to tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>
+// CHECK-SAME: tensor<1x128x768xi16> to tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>
 // CHECK-NEXT: onnx.MatMul
 // CHECK-SAME: (tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>, tensor<768x768x!quant.uniform<u8:f32, 0.0043040169402956963:137>>) -> tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>>
 // CHECK-NEXT: onnx.Add
 // CHECK-SAME: (tensor<768x!quant.uniform<u16:f32, 6.7978078277519671E-7:41309>>, tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>>) -> tensor<1x128x768x!quant.uniform<u16:f32, 2.0647853671107441E-4:31907>>
 // CHECK-NEXT: quant.scast
-// CHECK-SAME: tensor<1x128x768x!quant.uniform<u16:f32, 2.0647853671107441E-4:31907>> to tensor<1x128x768xui16>
+// CHECK-SAME: tensor<1x128x768x!quant.uniform<u16:f32, 2.0647853671107441E-4:31907>> to tensor<1x128x768xi16>
 // CHECK-NEXT: onnx.DequantizeLinear
-// CHECK-SAME: (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
+// CHECK-SAME: (tensor<1x128x768xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xf32>
 
 
-func.func @no_boundary_qdq(%arg0: tensor<1x128x768xui16>) -> tensor<1x128x768xui16> {
-  %0 = onnx.Constant dense<35166> : tensor<ui16>
+func.func @no_boundary_qdq(%arg0: tensor<1x128x768xi16>) -> tensor<1x128x768xi16> {
+  %0 = onnx.Constant dense<35166> : tensor<i16>
   %1 = onnx.Constant dense<2.13029256E-4> : tensor<f32>
-  %2 = onnx.Constant dense<137> : tensor<ui8>
+  %2 = onnx.Constant dense<137> : tensor<i8>
   %3 = onnx.Constant dense<0.00430401694> : tensor<f32>
-  %4 = onnx.Constant dense_resource<__elided__> : tensor<768x768xui8>
-  %5 = onnx.Constant dense<31929> : tensor<ui16>
+  %4 = onnx.Constant dense_resource<__elided__> : tensor<768x768xi8>
+  %5 = onnx.Constant dense<31929> : tensor<i16>
   %6 = onnx.Constant dense<2.06352008E-4> : tensor<f32>
-  %7 = onnx.Constant dense<31907> : tensor<ui16>
+  %7 = onnx.Constant dense<31907> : tensor<i16>
   %8 = onnx.Constant dense<2.06478537E-4> : tensor<f32>
-  %9 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
-  %10 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<768x768xui8>, tensor<f32>, tensor<ui8>) -> tensor<768x768xf32>
+  %9 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xf32>
+  %10 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<768x768xi8>, tensor<f32>, tensor<i8>) -> tensor<768x768xf32>
   %11 = "onnx.MatMul"(%9, %10) : (tensor<1x128x768xf32>, tensor<768x768xf32>) -> tensor<1x128x768xf32>
-  %12 = "onnx.QuantizeLinear"(%11, %6, %5) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
-  return %12 : tensor<1x128x768xui16>
+  %12 = "onnx.QuantizeLinear"(%11, %6, %5) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xi16>
+  return %12 : tensor<1x128x768xi16>
 }
 
 // CHECK-LABEL: @no_boundary_qdq
 // CHECK: onnx.Constant
 // CHECK-SAME: tensor<768x768x!quant.uniform<u8:f32, 0.0043040169402956963:137>>
 // CHECK-NEXT: quant.scast
-// CHECK-SAME: tensor<1x128x768xui16> to tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>
+// CHECK-SAME: tensor<1x128x768xi16> to tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>
 // CHECK-NEXT: onnx.MatMul
 // CHECK-SAME: (tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>, tensor<768x768x!quant.uniform<u8:f32, 0.0043040169402956963:137>>) -> tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>>
 // CHECK-NEXT: quant.scast
-// CHECK-SAME: tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>> to tensor<1x128x768xui16>
+// CHECK-SAME: tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>> to tensor<1x128x768xi16>
 
 
-func.func @unequal_qdq(%arg0: tensor<1x128x768xui16>) -> tensor<1x128x768xui16> {
-  %0 = onnx.Constant dense<32768> : tensor<ui16>
+func.func @unequal_qdq(%arg0: tensor<1x128x768xi16>) -> tensor<1x128x768xi16> {
+  %0 = onnx.Constant dense<32768> : tensor<i16>
   %1 = onnx.Constant dense<2.52349739E-4> : tensor<f32>
-  %2 = onnx.Constant dense<1474> : tensor<ui16>
+  %2 = onnx.Constant dense<1474> : tensor<i16>
   %3 = onnx.Constant dense<1.15280403E-4> : tensor<f32>
-  %4 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
+  %4 = "onnx.DequantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xf32>
   %5 = "onnx.Gelu"(%4) {approximate = "none"} : (tensor<1x128x768xf32>) -> tensor<1x128x768xf32>
-  %6 = "onnx.QuantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
-  %7 = "onnx.DequantizeLinear"(%6, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
+  %6 = "onnx.QuantizeLinear"(%5, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xi16>
+  %7 = "onnx.DequantizeLinear"(%6, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xf32>
   %8 = "onnx.Gelu"(%7) {approximate = "none"} : (tensor<1x128x768xf32>) -> tensor<1x128x768xf32>
-  %9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
-  return %9 : tensor<1x128x768xui16>
+  %9 = "onnx.QuantizeLinear"(%8, %3, %2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xi16>
+  return %9 : tensor<1x128x768xi16>
 }
 
 // CHECK-LABEL: @unequal_qdq
@@ -92,32 +92,32 @@ func.func @unequal_qdq(%arg0: tensor<1x128x768xui16>) -> tensor<1x128x768xui16> 
 // CHECK-NEXT: quant.scast
 
 func.func @multiuse_constant(%arg0: tensor<1x128x128xf32>) -> tensor<1x128x128xf32> {
-  %0 = onnx.Constant dense<35166> : tensor<ui16>
+  %0 = onnx.Constant dense<35166> : tensor<i16>
   %1 = onnx.Constant dense<2.13029256E-4> : tensor<f32>
-  %2 = onnx.Constant dense<137> : tensor<ui8>
+  %2 = onnx.Constant dense<137> : tensor<i8>
   %3 = onnx.Constant dense<0.00430401694> : tensor<f32>
-  %4 = onnx.Constant dense_resource<__elided__> : tensor<128x128xui8>
-  %5 = onnx.Constant dense<31929> : tensor<ui16>
+  %4 = onnx.Constant dense_resource<__elided__> : tensor<128x128xi8>
+  %5 = onnx.Constant dense<31929> : tensor<i16>
   %6 = onnx.Constant dense<2.06352008E-4> : tensor<f32>
-  %7 = onnx.Constant dense<41309> : tensor<ui16>
+  %7 = onnx.Constant dense<41309> : tensor<i16>
   %8 = onnx.Constant dense<6.79780783E-7> : tensor<f32>
-  %9 = onnx.Constant dense<31907> : tensor<ui16>
+  %9 = onnx.Constant dense<31907> : tensor<i16>
   %10 = onnx.Constant dense<2.06478537E-4> : tensor<f32>
-  %11 = "onnx.QuantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xui16>
-  %12 = "onnx.DequantizeLinear"(%11, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xf32>
-  %13 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<128x128xui8>, tensor<f32>, tensor<ui8>) -> tensor<128x128xf32>
+  %11 = "onnx.QuantizeLinear"(%arg0, %1, %0) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x128xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x128xi16>
+  %12 = "onnx.DequantizeLinear"(%11, %1, %0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x128xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x128xf32>
+  %13 = "onnx.DequantizeLinear"(%4, %3, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<128x128xi8>, tensor<f32>, tensor<i8>) -> tensor<128x128xf32>
   %14 = "onnx.MatMul"(%12, %13) : (tensor<1x128x128xf32>, tensor<128x128xf32>) -> tensor<1x128x128xf32>
-  %15 = "onnx.QuantizeLinear"(%14, %6, %5) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xui16>
-  %16 = "onnx.DequantizeLinear"(%4, %8, %7) {axis = 1 : si64, block_size = 0 : si64} : (tensor<128x128xui8>, tensor<f32>, tensor<ui16>) -> tensor<128x128xf32>
-  %17 = "onnx.DequantizeLinear"(%15, %6, %5) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xf32>
+  %15 = "onnx.QuantizeLinear"(%14, %6, %5) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x128xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x128xi16>
+  %16 = "onnx.DequantizeLinear"(%4, %8, %7) {axis = 1 : si64, block_size = 0 : si64} : (tensor<128x128xi8>, tensor<f32>, tensor<i16>) -> tensor<128x128xf32>
+  %17 = "onnx.DequantizeLinear"(%15, %6, %5) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x128xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x128xf32>
   %18 = "onnx.Add"(%16, %17) : (tensor<128x128xf32>, tensor<1x128x128xf32>) -> tensor<1x128x128xf32>
-  %19 = "onnx.QuantizeLinear"(%18, %10, %9) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x128xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xui16>
-  %20 = "onnx.DequantizeLinear"(%19, %10, %9) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x128xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x128xf32>
+  %19 = "onnx.QuantizeLinear"(%18, %10, %9) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x128xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x128xi16>
+  %20 = "onnx.DequantizeLinear"(%19, %10, %9) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x128xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x128xf32>
   return %20 : tensor<1x128x128xf32>
 }
 
 // CHECK-LABEL: @multiuse_constant
-// CHECK: [[CONST:%[0-9]+]] = onnx.Constant dense_resource<__elided__> : tensor<128x128xui8>
+// CHECK: [[CONST:%[0-9]+]] = onnx.Constant dense_resource<__elided__> : tensor<128x128xi8>
 // CHECK: quant.scast [[CONST]]
 // CHECK-SAME: tensor<128x128x!quant.uniform<u8:f32, 0.0043040169402956963:137>>
 // CHECK: quant.scast [[CONST]]


### PR DESCRIPTION
- Convert DQ/Q types to scast ops, which will be folded if the Quantized Types (including scale/zero-points) are equivalent.
- Convert Constant -> DQ into Constant -> qType if the constant has only one use.
- Add test-cases