### PR TITLE
Add --enable-xmc-passes CLI option and fix QuantTypesPass

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -98,6 +98,7 @@ std::vector<std::string> reportHeapBefore; // onnx-mlir only
 std::vector<std::string> reportHeapAfter;  // onnx-mlir only
 std::string modelTag;                      // onnx-mlir only
 bool enableConvOptPass;                    // onnx-mlir only
+bool enableXMCPasses;                      // onnx-mlir only
 bool disableConstantProp;                  // onnx-mlir only
 std::vector<std::string> extraLibPaths;    // onnx-mlir only
 std::vector<std::string> extraLibs;        // onnx-mlir only
@@ -771,6 +772,11 @@ static llvm::cl::opt<std::string, true> modelTagOpt("tag",
 static llvm::cl::opt<bool, true> enableConvOptPassOpt("enable-conv-opt-pass",
     llvm::cl::desc("Enable the ConvOptPass. Default is true."),
     llvm::cl::location(enableConvOptPass), llvm::cl::init(true),
+    llvm::cl::cat(OnnxMlirOptions));
+
+static llvm::cl::opt<bool, true> enableXMCPassesOpt("enable-xmc-passes",
+    llvm::cl::desc("Enable XMC xcompiler passes. Default is false."),
+    llvm::cl::location(enableXMCPasses), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<bool, true> disableConstantPropOpt("disable-constant-prop",

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -133,6 +133,7 @@ extern std::vector<std::string> reportHeapBefore; // onnx-mlir only
 extern std::vector<std::string> reportHeapAfter;  // onnx-mlir only
 extern std::string modelTag;                      // onnx-mlir only
 extern bool enableConvOptPass;                    // onnx-mlir only
+extern bool enableXMCPasses;                      // onnx-mlir only
 extern bool disableConstantProp;                  // onnx-mlir only
 extern std::vector<std::string> extraLibPaths;    // onnx-mlir only
 extern std::vector<std::string> extraLibs;        // onnx-mlir only

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -242,6 +242,7 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
     opts.instrumentOnnxNode = instrumentOnnxNode;
     opts.profileIR = profileIR;
     opts.instrumentStage = instrumentStage;
+    opts.enableXMCPasses = enableXMCPasses;
 
     addONNXToMLIRPasses(pm, /*target CPU*/ false,
         /*donotScrubDisposableElementsAttr=*/false, opts);

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -724,7 +724,7 @@ std::string dirName(StringRef inputFilename) {
     options.runOnnxShapeInference = runOnnxShapeInference;
     options.useOnnxModelTypesForCustomOps = useOnnxModelTypesForCustomOps;
     options.useOutputNameAsLocation = useOutputNameAsLocation;
-    options.addResultNamesAttr = addResultNamesAttr;
+    options.addResultNamesAttr = addResultNamesAttr || enableXMCPasses;
     options.allowMissingOutputTypes = allowMissingOutputTypes;
     options.invokeOnnxVersionConverter = invokeOnnxVersionConverter;
     options.shapeInformation = shapeInformation;
@@ -748,7 +748,7 @@ std::string dirName(StringRef inputFilename) {
   options.useOnnxModelTypes = useOnnxModelTypes;
   options.allowMissingOutputTypes = allowMissingOutputTypes;
   options.useOutputNameAsLocation = useOutputNameAsLocation;
-  options.addResultNamesAttr = addResultNamesAttr;
+  options.addResultNamesAttr = addResultNamesAttr || enableXMCPasses;
   options.invokeOnnxVersionConverter = invokeOnnxVersionConverter;
   options.allowSorting = allowSorting;
   options.shapeInformation = shapeInformation;

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -9,7 +9,7 @@
 using namespace mlir;
 namespace onnx_mlir {
 
-void addXmcMlirPasses(mlir::PassManager &pm, OnnxToMlirOptions opts) {
+void addXmcMlirPasses(mlir::OpPassManager &pm, OnnxToMlirOptions opts) {
   pm.addNestedPass<func::FuncOp>(
       onnx_mlir::createOptimizeOnnxRequantizationPass());
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createQuantTypesPass());

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -6,6 +6,7 @@
 
 namespace mlir {
 class ModuleOp;
+class OpPassManager;
 class PassManager;
 } // namespace mlir
 
@@ -43,7 +44,7 @@ struct OnnxToMlirOptions {
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     bool donotScrubDisposableElementsAttr = false, OnnxToMlirOptions opts = {});
 
-void addXmcMlirPasses(mlir::PassManager &pm, OnnxToMlirOptions opts = {});
+void addXmcMlirPasses(mlir::OpPassManager &pm, OnnxToMlirOptions opts = {});
 } // namespace onnx_mlir
 
 #endif

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -26,6 +26,7 @@
 
 #include "mlir/InitAllPasses.h"
 #include "mlir/Pass/PassRegistry.h"
+#include "src/Compiler/OnnxToMlirPasses.hpp"
 #include "src/Pass/Passes.hpp"
 
 using namespace mlir;
@@ -326,6 +327,9 @@ void registerOMPasses(int optLevel) {
   });
 
   mlir::registerPass(createQuantTypesPass);
+
+  mlir::PassPipelineRegistration<>("xmc-passes", "Run all XMC xcompiler passes",
+      [](mlir::OpPassManager &pm) { addXmcMlirPasses(pm); });
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {


### PR DESCRIPTION
- Add --enable-xmc-passes flag to expose the XMC pipeline from the command line and register it as a named pipeline for onnx-mlir-opt.
- Register ResultNamesUpdater as a listener on GreedyRewriteConfig in QuantPass.
- Auto-enable addResultNamesAttr when --enable-xmc-passes is active so ResultNames are populated during ONNX import.