### PR TITLE
feat: add option to disable onnx.Cast lowering to TOSA.

### DIFF
--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -26,10 +26,11 @@ namespace onnx_mlir {
 
 void populateONNXToTOSAConversionPattern(ConversionTarget &target,
     RewritePatternSet &patterns, TypeConverter &typeConverter, MLIRContext *ctx,
-    int64_t groupedConvThreshold, bool convertSliceOnlyWhenStepOne) {
+    int64_t groupedConvThreshold, bool convertSliceOnlyWhenStepOne,
+    bool disableCastLowering) {
   // Math
   populateLoweringONNXElementwiseOpToTOSAPattern(
-      target, patterns, typeConverter, ctx);
+      target, patterns, typeConverter, ctx, disableCastLowering);
   populateLoweringONNXReduceOpsToTOSAPattern(
       target, patterns, typeConverter, ctx);
   populateLoweringONNXGemmOpToTOSAPattern(target, patterns, typeConverter, ctx);
@@ -118,6 +119,9 @@ public:
       "convert-slice-only-when-step-one",
       llvm::cl::desc("If enabled, convert onnx.slice only if all steps are 1"),
       llvm::cl::ZeroOrMore, llvm::cl::init(false)};
+  Option<bool> disableCastLowering{*this, "disable-cast-lowering",
+      llvm::cl::desc("If enabled, disable the lowering of onnx.cast to tosa."),
+      llvm::cl::ZeroOrMore, llvm::cl::init(false)};
 };
 
 Value handleDynamicToStaticShapes(
@@ -195,7 +199,7 @@ void FrontendToTosaLoweringPass::runOnOperation() {
 
   // Define patterns
   populateONNXToTOSAConversionPattern(target, patterns, typeConverter, context,
-      groupedConvThreshold, convertSliceOnlyWhenStepOne);
+      groupedConvThreshold, convertSliceOnlyWhenStepOne, disableCastLowering);
 
   if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
     signalPassFailure();

--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -734,19 +734,22 @@ static void populateLoweringONNXElementwiseUnaryTemplateOpToTOSAPattern(
 }
 
 void populateLoweringONNXElementwiseOpToTOSAPattern(ConversionTarget &target,
-    RewritePatternSet &patterns, TypeConverter &typeConverter,
-    MLIRContext *ctx) {
+    RewritePatternSet &patterns, TypeConverter &typeConverter, MLIRContext *ctx,
+    bool disableCastLowering) {
   patterns.insert<ONNXReluOpLoweringToTOSA, ONNXLeakyReluOpLoweringToTOSA,
       ONNXMulOpLoweringToTosa, ONNXClipOpLoweringToTOSA,
       ONNXDivOpLoweringToTOSA, ONNXHardSigmoidOpLoweringToTOSA,
       ONNXSqrtOpLoweringToTOSA, ONNXEluOpLoweringToTOSA,
       ONNXPReluOpLoweringToTOSA, ONNXThresholdedReluOpLoweringToTOSA,
       ONNXSoftplusOpLoweringToTOSA, ONNXSeluOpLoweringToTOSA,
-      ONNXCastOpLoweringToTOSA, ONNXComparisonOpLoweringToTOSA<ONNXEqualOp>,
+      ONNXComparisonOpLoweringToTOSA<ONNXEqualOp>,
       ONNXComparisonOpLoweringToTOSA<ONNXGreaterOrEqualOp>,
       ONNXComparisonOpLoweringToTOSA<ONNXGreaterOp>,
       ONNXComparisonOpLoweringToTOSA<ONNXLessOrEqualOp>,
       ONNXComparisonOpLoweringToTOSA<ONNXLessOp>>(typeConverter, ctx);
+  if (!disableCastLowering) {
+    patterns.insert<ONNXCastOpLoweringToTOSA>(typeConverter, ctx);
+  }
 
   populateLoweringONNXElementwiseBinaryTemplateOpToTOSAPattern(
       patterns, typeConverter, ctx);

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -117,7 +117,8 @@ using TOSAOp = typename TOSADialectOp<Op>::Op;
 
 // `Math` directory methods:
 void populateLoweringONNXElementwiseOpToTOSAPattern(mlir::ConversionTarget &,
-    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *,
+    bool);
 void populateLoweringONNXGemmOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSoftmaxOpToTOSAPattern(mlir::ConversionTarget &,

--- a/test/mlir/conversion/onnx_to_tosa/Math/DisableCastLowering.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/DisableCastLowering.mlir
@@ -1,0 +1,64 @@
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa=disable-cast-lowering=true -cse %s -split-input-file | FileCheck %s
+
+func.func @test_cast_f32_i8(%arg0: tensor<13x21x1xf32>) -> tensor<13x21x1xi8> {
+  %0 = "onnx.Cast"(%arg0) {to = i8} : (tensor<13x21x1xf32>) -> tensor<13x21x1xi8>
+  "func.return"(%0) : (tensor<13x21x1xi8>) -> ()
+// CHECK-LABEL:   func.func @test_cast_f32_i8
+// CHECK: onnx.Cast
+}
+
+// -----
+
+func.func @test_cast_int4_and_uint4_to_from_int8_uint8(%arg0: tensor<1xi4>, %arg1: tensor<1xui4>) -> (tensor<1xi4>, tensor<1xui4>) {
+    %0 = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = i8} : (tensor<1xi4>) -> tensor<1xi8>
+    %1 = "onnx.Cast"(%0) {saturate = 1 : si64, to = i4} : (tensor<1xi8>) -> tensor<1xi4>
+    %2 = "onnx.Cast"(%arg1) {saturate = 1 : si64, to = ui8} : (tensor<1xui4>) -> tensor<1xui8>
+    %3 = "onnx.Cast"(%2) {saturate = 1 : si64, to = ui4} : (tensor<1xui8>) -> tensor<1xui4>
+    onnx.Return %1, %3 : tensor<1xi4>, tensor<1xui4>
+// CHECK-LABEL:  func.func @test_cast_int4_and_uint4_to_from_int8_uint8
+// CHECK: onnx.Cast
+// CHECK: onnx.Cast
+// CHECK: onnx.Cast
+// CHECK: onnx.Cast
+}
+
+// -----
+
+func.func @test_cast_int4_and_uint4_to_float_and_back(%arg0: tensor<1xi4>, %arg1: tensor<1xui4>) -> (tensor<1xi4>, tensor<1xui4>) {
+    %0 = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = f32} : (tensor<1xi4>) -> tensor<1xf32>
+    %1 = "onnx.Cast"(%0) {saturate = 1 : si64, to = i4} : (tensor<1xf32>) -> tensor<1xi4>
+    %2 = "onnx.Cast"(%arg1) {saturate = 1 : si64, to = f32} : (tensor<1xui4>) -> tensor<1xf32>
+    %3 = "onnx.Cast"(%2) {saturate = 1 : si64, to = ui4} : (tensor<1xf32>) -> tensor<1xui4>
+    onnx.Return %1, %3 : tensor<1xi4>, tensor<1xui4>
+// CHECK-LABEL:  func.func @test_cast_int4_and_uint4_to_float_and_back
+// CHECK: onnx.Cast
+// CHECK: onnx.Cast
+// CHECK: onnx.Cast
+// CHECK: onnx.Cast
+}
+
+// -----
+
+func.func @test_cast_f16_i8(%arg0: tensor<13x21x1xf16>) -> tensor<13x21x1xi8> {
+  %0 = "onnx.Cast"(%arg0) {to = i8} : (tensor<13x21x1xf16>) -> tensor<13x21x1xi8>
+  "func.return"(%0) : (tensor<13x21x1xi8>) -> ()
+// CHECK: onnx.Cast
+}
+
+// -----
+
+func.func @test_cast_i8_i1(%arg0: tensor<1x21x1x1xi8>) -> tensor<1x21x1x1xi1> {
+  %0 = "onnx.Cast"(%arg0) {to = i1} : (tensor<1x21x1x1xi8>) -> tensor<1x21x1x1xi1>
+  "func.return"(%0) : (tensor<1x21x1x1xi1>) -> ()
+// CHECK-LABEL:  func @test_cast_i8_i1
+// CHECK: onnx.Cast
+}
+
+// -----
+
+func.func @test_cast_f32_i1(%arg0: tensor<13x21x1xf32>) -> tensor<13x21x1xi1> {
+  %0 = "onnx.Cast"(%arg0) {to = i1} : (tensor<13x21x1xf32>) -> tensor<13x21x1xi1>
+  "func.return"(%0) : (tensor<13x21x1xi1>) -> ()
+// CHECK-LABEL: func @test_cast_f32_i1
+// CHECK: onnx.Cast
+}


### PR DESCRIPTION
ONNX and TOSA have different semantics of Cast operations, so we would like to able to control when the lowering from ONNX to TOSA for the `onnx.Cast` happens. This is particularly important if we want to make sure to capture `onnx.Cast` as a kernel.