### PR TITLE
Add onnx.Abs to tosa.Abs lowering with quant types

### DIFF
--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -5,7 +5,7 @@
 //====------ ConvertONNXToTOSA.cpp - ONNX dialects to TOSA lowering -------===//
 //
 // Copyright (c) 2022 Arm Limited.
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -174,11 +174,11 @@ void FrontendToTosaLoweringPass::runOnOperation() {
 
   // We use the type converter to legalize types before any conversion patterns
   // are executed. This ensures that we do not need to trigger separate
-  // conversion failures. Quantized types are not supported right now.
+  // conversion failures. Only per-tensor quantization is supported right now.
   TypeConverter typeConverter;
   typeConverter.addConversion([](Type type) -> std::optional<Type> {
     if (isTOSAInt(type) || isa<FloatType>(type) || isa<NoneType>(type) ||
-        isTOSABool(type))
+        isTOSABool(type) || isTOSAQuantizedInt(type))
       return type;
     return std::nullopt;
   });

--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Elementwise.cpp - Elementwise Op --------------------===//
 //
-// Copyright (c) 2022 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -29,6 +29,18 @@ namespace onnx_mlir {
 template <>
 struct TOSADialectOp<ONNXNegOp> {
   using Op = mlir::tosa::NegateOp;
+};
+
+struct IsIntOrFloatOrQuantizedInt {
+  static LogicalResult checkType(
+      ConversionPatternRewriter &rewriter, Type scalarType, Operation *op) {
+    if (!isa<FloatType>(scalarType) && !isTOSAInt(scalarType) &&
+        !isTOSAQuantizedInt(scalarType)) {
+      return rewriter.notifyMatchFailure(op,
+          "this operation only supports int, float, or quantized int types");
+    }
+    return success();
+  }
 };
 
 struct IsIntOrFloat {
@@ -724,7 +736,7 @@ static void populateLoweringONNXElementwiseUnaryTemplateOpToTOSAPattern(
       ONNXElementwiseUnaryOpLoweringToTOSA<ONNXNotOp, mlir::tosa::LogicalNotOp,
           IsBool, IsBool>,
       ONNXElementwiseUnaryOpLoweringToTOSA<ONNXAbsOp, mlir::tosa::AbsOp,
-          IsIntOrFloat, IsIntOrFloat>,
+          IsIntOrFloatOrQuantizedInt, IsIntOrFloatOrQuantizedInt>,
       ONNXElementwiseUnaryOpLoweringToTOSA<ONNXErfOp, mlir::tosa::ErfOp,
           IsFloat, IsFloat>,
       ONNXElementwiseUnaryOpLoweringToTOSA<ONNXSinOp, mlir::tosa::SinOp,

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -5,7 +5,7 @@
 //====------ ONNXToTOSACommon.hpp - ONNX dialects to TOSA lowering --------===//
 //
 // Copyright 2020-2024 The TensorFlow Authors. All Rights Reserved.
-// Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -102,6 +102,11 @@ inline bool isTOSAInt(mlir::Type type) {
 inline bool isTOSAFloat(mlir::Type type) {
   return mlir::isa<mlir::BFloat16Type, mlir::Float16Type, mlir::Float32Type>(
       type);
+}
+
+inline bool isTOSAQuantizedInt(mlir::Type type) {
+  auto quantizedType = mlir::dyn_cast<mlir::quant::UniformQuantizedType>(type);
+  return quantizedType && isTOSAInt(quantizedType.getStorageType());
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+
 // RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa -cse %s -split-input-file | FileCheck %s
 
 // -----
@@ -784,6 +786,29 @@ func.func @test_abs_f64(%arg0: tensor<3xf64>) -> tensor<3xf64> {
 // CHECK-LABEL:  func @test_abs_f64
 // CHECK-NOT:    onnx.Abs
 // CHECK:        return {{.*}}: tensor<3xf64>
+}
+
+func.func @test_abs_qi8(%arg0: tensor<3x!quant.uniform<i8:f32, 1.0>>) -> tensor<3x!quant.uniform<i8:f32, 1.0>> {
+  %0 = "onnx.Abs"(%arg0) : (tensor<3x!quant.uniform<i8:f32, 1.0>>) -> tensor<3x!quant.uniform<i8:f32, 1.0>>
+  return %0 : tensor<3x!quant.uniform<i8:f32, 1.0>>
+// CHECK-LABEL:  func @test_abs_qi8
+// CHECK-NEXT:     [[VAR_0_:%.+]] = tosa.abs [[PARAM_0_]] : (tensor<3x!quant.uniform<i8:f32, 1.000000e+00>>) -> tensor<3x!quant.uniform<i8:f32, 1.000000e+00>>
+// CHECK-NEXT:     return [[VAR_0_]] : tensor<3x!quant.uniform<i8:f32, 1.000000e+00>>
+// CHECK-NEXT:   }
+}
+
+// Per-channel quantized types use quant.uniform<i8:f32:1 {s0, s1, ...}>, 
+// which is not currently handled by the ONNX-to-TOSA elementwise conversion.
+// Only per-tensor uniform quantized types are supported.
+// This test checks that the conversion does not fail but keeps the original op.
+
+func.func @test_abs_qi8_channel(%arg0: tensor<3x4x!quant.uniform<i8:f32:1, {1.0, 2.0, 3.0, 4.0}>>) -> tensor<3x4x!quant.uniform<i8:f32:1, {1.0, 2.0, 3.0, 4.0}>> {
+  %0 = "onnx.Abs"(%arg0) : (tensor<3x4x!quant.uniform<i8:f32:1, {1.0, 2.0, 3.0, 4.0}>>) -> tensor<3x4x!quant.uniform<i8:f32:1, {1.0, 2.0, 3.0, 4.0}>>
+  return %0 : tensor<3x4x!quant.uniform<i8:f32:1, {1.0, 2.0, 3.0, 4.0}>>
+
+// CHECK-LABEL:  func @test_abs_qi8_channel
+// CHECK:        "onnx.Abs"
+// CHECK:        return
 }
 
 // -----


### PR DESCRIPTION
Changed that ONNX-to-TOSA conversion now allows for per-tensor quantized types from the quant dialect.
Provided test that shows onnx.Abs to tosa.Abs lowering with quant types.
