### PR TITLE
Set isCausal to 1 for GQA decomposition

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -3425,6 +3425,7 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
 
     attention.setQNumHeadsAttr(qNumHeads);
     attention.setKvNumHeadsAttr(kvNumHeads);
+    attention.setIsCausal(1);
 
     if (customOp->hasAttrOfType<IntegerAttr>("qk_output")) {
       auto qkOutput = customOp->getAttrOfType<IntegerAttr>("qk_output");

--- a/test/mlir/onnx/onnx_decompose_customop.mlir
+++ b/test/mlir/onnx/onnx_decompose_customop.mlir
@@ -641,7 +641,7 @@ func.func @minimal_gqa(%q: tensor<1x128x3072xf32>, %k: tensor<1x128x1536xf32>, %
 // CHECK-SAME:                           %[[VAL_2:.*]]: tensor<1x128x1536xf32>) -> tensor<1x128x3072xf32> {
 // CHECK:           %[[VAL_3:.*]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = "onnx.Attention"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_3]], %[[VAL_3]]) 
-// CHECK-SAME:         {is_causal = 0 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
+// CHECK-SAME:         {is_causal = 1 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
 // CHECK-SAME:         : (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>, none, none, none) -> (tensor<1x128x3072xf32>, none, none, none)
 // CHECK:           return %[[VAL_4]] : tensor<1x128x3072xf32>
 // CHECK:         }
@@ -673,7 +673,7 @@ func.func @gqa_3d_inputs_present_kv(
 // CHECK-SAME:                                        %[[VAL_4:.*]]: tensor<1x16x256x48xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x48xf32>) {
 // CHECK:           %[[VAL_5:.*]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]] = "onnx.Attention"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_5]], %[[VAL_3]], %[[VAL_4]]) 
-// CHECK-SAME:          {is_causal = 0 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
+// CHECK-SAME:          {is_causal = 1 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
 // CHECK-SAME:          : (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>, none, tensor<1x16x256x96xf32>, tensor<1x16x256x48xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x48xf32>, none)
 // CHECK:           return %[[VAL_6]], %[[VAL_7]], %[[VAL_8]] : tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x48xf32>
 // CHECK:         }
@@ -705,7 +705,7 @@ func.func @gqa_packed_inputs_3d(
 // CHECK:           %[[VAL_5:.*]]:3 = "onnx.Split"(%[[VAL_0]], %[[VAL_4]]) {axis = 2 : si64} : (tensor<1x128x6144xf32>, tensor<3xi64>) 
 // CHECK-SAME:          -> (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>)
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]] = "onnx.Attention"(%[[VAL_5]]#0, %[[VAL_5]]#1, %[[VAL_5]]#2, %[[VAL_3]], %[[VAL_1]], %[[VAL_2]]) 
-// CHECK-SAME           {is_causal = 0 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
+// CHECK-SAME           {is_causal = 1 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
 // CHECK-SAME:          : (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>, none, tensor<1x16x256x96xf32>, tensor<1x16x256x96xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, none)
 // CHECK:           return %[[VAL_6]], %[[VAL_7:.*]], %[[VAL_8:.*]] : tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>
 // CHECK:         }
@@ -747,7 +747,7 @@ func.func @gqa_packed_inputs_3d_rotary_embedding(
 // CHECK-SAME:          {interleaved = 0 : si64, num_heads = 16 : si64, rotary_embedding_dim = 0 : si64} 
 // CHECK-SAME:          : (tensor<1x128x1536xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<1x128x1536xf32>
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = "onnx.Attention"(%[[VAL_8]], %[[VAL_9]], %[[VAL_7]]#2, %[[VAL_5]], %[[VAL_1]], %[[VAL_2]]) 
-// CHECK-SAME:          {is_causal = 0 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
+// CHECK-SAME:          {is_causal = 1 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
 // CHECK-SAME:          : (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>, none, tensor<1x16x256x96xf32>, tensor<1x16x256x96xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, none)
 // CHECK:           return %[[VAL_10]], %[[VAL_11:.*]], %[[VAL_12:.*]] : tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>
 // CHECK:         }
@@ -792,7 +792,7 @@ func.func @gqa_rotary_embedding_with_position_ids(
 // CHECK-SAME:          {interleaved = 1 : si64, num_heads = 16 : si64, rotary_embedding_dim = 0 : si64} 
 // CHECK-SAME:          : (tensor<1x128x1536xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, tensor<1x128xi64>) -> tensor<1x128x1536xf32>
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]] = "onnx.Attention"(%[[VAL_10]], %[[VAL_11]], %[[VAL_2]], %[[VAL_9]], %[[VAL_3]], %[[VAL_4]]) 
-// CHECK-SAME:          {is_causal = 0 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
+// CHECK-SAME:          {is_causal = 1 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
 // CHECK-SAME:          : (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>, none, tensor<1x16x256x96xf32>, tensor<1x16x256x96xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, none)
 // CHECK:           return %[[VAL_12]], %[[VAL_13:.*]], %[[VAL_14:.*]] : tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>
 // CHECK:         }
@@ -826,7 +826,7 @@ func.func @gqa_with_attention_bias_and_qk_output(
 // CHECK-SAME:                                                        %[[VAL_3:.*]]: tensor<1x16x256x96xf32>, %[[VAL_4:.*]]: tensor<1x16x256x96xf32>,
 // CHECK-SAME:                                                        %[[VAL_5:.*]]: tensor<1x1x128x256xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, tensor<1x32x128x256xf32>) {
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]] = "onnx.Attention"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_5]], %[[VAL_3]], %[[VAL_4]]) 
-// CHECK-SAME:          {is_causal = 0 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
+// CHECK-SAME:          {is_causal = 1 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
 // CHECK-SAME:          : (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>, tensor<1x1x128x256xf32>, tensor<1x16x256x96xf32>, tensor<1x16x256x96xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, tensor<1x32x128x256xf32>)
 // CHECK:           return %[[VAL_7]], %[[VAL_8]], %[[VAL_9]], %[[VAL_10]] : tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, tensor<1x32x128x256xf32>
 // CHECK:         }
@@ -862,7 +862,7 @@ func.func @gqa_with_scale_softcap_and_qk_output_2(
 // CHECK-SAME:                                                         %[[VAL_4:.*]]: tensor<1x16x256x96xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, tensor<1x32x128x256xf32>) {
 // CHECK:           %[[VAL_6:.*]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]] = "onnx.Attention"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_6]], %[[VAL_3]], %[[VAL_4]]) 
-// CHECK-SAME:          {is_causal = 0 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 3 : si64, scale = 2.000000e+00 : f32, softcap = 1.000000e+01 : f32} 
+// CHECK-SAME:          {is_causal = 1 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 3 : si64, scale = 2.000000e+00 : f32, softcap = 1.000000e+01 : f32} 
 // CHECK-SAME:          : (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>, none, tensor<1x16x256x96xf32>, tensor<1x16x256x96xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, tensor<1x32x128x256xf32>)
 // CHECK:           return %[[VAL_7]], %[[VAL_8]], %[[VAL_9]], %[[VAL_10]] : tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, tensor<1x32x128x256xf32>
 // CHECK:         }


### PR DESCRIPTION
`microsoft.GroupQueryAttention` always applies a mask to the softmax in the attention: https://github.com/microsoft/onnxruntime/blob/a5dc0f95d8598f13d326765976ef39bd8253735d/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h#L337
This corresponds to the behavior toggled by the `isCausal` attribute for the `onnx.Attention` op: https://github.com/onnx/onnx/blob/da86640bf103421eb7336714ed0f0e22c0418f16/onnx/reference/ops/op_attention.py#L130-L140
