### PR TITLE
[AIESW-24088] Index cos and sin caches with default position ids

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -113,6 +113,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
       opts.enableConvTransposeDecomposeToPhasedConv,
       opts.enableConvTranspose1dDecomposeToPhasedConv,
       opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
+      opts.enableGroupQueryAttentionDecompose,
       opts.enableSplitToSliceDecompose));
   if (!opts.disableRecomposeOption)
     pm.addNestedPass<func::FuncOp>(
@@ -125,6 +126,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTransposeDecomposeToPhasedConv,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
         opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
+        opts.enableGroupQueryAttentionDecompose,
         opts.enableSplitToSliceDecompose));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
@@ -137,6 +139,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
               opts.enableConvTransposeDecomposeToPhasedConv,
               opts.enableConvTranspose1dDecomposeToPhasedConv,
               opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
+              opts.enableGroupQueryAttentionDecompose,
               opts.enableSplitToSliceDecompose));
     }
     // If quark quantized legalization is enabled, do a last const prop after it
@@ -196,6 +199,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTransposeDecomposeToPhasedConv,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
         opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
+        opts.enableGroupQueryAttentionDecompose,
         opts.enableSplitToSliceDecompose));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -19,6 +19,7 @@ struct OnnxToMlirOptions {
   bool enableConvTranspose1dDecomposeToPhasedConv = false;
   bool enableInstanceNormDecompose = true;
   bool enableMatmulNBitsDecompose = false;
+  bool enableGroupQueryAttentionDecompose = true;
   bool enableRemoveDqQAroundOp = false;
   bool enableRemoveBinary = false;
   bool enableFusePadIntoAvgpool = false;

--- a/src/Dialect/ONNX/ONNXOps/NN/RotaryEmbedding.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/RotaryEmbedding.cpp
@@ -75,6 +75,12 @@ LogicalResult ONNXRotaryEmbeddingOp::verify() {
     return onnx_mlir::Diagnostic::emitOperandHasUnexpectedRankError(
         *this->getOperation(), sinCache, sinCacheType.getRank(), "2 or 3");
 
+  if ((cosCacheType.getRank() == 2 || sinCacheType.getRank() == 2) &&
+      isNoneValue(adaptor.getPositionIds())) {
+    return emitOpError(
+        "input 'position_ids' must be provided when cos and sin caches are 2D");
+  }
+
   if (!cosCacheType.hasStaticShape() || !sinCacheType.hasStaticShape())
     return success(); // Won't be able to do any more checking at this stage.
 

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -3325,7 +3325,7 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
           customOp, "input 'head_sink' not supported by onnx.Attention");
 
     auto smoothSoftmax = customOp->getAttrOfType<IntegerAttr>("smooth_softmax");
-    if (smoothSoftmax && smoothSoftmax.getSInt() != 0)
+    if (smoothSoftmax && smoothSoftmax.getSInt() > 0)
       return rewriter.notifyMatchFailure(customOp,
           "attribute 'smooth_softmax' not supported by onnx.Attention");
 
@@ -3352,11 +3352,12 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
     // need to split them up if this is the case.
     ONNXConstantOp splitLens;
     ONNXSplitOp split;
+    int64_t headSize;
     if (isNoneValue(key) && isNoneValue(value)) {
       int64_t totalNumHeads = qNumHeads.getSInt() + 2 * kvNumHeads.getSInt();
       // microsoft.GroupQueryAttention assumes the head_size is the same for q,
       // k and v
-      int64_t headSize = queryType.getShape()[2] / totalNumHeads;
+      headSize = queryType.getShape()[2] / totalNumHeads;
 
       SmallVector<int64_t, 3> splitLensI64 = {headSize * qNumHeads.getSInt(),
           headSize * kvNumHeads.getSInt(), headSize * kvNumHeads.getSInt()};
@@ -3382,6 +3383,8 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
       query = split->getOpResult(0);
       key = split->getOpResult(1);
       value = split->getOpResult(2);
+    } else {
+      headSize = queryType.getShape()[2] / qNumHeads.getSInt();
     }
 
     // If do_rotary = 1, query and key need to be passed through a rotary
@@ -3391,9 +3394,74 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
     ONNXRotaryEmbeddingOp ropeKey;
     if (doRotary && doRotary.getSInt() > 0) {
       assert(numIn >= 9 && !isNoneValue(cosCache) && !isNoneValue(sinCache));
-
-      if (numIn < 10 || isNoneValue(positionIds))
+      // If do_rotary = 1 and no position ids are provided, we need to slice and
+      // transform the cos and sin caches to have shape:
+      // [batch_size, sequence_length, head_size / 2].
+      if (numIn < 10 || isNoneValue(positionIds)) {
         positionIds = none;
+
+        // We need to know the past sequence length to find the total sequence
+        // length (or vice versa). We could get the total sequence length from
+        // seqlens_k, but only if this input is a constant that we can read.
+        if (isNoneValue(pastKey))
+          return rewriter.notifyMatchFailure(
+              customOp, "expected 'past_ks' input to be provided");
+        auto pastKeyType = cast<ShapedType>(pastKey.getType());
+        if (!pastKeyType.hasStaticShape())
+          return rewriter.notifyMatchFailure(
+              customOp, "expected 'past_ks' input to have static type");
+
+        // Assuming the sequence length is the same kv_sequence_length
+        int64_t seqLen = queryType.getShape()[1];
+        int64_t pastSeqLen = pastKeyType.getShape()[2];
+        int64_t totalSeqLen = pastSeqLen + seqLen;
+
+        // The slice mimics indexing the cos/sin caches using the default
+        // pos_ids: [past_seq_len..total_seq_len].
+        onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(
+            rewriter, loc);
+        Value startsConst = create.onnx.constantInt64({pastSeqLen});
+        Value endsConst = create.onnx.constantInt64({totalSeqLen});
+        Value axesConst = create.onnx.constantInt64({0});
+        Value stepsConst = create.onnx.constantInt64({1});
+        toCheck.append({startsConst, endsConst, axesConst, stepsConst});
+
+        auto elementType = getElementTypeOrSelf(cosCache.getType());
+        auto cacheSlicedType =
+            RankedTensorType::get({seqLen, headSize / 2}, elementType);
+        auto cosCacheSliced = rewriter.create<ONNXSliceOp>(loc, cacheSlicedType,
+            cosCache, startsConst, endsConst, axesConst, stepsConst);
+        auto sinCacheSliced = rewriter.create<ONNXSliceOp>(loc, cacheSlicedType,
+            sinCache, startsConst, endsConst, axesConst, stepsConst);
+        toCheck.append({cosCacheSliced, sinCacheSliced});
+
+        // reshape to [1, sequence_length, head_size / 2]
+        auto cache3dType =
+            RankedTensorType::get({1, seqLen, headSize / 2}, elementType);
+        auto reshapeShapeConst =
+            create.onnx.constantInt64({1, seqLen, headSize / 2});
+        cosCache =
+            create.onnx.reshape(cache3dType, cosCacheSliced, reshapeShapeConst);
+        sinCache =
+            create.onnx.reshape(cache3dType, sinCacheSliced, reshapeShapeConst);
+        toCheck.append({reshapeShapeConst, cosCache, sinCache});
+
+        // Assume total/past sequence length is the same for every batch and
+        // broadcast the default pos_ids to get cos/sin caches with shape:
+        // [batch_size, sequence_length, head_size / 2]
+        int64_t batchSize = queryType.getShape()[0];
+        if (batchSize != 1) {
+          auto cacheBroadcastType = RankedTensorType::get(
+              {batchSize, seqLen, headSize / 2}, elementType);
+          auto broadcastShapeConst =
+              create.onnx.constantInt64({batchSize, seqLen, headSize / 2});
+          cosCache = create.onnx.expand(
+              cacheBroadcastType, cosCache, broadcastShapeConst);
+          sinCache = create.onnx.expand(
+              cacheBroadcastType, sinCache, broadcastShapeConst);
+          toCheck.append({broadcastShapeConst, cosCache, sinCache});
+        }
+      }
 
       int64_t rotaryInterleaved = 0;
       if (customOp->hasAttrOfType<IntegerAttr>("rotary_interleaved"))

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -3325,7 +3325,7 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
           customOp, "input 'head_sink' not supported by onnx.Attention");
 
     auto smoothSoftmax = customOp->getAttrOfType<IntegerAttr>("smooth_softmax");
-    if (smoothSoftmax && smoothSoftmax.getSInt() > 0)
+    if (smoothSoftmax && smoothSoftmax.getSInt() == 1)
       return rewriter.notifyMatchFailure(customOp,
           "attribute 'smooth_softmax' not supported by onnx.Attention");
 

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -3412,9 +3412,9 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
               customOp, "expected 'past_ks' input to have static type");
 
         // Assuming the sequence length is the same kv_sequence_length
-        int64_t seqLen = queryType.getShape()[1];
-        int64_t pastSeqLen = pastKeyType.getShape()[2];
-        int64_t totalSeqLen = pastSeqLen + seqLen;
+        const int64_t seqLen = queryType.getShape()[1];
+        const int64_t pastSeqLen = pastKeyType.getShape()[2];
+        const int64_t totalSeqLen = pastSeqLen + seqLen;
 
         // The slice mimics indexing the cos/sin caches using the default
         // pos_ids: [past_seq_len..total_seq_len].

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -4321,6 +4321,7 @@ struct DecomposeONNXToONNXPass
       bool enableConvTranspose1dDecomposeToPhasedConv = false,
       bool enableInstanceNormDecompose = true,
       bool enableMatmulNBitsDecompose = false,
+      bool enableGroupQueryAttentionDecompose = true,
       bool enableSplitToSliceDecompose = false) {
     this->target = target;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
@@ -4330,6 +4331,8 @@ struct DecomposeONNXToONNXPass
         enableConvTranspose1dDecomposeToPhasedConv;
     this->enableInstanceNormDecompose = enableInstanceNormDecompose;
     this->enableMatmulNBitsDecompose = enableMatmulNBitsDecompose;
+    this->enableGroupQueryAttentionDecompose =
+        enableGroupQueryAttentionDecompose;
     this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
   }
 
@@ -4345,6 +4348,8 @@ struct DecomposeONNXToONNXPass
         pass.enableInstanceNormDecompose.getValue();
     this->enableMatmulNBitsDecompose =
         pass.enableMatmulNBitsDecompose.getValue();
+    this->enableGroupQueryAttentionDecompose =
+        pass.enableGroupQueryAttentionDecompose.getValue();
     this->enableSplitToSliceDecompose =
         pass.enableSplitToSliceDecompose.getValue();
   }
@@ -4387,6 +4392,12 @@ struct DecomposeONNXToONNXPass
                      "dequantize linear and matmul ops"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableGroupQueryAttentionDecompose{*this,
+      "enable-groupqueryattention-decompose",
+      llvm::cl::desc("Enable decomposition of Microsoft GroupQueryAttention to "
+                     "onnx.Attention and onnx.RotaryEmbedding ops"),
+      ::llvm::cl::init(true)};
+
   Option<bool> enableSplitToSliceDecompose{*this, "enable-split-to-slice",
       llvm::cl::desc("Enable decomposition of Split to Slice operations"),
       ::llvm::cl::init(false)};
@@ -4404,7 +4415,8 @@ void DecomposeONNXToONNXPass::runOnOperation() {
   onnx_mlir::getDecomposeONNXToONNXPatterns(patterns,
       enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
-      enableMatmulNBitsDecompose, enableSplitToSliceDecompose);
+      enableMatmulNBitsDecompose, enableGroupQueryAttentionDecompose,
+      enableSplitToSliceDecompose);
   patterns.insert<ReplaceCastLikeByCastPattern>(context);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
@@ -4426,7 +4438,7 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
-    bool enableSplitToSliceDecompose) {
+    bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose) {
   MLIRContext *context = patterns.getContext();
   populateWithGenerated(patterns);
   if (enableConvTransposeDecompose)
@@ -4455,7 +4467,8 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
   patterns.insert<MicrosoftSkipLayerNorm>(context);
   patterns.insert<SimplifiedLayerNorm>(context);
   patterns.insert<MicrosoftSkipSimplifiedLayerNorm>(context);
-  patterns.insert<MicrosoftGroupQueryAttention>(context);
+  if (enableGroupQueryAttentionDecompose)
+    patterns.insert<MicrosoftGroupQueryAttention>(context);
   patterns.insert<MicrosoftRotaryEmbedding>(context);
   if (enableMatmulNBitsDecompose)
     patterns.insert<MicrosoftMatmulNBits>(context);
@@ -4484,9 +4497,10 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createDecomposeONNXToONNXPass(
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
-    bool enableSplitToSliceDecompose) {
+    bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose) {
   return std::make_unique<DecomposeONNXToONNXPass>(target,
       enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
-      enableMatmulNBitsDecompose, enableSplitToSliceDecompose);
+      enableMatmulNBitsDecompose, enableGroupQueryAttentionDecompose,
+      enableSplitToSliceDecompose);
 }

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -31,6 +31,7 @@ void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
+    bool enableGroupQueryAttentionDecompose,
     bool enableSplitToSliceDecompose = false);
 
 } // namespace onnx_mlir

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -123,6 +123,12 @@ struct ONNXHybridTransformPass
                      "dequantize linear and matmul ops"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableGroupQueryAttentionDecompose{*this,
+      "enable-groupqueryattention-decompose",
+      llvm::cl::desc("Enable decomposition of Microsoft GroupQueryAttention to "
+                     "onnx.Attention and onnx.RotaryEmbedding ops"),
+      ::llvm::cl::init(true)};
+
   Option<bool> enableSplitToSliceDecompose{*this,
       "enable-split-to-slice-decompose",
       llvm::cl::desc("Enable decomposition of Split to Slice"),
@@ -136,6 +142,7 @@ struct ONNXHybridTransformPass
       bool enableConvTransposeDecomposeToPhasedConv,
       bool enableConvTranspose1dDecomposeToPhasedConv,
       bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
+      bool enableGroupQueryAttentionDecompose,
       bool enableSplitToSliceDecompose) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
@@ -146,6 +153,8 @@ struct ONNXHybridTransformPass
         enableConvTranspose1dDecomposeToPhasedConv;
     this->enableInstanceNormDecompose = enableInstanceNormDecompose;
     this->enableMatmulNBitsDecompose = enableMatmulNBitsDecompose;
+    this->enableGroupQueryAttentionDecompose =
+        enableGroupQueryAttentionDecompose;
     this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
   }
 
@@ -196,7 +205,7 @@ struct ONNXHybridTransformPass
           enableConvTransposeDecomposeToPhasedConv,
           enableConvTranspose1dDecomposeToPhasedConv,
           enableInstanceNormDecompose, enableMatmulNBitsDecompose,
-          enableSplitToSliceDecompose);
+          enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose);
     }
 
     if (recomposition) {
@@ -243,10 +252,11 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
-    bool enableSplitToSliceDecompose) {
+    bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
-      enableMatmulNBitsDecompose, enableSplitToSliceDecompose);
+      enableMatmulNBitsDecompose, enableGroupQueryAttentionDecompose,
+      enableSplitToSliceDecompose);
 }

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -43,6 +43,7 @@ std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
     bool enableConvTranspose1dDecomposeToPhasedConv = false,
     bool enableInstanceNormDecompose = true,
     bool enableMatmulNBitsDecompose = false,
+    bool enableGroupQueryAttentionDecompose = true,
     bool enableSplitToSliceDecompose = false);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "");
@@ -91,6 +92,7 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableConvTranspose1dDecomposeToPhasedConv = false,
     bool enableInstanceNormDecompose = true,
     bool enableMatmulNBitsDecompose = false,
+    bool enableGroupQueryAttentionDecompose = true,
     bool enableSplitToSliceDecompose = false);
 
 /// Pass for analyzing unknown dimension in ONNX operations.

--- a/test/mlir/onnx/invalid.mlir
+++ b/test/mlir/onnx/invalid.mlir
@@ -893,55 +893,55 @@ func.func @test_random_normal_like_wrong_dtype(%arg0: tensor<1x1x28x28xf32>) -> 
 
 // -----
 
-func.func @test_rotary_embedding_missing_num_heads(%data: tensor<1x128x3072xf32>, %cos_cache: tensor<4096x48xf32>, %sin_cache: tensor<4096x48xf32>) -> tensor<*xf32> {
+func.func @test_rotary_embedding_missing_num_heads(%data: tensor<1x128x3072xf32>, %cos_cache: tensor<1x128x48xf32>, %sin_cache: tensor<1x128x48xf32>) -> tensor<*xf32> {
   %pos_ids = "onnx.NoValue"() {value} : () -> none
   // expected-error @+1 {{'onnx.RotaryEmbedding' op attribute 'num_heads' must be provided when input is a 3D tensor.}}
-  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) : (tensor<1x128x3072xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<*xf32>
+  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) : (tensor<1x128x3072xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<*xf32>
   return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @test_rotary_embedding_bad_dtype(%data: tensor<1x128x3072xi64>, %cos_cache: tensor<4096x48xi64>, %sin_cache: tensor<4096x48xi64>) -> tensor<*xi64> {
+func.func @test_rotary_embedding_bad_dtype(%data: tensor<1x128x3072xi64>, %cos_cache: tensor<1x128x48xi64>, %sin_cache: tensor<1x128x48xi64>) -> tensor<*xi64> {
   %pos_ids = "onnx.NoValue"() {value} : () -> none
   // expected-error @+1 {{'onnx.RotaryEmbedding' op operand #0 must be tensor of 32-bit float values or tensor of 16-bit float values or tensor of bfloat16 type values}}
-  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) : (tensor<1x128x3072xi64>, tensor<4096x48xi64>, tensor<4096x48xi64>, none) -> tensor<*xi64>
+  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) : (tensor<1x128x3072xi64>, tensor<1x128x48xi64>, tensor<1x128x48xi64>, none) -> tensor<*xi64>
   return %0 : tensor<*xi64>
 }
 
 // -----
 
-func.func @test_rotary_embedding_4d_odd_head_size(%data: tensor<1x32x128x95xf32>, %cos_cache: tensor<4096x48xf32>, %sin_cache: tensor<4096x48xf32>) -> tensor<*xf32> {
+func.func @test_rotary_embedding_4d_odd_head_size(%data: tensor<1x32x128x95xf32>, %cos_cache: tensor<1x128x48xf32>, %sin_cache: tensor<1x128x48xf32>) -> tensor<*xf32> {
   %pos_ids = "onnx.NoValue"() {value} : () -> none
   // expected-error @+1 {{onnx.RotaryEmbedding: operand '<block argument> of type 'tensor<1x32x128x95xf32>' at index: 0' has dimension at index 3 with value 95, value should be even}}
-  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64} : (tensor<1x32x128x95xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<*xf32>
+  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64} : (tensor<1x32x128x95xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<*xf32>
   return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @test_rotary_embedding_3d_odd_head_size(%data: tensor<1x128x3040xf32>, %cos_cache: tensor<4096x48xf32>, %sin_cache: tensor<4096x48xf32>) -> tensor<*xf32> {
+func.func @test_rotary_embedding_3d_odd_head_size(%data: tensor<1x128x3040xf32>, %cos_cache: tensor<1x128x48xf32>, %sin_cache: tensor<1x128x48xf32>) -> tensor<*xf32> {
   %pos_ids = "onnx.NoValue"() {value} : () -> none
   // expected-error @+1 {{onnx.RotaryEmbedding: operand '<block argument> of type 'tensor<1x128x3040xf32>' at index: 0' has dimension at index 2 with value 3040, value should be divisible by 32 * 2}}
-  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64} : (tensor<1x128x3040xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<*xf32>
+  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64} : (tensor<1x128x3040xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<*xf32>
   return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @test_rotary_embedding_bad_embedding_dim(%data: tensor<1x32x128x96xf32>, %cos_cache: tensor<4096x48xf32>, %sin_cache: tensor<4096x48xf32>) -> tensor<*xf32> {
+func.func @test_rotary_embedding_bad_embedding_dim(%data: tensor<1x32x128x96xf32>, %cos_cache: tensor<1x128x48xf32>, %sin_cache: tensor<1x128x48xf32>) -> tensor<*xf32> {
   %pos_ids = "onnx.NoValue"() {value} : () -> none
-  // expected-error @+1 {{onnx.RotaryEmbedding: operand '<block argument> of type 'tensor<4096x48xf32>' at index: 1' has dimension at index 1 with value 48, value should be 50}}
-  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64, rotary_embedding_dim = 100: si64} : (tensor<1x32x128x96xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<*xf32>
+  // expected-error @+1 {{onnx.RotaryEmbedding: operand '<block argument> of type 'tensor<1x128x48xf32>' at index: 1' has dimension at index 2 with value 48, value should be 50}}
+  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64, rotary_embedding_dim = 100: si64} : (tensor<1x32x128x96xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<*xf32>
   return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @test_rotary_embedding_bad_input_rank(%data: tensor<1x2x32x128x96xf32>, %cos_cache: tensor<4096x48xf32>, %sin_cache: tensor<4096x48xf32>) -> tensor<*xf32> {
+func.func @test_rotary_embedding_bad_input_rank(%data: tensor<1x2x32x128x96xf32>, %cos_cache: tensor<1x128x48xf32>, %sin_cache: tensor<1x128x48xf32>) -> tensor<*xf32> {
   %pos_ids = "onnx.NoValue"() {value} : () -> none
   // expected-error @+1 {{onnx.RotaryEmbedding: operand '<block argument> of type 'tensor<1x2x32x128x96xf32>' at index: 0' has rank 5, rank should be 3 or 4}}
-  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64} : (tensor<1x2x32x128x96xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<*xf32>
+  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64} : (tensor<1x2x32x128x96xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<*xf32>
   return %0 : tensor<*xf32>
 }
 
@@ -956,15 +956,23 @@ func.func @test_rotary_embedding_bad_caches_rank(%data: tensor<1x32x128x96xf32>,
 
 // -----
 
-func.func @test_rotary_embedding_bad_num_heads(%data: tensor<1x128x3072xf32>, %cos_cache: tensor<4096x48xf32>, %sin_cache: tensor<4096x48xf32>) -> tensor<*xf32> {
+func.func @test_rotary_embedding_bad_num_heads(%data: tensor<1x128x3072xf32>, %cos_cache: tensor<1x128x48xf32>, %sin_cache: tensor<1x128x48xf32>) -> tensor<*xf32> {
   %pos_ids = "onnx.NoValue"() {value} : () -> none
   // expected-error @+1 {{onnx.RotaryEmbedding: operand '<block argument> of type 'tensor<1x128x3072xf32>' at index: 0' has dimension at index 2 with value 3072, value should be divisible by 31}}
-  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 31: si64} : (tensor<1x128x3072xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<*xf32>
+  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 31: si64} : (tensor<1x128x3072xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<*xf32>
   return %0 : tensor<*xf32>
 }
 
 // -----
 
+func.func @test_rotary_embedding_2d_caches_no_num_heads(%data: tensor<1x128x3072xf32>, %cos_cache: tensor<4096x48xf32>, %sin_cache: tensor<4096x48xf32>) -> tensor<*xf32> {
+  %pos_ids = "onnx.NoValue"() {value} : () -> none
+  // expected-error @+1 {{'onnx.RotaryEmbedding' op input 'position_ids' must be provided when cos and sin caches are 2D}}
+  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64} : (tensor<1x128x3072xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}
+
+// -----
 func.func @test_attention_bad_q_rank(%q: tensor<1x2x32x128x96xf32>, %k: tensor<1x16x128x96xf32>, %v: tensor<1x16x128x48xf32>) -> tensor<*xf32> {
   %none = "onnx.NoValue"() {value} : () -> none
   // expected-error @+1 {{onnx.Attention: operand '<block argument> of type 'tensor<1x2x32x128x96xf32>' at index: 0' has rank 5, rank should be 3 or 4}}

--- a/test/mlir/onnx/onnx_decompose_customop.mlir
+++ b/test/mlir/onnx/onnx_decompose_customop.mlir
@@ -712,7 +712,7 @@ func.func @gqa_packed_inputs_3d(
 
 // -----
 
-func.func @gqa_packed_inputs_3d_rotary_embedding(
+func.func @gqa_packed_inputs_3d_rotary_embedding_no_position_ids(
   %qkv: tensor<1x128x6144xf32>, 
   %past_k: tensor<1x16x256x96xf32>, 
   %past_v: tensor<1x16x256x96xf32>,
@@ -731,21 +731,37 @@ func.func @gqa_packed_inputs_3d_rotary_embedding(
   }: (tensor<1x128x6144xf32>, none, none, tensor<1x16x256x96xf32>, tensor<1x16x256x96xf32>, tensor<1x1xi32>, tensor<i32>, tensor<4096x48xf32>, tensor<4096x48xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>)
   return %out, %present_k, %present_v : tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>
 }
-// CHECK-LABEL:   func.func @gqa_packed_inputs_3d_rotary_embedding(
+// CHECK-LABEL:   func.func @gqa_packed_inputs_3d_rotary_embedding_no_position_ids(
 // CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<1x128x6144xf32>,
 // CHECK-SAME:                                                     %[[VAL_1:.*]]: tensor<1x16x256x96xf32>, %[[VAL_2:.*]]: tensor<1x16x256x96xf32>,
-// CHECK-SAME:                                                     %[[VAL_3:.*]]: tensor<4096x48xf32>,
-// CHECK-SAME:                                                     %[[VAL_4:.*]]: tensor<4096x48xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>) {
+// CHECK-SAME:                                                     %[[COS_CACHE:.*]]: tensor<4096x48xf32>,
+// CHECK-SAME:                                                     %[[SIN_CACHE:.*]]: tensor<4096x48xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>) {
+
+// CHECK-DAG:       %[[START:.*]] = onnx.Constant dense<256> : tensor<1xi64>
+// CHECK-DAG:       %[[END:.*]] = onnx.Constant dense<384> : tensor<1xi64>
+// CHECK-DAG:       %[[AXES:.*]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       %[[STEPS:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       %[[RESHAPE_SHAPE:.*]] = onnx.Constant dense<[1, 128, 48]> : tensor<3xi64>
+
 // CHECK:           %[[VAL_5:.*]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[3072, 1536, 1536]> : tensor<3xi64>
 // CHECK:           %[[VAL_7:.*]]:3 = "onnx.Split"(%[[VAL_0]], %[[VAL_6]]) {axis = 2 : si64} 
 // CHECK-SAME:          : (tensor<1x128x6144xf32>, tensor<3xi64>) -> (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>)
-// CHECK:           %[[VAL_8:.*]] = "onnx.RotaryEmbedding"(%[[VAL_7]]#0, %[[VAL_3]], %[[VAL_4]], %[[VAL_5]]) 
+
+// CHECK:           %[[COS_SLICE:.*]] = "onnx.Slice"(%[[COS_CACHE]], %[[START]], %[[END]], %[[AXES]], %[[STEPS]]) 
+// CHECK:           %[[SIN_SLICE:.*]] = "onnx.Slice"(%[[SIN_CACHE]], %[[START]], %[[END]], %[[AXES]], %[[STEPS]]) 
+
+// CHECK:           %[[COS_RESHAPE:.*]] = "onnx.Reshape"(%[[COS_SLICE]], %[[RESHAPE_SHAPE]]) 
+// CHECK:           %[[SIN_RESHAPE:.*]] = "onnx.Reshape"(%[[SIN_SLICE]], %[[RESHAPE_SHAPE]]) 
+
+// CHECK:           %[[VAL_8:.*]] = "onnx.RotaryEmbedding"(%[[VAL_7]]#0, %[[COS_RESHAPE]], %[[SIN_RESHAPE]], %[[VAL_5]]) 
 // CHECK-SAME:          {interleaved = 0 : si64, num_heads = 32 : si64, rotary_embedding_dim = 0 : si64} 
-// CHECK-SAME:          : (tensor<1x128x3072xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<1x128x3072xf32>
-// CHECK:           %[[VAL_9:.*]] = "onnx.RotaryEmbedding"(%[[VAL_7]]#1, %[[VAL_3]], %[[VAL_4]], %[[VAL_5]]) 
+// CHECK-SAME:          : (tensor<1x128x3072xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<1x128x3072xf32>
+
+// CHECK:           %[[VAL_9:.*]] = "onnx.RotaryEmbedding"(%[[VAL_7]]#1, %[[COS_RESHAPE]], %[[SIN_RESHAPE]], %[[VAL_5]]) 
 // CHECK-SAME:          {interleaved = 0 : si64, num_heads = 16 : si64, rotary_embedding_dim = 0 : si64} 
-// CHECK-SAME:          : (tensor<1x128x1536xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<1x128x1536xf32>
+// CHECK-SAME:          : (tensor<1x128x1536xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<1x128x1536xf32>
+
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = "onnx.Attention"(%[[VAL_8]], %[[VAL_9]], %[[VAL_7]]#2, %[[VAL_5]], %[[VAL_1]], %[[VAL_2]]) 
 // CHECK-SAME:          {is_causal = 1 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
 // CHECK-SAME:          : (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>, none, tensor<1x16x256x96xf32>, tensor<1x16x256x96xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, none)
@@ -865,6 +881,68 @@ func.func @gqa_with_scale_softcap_and_qk_output_2(
 // CHECK-SAME:          {is_causal = 1 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 3 : si64, scale = 2.000000e+00 : f32, softcap = 1.000000e+01 : f32} 
 // CHECK-SAME:          : (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>, none, tensor<1x16x256x96xf32>, tensor<1x16x256x96xf32>) -> (tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, tensor<1x32x128x256xf32>)
 // CHECK:           return %[[VAL_7]], %[[VAL_8]], %[[VAL_9]], %[[VAL_10]] : tensor<1x128x3072xf32>, tensor<1x16x384x96xf32>, tensor<1x16x384x96xf32>, tensor<1x32x128x256xf32>
+// CHECK:         }
+
+// -----
+
+func.func @gqa_batch4_do_rotary_no_position_ids(
+  %q: tensor<4x128x3072xf32>, 
+  %k: tensor<4x128x1536xf32>, 
+  %v: tensor<4x128x1536xf32>,
+  %past_k: tensor<4x16x256x96xf32>, 
+  %past_v: tensor<4x16x256x48xf32>,
+  %cos_cache: tensor<4096x48xf32>, 
+  %sin_cache: tensor<4096x48xf32>
+) -> (tensor<4x128x3072xf32>, tensor<4x16x384x96xf32>, tensor<4x16x384x48xf32>) {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %total_seqlen = "onnx.Constant"() {value = dense<256> : tensor<i32>} : () -> tensor<i32>
+  %seqlens = "onnx.Constant"() {value = dense<255> : tensor<4x1xi32>} : () -> tensor<4x1xi32>
+  %out, %present_k, %present_v = "onnx.Custom"(%q, %k, %v, %past_k, %past_v, %seqlens, %total_seqlen, %cos_cache, %sin_cache) {
+    domain_name = "com.microsoft",
+    function_name = "GroupQueryAttention",
+    do_rotary = 1 : si64,
+    kv_num_heads = 16 : si64,
+    num_heads = 32 : si64  
+  }: (tensor<4x128x3072xf32>, tensor<4x128x1536xf32>, tensor<4x128x1536xf32>, tensor<4x16x256x96xf32>, tensor<4x16x256x48xf32>, tensor<4x1xi32>, tensor<i32>, tensor<4096x48xf32>, tensor<4096x48xf32>) -> (tensor<4x128x3072xf32>, tensor<4x16x384x96xf32>, tensor<4x16x384x48xf32>)
+  return %out, %present_k, %present_v : tensor<4x128x3072xf32>, tensor<4x16x384x96xf32>, tensor<4x16x384x48xf32>
+}
+// CHECK-LABEL:   func.func @gqa_batch4_do_rotary_no_position_ids(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<4x128x3072xf32>,
+// CHECK-SAME:                                                     %[[VAL_1:.*]]: tensor<4x128x1536xf32>, %[[VAL_2:.*]]: tensor<4x128x1536xf32>,
+// CHECK-SAME:                                                     %[[VAL_3:.*]]: tensor<4x16x256x96xf32>,
+// CHECK-SAME:                                                     %[[VAL_4:.*]]: tensor<4x16x256x48xf32>,
+// CHECK-SAME:                                                     %[[COS_CACHE:.*]]: tensor<4096x48xf32>,
+// CHECK-SAME:                                                     %[[SIN_CACHE:.*]]: tensor<4096x48xf32>) -> (tensor<4x128x3072xf32>, tensor<4x16x384x96xf32>, tensor<4x16x384x48xf32>) {
+
+// CHECK-DAG:       %[[START:.*]] = onnx.Constant dense<256> : tensor<1xi64>
+// CHECK-DAG:       %[[END:.*]] = onnx.Constant dense<384> : tensor<1xi64>
+// CHECK-DAG:       %[[AXES:.*]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       %[[STEPS:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       %[[RESHAPE_SHAPE:.*]] = onnx.Constant dense<[1, 128, 48]> : tensor<3xi64>
+// CHECK-DAG:       %[[BROADCAST_SHAPE:.*]] = onnx.Constant dense<[4, 128, 48]> : tensor<3xi64>
+// CHECK-DAG:       %[[NONE:.*]] = "onnx.NoValue"() {value} : () -> none
+
+// CHECK:           %[[COS_SLICE:.*]] = "onnx.Slice"(%[[COS_CACHE]], %[[START]], %[[END]], %[[AXES]], %[[STEPS]]) 
+// CHECK:           %[[SIN_SLICE:.*]] = "onnx.Slice"(%[[SIN_CACHE]], %[[START]], %[[END]], %[[AXES]], %[[STEPS]]) 
+
+// CHECK:           %[[COS_RESHAPE:.*]] = "onnx.Reshape"(%[[COS_SLICE]], %[[RESHAPE_SHAPE]]) 
+// CHECK:           %[[SIN_RESHAPE:.*]] = "onnx.Reshape"(%[[SIN_SLICE]], %[[RESHAPE_SHAPE]]) 
+
+// CHECK:           %[[COS_BROADCAST:.*]] = "onnx.Expand"(%[[COS_RESHAPE]], %[[BROADCAST_SHAPE]]) 
+// CHECK:           %[[SIN_BROADCAST:.*]] = "onnx.Expand"(%[[SIN_RESHAPE]], %[[BROADCAST_SHAPE]]) 
+
+// CHECK:           %[[VAL_8:.*]] = "onnx.RotaryEmbedding"(%[[VAL_0]], %[[COS_BROADCAST]], %[[SIN_BROADCAST]], %[[NONE]]) 
+// CHECK-SAME:          {interleaved = 0 : si64, num_heads = 32 : si64, rotary_embedding_dim = 0 : si64} 
+// CHECK-SAME:          : (tensor<4x128x3072xf32>, tensor<4x128x48xf32>, tensor<4x128x48xf32>, none) -> tensor<4x128x3072xf32>
+
+// CHECK:           %[[VAL_9:.*]] = "onnx.RotaryEmbedding"(%[[VAL_1]], %[[COS_BROADCAST]], %[[SIN_BROADCAST]], %[[NONE]]) 
+// CHECK-SAME:          {interleaved = 0 : si64, num_heads = 16 : si64, rotary_embedding_dim = 0 : si64} 
+// CHECK-SAME:          : (tensor<4x128x1536xf32>, tensor<4x128x48xf32>, tensor<4x128x48xf32>, none) -> tensor<4x128x1536xf32>
+
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = "onnx.Attention"(%[[VAL_8]], %[[VAL_9]], %[[VAL_2]], %[[NONE]], %[[VAL_3]], %[[VAL_4]]) 
+// CHECK-SAME:          {is_causal = 1 : si64, kv_num_heads = 16 : si64, q_num_heads = 32 : si64, qk_matmul_output_mode = 0 : si64, softcap = 0.000000e+00 : f32} 
+// CHECK-SAME:          : (tensor<4x128x3072xf32>, tensor<4x128x1536xf32>, tensor<4x128x1536xf32>, none, tensor<4x16x256x96xf32>, tensor<4x16x256x48xf32>) -> (tensor<4x128x3072xf32>, tensor<4x16x384x96xf32>, tensor<4x16x384x48xf32>, none)
+// CHECK:           return %[[VAL_10]], %[[VAL_11:.*]], %[[VAL_12:.*]] : tensor<4x128x3072xf32>, tensor<4x16x384x96xf32>, tensor<4x16x384x48xf32>
 // CHECK:         }
 
 // -----

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -4494,24 +4494,24 @@ func.func @test_slice_negative_steps_mixed_dialects(%arg0: tensor<100x200xf32>) 
 /// Test shape inference for RotaryEncoder.
 //===----------------------------------------------------------------------===//
 
-func.func @test_rotary_embedding_4d_no_pos_ids(%data: tensor<1x32x128x96xf32>, %cos_cache: tensor<4096x48xf32>, %sin_cache: tensor<4096x48xf32>) -> tensor<*xf32> {
+func.func @test_rotary_embedding_4d_no_pos_ids(%data: tensor<1x32x128x96xf32>, %cos_cache: tensor<1x128x48xf32>, %sin_cache: tensor<1x128x48xf32>) -> tensor<*xf32> {
   %pos_ids = "onnx.NoValue"() {value} : () -> none
-  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64} : (tensor<1x32x128x96xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<*xf32>
+  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64} : (tensor<1x32x128x96xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<*xf32>
   return %0 : tensor<*xf32>
 }
 // CHECK-LABEL:  func.func @test_rotary_embedding_4d_no_pos_ids
 // CHECK:          "onnx.RotaryEmbedding"
-// CHECK-SAME:       (tensor<1x32x128x96xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<1x32x128x96xf32>
+// CHECK-SAME:       (tensor<1x32x128x96xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<1x32x128x96xf32>
 
 
-func.func @test_rotary_embedding_3d_no_pos_ids(%data: tensor<1x128x3072xf32>, %cos_cache: tensor<4096x48xf32>, %sin_cache: tensor<4096x48xf32>) -> tensor<*xf32> {
+func.func @test_rotary_embedding_3d_no_pos_ids(%data: tensor<1x128x3072xf32>, %cos_cache: tensor<1x128x48xf32>, %sin_cache: tensor<1x128x48xf32>) -> tensor<*xf32> {
   %pos_ids = "onnx.NoValue"() {value} : () -> none
-  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64} : (tensor<1x128x3072xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<*xf32>
+  %0 = "onnx.RotaryEmbedding"(%data, %cos_cache, %sin_cache, %pos_ids) {num_heads = 32: si64} : (tensor<1x128x3072xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<*xf32>
   return %0 : tensor<*xf32>
 }
 // CHECK-LABEL:  func.func @test_rotary_embedding_3d_no_pos_ids
 // CHECK:          "onnx.RotaryEmbedding"
-// CHECK-SAME:       (tensor<1x128x3072xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, none) -> tensor<1x128x3072xf32>
+// CHECK-SAME:       (tensor<1x128x3072xf32>, tensor<1x128x48xf32>, tensor<1x128x48xf32>, none) -> tensor<1x128x3072xf32>
 
 
 // -----


### PR DESCRIPTION
`onnx.RotaryEmbedding` requires the `cos/sin_cache` inputs to have the shape `[batch_size, seq_len, head_size/2]` when `pos_ids` is not provided. We therefore need to index the (i.e. slice) the `cos/sin_cache` inputs using the default pos_ids as described in Microsoft's onnx runtime implementation: https://github.com/microsoft/onnxruntime/blob/bb3866cf34c44f33df617d09dac6f15d55a0f890/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc#L155-L164.
Namely, the default pos_ids are [past_sequence_length..total_sequence_length]

Note that we assume that all batches have the same total_sequence_length and that this is equal to sequence_length + past_sequence_length (as required by onnx.Attention).