### PR TITLE
Changes needed for xcompiler-mlir

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -49,6 +49,7 @@ bool enableKrnlBufferReuse;                            // common for both
 bool enableConvTransposeDecomposeToPhasedConv;         // common for both
 bool enableConvTranspose1dDecomposeToPhasedConv;       // common for both
 bool enableQuarkQuantizerLegalization;                 // common for both
+bool disableBatchNormDecompose;                        // common for both
 bool enableSafeCodeGen;                                // common for both
 bool disableMemRefPrefetch;                            // common for both
 uint64_t compilationNumThreads;                        // common for both
@@ -320,6 +321,15 @@ static llvm::cl::opt<bool, true> enableQuarkQuantizerLegalizationOptionOpt(
     "enable-quark-quantizer-legalization",
     llvm::cl::desc("Enable legalization of ONNX models quantized by quark."),
     llvm::cl::location(enableQuarkQuantizerLegalization), llvm::cl::init(false),
+    llvm::cl::cat(OnnxMlirCommonOptions));
+
+static llvm::cl::opt<bool, true> disableBatchNormDecomposeOpt(
+    "disable-batchnorm-decompose",
+    llvm::cl::desc(
+        "Disable decomposition of BatchNormInferenceMode into elementwise "
+        "patterns (default=false). Set to 'true' to keep BatchNorm as a "
+        "single op."),
+    llvm::cl::location(disableBatchNormDecompose), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirCommonOptions));
 
 // Options for onnx-mlir only

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -86,6 +86,7 @@ extern bool disableMemRefPrefetch;                            // common for both
 extern bool enableConvTransposeDecomposeToPhasedConv;         // common for both
 extern bool enableConvTranspose1dDecomposeToPhasedConv;       // common for both
 extern bool enableQuarkQuantizerLegalization;                 // common for both
+extern bool disableBatchNormDecompose;                        // common for both
 extern uint64_t compilationNumThreads;                        // common for both
 // AMD: Decompose unconditionally
 // extern std::vector<std::string> decomposeOpsInONNX; // common for both

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -228,6 +228,7 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
         enableConvTransposeDecomposeToPhasedConv;
     opts.enableConvTranspose1dDecomposeToPhasedConv =
         enableConvTranspose1dDecomposeToPhasedConv;
+    opts.disableBatchNormDecompose = disableBatchNormDecompose;
     opts.disableRecomposeOption = disableRecomposeOption;
     opts.enableONNXHybridPass = enableONNXHybridPass;
     opts.enableConvOptPass = enableConvOptPass;

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -103,6 +103,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   // In future, only the dynamic pass, ONNXOpTransformPass, will be used for
   // this function.
 
+  configureBatchNormCanonicalization(opts.disableBatchNormDecompose);
+
   if (!donotScrubDisposableElementsAttr)
     pm.addInstrumentation(
         std::make_unique<DisposableGarbageCollector>(pm.getContext()));

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -26,6 +26,8 @@ struct OnnxToMlirOptions {
   bool enableXMCPasses = false;
   bool enableSplitToSliceDecompose = false;
 
+  bool disableBatchNormDecompose = false;
+
   bool disableRecomposeOption = false;
   bool enableONNXHybridPass = true;
   bool enableConvOptPass = true;

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -6161,22 +6161,22 @@ def ONNXQLinearConvOp:ONNX_Op<"QLinearConv",
   When bias is present it must be quantized using scale = input scale * weight scale and
   zero point as 0.
   }];
-  let arguments = (ins AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$x,
+  let arguments = (ins AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI16]>, TensorOf<[UI8]>]>:$x,
     AnyTypeOf<[TensorOf<[F32]>, TensorOf<[quant_QuantizedType]>]>:$x_scale,
-    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$x_zero_point,
-    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$w,
+    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI16]>, TensorOf<[UI8]>]>:$x_zero_point,
+    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI16]>, TensorOf<[UI8]>]>:$w,
     AnyTypeOf<[TensorOf<[F32]>, TensorOf<[quant_QuantizedType]>]>:$w_scale,
-    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$w_zero_point,
+    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI16]>, TensorOf<[UI8]>]>:$w_zero_point,
     AnyTypeOf<[TensorOf<[F32]>, TensorOf<[quant_QuantizedType]>]>:$y_scale,
-    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$y_zero_point,
-    AnyTypeOf<[TensorOf<[I32]>, NoneType]>:$B,
+    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI16]>, TensorOf<[UI8]>]>:$y_zero_point,
+    AnyTypeOf<[TensorOf<[I32]>, TensorOf<[UI16]>, TensorOf<[I16]>, TensorOf<[I8]>, NoneType]>:$B,
     DefaultValuedStrAttr<StrAttr, "NOTSET">:$auto_pad,
     OptionalAttr<I64ArrayAttr>:$dilations,
     DefaultValuedAttr<SI64Attr, "1">:$group,
     OptionalAttr<I64ArrayAttr>:$kernel_shape,
     OptionalAttr<I64ArrayAttr>:$pads,
     OptionalAttr<I64ArrayAttr>:$strides);
-  let results = (outs AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$y);
+  let results = (outs AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI16]>, TensorOf<[UI8]>]>:$y);
   let extraClassDeclaration = [{
     static int getNumberOfOperands() {
       return 9;
@@ -6214,15 +6214,15 @@ def ONNXQLinearMatMulOp:ONNX_Op<"QLinearMatMul",
   have shape [D1, D2, M, 1] for per row quantization and shape [D1, D2, 1, K] for per column quantization.
   Production must never overflow, and accumulation may overflow if and only if in 32 bits.
   }];
-  let arguments = (ins AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$a,
+  let arguments = (ins AnyTypeOf<[TensorOf<[I8]>, TensorOf<[I16]>, TensorOf<[UI16]>, TensorOf<[UI8]>]>:$a,
     AnyTypeOf<[TensorOf<[F32]>, TensorOf<[quant_QuantizedType]>]>:$a_scale,
-    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$a_zero_point,
-    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$b,
+    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[I16]>, TensorOf<[UI16]>]>:$a_zero_point,
+    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[I16]>, TensorOf<[UI16]>]>:$b,
     AnyTypeOf<[TensorOf<[F32]>, TensorOf<[quant_QuantizedType]>]>:$b_scale,
-    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$b_zero_point,
+    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[I16]>, TensorOf<[UI16]>]>:$b_zero_point,
     AnyTypeOf<[TensorOf<[F32]>, TensorOf<[quant_QuantizedType]>]>:$y_scale,
-    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$y_zero_point);
-  let results = (outs AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>]>:$y);
+    AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[I16]>, TensorOf<[UI16]>]>:$y_zero_point);
+  let results = (outs AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[I16]>, TensorOf<[UI16]>]>:$y);
   let extraClassDeclaration = [{
     static int getNumberOfOperands() {
       return 8;

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -31,6 +31,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
 #include "src/Dialect/Mlir/DialectBuilder.hpp"
@@ -41,6 +42,13 @@
 #include "src/Support/TypeUtilities.hpp"
 
 #define DEBUG_TYPE "rewrite"
+
+static llvm::cl::opt<bool> disableBatchNormDecompose(
+    "disable-batchnorm-decompose",
+    llvm::cl::desc(
+        "Disable decomposition of BatchNormInferenceMode into Conv patterns "
+        "(default=false). Set to 'true' to keep BatchNorm as a single op."),
+    llvm::cl::init(false));
 
 using namespace mlir;
 using namespace onnx_mlir;
@@ -2980,8 +2988,10 @@ struct FusePadIntoAveragePoolPattern
 void ONNXBatchNormalizationInferenceModeOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<FuseBatchNormInferenceModeConvPattern>(context);
-  results.insert<RewriteBatchNormInferenceModeConvPattern1>(context);
-  results.insert<RewriteBatchNormInferenceModeConvPattern2>(context);
+  if (!disableBatchNormDecompose) {
+    results.insert<RewriteBatchNormInferenceModeConvPattern1>(context);
+    results.insert<RewriteBatchNormInferenceModeConvPattern2>(context);
+  }
 }
 
 /// on the ONNXAddOp.

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -31,7 +31,6 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
 #include "src/Dialect/Mlir/DialectBuilder.hpp"
@@ -39,16 +38,13 @@
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 #include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
+#include "src/Pass/Passes.hpp"
 #include "src/Support/TypeUtilities.hpp"
 
 #define DEBUG_TYPE "rewrite"
 
-static llvm::cl::opt<bool> disableBatchNormDecompose(
-    "disable-batchnorm-decompose",
-    llvm::cl::desc(
-        "Disable decomposition of BatchNormInferenceMode into Conv patterns "
-        "(default=false). Set to 'true' to keep BatchNorm as a single op."),
-    llvm::cl::init(false));
+// Populated by configureBatchNormCanonicalization().
+static bool disableBatchNormDecompose = false;
 
 using namespace mlir;
 using namespace onnx_mlir;
@@ -3370,3 +3366,8 @@ void ONNXWhereOp::getCanonicalizationPatterns(
 // on the ONNXDequantizeLinearOp.
 void ONNXDequantizeLinearOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {}
+
+void onnx_mlir::configureBatchNormCanonicalization(
+    bool disableBatchNormDecomposeOption) {
+  disableBatchNormDecompose = disableBatchNormDecomposeOption;
+}

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -57,6 +57,9 @@ std::unique_ptr<mlir::Pass> createShapeInferencePass();
 void configureConstPropONNXToONNXPass(bool roundFPToInt, int expansionBound,
     llvm::ArrayRef<std::string> disabledPatterns, bool constantPropIsDisabled);
 
+// To configure whether BatchNorm decomposition is disabled in canonicalization.
+void configureBatchNormCanonicalization(bool disableBatchNormDecompose);
+
 std::unique_ptr<mlir::Pass> createConstPropONNXToONNXPass();
 
 std::unique_ptr<mlir::Pass> createQDQCanonicalizePass(


### PR DESCRIPTION
- More datatype support in QLinearConv, QLinearMatMul (UI16/ I16)
- Add an option to disable 2 BatchNormInferenceMode canonicalization patterns