### PR TITLE
Add ONNX CSE pass without discardable attrs

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -12,6 +12,7 @@ namespace onnx_mlir {
 void addXmcMlirPasses(mlir::OpPassManager &pm, OnnxToMlirOptions opts) {
   pm.addNestedPass<func::FuncOp>(
       onnx_mlir::createOptimizeOnnxRequantizationPass());
+  pm.addNestedPass<func::FuncOp>(createONNXCSEPass());
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createQuantTypesPass());
   pm.addNestedPass<func::FuncOp>(
       onnx_mlir::createConvertInstanceNormToGroupNormPass());

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -52,6 +52,7 @@ add_onnx_mlir_library(OMONNXRewrite
   SetONNXNodeName.cpp
   Recompose.cpp
   LegalizeQuarkQuantizedOps.cpp
+  ONNXCSE.cpp
   QuantTypes.cpp
   ConvertToChannelLast.cpp
   ResultNamesUpdater.cpp

--- a/src/Dialect/ONNX/Transforms/ONNXCSE.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXCSE.cpp
@@ -1,0 +1,99 @@
+// (c) Copyright 2022 - 2025 Advanced Micro Devices, Inc. All Rights reserved.
+
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/STLExtras.h"
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Pass/Pass.h>
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+class ONNXCSEOperationInfo : public DenseMapInfo<Operation *> {
+public:
+  static unsigned getHashValue(const Operation *opC) {
+    auto *op = const_cast<Operation *>(opC);
+    auto hash = llvm::hash_combine(op->getName(), op->hashProperties());
+    for (auto operand : op->getOperands())
+      hash = llvm::hash_combine(hash, hash_value(operand));
+    hash = llvm::hash_combine(hash, op->getResultTypes());
+    return hash;
+  }
+
+  static bool isEqual(const Operation *lhsC, const Operation *rhsC) {
+    auto *lhs = const_cast<Operation *>(lhsC);
+    auto *rhs = const_cast<Operation *>(rhsC);
+    if (lhs == rhs)
+      return true;
+    if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
+        rhs == getTombstoneKey() || rhs == getEmptyKey())
+      return false;
+
+    if (lhs->getName() != rhs->getName() ||
+        lhs->getNumOperands() != rhs->getNumOperands() ||
+        lhs->getNumResults() != rhs->getNumResults() ||
+        !lhs->getName().compareOpProperties(
+            lhs->getPropertiesStorage(), rhs->getPropertiesStorage()))
+      return false;
+
+    for (auto [lhsO, rhsO] :
+        llvm::zip(lhs->getOperands(), rhs->getOperands())) {
+      if (lhsO != rhsO)
+        return false;
+    }
+
+    for (auto [lhsR, rhsR] : llvm::zip(lhs->getResults(), rhs->getResults())) {
+      if (lhsR.getType() != rhsR.getType())
+        return false;
+    }
+
+    return true;
+  }
+};
+
+class ONNXCSEPass
+    : public PassWrapper<ONNXCSEPass, OperationPass<func::FuncOp>> {
+public:
+  [[nodiscard]] StringRef getName() const override { return "onnx-cse"; }
+
+  [[nodiscard]] StringRef getArgument() const override { return "onnx-cse"; }
+
+  [[nodiscard]] StringRef getDescription() const override {
+    return "CSE that ignores discardable attributes, but only considers "
+           "defined properties.";
+  }
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    llvm::SmallDenseSet<Operation *> opsToErase;
+    // Don't erase ops while iterating with getOps
+    for (Operation &op : func.getOps()) {
+      if (auto memInterface = dyn_cast<MemoryEffectOpInterface>(op)) {
+        if (!memInterface.hasNoEffect())
+          continue;
+      }
+      llvm::errs() << "Op: " << op << '\n';
+      auto foundOpIter = knownOps.find(&op);
+      if (foundOpIter != knownOps.end()) {
+        llvm::errs() << "Matched\n";
+        op.replaceAllUsesWith((*foundOpIter)->getResults());
+        opsToErase.insert(&op);
+        continue;
+      }
+      knownOps.insert(&op);
+    }
+    for (auto *op : opsToErase)
+      op->erase();
+  }
+
+private:
+  DenseSet<Operation *, ONNXCSEOperationInfo> knownOps;
+};
+
+std::unique_ptr<Pass> createONNXCSEPass() {
+  return std::make_unique<ONNXCSEPass>();
+}
+
+} // namespace onnx_mlir

--- a/src/Dialect/ONNX/Transforms/ONNXCSE.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXCSE.cpp
@@ -14,12 +14,11 @@ namespace onnx_mlir {
 class ONNXCSEOperationInfo : public DenseMapInfo<Operation *> {
 public:
   static unsigned getHashValue(const Operation *opC) {
-    auto *op = const_cast<Operation *>(opC);
-    auto hash = llvm::hash_combine(op->getName(), op->hashProperties());
-    for (auto operand : op->getOperands())
-      hash = llvm::hash_combine(hash, hash_value(operand));
-    hash = llvm::hash_combine(hash, op->getResultTypes());
-    return hash;
+    return OperationEquivalence::computeHash(const_cast<Operation *>(opC),
+        /*hashOperands=*/OperationEquivalence::directHashValue,
+        /*hashResults=*/OperationEquivalence::ignoreHashValue,
+        OperationEquivalence::IgnoreLocations |
+            OperationEquivalence::IgnoreDiscardableAttrs);
   }
 
   static bool isEqual(const Operation *lhsC, const Operation *rhsC) {
@@ -30,26 +29,10 @@ public:
     if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
         rhs == getTombstoneKey() || rhs == getEmptyKey())
       return false;
-
-    if (lhs->getName() != rhs->getName() ||
-        lhs->getNumOperands() != rhs->getNumOperands() ||
-        lhs->getNumResults() != rhs->getNumResults() ||
-        !lhs->getName().compareOpProperties(
-            lhs->getPropertiesStorage(), rhs->getPropertiesStorage()))
-      return false;
-
-    for (auto [lhsO, rhsO] :
-        llvm::zip(lhs->getOperands(), rhs->getOperands())) {
-      if (lhsO != rhsO)
-        return false;
-    }
-
-    for (auto [lhsR, rhsR] : llvm::zip(lhs->getResults(), rhs->getResults())) {
-      if (lhsR.getType() != rhsR.getType())
-        return false;
-    }
-
-    return true;
+    return OperationEquivalence::isEquivalentTo(const_cast<Operation *>(lhsC),
+        const_cast<Operation *>(rhsC),
+        OperationEquivalence::IgnoreLocations |
+            OperationEquivalence::IgnoreDiscardableAttrs);
   }
 };
 
@@ -74,10 +57,8 @@ public:
         if (!memInterface.hasNoEffect())
           continue;
       }
-      llvm::errs() << "Op: " << op << '\n';
-      auto foundOpIter = knownOps.find(&op);
-      if (foundOpIter != knownOps.end()) {
-        llvm::errs() << "Matched\n";
+      if (auto foundOpIter = knownOps.find(&op);
+          foundOpIter != knownOps.end()) {
         op.replaceAllUsesWith((*foundOpIter)->getResults());
         opsToErase.insert(&op);
         continue;

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -62,6 +62,8 @@ std::unique_ptr<mlir::Pass> createConstPropONNXToONNXPass();
 std::unique_ptr<mlir::Pass> createQDQCanonicalizePass(
     bool removeBinary = false, bool removeQDQAroundOps = false);
 
+std::unique_ptr<mlir::Pass> createONNXCSEPass();
+
 std::unique_ptr<mlir::Pass> createQuantTypesPass();
 
 /// Pass for instrument the ops in specific stage.

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -335,6 +335,7 @@ void registerOMPasses(int optLevel) {
   });
 
   mlir::registerPass(createQuantTypesPass);
+  mlir::registerPass(createONNXCSEPass);
 
   mlir::PassPipelineRegistration<>("xmc-passes", "Run all XMC xcompiler passes",
       [](mlir::OpPassManager &pm) { addXmcMlirPasses(pm); });

--- a/test/mlir/onnx/onnx_cse.mlir
+++ b/test/mlir/onnx/onnx_cse.mlir
@@ -1,6 +1,6 @@
-// RUN: onnx-mlir-opt --cse %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt -onnx-cse %s -split-input-file | FileCheck %s
 
-// COM: Test MLIR CSE pass with ONNX operations to remove common sub-expressions.
+// COM: Test ONNX CSE pass with ONNX operations to remove common sub-expressions.
 func.func @test_cse(%arg0: tensor<*xf32>) -> tensor<*xf32> {
   %0 = "onnx.Log"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
   %1 = "onnx.Tanh"(%0) : (tensor<*xf32>) -> tensor<*xf32>
@@ -11,4 +11,20 @@ func.func @test_cse(%arg0: tensor<*xf32>) -> tensor<*xf32> {
   // CHECK-NEXT: "onnx.Log"
   // CHECK-COUNT-1: "onnx.Tanh"
   // CHECK-NEXT: "onnx.Add"
+}
+
+// -----
+
+func.func @test_cse_noattrs() -> (tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) {
+  %0 = onnx.Constant dense<0> : tensor<i8>
+  %1 = onnx.Constant dense<127> : tensor<64xi8>
+  %2 = onnx.Constant dense<0.00787401571> : tensor<f32>
+  %3 = "onnx.DequantizeLinear"(%1, %2, %0) {axis = 1 : si64, block_size = 0 : si64, onnx_node_name = "a"} : (tensor<64xi8>, tensor<f32>, tensor<i8>) -> tensor<64xf32>
+  %4 = "onnx.DequantizeLinear"(%1, %2, %0) {axis = 1 : si64, block_size = 0 : si64, onnx_node_name = "b"} : (tensor<64xi8>, tensor<f32>, tensor<i8>) -> tensor<64xf32>
+  %5 = "onnx.DequantizeLinear"(%1, %2, %0) {axis = 1 : si64, block_size = 0 : si64, onnx_node_name = "c"} : (tensor<64xi8>, tensor<f32>, tensor<i8>) -> tensor<64xf32>
+  return %3, %4, %5 : tensor<64xf32>, tensor<64xf32>, tensor<64xf32>
+
+  // CHECK-LABEL: test_cse_noattrs
+  // CHECK-COUNT-1: [[DQ:%[0-9]+]] = "onnx.DequantizeLinear"
+  // CHECK-NEXT: return [[DQ]], [[DQ]], [[DQ]]
 }


### PR DESCRIPTION
- Since we add discardable attributes like "onnx_node_name" and "ResultNames", which are not defined "properties" of the ops, while CSE'ing, we have to eliminate by not considering those attributes.