### PR TITLE
Add fold of trivial resize ops (input shape = output shape)

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -949,6 +949,41 @@ private:
 };
 
 // =============================================================================
+// Rewrite pattern for redundant resize (scale=1 or same input/output size)
+// =============================================================================
+//
+// A resize with equal input and output dimensions is a noop.
+// This assumes coordinate transformation mode is not "tf_crop_and_resize".
+class RemoveRedundantResizePattern : public OpRewritePattern<ONNXResizeOp> {
+public:
+  using OpRewritePattern<ONNXResizeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXResizeOp onnxResizeOp, PatternRewriter &rewriter) const override {
+
+    auto inputType =
+        mlir::dyn_cast<RankedTensorType>(onnxResizeOp.getX().getType());
+    auto outputType = mlir::dyn_cast<RankedTensorType>(onnxResizeOp.getType());
+
+    if (!inputType || !outputType)
+      return failure();
+
+    if (!inputType.hasStaticShape() || !outputType.hasStaticShape())
+      return failure();
+
+    if (inputType.getShape() != outputType.getShape())
+      return failure();
+
+    if (onnxResizeOp.getCoordinateTransformationMode() == "tf_crop_and_resize")
+      return failure();
+
+    rewriter.replaceOp(onnxResizeOp, onnxResizeOp.getX());
+
+    return success();
+  }
+};
+
+// =============================================================================
 // Rewrite pattern for loop (not handled in Rewrite.td).
 // =============================================================================
 
@@ -3226,6 +3261,7 @@ void ONNXReshapeOp::getCanonicalizationPatterns(
 void ONNXResizeOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
   result.insert<EmptyTensorInputsResizePattern>(context);
+  result.insert<RemoveRedundantResizePattern>(context);
 }
 
 /// on the ONNXRNNOp.

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -287,6 +287,54 @@ func.func @test_resize_empty_tensor_inputs(%8: tensor<0xf32>, %714: tensor<*xf32
 
 // -----
 
+// CHECK-LABEL: func @test_remove_redundant_resize(%arg0: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32> {
+func.func @test_remove_redundant_resize(%arg0: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32> {
+  %noval = "onnx.NoValue"() {value} : () -> none
+  %shape = "onnx.Constant"() {value = dense<[1, 256, 56, 56]> : tensor<4xi64>} : () -> tensor<4xi64>
+  %0 = "onnx.Resize"(%arg0, %noval, %noval, %shape) 
+  { 
+    antialias = 0 : si64, 
+    coordinate_transformation_mode = "pytorch_half_pixel", 
+    cubic_coeff_a = -7.500000e-01 : f32, 
+    exclude_outside = 0 : si64, 
+    extrapolation_value = 0.000000e+00 : f32, 
+    keep_aspect_ratio_policy = "stretch", 
+    mode = "linear", 
+    nearest_mode = "floor"
+  } : (tensor<1x256x56x56xf32>, none, none, tensor<4xi64>) -> tensor<1x256x56x56xf32>
+  // CHECK-NOT: onnx.Resize
+  // CHECK-NEXT: onnx.Return %arg0 : tensor<1x256x56x56xf32>
+  "onnx.Return"(%0) : (tensor<1x256x56x56xf32>) -> ()
+}
+
+// -----
+
+// Verify that a redundant resize with tf_crop_and_resize is NOT removed,
+// because the ROI crops to a sub-region even when input/output shapes match.
+
+// CHECK-LABEL: func @test_no_remove_redundant_resize_tf_crop_and_resize
+func.func @test_no_remove_redundant_resize_tf_crop_and_resize(%arg0: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32> {
+  %noval = "onnx.NoValue"() {value} : () -> none
+  %roi = "onnx.Constant"() {value = dense<[0.0, 0.0, 0.2, 0.2, 1.0, 1.0, 0.8, 0.8]> : tensor<8xf32>} : () -> tensor<8xf32>
+  %shape = "onnx.Constant"() {value = dense<[1, 256, 56, 56]> : tensor<4xi64>} : () -> tensor<4xi64>
+  %0 = "onnx.Resize"(%arg0, %roi, %noval, %shape)
+  {
+    antialias = 0 : si64,
+    coordinate_transformation_mode = "tf_crop_and_resize",
+    cubic_coeff_a = -7.500000e-01 : f32,
+    exclude_outside = 0 : si64,
+    extrapolation_value = 0.000000e+00 : f32,
+    keep_aspect_ratio_policy = "stretch",
+    mode = "nearest",
+    nearest_mode = "floor"
+  } : (tensor<1x256x56x56xf32>, tensor<8xf32>, none, tensor<4xi64>) -> tensor<1x256x56x56xf32>
+  // CHECK: onnx.Resize
+  // CHECK: onnx.Return
+  "onnx.Return"(%0) : (tensor<1x256x56x56xf32>) -> ()
+}
+
+// -----
+
 // Check the combining of transposes into a simple transpose.
 // CHECK-LABEL: func @test_transpose_fusion(%arg0: tensor<10x11x12x13xf32>) -> tensor<11x10x13x12xf32> {
 func.func @test_transpose_fusion(%arg0: tensor<10x11x12x13xf32>) -> tensor<11x10x13x12xf32> {


### PR DESCRIPTION
Added canonicalization pass which removes onnx.Resize ops if their input- and output shape are identical.