### PR TITLE
Preserve fused location when folding QDQ around data movement ops

### DIFF
--- a/src/Dialect/ONNX/Transforms/QDQAroundOpOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/QDQAroundOpOpt.cpp
@@ -167,8 +167,10 @@ public:
       transform(op->getOperands(), std::back_inserter(newInputs),
           [&](Value operand) { return irMapping.lookupOrDefault(operand); });
 
+      auto fusedLoc =
+          rewriter.getFusedLoc({qOp.getLoc(), op.getLoc(), dqOp.getLoc()});
       auto newOp =
-          rewriter.create<T>(op.getLoc(), TypeRange{qOp.getResult().getType()},
+          rewriter.create<T>(fusedLoc, TypeRange{qOp.getResult().getType()},
               ValueRange{newInputs}, op->getAttrs());
       rewriter.replaceOp(qOp, newOp.getResult());
       return success();


### PR DESCRIPTION
RemoveQDQAroundOpPattern was using only the inner op's location when folding DQ -> Op -> Q into Op(i8), losing provenance of the removed Q and DQ nodes. Use a fused location combining all three ops so downstream passes retain the full folding history.