### PR TITLE
Add XFEBatchNormalization op with channel-last (NHWC) layout

### DIFF
--- a/src/Builder/OpBuildTable.inc
+++ b/src/Builder/OpBuildTable.inc
@@ -225,6 +225,7 @@ dialect_op_version_map_["com.amd.xfe"]["AveragePool"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["MaxPool"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["GlobalAveragePool"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["GlobalMaxPool"] = {1};
+dialect_op_version_map_["com.amd.xfe"]["BatchNormalization"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["InstanceNormalization"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["DepthToSpace"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["SpaceToDepth"] = {1};
@@ -239,6 +240,7 @@ dialect_op_version_map_["com.amd.xfe"]["AveragePool"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["MaxPool"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["GlobalAveragePool"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["GlobalMaxPool"] = {1};
+dialect_op_version_map_["com.amd.xfe"]["BatchNormalization"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["InstanceNormalization"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["DepthToSpace"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["SpaceToDepth"] = {1};
@@ -763,6 +765,8 @@ import_handler_map_["com.amd.xfe"]["GlobalAveragePool"] =
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFEGlobalAveragePoolOp>;
 import_handler_map_["com.amd.xfe"]["GlobalMaxPool"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFEGlobalMaxPoolOp>;
+import_handler_map_["com.amd.xfe"]["BatchNormalization"] = 
+   &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFEBatchNormalizationOp>;
 import_handler_map_["com.amd.xfe"]["InstanceNormalization"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFEInstanceNormalizationOp>;
 import_handler_map_["com.amd.xfe"]["DepthToSpace"] = 
@@ -996,6 +1000,7 @@ dialect_op_opsets_map_["com.amd.xcompiler"]["DepthwiseConv"] = {1};
 dialect_op_opsets_map_["com.amd.xcompiler"]["FusedEltwise"] = {1};
 dialect_op_opsets_map_["com.amd.xcompiler"]["Requantize"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["AveragePool"] = {1};
+dialect_op_opsets_map_["com.amd.xfe"]["BatchNormalization"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["Conv"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["DepthToSpace"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["GlobalAveragePool"] = {1};
@@ -1015,6 +1020,7 @@ dialect_op_opsets_map_["com.amd.xfe"]["AveragePool"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["MaxPool"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["GlobalAveragePool"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["GlobalMaxPool"] = {1};
+dialect_op_opsets_map_["com.amd.xfe"]["BatchNormalization"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["InstanceNormalization"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["DepthToSpace"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["SpaceToDepth"] = {1};

--- a/src/Dialect/ONNX/ONNXOps/Additional/XFE.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XFE.cpp
@@ -57,6 +57,12 @@ LogicalResult XFEGlobalMaxPoolOp::inferShapes(
       this->getOperation(), doShapeInference);
 }
 
+LogicalResult XFEBatchNormalizationOp::inferShapes(
+    std::function<void(Region &)> doShapeInference) {
+  return XFEBatchNormalizationOpShapeInference(
+      this->getOperation(), doShapeInference);
+}
+
 LogicalResult XFEInstanceNormalizationOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   return XFEInstanceNormalizationOpShapeInference(
@@ -110,6 +116,10 @@ LogicalResult XFEGlobalAveragePoolOp::verify() {
 
 LogicalResult XFEGlobalMaxPoolOp::verify() {
   return XFEGlobalMaxPoolOpVerify(this->getOperation());
+}
+
+LogicalResult XFEBatchNormalizationOp::verify() {
+  return XFEBatchNormalizationOpVerify(this->getOperation());
 }
 
 LogicalResult XFEInstanceNormalizationOp::verify() {

--- a/src/Dialect/ONNX/ONNXOps/Additional/XFEShapeInference.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XFEShapeInference.cpp
@@ -568,6 +568,37 @@ LogicalResult XFEGlobalMaxPoolOpShapeInference(
   return success();
 }
 
+LogicalResult XFEBatchNormalizationOpShapeInference(
+    Operation *op, std::function<void(Region &)> doShapeInference) {
+  auto bnOp = dyn_cast<XFEBatchNormalizationOp>(op);
+  if (!bnOp)
+    return failure();
+
+  Value input = bnOp.getX();
+  if (!hasShapeAndRank(input))
+    return success();
+
+  auto inputType = mlir::cast<ShapedType>(input.getType());
+  auto inputShape = inputType.getShape(); // [N, spatial_dims..., C]
+
+  if (inputShape.size() < 3)
+    return op->emitError(
+        "BatchNormalizationChannelLast requires at least 3D input tensor");
+
+  // Batch normalization preserves the input shape
+  // Output shape: same as input
+  SmallVector<int64_t, 6> outputShape(inputShape.begin(), inputShape.end());
+
+  Type elementType = inputType.getElementType();
+  if (auto existingType = dyn_cast<ShapedType>(bnOp.getY().getType())) {
+    elementType = existingType.getElementType();
+  }
+  auto resultType = RankedTensorType::get(outputShape, elementType);
+  bnOp.getY().setType(resultType);
+
+  return success();
+}
+
 LogicalResult XFEInstanceNormalizationOpShapeInference(
     Operation *op, std::function<void(Region &)> doShapeInference) {
   auto normOp = dyn_cast<XFEInstanceNormalizationOp>(op);

--- a/src/Dialect/ONNX/ONNXOps/Additional/XFEShapeInference.hpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XFEShapeInference.hpp
@@ -42,6 +42,10 @@ LogicalResult XFEGlobalAveragePoolOpShapeInference(
 LogicalResult XFEGlobalMaxPoolOpShapeInference(
     Operation *op, std::function<void(Region &)> doShapeInference);
 
+// Shape inference for BatchNormalizationChannelLast
+LogicalResult XFEBatchNormalizationOpShapeInference(
+    Operation *op, std::function<void(Region &)> doShapeInference);
+
 // Shape inference for InstanceNormalizationChannelLast
 LogicalResult XFEInstanceNormalizationOpShapeInference(
     Operation *op, std::function<void(Region &)> doShapeInference);

--- a/src/Dialect/ONNX/ONNXOps/Additional/XFEVerify.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XFEVerify.cpp
@@ -105,6 +105,14 @@ LogicalResult XFEGlobalMaxPoolOpVerify(Operation *op) {
   return success();
 }
 
+LogicalResult XFEBatchNormalizationOpVerify(Operation *op) {
+  // BatchNormalizationChannelLast expects:
+  // - X: input tensor with channel-last layout (rank >= 3)
+  // - scale, B: 1D tensors of size C
+  // - input_mean, input_var: 1D tensors of size C
+  return success();
+}
+
 LogicalResult XFEInstanceNormalizationOpVerify(Operation *op) {
   // TODO: Implement verification for InstanceNormalizationChannelLast
   //

--- a/src/Dialect/ONNX/ONNXOps/Additional/XFEVerify.hpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XFEVerify.hpp
@@ -35,6 +35,9 @@ LogicalResult XFEGlobalAveragePoolOpVerify(Operation *op);
 // Verify for GlobalMaxPoolChannelLast
 LogicalResult XFEGlobalMaxPoolOpVerify(Operation *op);
 
+// Verify for BatchNormalizationChannelLast
+LogicalResult XFEBatchNormalizationOpVerify(Operation *op);
+
 // Verify for InstanceNormalizationChannelLast
 LogicalResult XFEInstanceNormalizationOpVerify(Operation *op);
 

--- a/src/Dialect/ONNX/Transforms/ConvertToChannelLast.cpp
+++ b/src/Dialect/ONNX/Transforms/ConvertToChannelLast.cpp
@@ -19,6 +19,7 @@
 // - MaxPool -> XFEMaxPool
 // - GlobalAveragePool -> XFEGlobalAveragePool
 // - GlobalMaxPool -> XFEGlobalMaxPool
+// - BatchNormalizationInferenceMode -> XFEBatchNormalization
 // - InstanceNormalization -> XFEInstanceNormalization
 // - DepthToSpace -> XFEDepthToSpace
 // - SpaceToDepth -> XFESpaceToDepth
@@ -531,6 +532,59 @@ struct GlobalMaxPoolToChannelLastPattern
   }
 };
 
+// Pattern to convert BatchNormalizationInferenceMode to XFEBatchNormalization
+struct BatchNormToChannelLastPattern
+    : public OpRewritePattern<ONNXBatchNormalizationInferenceModeOp> {
+  using OpRewritePattern<
+      ONNXBatchNormalizationInferenceModeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ONNXBatchNormalizationInferenceModeOp bnOp,
+      PatternRewriter &rewriter) const override {
+    Location loc = bnOp.getLoc();
+    Value input = bnOp.getX();
+    Value scale = bnOp.getScale();
+    Value B = bnOp.getB();
+    Value mean = bnOp.getMean();
+    Value var = bnOp.getVar();
+
+    auto inputType = mlir::dyn_cast<RankedTensorType>(input.getType());
+    if (!inputType || inputType.getRank() < 3)
+      return failure();
+
+    int64_t rank = inputType.getRank();
+
+    // Transpose input to channel-last
+    Value inputChannelLast = createInputTranspose(
+        rewriter, loc, input, rank, inputType.getElementType());
+
+    // Create XFEBatchNormalization operation
+    auto origOutputType = mlir::cast<ShapedType>(bnOp.getType());
+    Type outputElementType = origOutputType.getElementType();
+    auto bnChannelLastOp = rewriter.create<XFEBatchNormalizationOp>(loc,
+        UnrankedTensorType::get(outputElementType), inputChannelLast, scale, B,
+        mean, var, bnOp.getEpsilonAttr(), bnOp.getMomentumAttr());
+
+    // Transfer onnx_node_name attribute
+    transferOnnxNodeName(bnOp, bnChannelLastOp);
+
+    // Run shape inference
+    if (failed(bnChannelLastOp.inferShapes(nullptr))) {
+      return failure();
+    }
+
+    // Transpose output back to NCHW
+    auto xfeOutputType =
+        mlir::cast<ShapedType>(bnChannelLastOp.getY().getType());
+    auto transposeOutputType = RankedTensorType::get(
+        origOutputType.getShape(), xfeOutputType.getElementType());
+    Value outputNCHW = createOutputTranspose(
+        rewriter, loc, bnChannelLastOp.getY(), transposeOutputType, rank);
+
+    rewriter.replaceOp(bnOp, outputNCHW);
+    return success();
+  }
+};
+
 // Pattern to convert InstanceNormalization to XFEInstanceNormalization
 struct InstanceNormToChannelLastPattern
     : public OpRewritePattern<ONNXInstanceNormalizationOp> {
@@ -968,6 +1022,7 @@ struct ConvertToChannelLastPass : public PassWrapper<ConvertToChannelLastPass,
     patterns.add<MaxPoolToChannelLastPattern>(context);
     patterns.add<GlobalAveragePoolToChannelLastPattern>(context);
     patterns.add<GlobalMaxPoolToChannelLastPattern>(context);
+    patterns.add<BatchNormToChannelLastPattern>(context);
     patterns.add<InstanceNormToChannelLastPattern>(context);
     patterns.add<DepthToSpaceToChannelLastPattern>(context);
     patterns.add<SpaceToDepthToChannelLastPattern>(context);

--- a/src/Dialect/ONNX/XFEOps.td
+++ b/src/Dialect/ONNX/XFEOps.td
@@ -221,6 +221,40 @@ def XFEGlobalMaxPoolOp:ONNX_Op<"XFEGlobalMaxPool",
   let hasVerifier = 1;
 }
 
+def XFEBatchNormalizationOp:ONNX_Op<"XFEBatchNormalization",
+  [Pure, OpVersionTrait<1>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let summary = "BatchNormalizationChannelLast operation";
+  let description = [{
+  Batch normalization with channel-last layout (channels innermost). Carries out batch normalization with input/output tensors in channel-last format instead of NCHW. Uses pre-computed mean and variance for inference mode.
+  }];
+  let arguments = (ins AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[quant_QuantizedType]>]>:$X,
+    AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[quant_QuantizedType]>]>:$scale,
+    AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[quant_QuantizedType]>]>:$B,
+    AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>]>:$input_mean,
+    AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>]>:$input_var,
+    DefaultValuedAttr<F32Attr, "1e-05">:$epsilon,
+    DefaultValuedAttr<F32Attr, "0.9">:$momentum);
+  let results = (outs AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[quant_QuantizedType]>]>:$Y);
+  let extraClassDeclaration = [{
+    static int getNumberOfOperands() {
+      return 5;
+    }
+    static int getNumberOfResults() {
+      return 1;
+    }
+    static std::vector<int> getTypeMap() {
+      return {30};
+    }
+  }];
+  let extraClassDefinition = [{
+    onnx_mlir::ONNXOpShapeHelper * $cppClass::getShapeHelper(mlir::Operation *op, llvm::ArrayRef<mlir::Value> oper, 
+        onnx_mlir::IndexExprBuilder *ieb, onnx_mlir::IndexExprScope *scope) {
+      return nullptr;
+    }
+  }];
+  let hasVerifier = 1;
+}
+
 def XFEInstanceNormalizationOp:ONNX_Op<"XFEInstanceNormalization",
   [Pure, OpVersionTrait<1>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
   let summary = "InstanceNormalizationChannelLast operation";

--- a/utils/xfe_ops_schema.yaml
+++ b/utils/xfe_ops_schema.yaml
@@ -283,6 +283,68 @@
   max_output: 1
 
 # ==============================================================================
+# BatchNormalization: Batch normalization with channel-last (NHWC) layout
+# Normalizes along the channel (last) dimension: y = scale * (x - mean) / sqrt(var + epsilon) + B
+# ==============================================================================
+- name: BatchNormalization
+  domain: com.amd.xfe
+  since_version: 1
+  support_level: COMMON
+  description: 'Batch normalization with channel-last layout (channels innermost). Carries out batch normalization with input/output tensors in channel-last format instead of NCHW. Uses pre-computed mean and variance for inference mode.'
+  meta_attributes:
+  - onnx_opset: 15
+  - verify: True
+  - fold: False
+  inputs:
+  - name: X
+    description: Input data tensor with channel-last layout (batch, spatial_dims..., channels)
+    type_str: T
+  - name: scale
+    description: 1D scale tensor of size C (number of channels)
+    type_str: T
+  - name: B
+    description: 1D bias tensor of size C (number of channels)
+    type_str: T
+  - name: input_mean
+    description: 1D running mean tensor of size C
+    type_str: U
+  - name: input_var
+    description: 1D running variance tensor of size C
+    type_str: U
+  outputs:
+  - name: Y
+    description: Output data tensor with channel-last layout, same shape as input
+    type_str: T
+  attributes:
+  - name: epsilon
+    description: Small value to add to variance to avoid division by zero
+    type: float
+    default_value: 1e-05
+  - name: momentum
+    description: Factor used in computing the running mean and variance (unused in inference)
+    type: float
+    default_value: 0.9
+  type_constraints:
+  - type_param: T
+    description: Constrain input and output types to float tensors.
+    allowed_types:
+    - tensor(float16)
+    - tensor(float)
+    - tensor(double)
+    - tensor(bfloat16)
+  - type_param: U
+    description: Constrain mean and var types to float tensors.
+    allowed_types:
+    - tensor(float16)
+    - tensor(float)
+    - tensor(double)
+    - tensor(bfloat16)
+  min_input: 5
+  max_input: 5
+  min_output: 1
+  max_output: 1
+
+# ==============================================================================
 # InstanceNormalization: Instance normalization with channel-last (NHWC) layout
 # Normalizes per instance per channel: y = scale * (x - mean) / sqrt(variance + epsilon) + B
 # ==============================================================================


### PR DESCRIPTION
- Define XFEBatchNormalization in xfe_ops_schema.yaml and XFEOps.td
- Add shape inference and verify implementations
- Add BatchNormToChannelLastPattern in ConvertToChannelLast.cpp
- Add dispatch for inferShapes/verify in XFE.cpp
- Add OpBuildTable.inc for generated op builder