### PR TITLE
Fix negative &  zero quant scale values produced by ORT [AIESW-27110]

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -10,6 +10,7 @@ using namespace mlir;
 namespace onnx_mlir {
 
 void addXmcMlirPasses(mlir::OpPassManager &pm, OnnxToMlirOptions opts) {
+  pm.addNestedPass<func::FuncOp>(createFixNegScalePass());
   pm.addNestedPass<func::FuncOp>(
       onnx_mlir::createOptimizeOnnxRequantizationPass());
   pm.addNestedPass<func::FuncOp>(createONNXCSEPass());

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -54,6 +54,7 @@ add_onnx_mlir_library(OMONNXRewrite
   LegalizeQuarkQuantizedOps.cpp
   ONNXCSE.cpp
   QuantTypes.cpp
+  FixNegScale.cpp
   ConvertToChannelLast.cpp
   ResultNamesUpdater.cpp
   xmc/MergeSliceConcatPass.cpp

--- a/src/Dialect/ONNX/Transforms/FixNegScale.cpp
+++ b/src/Dialect/ONNX/Transforms/FixNegScale.cpp
@@ -29,8 +29,8 @@ public:
       return rewriter.notifyMatchFailure(dqOp, "scale not a scalar float");
 
     APFloat scaleVal = scaleAttr.getSplatValue<APFloat>();
-    if (!scaleVal.isNegative())
-      return rewriter.notifyMatchFailure(dqOp, "scale is not negative");
+    if (!scaleVal.isNegative() && !scaleVal.isZero())
+      return rewriter.notifyMatchFailure(dqOp, "scale is positive");
 
     // Data input (x) must be a scalar integer constant with value 1.
     auto xOp = dqOp.getX().getDefiningOp<ONNXConstantOp>();
@@ -70,23 +70,33 @@ public:
                                : zpVal.getSExtValue() != 0)
       return rewriter.notifyMatchFailure(dqOp, "zero point value is not 0");
 
-    // Negate scale.
-    APFloat negScale = scaleVal;
-    negScale.changeSign();
-    auto negScaleAttr = DenseElementsAttr::get(
-        cast<ShapedType>(scaleOp.getResult().getType()), negScale);
+    auto scaleShapedTy = cast<ShapedType>(scaleOp.getResult().getType());
+    auto xShapedTy = cast<ShapedType>(xOp.getResult().getType());
+    auto zpShapedTy = cast<ShapedType>(zpOp.getResult().getType());
 
-    // Swap x and zp: new x = 0, new zp = 1.
-    auto newXAttr =
-        DenseElementsAttr::get(cast<ShapedType>(xOp.getResult().getType()),
-            IntegerAttr::get(xIntType, 0));
-    auto newZpAttr =
-        DenseElementsAttr::get(cast<ShapedType>(zpOp.getResult().getType()),
-            IntegerAttr::get(zpIntType, 1));
+    DenseElementsAttr newScaleAttr, newXAttr, newZpAttr;
+    if (scaleVal.isZero()) {
+      // Zero scale: set x=0, zp=0, scale=1.0 so output is (0-0)*1.0 = 0.
+      APFloat one(scaleVal.getSemantics(), 1);
+      newScaleAttr = DenseElementsAttr::get(scaleShapedTy, one);
+      newXAttr =
+          DenseElementsAttr::get(xShapedTy, IntegerAttr::get(xIntType, 0));
+      newZpAttr =
+          DenseElementsAttr::get(zpShapedTy, IntegerAttr::get(zpIntType, 0));
+    } else {
+      // Negative scale: negate scale, swap x and zp values.
+      APFloat negScale = scaleVal;
+      negScale.changeSign();
+      newScaleAttr = DenseElementsAttr::get(scaleShapedTy, negScale);
+      newXAttr =
+          DenseElementsAttr::get(xShapedTy, IntegerAttr::get(xIntType, 0));
+      newZpAttr =
+          DenseElementsAttr::get(zpShapedTy, IntegerAttr::get(zpIntType, 1));
+    }
 
     Location loc = dqOp.getLoc();
     auto newScaleOp =
-        rewriter.create<ONNXConstantOp>(loc, Attribute(), negScaleAttr);
+        rewriter.create<ONNXConstantOp>(loc, Attribute(), newScaleAttr);
     auto newXOp = rewriter.create<ONNXConstantOp>(loc, Attribute(), newXAttr);
     auto newZpOp = rewriter.create<ONNXConstantOp>(loc, Attribute(), newZpAttr);
 

--- a/src/Dialect/ONNX/Transforms/FixNegScale.cpp
+++ b/src/Dialect/ONNX/Transforms/FixNegScale.cpp
@@ -1,0 +1,120 @@
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Pass/Pass.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+
+#include "src/Dialect/ONNX/ONNXDialect.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+class FixNegScale : public OpRewritePattern<ONNXDequantizeLinearOp> {
+public:
+  using OpRewritePattern<ONNXDequantizeLinearOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXDequantizeLinearOp dqOp, PatternRewriter &rewriter) const override {
+    // Scale must be a constant.
+    auto scaleOp = dqOp.getXScale().getDefiningOp<ONNXConstantOp>();
+    if (!scaleOp)
+      return rewriter.notifyMatchFailure(dqOp, "scale not a constant");
+
+    auto scaleAttr =
+        dyn_cast_if_present<DenseFPElementsAttr>(scaleOp.getValueAttr());
+    if (!scaleAttr || scaleAttr.getNumElements() != 1)
+      return rewriter.notifyMatchFailure(dqOp, "scale not a scalar float");
+
+    APFloat scaleVal = scaleAttr.getSplatValue<APFloat>();
+    if (!scaleVal.isNegative())
+      return rewriter.notifyMatchFailure(dqOp, "scale is not negative");
+
+    // Data input (x) must be a scalar integer constant with value 1.
+    auto xOp = dqOp.getX().getDefiningOp<ONNXConstantOp>();
+    if (!xOp)
+      return rewriter.notifyMatchFailure(dqOp, "x not a constant");
+
+    auto xAttr =
+        dyn_cast_if_present<DenseIntOrFPElementsAttr>(xOp.getValueAttr());
+    if (!xAttr || xAttr.getNumElements() != 1)
+      return rewriter.notifyMatchFailure(dqOp, "x not a scalar");
+
+    auto xIntType = dyn_cast<IntegerType>(xAttr.getElementType());
+    if (!xIntType)
+      return rewriter.notifyMatchFailure(dqOp, "x not an integer type");
+
+    APInt xVal = xAttr.getSplatValue<APInt>();
+    if (xIntType.isUnsigned() ? xVal.getZExtValue() != 1
+                              : xVal.getSExtValue() != 1)
+      return rewriter.notifyMatchFailure(dqOp, "x value is not 1");
+
+    // Zero-point must be a scalar integer constant with value 0.
+    auto zpOp = dqOp.getXZeroPoint().getDefiningOp<ONNXConstantOp>();
+    if (!zpOp)
+      return rewriter.notifyMatchFailure(dqOp, "zero point not a constant");
+
+    auto zpAttr =
+        dyn_cast_if_present<DenseIntOrFPElementsAttr>(zpOp.getValueAttr());
+    if (!zpAttr || zpAttr.getNumElements() != 1)
+      return rewriter.notifyMatchFailure(dqOp, "zero point not a scalar");
+
+    auto zpIntType = dyn_cast<IntegerType>(zpAttr.getElementType());
+    if (!zpIntType)
+      return rewriter.notifyMatchFailure(dqOp, "zero point not integer type");
+
+    APInt zpVal = zpAttr.getSplatValue<APInt>();
+    if (zpIntType.isUnsigned() ? zpVal.getZExtValue() != 0
+                               : zpVal.getSExtValue() != 0)
+      return rewriter.notifyMatchFailure(dqOp, "zero point value is not 0");
+
+    // Negate scale.
+    APFloat negScale = scaleVal;
+    negScale.changeSign();
+    auto negScaleAttr = DenseElementsAttr::get(
+        cast<ShapedType>(scaleOp.getResult().getType()), negScale);
+
+    // Swap x and zp: new x = 0, new zp = 1.
+    auto newXAttr =
+        DenseElementsAttr::get(cast<ShapedType>(xOp.getResult().getType()),
+            IntegerAttr::get(xIntType, 0));
+    auto newZpAttr =
+        DenseElementsAttr::get(cast<ShapedType>(zpOp.getResult().getType()),
+            IntegerAttr::get(zpIntType, 1));
+
+    Location loc = dqOp.getLoc();
+    auto newScaleOp =
+        rewriter.create<ONNXConstantOp>(loc, Attribute(), negScaleAttr);
+    auto newXOp = rewriter.create<ONNXConstantOp>(loc, Attribute(), newXAttr);
+    auto newZpOp = rewriter.create<ONNXConstantOp>(loc, Attribute(), newZpAttr);
+
+    rewriter.replaceOpWithNewOp<ONNXDequantizeLinearOp>(dqOp, dqOp.getType(),
+        newXOp.getResult(), newScaleOp.getResult(), newZpOp.getResult(),
+        dqOp.getAxisAttr(), dqOp.getBlockSizeAttr());
+    return success();
+  }
+};
+
+class FixNegScalePass
+    : public PassWrapper<FixNegScalePass, OperationPass<func::FuncOp>> {
+  [[nodiscard]] StringRef getArgument() const override {
+    return "fix-neg-scale";
+  }
+
+  void runOnOperation() override {
+    auto func = getOperation();
+    auto *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.add<FixNegScale>(ctx);
+    if (failed(applyPatternsGreedily(func, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+std::unique_ptr<Pass> createFixNegScalePass() {
+  return std::make_unique<FixNegScalePass>();
+}
+
+} // namespace onnx_mlir

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -69,6 +69,8 @@ std::unique_ptr<mlir::Pass> createONNXCSEPass();
 
 std::unique_ptr<mlir::Pass> createQuantTypesPass();
 
+std::unique_ptr<mlir::Pass> createFixNegScalePass();
+
 /// Pass for instrument the ops in specific stage.
 std::unique_ptr<mlir::Pass> createInstrumentPass();
 std::unique_ptr<mlir::Pass> createInstrumentPass(

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -336,6 +336,7 @@ void registerOMPasses(int optLevel) {
 
   mlir::registerPass(createQuantTypesPass);
   mlir::registerPass(createONNXCSEPass);
+  mlir::registerPass(createFixNegScalePass);
 
   mlir::PassPipelineRegistration<>("xmc-passes", "Run all XMC xcompiler passes",
       [](mlir::OpPassManager &pm) { addXmcMlirPasses(pm); });

--- a/test/mlir/onnx/onnx_fix_neg_scale.mlir
+++ b/test/mlir/onnx/onnx_fix_neg_scale.mlir
@@ -1,0 +1,83 @@
+// RUN: onnx-mlir-opt %s -fix-neg-scale | FileCheck %s
+
+// i8: negative scale with x=1, zp=0
+func.func @fix_neg_scale_i8() -> tensor<f32> {
+  %0 = onnx.Constant dense<1> : tensor<i8>
+  %1 = onnx.Constant dense<-5.000000e+02> : tensor<f32>
+  %2 = onnx.Constant dense<0> : tensor<i8>
+  %3 = "onnx.DequantizeLinear"(%0, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<i8>, tensor<f32>, tensor<i8>) -> tensor<f32>
+  return %3 : tensor<f32>
+}
+// CHECK-LABEL: @fix_neg_scale_i8
+// CHECK-DAG: [[X:%.*]] = onnx.Constant dense<0> : tensor<i8>
+// CHECK-DAG: [[SCALE:%.*]] = onnx.Constant dense<5.000000e+02> : tensor<f32>
+// CHECK-DAG: [[ZP:%.*]] = onnx.Constant dense<1> : tensor<i8>
+// CHECK: "onnx.DequantizeLinear"([[X]], [[SCALE]], [[ZP]])
+
+// ui8: negative scale with x=1, zp=0
+func.func @fix_neg_scale_ui8() -> tensor<f32> {
+  %0 = onnx.Constant dense<1> : tensor<ui8>
+  %1 = onnx.Constant dense<-2.500000e-01> : tensor<f32>
+  %2 = onnx.Constant dense<0> : tensor<ui8>
+  %3 = "onnx.DequantizeLinear"(%0, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui8>, tensor<f32>, tensor<ui8>) -> tensor<f32>
+  return %3 : tensor<f32>
+}
+// CHECK-LABEL: @fix_neg_scale_ui8
+// CHECK-DAG: [[X:%.*]] = onnx.Constant dense<0> : tensor<ui8>
+// CHECK-DAG: [[SCALE:%.*]] = onnx.Constant dense<2.500000e-01> : tensor<f32>
+// CHECK-DAG: [[ZP:%.*]] = onnx.Constant dense<1> : tensor<ui8>
+// CHECK: "onnx.DequantizeLinear"([[X]], [[SCALE]], [[ZP]])
+
+// i16: negative scale with x=1, zp=0
+func.func @fix_neg_scale_i16() -> tensor<f32> {
+  %0 = onnx.Constant dense<1> : tensor<i16>
+  %1 = onnx.Constant dense<-1.000000e-01> : tensor<f32>
+  %2 = onnx.Constant dense<0> : tensor<i16>
+  %3 = "onnx.DequantizeLinear"(%0, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<i16>, tensor<f32>, tensor<i16>) -> tensor<f32>
+  return %3 : tensor<f32>
+}
+// CHECK-LABEL: @fix_neg_scale_i16
+// CHECK-DAG: [[X:%.*]] = onnx.Constant dense<0> : tensor<i16>
+// CHECK-DAG: [[SCALE:%.*]] = onnx.Constant dense<1.000000e-01> : tensor<f32>
+// CHECK-DAG: [[ZP:%.*]] = onnx.Constant dense<1> : tensor<i16>
+// CHECK: "onnx.DequantizeLinear"([[X]], [[SCALE]], [[ZP]])
+
+// ui16: negative scale with x=1, zp=0
+func.func @fix_neg_scale_ui16() -> tensor<f32> {
+  %0 = onnx.Constant dense<1> : tensor<ui16>
+  %1 = onnx.Constant dense<-2.000000e-01> : tensor<f32>
+  %2 = onnx.Constant dense<0> : tensor<ui16>
+  %3 = "onnx.DequantizeLinear"(%0, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+  return %3 : tensor<f32>
+}
+// CHECK-LABEL: @fix_neg_scale_ui16
+// CHECK-DAG: [[X:%.*]] = onnx.Constant dense<0> : tensor<ui16>
+// CHECK-DAG: [[SCALE:%.*]] = onnx.Constant dense<2.000000e-01> : tensor<f32>
+// CHECK-DAG: [[ZP:%.*]] = onnx.Constant dense<1> : tensor<ui16>
+// CHECK: "onnx.DequantizeLinear"([[X]], [[SCALE]], [[ZP]])
+
+// Negative test: positive scale should not be transformed
+func.func @no_fix_positive_scale() -> tensor<f32> {
+  %0 = onnx.Constant dense<1> : tensor<i8>
+  %1 = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %2 = onnx.Constant dense<0> : tensor<i8>
+  %3 = "onnx.DequantizeLinear"(%0, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<i8>, tensor<f32>, tensor<i8>) -> tensor<f32>
+  return %3 : tensor<f32>
+}
+// CHECK-LABEL: @no_fix_positive_scale
+// CHECK: onnx.Constant dense<1> : tensor<i8>
+// CHECK: onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CHECK: onnx.Constant dense<0> : tensor<i8>
+
+// Negative test: x != 1 should not be transformed
+func.func @no_fix_x_not_one() -> tensor<f32> {
+  %0 = onnx.Constant dense<5> : tensor<i8>
+  %1 = onnx.Constant dense<-5.000000e-01> : tensor<f32>
+  %2 = onnx.Constant dense<0> : tensor<i8>
+  %3 = "onnx.DequantizeLinear"(%0, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<i8>, tensor<f32>, tensor<i8>) -> tensor<f32>
+  return %3 : tensor<f32>
+}
+// CHECK-LABEL: @no_fix_x_not_one
+// CHECK: onnx.Constant dense<5> : tensor<i8>
+// CHECK: onnx.Constant dense<-5.000000e-01> : tensor<f32>
+// CHECK: onnx.Constant dense<0> : tensor<i8>

--- a/test/mlir/onnx/onnx_fix_neg_scale.mlir
+++ b/test/mlir/onnx/onnx_fix_neg_scale.mlir
@@ -56,6 +56,32 @@ func.func @fix_neg_scale_ui16() -> tensor<f32> {
 // CHECK-DAG: [[ZP:%.*]] = onnx.Constant dense<1> : tensor<ui16>
 // CHECK: "onnx.DequantizeLinear"([[X]], [[SCALE]], [[ZP]])
 
+// Zero scale with x=1, zp=0: scale becomes 1.0, x=0, zp=0
+func.func @fix_zero_scale_i8() -> tensor<f32> {
+  %0 = onnx.Constant dense<1> : tensor<i8>
+  %1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+  %2 = onnx.Constant dense<0> : tensor<i8>
+  %3 = "onnx.DequantizeLinear"(%0, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<i8>, tensor<f32>, tensor<i8>) -> tensor<f32>
+  return %3 : tensor<f32>
+}
+// CHECK-LABEL: @fix_zero_scale_i8
+// CHECK-DAG: [[X:%.*]] = onnx.Constant dense<0> : tensor<i8>
+// CHECK-DAG: [[SCALE:%.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK: "onnx.DequantizeLinear"([[X]], [[SCALE]], [[X]])
+
+// Zero scale with unsigned type
+func.func @fix_zero_scale_ui16() -> tensor<f32> {
+  %0 = onnx.Constant dense<1> : tensor<ui16>
+  %1 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+  %2 = onnx.Constant dense<0> : tensor<ui16>
+  %3 = "onnx.DequantizeLinear"(%0, %1, %2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<ui16>, tensor<f32>, tensor<ui16>) -> tensor<f32>
+  return %3 : tensor<f32>
+}
+// CHECK-LABEL: @fix_zero_scale_ui16
+// CHECK-DAG: [[X:%.*]] = onnx.Constant dense<0> : tensor<ui16>
+// CHECK-DAG: [[SCALE:%.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK: "onnx.DequantizeLinear"([[X]], [[SCALE]], [[X]])
+
 // Negative test: positive scale should not be transformed
 func.func @no_fix_positive_scale() -> tensor<f32> {
   %0 = onnx.Constant dense<1> : tensor<i8>


### PR DESCRIPTION
ORT optimization [WhereDummyDq](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/optimizer/qdq_transformer/where_dummy_dq.cc) produces dummy DequantizeLinear ops that are invalid, which have negative scale or zero scale values. This pass reverts that to have only positive scale, while also producing the correct result.

This will avoid issues in the QuantTypes pass, as it only accepts strictly positive scales.