### PR TITLE
Update XMC passes to address xir differences

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Additional/XCOMPILERVerify.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XCOMPILERVerify.cpp
@@ -18,7 +18,7 @@ LogicalResult XCOMPILERFusedEltwiseOpVerify(Operation *op) {
   StringRef type = fusedEltwiseOp.getType();
 
   // leakyrelu_alpha, prelu_in, prelu_shift exist only if nonlinear == LEAKYRELU
-  bool isLeakyRelu = (nonlinear == "LEAKYRELU" || type == "LEAKYRELU");
+  bool isLeakyRelu = (nonlinear == "LEAKYRELU" || type == "LEAKYRELU"|| type == "PRELU");
   if (fusedEltwiseOp.getLeakyreluAlphaAttr() && !isLeakyRelu)
     return op->emitOpError(
         "'leakyrelu_alpha' is only valid when nonlinear is LEAKYRELU");

--- a/src/Dialect/ONNX/ONNXOps/Additional/XCOMPILERVerify.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XCOMPILERVerify.cpp
@@ -18,7 +18,8 @@ LogicalResult XCOMPILERFusedEltwiseOpVerify(Operation *op) {
   StringRef type = fusedEltwiseOp.getType();
 
   // leakyrelu_alpha, prelu_in, prelu_shift exist only if nonlinear == LEAKYRELU
-  bool isLeakyRelu = (nonlinear == "LEAKYRELU" || type == "LEAKYRELU"|| type == "PRELU");
+  bool isLeakyRelu =
+      (nonlinear == "LEAKYRELU" || type == "LEAKYRELU" || type == "PRELU");
   if (fusedEltwiseOp.getLeakyreluAlphaAttr() && !isLeakyRelu)
     return op->emitOpError(
         "'leakyrelu_alpha' is only valid when nonlinear is LEAKYRELU");

--- a/src/Dialect/ONNX/ONNXOps/Additional/XCOMPILERVerify.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XCOMPILERVerify.cpp
@@ -18,7 +18,7 @@ LogicalResult XCOMPILERFusedEltwiseOpVerify(Operation *op) {
   StringRef type = fusedEltwiseOp.getType();
 
   // leakyrelu_alpha, prelu_in, prelu_shift exist only if nonlinear == LEAKYRELU
-  bool isLeakyRelu = (nonlinear == "LEAKYRELU");
+  bool isLeakyRelu = (nonlinear == "LEAKYRELU" || type == "LEAKYRELU");
   if (fusedEltwiseOp.getLeakyreluAlphaAttr() && !isLeakyRelu)
     return op->emitOpError(
         "'leakyrelu_alpha' is only valid when nonlinear is LEAKYRELU");

--- a/src/Dialect/ONNX/ONNXOps/Additional/XCOMPILERVerify.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XCOMPILERVerify.cpp
@@ -18,8 +18,7 @@ LogicalResult XCOMPILERFusedEltwiseOpVerify(Operation *op) {
   StringRef type = fusedEltwiseOp.getType();
 
   // leakyrelu_alpha, prelu_in, prelu_shift exist only if nonlinear == LEAKYRELU
-  bool isLeakyRelu =
-      (nonlinear == "LEAKYRELU" || type == "LEAKYRELU" || type == "PRELU");
+  bool isLeakyRelu = (nonlinear == "LEAKYRELU" || type == "LEAKYRELU");
   if (fusedEltwiseOp.getLeakyreluAlphaAttr() && !isLeakyRelu)
     return op->emitOpError(
         "'leakyrelu_alpha' is only valid when nonlinear is LEAKYRELU");

--- a/src/Dialect/ONNX/Transforms/xmc/ConvertSCastPairToRequantizePass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ConvertSCastPairToRequantizePass.cpp
@@ -107,10 +107,6 @@ struct ConvertSCastPairToRequantizePattern
     if (!isa<quant::QuantizedType>(inputElemType))
       return failure();
 
-    // Check that the intermediate value has only one use (the second scast)
-    if (!midValue.hasOneUse())
-      return failure();
-
     // Extract input quantization parameters
     auto inputQType = dyn_cast<quant::UniformQuantizedType>(inputElemType);
     auto inputQPerAxis =

--- a/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
@@ -67,11 +67,9 @@ static IntegerAttr getSI64Attr(PatternRewriter &rewriter, int64_t value) {
 }
 
 // Canonicalize activation op types following the xcompiler ReplaceQDQConvPass
-// convention. Alpha == 26/256 is the native HW leaky-relu; all other alphas
-// (including 0 from plain ReLU) are PRELU with integer mul/shift factors.
+// Canonicalize LeakyReLU op type to LEAKYRELU with alpha and prelu factors.
 // Returns {mappedOpType, leakyrelu_alpha, prelu_in, prelu_shift}.
 // mappedOpType is empty when no remapping is needed.
-static constexpr float kNativeLeakyReluAlpha = 26.0f / 256.0f;
 
 // ReLU on UINT8 with zero_point=0 is a no-op: unsigned values are already
 // non-negative, so clamping at zero has no effect.
@@ -92,22 +90,14 @@ static bool isReluNoOp(Operation *op) {
 
 static std::tuple<StringRef, FloatAttr, IntegerAttr, IntegerAttr>
 computeActivationMapping(Operation *op, PatternRewriter &rewriter) {
-  auto mapAlpha = [&](float alpha) {
-    auto alphaAttr = rewriter.getFloatAttr(rewriter.getF32Type(), alpha);
-    auto [M, N] = getLeakyReluAlphaToPreluFactor(alpha);
-    StringRef opType = (alpha == kNativeLeakyReluAlpha) ? "LEAKYRELU" : "PRELU";
-    return std::make_tuple(
-        opType, alphaAttr, getSI64Attr(rewriter, M), getSI64Attr(rewriter, N));
-  };
-  if (isa<ONNXReluOp>(op)) {
-    if (isReluNoOp(op))
-      return {"", FloatAttr(), IntegerAttr(), IntegerAttr()};
-    return mapAlpha(0.0f);
-  }
   if (auto leakyOp = dyn_cast<ONNXLeakyReluOp>(op)) {
     FloatAttr alphaAttr = leakyOp.getAlphaAttr();
     float alpha = alphaAttr ? alphaAttr.getValue().convertToFloat() : 0.01f;
-    return mapAlpha(alpha);
+    if (!alphaAttr)
+      alphaAttr = rewriter.getFloatAttr(rewriter.getF32Type(), alpha);
+    auto [M, N] = getLeakyReluAlphaToPreluFactor(alpha);
+    return {"LEAKYRELU", alphaAttr, getSI64Attr(rewriter, M),
+        getSI64Attr(rewriter, N)};
   }
   return {"", FloatAttr(), IntegerAttr(), IntegerAttr()};
 }
@@ -307,7 +297,6 @@ struct FuseQuantizedEltwiseWithoutActivation
     if (!mappedOpType.empty())
       opType = mappedOpType;
 
-    // Verifier requires nonlinear=="LEAKYRELU" when prelu attrs are present.
     StringRef nonlinear = "NONE";
 
     auto fusedOp = rewriter.create<XCOMPILERFusedEltwiseOp>(eltwiseOp.getLoc(),

--- a/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
@@ -461,6 +461,26 @@ struct FuseQuantizedEltwiseActivation : public OpRewritePattern<ActivationOp> {
       return rewriter.notifyMatchFailure(
           activationOp, "activation output not quantized");
 
+    // Verify scale/zp consistency between eltwise output and activation output.
+    // If they differ, there's an implicit requantization that would be lost by
+    // fusing. (Mirrors xcompiler ReplaceQDQEltwisePass line 764.)
+    {
+      auto eltwiseResultType =
+          mlir::cast<RankedTensorType>(eltwiseOp.getResult().getType());
+      auto activationResultType =
+          mlir::cast<RankedTensorType>(activationOp.getResult().getType());
+      auto eltwiseQType = mlir::dyn_cast<mlir::quant::UniformQuantizedType>(
+          eltwiseResultType.getElementType());
+      auto activationQType = mlir::dyn_cast<mlir::quant::UniformQuantizedType>(
+          activationResultType.getElementType());
+      if (eltwiseQType && activationQType &&
+          (std::fabs(eltwiseQType.getScale() - activationQType.getScale()) >
+                  1e-6 ||
+              eltwiseQType.getZeroPoint() != activationQType.getZeroPoint()))
+        return rewriter.notifyMatchFailure(activationOp,
+            "eltwise and activation have different quantization parameters");
+    }
+
     LLVM_DEBUG(llvm::dbgs() << "Fusing quantized eltwise+activation into "
                                "onnx.XCOMPILERFusedEltwise: "
                             << eltwiseOp->getName() << " + "
@@ -471,6 +491,30 @@ struct FuseQuantizedEltwiseActivation : public OpRewritePattern<ActivationOp> {
     if (opType.empty())
       return rewriter.notifyMatchFailure(
           activationOp, "unsupported eltwise op");
+
+    // ReLU on UINT8 with zero_point=0 is a no-op. Fuse the eltwise without
+    // any activation (nonlinear="NONE"), effectively dropping the ReLU.
+    if (isReluNoOp(activationOp.getOperation())) {
+      if (isUnary)
+        b = rewriter.create<ONNXNoneOp>(eltwiseOp.getLoc()).getResult();
+      auto fusedOp = rewriter.create<XCOMPILERFusedEltwiseOp>(
+          eltwiseOp.getLoc(), activationOp.getType(), a, b,
+          /*clip_max=*/IntegerAttr(),
+          /*clip_min=*/IntegerAttr(),
+          /*enable_lut_sigmoid=*/rewriter.getBoolAttr(false),
+          /*leakyrelu_alpha=*/FloatAttr(),
+          /*mul_y=*/FloatAttr(),
+          /*nonlinear=*/rewriter.getStringAttr("NONE"),
+          /*nonlinear_in_scales=*/FloatAttr(),
+          /*nonlinear_in_zeropoints=*/IntegerAttr(),
+          /*prelu_in=*/IntegerAttr(),
+          /*prelu_shift=*/IntegerAttr(),
+          /*type=*/rewriter.getStringAttr(opType));
+      rewriter.replaceOp(activationOp, fusedOp.getResult());
+      if (eltwiseOp->use_empty())
+        rewriter.eraseOp(eltwiseOp);
+      return success();
+    }
 
     // Determine nonlinear type and collect attributes
     StringRef nonlinear;

--- a/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
@@ -40,6 +40,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <iostream>
+
 #define DEBUG_TYPE "replace-qdq-eltwise"
 
 using namespace mlir;
@@ -66,20 +68,54 @@ static IntegerAttr getSI64Attr(PatternRewriter &rewriter, int64_t value) {
   return rewriter.getIntegerAttr(si64, value);
 }
 
-// For LeakyRelu ops, return (leakyrelu_alpha, prelu_in, prelu_shift); else
-// empty attrs. Used by Pattern 1 so LeakyRelu is handled in the generic path.
-static std::tuple<FloatAttr, IntegerAttr, IntegerAttr>
-getLeakyReluAttrsIfApplicable(Operation *op, PatternRewriter &rewriter) {
-  auto leakyOp = dyn_cast<ONNXLeakyReluOp>(op);
-  if (!leakyOp) {
-    return {FloatAttr(), IntegerAttr(), IntegerAttr()};
+
+// Canonicalize activation op types following the xcompiler ReplaceQDQConvPass
+// convention. Alpha == 26/256 is the native HW leaky-relu; all other alphas
+// (including 0 from plain ReLU) are PRELU with integer mul/shift factors.
+// Returns {mappedOpType, leakyrelu_alpha, prelu_in, prelu_shift}.
+// mappedOpType is empty when no remapping is needed.
+static constexpr float kNativeLeakyReluAlpha = 26.0f / 256.0f;
+
+// ReLU on UINT8 with zero_point=0 is a no-op: unsigned values are already
+// non-negative, so clamping at zero has no effect.
+static bool isReluNoOp(Operation *op) {
+  if (!isa<ONNXReluOp>(op))
+    return false;
+  auto resultType = op->getResult(0).getType();
+  auto tensorType = mlir::dyn_cast<RankedTensorType>(resultType);
+  if (!tensorType)
+    return false;
+  auto uq = mlir::dyn_cast<mlir::quant::UniformQuantizedType>(
+      tensorType.getElementType());
+  if (!uq)
+    return false;
+  if (uq.getStorageType().isUnsignedInteger(8) && uq.getZeroPoint() == 0) {
+    std::cout << "isReluNoOp true" << std::endl;
   }
-  FloatAttr alphaAttr = leakyOp.getAlphaAttr();
-  float alpha = alphaAttr ? alphaAttr.getValue().convertToFloat() : 0.01f;
-  if (!alphaAttr)
-    alphaAttr = rewriter.getFloatAttr(rewriter.getF32Type(), alpha);
-  auto [M, N] = getLeakyReluAlphaToPreluFactor(alpha);
-  return {alphaAttr, getSI64Attr(rewriter, M), getSI64Attr(rewriter, N)};
+  return uq.getStorageType().isUnsignedInteger(8) && uq.getZeroPoint() == 0;
+}
+
+static std::tuple<StringRef, FloatAttr, IntegerAttr, IntegerAttr>
+computeActivationMapping(Operation *op, PatternRewriter &rewriter) {
+  auto mapAlpha = [&](float alpha) {
+    auto alphaAttr = rewriter.getFloatAttr(rewriter.getF32Type(), alpha);
+    auto [M, N] = getLeakyReluAlphaToPreluFactor(alpha);
+    StringRef opType =
+        (alpha == kNativeLeakyReluAlpha) ? "LEAKYRELU" : "PRELU";
+    return std::make_tuple(opType, alphaAttr, getSI64Attr(rewriter, M),
+                           getSI64Attr(rewriter, N));
+  };
+  if (isa<ONNXReluOp>(op)) {
+    if (isReluNoOp(op))
+      return {"", FloatAttr(), IntegerAttr(), IntegerAttr()};
+    return mapAlpha(0.0f);
+  }
+  if (auto leakyOp = dyn_cast<ONNXLeakyReluOp>(op)) {
+    FloatAttr alphaAttr = leakyOp.getAlphaAttr();
+    float alpha = alphaAttr ? alphaAttr.getValue().convertToFloat() : 0.01f;
+    return mapAlpha(alpha);
+  }
+  return {"", FloatAttr(), IntegerAttr(), IntegerAttr()};
 }
 
 // True if value is produced by an eltwise op that Pattern 2 fuses with Relu/
@@ -188,6 +224,7 @@ struct FuseQuantizedEltwiseWithoutActivation
 
   LogicalResult matchAndRewrite(
       EltwiseOp eltwiseOp, PatternRewriter &rewriter) const override {
+    std::cout << "FuseQuantizedEltwiseWithoutActivation" << std::endl;
     // Handle unary and binary eltwise ops.
     Value a = nullptr, b = nullptr;
     bool isUnary = false;
@@ -232,15 +269,22 @@ struct FuseQuantizedEltwiseWithoutActivation
     LLVM_DEBUG(llvm::dbgs()
                << "Fusing quantized eltwise into onnx.XCOMPILERFusedEltwise: "
                << eltwiseOp->getName() << "\n");
-
+               
+    // ReLU on UINT8 with zero_point=0 is a no-op: remove it entirely.
+    if (isUnary && isReluNoOp(eltwiseOp.getOperation())) {
+      rewriter.replaceOp(eltwiseOp, a);
+      return success();
+    }
     // Only create IR (e.g. onnx.NoValue) after we know we will rewrite.
     if (isUnary)
       b = rewriter.create<ONNXNoneOp>(eltwiseOp.getLoc()).getResult();
 
-    auto [leakyAlpha, preluIn, preluShift] =
-        getLeakyReluAttrsIfApplicable(eltwiseOp.getOperation(), rewriter);
-    // Verifier requires nonlinear=LEAKYRELU when leakyrelu_alpha/prelu_* are
-    // set.
+    auto [mappedOpType, leakyAlpha, preluIn, preluShift] =
+        computeActivationMapping(eltwiseOp.getOperation(), rewriter);
+    if (!mappedOpType.empty())
+      opType = mappedOpType;
+    
+    // Verifier requires nonlinear=="LEAKYRELU" when prelu attrs are present.
     StringRef nonlinear = leakyAlpha ? "LEAKYRELU" : "NONE";
 
     auto fusedOp = rewriter.create<XCOMPILERFusedEltwiseOp>(eltwiseOp.getLoc(),

--- a/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
@@ -112,14 +112,44 @@ computeActivationMapping(Operation *op, PatternRewriter &rewriter) {
   return {"", FloatAttr(), IntegerAttr(), IntegerAttr()};
 }
 
-// True if value is produced by an eltwise op that Pattern 2 fuses with Relu/
-// LeakyRelu. Pattern 1 should not fuse standalone Relu/LeakyRelu in that case.
+// Check if two quantized types have matching scale and zero_point.
+static bool hasMatchingQuantParams(Type typeA, Type typeB) {
+  auto tensorA = mlir::dyn_cast<RankedTensorType>(typeA);
+  auto tensorB = mlir::dyn_cast<RankedTensorType>(typeB);
+  if (!tensorA || !tensorB)
+    return false;
+  auto qA = mlir::dyn_cast<mlir::quant::UniformQuantizedType>(
+      tensorA.getElementType());
+  auto qB = mlir::dyn_cast<mlir::quant::UniformQuantizedType>(
+      tensorB.getElementType());
+  if (!qA || !qB)
+    return false;
+  return std::fabs(qA.getScale() - qB.getScale()) <= 1e-6 &&
+         qA.getZeroPoint() == qB.getZeroPoint();
+}
+
+// True if value is produced by an eltwise op that Pattern 2 can fuse with
+// Relu/LeakyRelu. Pattern 1 should not fuse standalone Relu/LeakyRelu in that
+// case. However, if the quantization parameters between the eltwise output and
+// the activation output don't match, Pattern 2 will reject the fusion, so
+// Pattern 1 should handle it.
 static bool isInputFromPattern2Eltwise(Value v) {
   Operation *def = v.getDefiningOp();
   if (!def)
     return false;
-  return isa<ONNXAddOp, ONNXSubOp, ONNXMulOp, ONNXDivOp, ONNXTanhOp,
-      ONNXSqrtOp>(def);
+  if (!isa<ONNXAddOp, ONNXSubOp, ONNXMulOp, ONNXDivOp, ONNXTanhOp, ONNXSqrtOp>(
+          def))
+    return false;
+  // Check that the activation (user of def's result) has matching quant params.
+  // If not, Pattern 2 will reject, so don't defer.
+  for (Operation *user : def->getResult(0).getUsers()) {
+    if (isa<ONNXReluOp, ONNXLeakyReluOp>(user)) {
+      if (!hasMatchingQuantParams(
+              def->getResult(0).getType(), user->getResult(0).getType()))
+        return false;
+    }
+  }
+  return true;
 }
 
 // Check if type is quantized
@@ -463,23 +493,11 @@ struct FuseQuantizedEltwiseActivation : public OpRewritePattern<ActivationOp> {
 
     // Verify scale/zp consistency between eltwise output and activation output.
     // If they differ, there's an implicit requantization that would be lost by
-    // fusing. (Mirrors xcompiler ReplaceQDQEltwisePass line 764.)
-    {
-      auto eltwiseResultType =
-          mlir::cast<RankedTensorType>(eltwiseOp.getResult().getType());
-      auto activationResultType =
-          mlir::cast<RankedTensorType>(activationOp.getResult().getType());
-      auto eltwiseQType = mlir::dyn_cast<mlir::quant::UniformQuantizedType>(
-          eltwiseResultType.getElementType());
-      auto activationQType = mlir::dyn_cast<mlir::quant::UniformQuantizedType>(
-          activationResultType.getElementType());
-      if (eltwiseQType && activationQType &&
-          (std::fabs(eltwiseQType.getScale() - activationQType.getScale()) >
-                  1e-6 ||
-              eltwiseQType.getZeroPoint() != activationQType.getZeroPoint()))
-        return rewriter.notifyMatchFailure(activationOp,
-            "eltwise and activation have different quantization parameters");
-    }
+    // fusing.
+    if (!hasMatchingQuantParams(eltwiseOp.getResult().getType(),
+            activationOp.getResult().getType()))
+      return rewriter.notifyMatchFailure(activationOp,
+          "eltwise and activation have different quantization parameters");
 
     LLVM_DEBUG(llvm::dbgs() << "Fusing quantized eltwise+activation into "
                                "onnx.XCOMPILERFusedEltwise: "

--- a/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
@@ -40,8 +40,6 @@
 #include <type_traits>
 #include <utility>
 
-#include <iostream>
-
 #define DEBUG_TYPE "replace-qdq-eltwise"
 
 using namespace mlir;
@@ -68,7 +66,6 @@ static IntegerAttr getSI64Attr(PatternRewriter &rewriter, int64_t value) {
   return rewriter.getIntegerAttr(si64, value);
 }
 
-
 // Canonicalize activation op types following the xcompiler ReplaceQDQConvPass
 // convention. Alpha == 26/256 is the native HW leaky-relu; all other alphas
 // (including 0 from plain ReLU) are PRELU with integer mul/shift factors.
@@ -89,9 +86,7 @@ static bool isReluNoOp(Operation *op) {
       tensorType.getElementType());
   if (!uq)
     return false;
-  if (uq.getStorageType().isUnsignedInteger(8) && uq.getZeroPoint() == 0) {
-    std::cout << "isReluNoOp true" << std::endl;
-  }
+
   return uq.getStorageType().isUnsignedInteger(8) && uq.getZeroPoint() == 0;
 }
 
@@ -100,10 +95,9 @@ computeActivationMapping(Operation *op, PatternRewriter &rewriter) {
   auto mapAlpha = [&](float alpha) {
     auto alphaAttr = rewriter.getFloatAttr(rewriter.getF32Type(), alpha);
     auto [M, N] = getLeakyReluAlphaToPreluFactor(alpha);
-    StringRef opType =
-        (alpha == kNativeLeakyReluAlpha) ? "LEAKYRELU" : "PRELU";
-    return std::make_tuple(opType, alphaAttr, getSI64Attr(rewriter, M),
-                           getSI64Attr(rewriter, N));
+    StringRef opType = (alpha == kNativeLeakyReluAlpha) ? "LEAKYRELU" : "PRELU";
+    return std::make_tuple(
+        opType, alphaAttr, getSI64Attr(rewriter, M), getSI64Attr(rewriter, N));
   };
   if (isa<ONNXReluOp>(op)) {
     if (isReluNoOp(op))
@@ -224,7 +218,6 @@ struct FuseQuantizedEltwiseWithoutActivation
 
   LogicalResult matchAndRewrite(
       EltwiseOp eltwiseOp, PatternRewriter &rewriter) const override {
-    std::cout << "FuseQuantizedEltwiseWithoutActivation" << std::endl;
     // Handle unary and binary eltwise ops.
     Value a = nullptr, b = nullptr;
     bool isUnary = false;
@@ -269,7 +262,7 @@ struct FuseQuantizedEltwiseWithoutActivation
     LLVM_DEBUG(llvm::dbgs()
                << "Fusing quantized eltwise into onnx.XCOMPILERFusedEltwise: "
                << eltwiseOp->getName() << "\n");
-               
+
     // ReLU on UINT8 with zero_point=0 is a no-op: remove it entirely.
     if (isUnary && isReluNoOp(eltwiseOp.getOperation())) {
       rewriter.replaceOp(eltwiseOp, a);
@@ -283,9 +276,9 @@ struct FuseQuantizedEltwiseWithoutActivation
         computeActivationMapping(eltwiseOp.getOperation(), rewriter);
     if (!mappedOpType.empty())
       opType = mappedOpType;
-    
+
     // Verifier requires nonlinear=="LEAKYRELU" when prelu attrs are present.
-    StringRef nonlinear = leakyAlpha ? "LEAKYRELU" : "NONE";
+    StringRef nonlinear = "NONE";
 
     auto fusedOp = rewriter.create<XCOMPILERFusedEltwiseOp>(eltwiseOp.getLoc(),
         eltwiseOp.getType(), // result type (quantized)

--- a/src/Dialect/ONNX/Transforms/xmc/Resize_to_conv.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/Resize_to_conv.cpp
@@ -10,7 +10,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-
+#include "mlir/Dialect/Quant/IR/QuantTypes.h"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp"
 
@@ -818,6 +818,10 @@ struct TransferResizeLinearToDwConv
 
     auto inputType = mlir::dyn_cast<RankedTensorType>(input.getType());
     if (!inputType)
+      return failure();
+
+    // Skip if the input is quantized <E2><80><94> this pass only handles float tensors.
+    if (mlir::isa<mlir::quant::QuantizedType>(inputType.getElementType()))
       return failure();
 
     // Only handle linear/trilinear resize

--- a/src/Dialect/ONNX/Transforms/xmc/Resize_to_conv.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/Resize_to_conv.cpp
@@ -5,12 +5,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Quant/IR/QuantTypes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "mlir/Dialect/Quant/IR/QuantTypes.h"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp"
 
@@ -820,7 +820,8 @@ struct TransferResizeLinearToDwConv
     if (!inputType)
       return failure();
 
-    // Skip if the input is quantized <E2><80><94> this pass only handles float tensors.
+    // Skip if the input is quantized <E2><80><94> this pass only handles float
+    // tensors.
     if (mlir::isa<mlir::quant::QuantizedType>(inputType.getElementType()))
       return failure();
 

--- a/test/mlir/onnx/xmc/ConvertSCastPairToRequantize.mlir
+++ b/test/mlir/onnx/xmc/ConvertSCastPairToRequantize.mlir
@@ -86,13 +86,13 @@ func.func @single_scast_no_pair(%arg0: tensor<1x32x7x7x!quant.uniform<i8:f32, 0.
 
 // -----
 
-// Test 7: scast pair where intermediate has multiple uses - should NOT convert
+// Test 7: scast pair where intermediate has multiple uses - should still convert
+// the second scast to XCOMPILERRequantize; first scast stays for the other use.
 // CHECK-LABEL: @scast_pair_multi_use
 func.func @scast_pair_multi_use(%arg0: tensor<1x32x7x7x!quant.uniform<i8:f32, 0.05:0>>) -> (tensor<1x32x7x7x!quant.uniform<i8:f32, 0.07:0>>, tensor<1x32x7x7xi8>) {
     %0 = quant.scast %arg0 : tensor<1x32x7x7x!quant.uniform<i8:f32, 0.05:0>> to tensor<1x32x7x7xi8>
     %1 = quant.scast %0 : tensor<1x32x7x7xi8> to tensor<1x32x7x7x!quant.uniform<i8:f32, 0.07:0>>
     return %1, %0 : tensor<1x32x7x7x!quant.uniform<i8:f32, 0.07:0>>, tensor<1x32x7x7xi8>
 }
-// CHECK-NOT: onnx.XCOMPILERRequantize
 // CHECK: quant.scast
-// CHECK: quant.scast
+// CHECK: "onnx.XCOMPILERRequantize"

--- a/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
+++ b/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
@@ -423,8 +423,7 @@ func.func @test_quantized_mod_no_activation(
 }
 
 // -----
-// Test Pattern 1: Standalone Relu (u8, zp!=0) -> fused PRELU (alpha=0)
-// Following xcompiler convention: ReLU → LEAKYRELU(alpha=0) → PRELU
+// Test Pattern 1: Standalone Relu (u8, zp!=0) -> fused RELU
 // CHECK-LABEL: func.func @test_quantized_relu_standalone
 func.func @test_quantized_relu_standalone(
     %arg0: tensor<1x8x8x8x!quant.uniform<u8:f32, 0.02:128>>)
@@ -436,17 +435,13 @@ func.func @test_quantized_relu_standalone(
 
   // CHECK: %[[NOVAL:.*]] = "onnx.NoValue"()
   // CHECK: %[[FUSED:.*]] = "onnx.XCOMPILERFusedEltwise"(%arg0, %[[NOVAL]])
-  // CHECK-SAME: leakyrelu_alpha = 0.000000e+00 : f32
   // CHECK-SAME: nonlinear = "NONE"
-  // CHECK-SAME: prelu_in = 0 : si64
-  // CHECK-SAME: prelu_shift = 8 : si64
-  // CHECK-SAME: type = "PRELU"
+  // CHECK-SAME: type = "RELU"
   // CHECK: return %[[FUSED]]
 }
 
 // -----
-// Test Pattern 1: Standalone LeakyRelu (alpha=0.01, != 26/256) -> fused PRELU
-// Following xcompiler convention: alpha != 26/256 → PRELU
+// Test Pattern 1: Standalone LeakyRelu -> fused LEAKYRELU with alpha attrs
 // CHECK-LABEL: func.func @test_quantized_leakyrelu_standalone
 func.func @test_quantized_leakyrelu_standalone(
     %arg0: tensor<1x8x8x8x!quant.uniform<u8:f32, 0.02:128>>)
@@ -462,7 +457,7 @@ func.func @test_quantized_leakyrelu_standalone(
   // CHECK-SAME: nonlinear = "NONE"
   // CHECK-SAME: prelu_in = 3 : si64
   // CHECK-SAME: prelu_shift = 8 : si64
-  // CHECK-SAME: type = "PRELU"
+  // CHECK-SAME: type = "LEAKYRELU"
   // CHECK: return %[[FUSED]]
 }
 

--- a/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
+++ b/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
@@ -423,7 +423,8 @@ func.func @test_quantized_mod_no_activation(
 }
 
 // -----
-// Test Pattern 1: Standalone Relu (no preceding eltwise) -> fused RELU
+// Test Pattern 1: Standalone Relu (u8, zp!=0) -> fused PRELU (alpha=0)
+// Following xcompiler convention: ReLU → LEAKYRELU(alpha=0) → PRELU
 // CHECK-LABEL: func.func @test_quantized_relu_standalone
 func.func @test_quantized_relu_standalone(
     %arg0: tensor<1x8x8x8x!quant.uniform<u8:f32, 0.02:128>>)
@@ -435,13 +436,17 @@ func.func @test_quantized_relu_standalone(
 
   // CHECK: %[[NOVAL:.*]] = "onnx.NoValue"()
   // CHECK: %[[FUSED:.*]] = "onnx.XCOMPILERFusedEltwise"(%arg0, %[[NOVAL]])
+  // CHECK-SAME: leakyrelu_alpha = 0.000000e+00 : f32
   // CHECK-SAME: nonlinear = "NONE"
-  // CHECK-SAME: type = "RELU"
+  // CHECK-SAME: prelu_in = 0 : si64
+  // CHECK-SAME: prelu_shift = 8 : si64
+  // CHECK-SAME: type = "PRELU"
   // CHECK: return %[[FUSED]]
 }
 
 // -----
-// Test Pattern 1: Standalone LeakyRelu (no preceding eltwise) -> fused LEAKYRELU
+// Test Pattern 1: Standalone LeakyRelu (alpha=0.01, != 26/256) -> fused PRELU
+// Following xcompiler convention: alpha != 26/256 → PRELU
 // CHECK-LABEL: func.func @test_quantized_leakyrelu_standalone
 func.func @test_quantized_leakyrelu_standalone(
     %arg0: tensor<1x8x8x8x!quant.uniform<u8:f32, 0.02:128>>)
@@ -454,10 +459,10 @@ func.func @test_quantized_leakyrelu_standalone(
   // CHECK: %[[NOVAL:.*]] = "onnx.NoValue"()
   // CHECK: %[[FUSED:.*]] = "onnx.XCOMPILERFusedEltwise"(%arg0, %[[NOVAL]])
   // CHECK-SAME: leakyrelu_alpha = {{[0-9.e+-]+}} : f32
-  // CHECK-SAME: nonlinear = "LEAKYRELU"
+  // CHECK-SAME: nonlinear = "NONE"
   // CHECK-SAME: prelu_in = 3 : si64
   // CHECK-SAME: prelu_shift = 8 : si64
-  // CHECK-SAME: type = "LEAKYRELU"
+  // CHECK-SAME: type = "PRELU"
   // CHECK: return %[[FUSED]]
 }
 


### PR DESCRIPTION
Resize to Conv conversion doesnot happen for quantized inputs
Remove Redundant Relu (UINT with zp = 0)
Make Nonlinear as "NONE" when converting Relu/LeakyRelu to EltwiseOp
Remove HasOneUse check for converting doubleScast to Requantize
Prevent EltwiseOp + Activation fusion when scale/zp dont match