### PR TITLE
XCompiler Fused Eltwise op fix

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Additional/XCOMPILERVerify.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XCOMPILERVerify.cpp
@@ -18,7 +18,7 @@ LogicalResult XCOMPILERFusedEltwiseOpVerify(Operation *op) {
   StringRef type = fusedEltwiseOp.getType();
 
   // leakyrelu_alpha, prelu_in, prelu_shift exist only if nonlinear == LEAKYRELU
-  bool isLeakyRelu = (nonlinear == "LEAKYRELU");
+  bool isLeakyRelu = (nonlinear == "LEAKYRELU" || type == "LEAKYRELU");
   if (fusedEltwiseOp.getLeakyreluAlphaAttr() && !isLeakyRelu)
     return op->emitOpError(
         "'leakyrelu_alpha' is only valid when nonlinear is LEAKYRELU");

--- a/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
@@ -239,9 +239,8 @@ struct FuseQuantizedEltwiseWithoutActivation
 
     auto [leakyAlpha, preluIn, preluShift] =
         getLeakyReluAttrsIfApplicable(eltwiseOp.getOperation(), rewriter);
-    // Verifier requires nonlinear=LEAKYRELU when leakyrelu_alpha/prelu_* are
-    // set.
-    StringRef nonlinear = leakyAlpha ? "LEAKYRELU" : "NONE";
+    
+    StringRef nonlinear = "NONE";
 
     auto fusedOp = rewriter.create<XCOMPILERFusedEltwiseOp>(eltwiseOp.getLoc(),
         eltwiseOp.getType(), // result type (quantized)

--- a/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
+++ b/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
@@ -454,7 +454,7 @@ func.func @test_quantized_leakyrelu_standalone(
   // CHECK: %[[NOVAL:.*]] = "onnx.NoValue"()
   // CHECK: %[[FUSED:.*]] = "onnx.XCOMPILERFusedEltwise"(%arg0, %[[NOVAL]])
   // CHECK-SAME: leakyrelu_alpha = {{[0-9.e+-]+}} : f32
-  // CHECK-SAME: nonlinear = "LEAKYRELU"
+  // CHECK-SAME: nonlinear = "NONE"
   // CHECK-SAME: prelu_in = 3 : si64
   // CHECK-SAME: prelu_shift = 8 : si64
   // CHECK-SAME: type = "LEAKYRELU"


### PR DESCRIPTION
Set nonlinear=none if type=leaky-relu


"nonlinear" attribute should be set if an activation op follows the eltwise op