### PR TITLE
CSE: Include attributes but skip ignorable attrs

### DIFF
--- a/src/Dialect/ONNX/Transforms/ONNXCSE.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXCSE.cpp
@@ -16,8 +16,8 @@ class ONNXCSEOperationInfo : public DenseMapInfo<Operation *> {
 public:
   static unsigned getHashValue(const Operation *opC) {
     auto *op = const_cast<Operation *>(opC);
-    llvm::hash_code hash = llvm::hash_combine(op->getName(),
-        op->hashProperties());
+    llvm::hash_code hash =
+        llvm::hash_combine(op->getName(), op->hashProperties());
 
     // Remove ignorable attributes while computing hash
     SmallVector<NamedAttribute> attrs(op->getRawDictionaryAttrs().getValue());
@@ -25,7 +25,9 @@ public:
     while ((pos = llvm::find_if(attrs, [](NamedAttribute attr) {
       StringRef key = attr.getName().getValue();
       return key == "onnx_node_name" || key == "ResultNames";
-    })) != attrs.end()) { attrs.erase(pos); }
+    })) != attrs.end()) {
+      attrs.erase(pos);
+    }
     llvm::sort(attrs);
     hash = llvm::hash_combine(hash, ArrayRef(attrs));
 

--- a/src/Dialect/ONNX/Transforms/ONNXCSE.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXCSE.cpp
@@ -1,5 +1,6 @@
 // (c) Copyright 2022 - 2025 Advanced Micro Devices, Inc. All Rights reserved.
 
+#include "mlir/IR/Attributes.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/Hashing.h"
@@ -14,11 +15,24 @@ namespace onnx_mlir {
 class ONNXCSEOperationInfo : public DenseMapInfo<Operation *> {
 public:
   static unsigned getHashValue(const Operation *opC) {
-    return OperationEquivalence::computeHash(const_cast<Operation *>(opC),
-        /*hashOperands=*/OperationEquivalence::directHashValue,
-        /*hashResults=*/OperationEquivalence::ignoreHashValue,
-        OperationEquivalence::IgnoreLocations |
-            OperationEquivalence::IgnoreDiscardableAttrs);
+    auto *op = const_cast<Operation *>(opC);
+    llvm::hash_code hash = llvm::hash_combine(op->getName(),
+        op->hashProperties());
+
+    // Remove ignorable attributes while computing hash
+    SmallVector<NamedAttribute> attrs(op->getRawDictionaryAttrs().getValue());
+    NamedAttribute *pos;
+    while ((pos = llvm::find_if(attrs, [](NamedAttribute attr) {
+      StringRef key = attr.getName().getValue();
+      return key == "onnx_node_name" || key == "ResultNames";
+    })) != attrs.end()) { attrs.erase(pos); }
+    llvm::sort(attrs);
+    hash = llvm::hash_combine(hash, ArrayRef(attrs));
+
+    for (Value operand : op->getOperands())
+      hash = llvm::hash_combine(hash, hash_value(operand));
+    hash = llvm::hash_combine(hash, op->getResultTypes());
+    return hash;
   }
 
   static bool isEqual(const Operation *lhsC, const Operation *rhsC) {
@@ -29,10 +43,35 @@ public:
     if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
         rhs == getTombstoneKey() || rhs == getEmptyKey())
       return false;
-    return OperationEquivalence::isEquivalentTo(const_cast<Operation *>(lhsC),
-        const_cast<Operation *>(rhsC),
-        OperationEquivalence::IgnoreLocations |
-            OperationEquivalence::IgnoreDiscardableAttrs);
+
+    if (lhs->getName() != rhs->getName() ||
+        lhs->getNumOperands() != rhs->getNumOperands() ||
+        lhs->getNumResults() != rhs->getNumResults() ||
+        !lhs->getName().compareOpProperties(
+            lhs->getPropertiesStorage(), rhs->getPropertiesStorage()))
+      return false;
+
+    // Compare attributes, skipping ignorable attributes
+    for (auto lhsA : lhs->getAttrs()) {
+      StringRef key = lhsA.getName().getValue();
+      if (key == "onnx_node_name" || key == "ResultNames")
+        continue;
+      if (!rhs->hasAttr(key) || rhs->getAttr(key) != lhsA.getValue())
+        return false;
+    }
+
+    for (auto [lhsO, rhsO] :
+        llvm::zip(lhs->getOperands(), rhs->getOperands())) {
+      if (lhsO != rhsO)
+        return false;
+    }
+
+    for (auto [lhsR, rhsR] : llvm::zip(lhs->getResults(), rhs->getResults())) {
+      if (lhsR.getType() != rhsR.getType())
+        return false;
+    }
+
+    return true;
   }
 };
 

--- a/test/mlir/onnx/onnx_cse.mlir
+++ b/test/mlir/onnx/onnx_cse.mlir
@@ -28,3 +28,21 @@ func.func @test_cse_noattrs() -> (tensor<64xf32>, tensor<64xf32>, tensor<64xf32>
   // CHECK-COUNT-1: [[DQ:%[0-9]+]] = "onnx.DequantizeLinear"
   // CHECK-NEXT: return [[DQ]], [[DQ]], [[DQ]]
 }
+
+// -----
+
+func.func @diff_attrs(%arg0: tensor<f32>) -> tensor<f32> {
+  %0 = onnx.Constant dense<1.000000e+00> : tensor<f32>
+  %1 = onnx.Constant dense<2.000000e+00> : tensor<f32>
+  %2 = "onnx.LeakyRelu"(%arg0) {alpha = 1.000000e-01 : f32} : (tensor<f32>) -> tensor<f32>
+  %3 = "onnx.LeakyRelu"(%arg0) {alpha = 2.000000e-01 : f32} : (tensor<f32>) -> tensor<f32>
+  %4 = "onnx.Add"(%2, %0) {ResultNames = ["add1_out"], onnx_node_name = "add1"} : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  %5 = "onnx.Add"(%3, %1) {ResultNames = ["add2_out"], onnx_node_name = "add2"} : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  %6 = "onnx.Add"(%4, %5) {ResultNames = ["final_add_out"], onnx_node_name = "final_add"} : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  return %6 : tensor<f32>
+
+  // CHECK-LABEL: @diff_attrs
+  // CHECK-COUNT-2: onnx.Constant
+  // CHECK-COUNT-2: "onnx.LeakyRelu"
+  // CHECK-COUNT-3: "onnx.Add"
+}


### PR DESCRIPTION
- ONNX doesn't define the required attributes as "properties", hence **all the attributes are discardable attributes**.
- We have to compare the attributes but ignore the "onnx_node_name" and "ResultNames" attributes.