### PR TITLE
Signless integer should set signed flag for QTypes

### DIFF
--- a/src/Dialect/ONNX/Transforms/QuantTypes.cpp
+++ b/src/Dialect/ONNX/Transforms/QuantTypes.cpp
@@ -65,36 +65,34 @@ std::variant<quant::QuantizedType, StringLiteral> getQuantType(QDQOp op) {
     ();
   }
 
+  bool isSigned =
+      storageType.isSignedInteger() || storageType.isSignlessInteger();
+
   if (scale.getNumElements() == 1 && zeropoint.getNumElements() == 1) {
-    return quant::UniformQuantizedType::get(storageType.isSignedInteger(),
-        storageType, expressedType,
+    return quant::UniformQuantizedType::get(isSigned, storageType,
+        expressedType,
         scale.template getSplatValue<APFloat>().convertToDouble(),
-        storageType.isSignedInteger()
-            ? zeropoint.template getSplatValue<APInt>().getSExtValue()
-            : zeropoint.template getSplatValue<APInt>().getZExtValue(),
+        isSigned ? zeropoint.template getSplatValue<APInt>().getSExtValue()
+                 : zeropoint.template getSplatValue<APInt>().getZExtValue(),
         quant::QuantizedType::getDefaultMinimumForInteger(
-            storageType.isSignedInteger(), storageType.getIntOrFloatBitWidth()),
+            isSigned, storageType.getIntOrFloatBitWidth()),
         quant::QuantizedType::getDefaultMaximumForInteger(
-            storageType.isSignedInteger(),
-            storageType.getIntOrFloatBitWidth()));
+            isSigned, storageType.getIntOrFloatBitWidth()));
   } else if (op.getBlockSize() == 0) {
     SmallVector<double> scales(scale.getNumElements());
     llvm::transform(scale.template getValues<APFloat>(), scales.begin(),
         [](APFloat apFloat) { return apFloat.convertToDouble(); });
     SmallVector<int64_t> zeropoints(zeropoint.getNumElements());
     llvm::transform(zeropoint.template getValues<APInt>(), zeropoints.begin(),
-        [storageType](APInt apInt) {
-          return storageType.isSignedInteger() ? apInt.getSExtValue()
-                                               : apInt.getZExtValue();
+        [isSigned](APInt apInt) {
+          return isSigned ? apInt.getSExtValue() : apInt.getZExtValue();
         });
-    return quant::UniformQuantizedPerAxisType::get(
-        storageType.isSignedInteger(), storageType, expressedType, scales,
-        zeropoints, op.getAxis(),
+    return quant::UniformQuantizedPerAxisType::get(isSigned, storageType,
+        expressedType, scales, zeropoints, op.getAxis(),
         quant::QuantizedType::getDefaultMinimumForInteger(
-            storageType.isSignedInteger(), storageType.getIntOrFloatBitWidth()),
+            isSigned, storageType.getIntOrFloatBitWidth()),
         quant::QuantizedType::getDefaultMaximumForInteger(
-            storageType.isSignedInteger(),
-            storageType.getIntOrFloatBitWidth()));
+            isSigned, storageType.getIntOrFloatBitWidth()));
   }
 
   // TODO: Add support for blockwise quantization

--- a/src/Dialect/ONNX/Transforms/QuantTypes.cpp
+++ b/src/Dialect/ONNX/Transforms/QuantTypes.cpp
@@ -72,8 +72,9 @@ std::variant<quant::QuantizedType, StringLiteral> getQuantType(QDQOp op) {
     return quant::UniformQuantizedType::get(isSigned, storageType,
         expressedType,
         scale.template getSplatValue<APFloat>().convertToDouble(),
-        isSigned ? zeropoint.template getSplatValue<APInt>().getSExtValue()
-                 : zeropoint.template getSplatValue<APInt>().getZExtValue(),
+        storageType.isSignedInteger()
+            ? zeropoint.template getSplatValue<APInt>().getSExtValue()
+            : zeropoint.template getSplatValue<APInt>().getZExtValue(),
         quant::QuantizedType::getDefaultMinimumForInteger(
             isSigned, storageType.getIntOrFloatBitWidth()),
         quant::QuantizedType::getDefaultMaximumForInteger(
@@ -84,8 +85,9 @@ std::variant<quant::QuantizedType, StringLiteral> getQuantType(QDQOp op) {
         [](APFloat apFloat) { return apFloat.convertToDouble(); });
     SmallVector<int64_t> zeropoints(zeropoint.getNumElements());
     llvm::transform(zeropoint.template getValues<APInt>(), zeropoints.begin(),
-        [isSigned](APInt apInt) {
-          return isSigned ? apInt.getSExtValue() : apInt.getZExtValue();
+        [storageType](APInt apInt) {
+          return storageType.isSignedInteger() ? apInt.getSExtValue()
+                                               : apInt.getZExtValue();
         });
     return quant::UniformQuantizedPerAxisType::get(isSigned, storageType,
         expressedType, scales, zeropoints, op.getAxis(),

--- a/test/mlir/onnx/onnx_quanttypes.mlir
+++ b/test/mlir/onnx/onnx_quanttypes.mlir
@@ -30,13 +30,13 @@ func.func @matmul_add(%arg0: tensor<1x128x768xf32>) -> tensor<1x128x768xf32> {
 // CHECK: onnx.QuantizeLinear
 // CHECK-SAME: (tensor<1x128x768xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xi16>
 // CHECK-NEXT: quant.scast
-// CHECK-SAME: tensor<1x128x768xi16> to tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>
+// CHECK-SAME: tensor<1x128x768xi16> to tensor<1x128x768x!quant.uniform<i16:f32, 2.1302925597410649E-4:35166>>
 // CHECK-NEXT: onnx.MatMul
-// CHECK-SAME: (tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>, tensor<768x768x!quant.uniform<u8:f32, 0.0043040169402956963:137>>) -> tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>>
+// CHECK-SAME: (tensor<1x128x768x!quant.uniform<i16:f32, 2.1302925597410649E-4:35166>>, tensor<768x768x!quant.uniform<i8:f32, 0.0043040169402956963:137>>) -> tensor<1x128x768x!quant.uniform<i16:f32, 2.0635200780816376E-4:31929>>
 // CHECK-NEXT: onnx.Add
-// CHECK-SAME: (tensor<768x!quant.uniform<u16:f32, 6.7978078277519671E-7:41309>>, tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>>) -> tensor<1x128x768x!quant.uniform<u16:f32, 2.0647853671107441E-4:31907>>
+// CHECK-SAME: (tensor<768x!quant.uniform<i16:f32, 6.7978078277519671E-7:41309>>, tensor<1x128x768x!quant.uniform<i16:f32, 2.0635200780816376E-4:31929>>) -> tensor<1x128x768x!quant.uniform<i16:f32, 2.0647853671107441E-4:31907>>
 // CHECK-NEXT: quant.scast
-// CHECK-SAME: tensor<1x128x768x!quant.uniform<u16:f32, 2.0647853671107441E-4:31907>> to tensor<1x128x768xi16>
+// CHECK-SAME: tensor<1x128x768x!quant.uniform<i16:f32, 2.0647853671107441E-4:31907>> to tensor<1x128x768xi16>
 // CHECK-NEXT: onnx.DequantizeLinear
 // CHECK-SAME: (tensor<1x128x768xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x768xf32>
 
@@ -60,13 +60,13 @@ func.func @no_boundary_qdq(%arg0: tensor<1x128x768xi16>) -> tensor<1x128x768xi16
 
 // CHECK-LABEL: @no_boundary_qdq
 // CHECK: onnx.Constant
-// CHECK-SAME: tensor<768x768x!quant.uniform<u8:f32, 0.0043040169402956963:137>>
+// CHECK-SAME: tensor<768x768x!quant.uniform<i8:f32, 0.0043040169402956963:137>>
 // CHECK-NEXT: quant.scast
-// CHECK-SAME: tensor<1x128x768xi16> to tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>
+// CHECK-SAME: tensor<1x128x768xi16> to tensor<1x128x768x!quant.uniform<i16:f32, 2.1302925597410649E-4:35166>>
 // CHECK-NEXT: onnx.MatMul
-// CHECK-SAME: (tensor<1x128x768x!quant.uniform<u16:f32, 2.1302925597410649E-4:35166>>, tensor<768x768x!quant.uniform<u8:f32, 0.0043040169402956963:137>>) -> tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>>
+// CHECK-SAME: (tensor<1x128x768x!quant.uniform<i16:f32, 2.1302925597410649E-4:35166>>, tensor<768x768x!quant.uniform<i8:f32, 0.0043040169402956963:137>>) -> tensor<1x128x768x!quant.uniform<i16:f32, 2.0635200780816376E-4:31929>>
 // CHECK-NEXT: quant.scast
-// CHECK-SAME: tensor<1x128x768x!quant.uniform<u16:f32, 2.0635200780816376E-4:31929>> to tensor<1x128x768xi16>
+// CHECK-SAME: tensor<1x128x768x!quant.uniform<i16:f32, 2.0635200780816376E-4:31929>> to tensor<1x128x768xi16>
 
 
 func.func @unequal_qdq(%arg0: tensor<1x128x768xi16>) -> tensor<1x128x768xi16> {
@@ -120,9 +120,9 @@ func.func @multiuse_constant(%arg0: tensor<1x128x128xf32>) -> tensor<1x128x128xf
 // CHECK-LABEL: @multiuse_constant
 // CHECK: [[CONST:%[0-9]+]] = onnx.Constant dense_resource<__elided__> : tensor<128x128xi8>
 // CHECK: quant.scast [[CONST]]
-// CHECK-SAME: tensor<128x128x!quant.uniform<u8:f32, 0.0043040169402956963:137>>
+// CHECK-SAME: tensor<128x128x!quant.uniform<i8:f32, 0.0043040169402956963:137>>
 // CHECK: quant.scast [[CONST]]
-// CHECK-SAME: tensor<128x128x!quant.uniform<u8:f32, 6.7978078277519671E-7:41309>>
+// CHECK-SAME: tensor<128x128x!quant.uniform<i8:f32, 6.7978078277519671E-7:41309>>
 
 
 func.func @channelwise_quantization(%arg0: tensor<1x128x128xi16>) -> tensor<1x128x128xi16> {
@@ -139,6 +139,6 @@ func.func @channelwise_quantization(%arg0: tensor<1x128x128xi16>) -> tensor<1x12
 // CHECK-LABEL: @channelwise_quantization
 // CHECK: quant.scast
 // CHECK-NEXT: onnx.Gelu
-// CHECK-SAME: (tensor<1x128x128x!quant.uniform<u16:f32:2
-// CHECK-SAME: -> tensor<1x128x128x!quant.uniform<u16:f32:2
+// CHECK-SAME: (tensor<1x128x128x!quant.uniform<i16:f32:2
+// CHECK-SAME: -> tensor<1x128x128x!quant.uniform<i16:f32:2
 // CHECK-NEXT: quant.scast


### PR DESCRIPTION
- Fixes issue where signed integer storage type is converted to unsigned type.