### PR TITLE
Existing TensorNames should not be overwritten

### DIFF
--- a/src/Dialect/ONNX/Transforms/QDQAroundOpOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/QDQAroundOpOpt.cpp
@@ -6,6 +6,8 @@
 //===----------------------------------------------------------------------===//
 
 #include <cmath>
+#include <llvm/ADT/STLExtras.h>
+#include <mlir/IR/Attributes.h>
 #include <mlir/IR/IRMapping.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
@@ -167,9 +169,15 @@ public:
       transform(op->getOperands(), std::back_inserter(newInputs),
           [&](Value operand) { return irMapping.lookupOrDefault(operand); });
 
+      SmallVector<NamedAttribute> filteredAttrs(op->getAttrs());
+      if (auto foundIter = llvm::find_if(filteredAttrs,
+              [](NamedAttribute kv) { return kv.getName() == "ResultNames"; });
+          foundIter != filteredAttrs.end())
+        filteredAttrs.erase(foundIter);
+
       auto newOp =
           rewriter.create<T>(op.getLoc(), TypeRange{qOp.getResult().getType()},
-              ValueRange{newInputs}, op->getAttrs());
+              ValueRange{newInputs}, filteredAttrs);
       rewriter.replaceOp(qOp, newOp.getResult());
       return success();
     }

--- a/src/Dialect/ONNX/Transforms/QDQAroundOpOpt.cpp
+++ b/src/Dialect/ONNX/Transforms/QDQAroundOpOpt.cpp
@@ -6,8 +6,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <cmath>
-#include <llvm/ADT/STLExtras.h>
-#include <mlir/IR/Attributes.h>
 #include <mlir/IR/IRMapping.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
@@ -169,15 +167,9 @@ public:
       transform(op->getOperands(), std::back_inserter(newInputs),
           [&](Value operand) { return irMapping.lookupOrDefault(operand); });
 
-      SmallVector<NamedAttribute> filteredAttrs(op->getAttrs());
-      if (auto foundIter = llvm::find_if(filteredAttrs,
-              [](NamedAttribute kv) { return kv.getName() == "ResultNames"; });
-          foundIter != filteredAttrs.end())
-        filteredAttrs.erase(foundIter);
-
       auto newOp =
           rewriter.create<T>(op.getLoc(), TypeRange{qOp.getResult().getType()},
-              ValueRange{newInputs}, filteredAttrs);
+              ValueRange{newInputs}, op->getAttrs());
       rewriter.replaceOp(qOp, newOp.getResult());
       return success();
     }

--- a/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
+++ b/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
@@ -30,9 +30,11 @@ void ResultNamesUpdater::notifyOperationReplaced(
   if (!resultNamesArray)
     return;
 
-  if (auto replResultNames =
-          replacement->getAttrOfType<ArrayAttr>("ResultNames");
-      replResultNames && llvm::all_of(replResultNames, isTensorName))
+  // Always overwrite on newly created op
+  bool newOp = replacement->getUses().empty();
+  // Check if ResultNames exist already
+  auto replResultNames = replacement->getAttrOfType<ArrayAttr>("ResultNames");
+  if (!newOp && replResultNames && llvm::all_of(replResultNames, isTensorName))
     return;
 
   replacement->setAttr("ResultNames", resultNamesArray);
@@ -64,7 +66,8 @@ void ResultNamesUpdater::notifyOperationReplaced(
       if (auto existing = replOp->getAttrOfType<ArrayAttr>("ResultNames"))
         replResultNames = SmallVector<Attribute>(existing.getValue());
 
-      if (isTensorName(replResultNames[replResult.getResultNumber()]))
+      bool newOp = replOp->getUses().empty();
+      if (!newOp && isTensorName(replResultNames[replResult.getResultNumber()]))
         continue;
 
       // Replace the ResultName of current result

--- a/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
+++ b/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
@@ -8,41 +8,68 @@
 
 #include "src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp"
 
+using namespace mlir;
+
 namespace onnx_mlir {
 
+namespace {
+
+bool isTensorName(Attribute attr) {
+  if (auto strAttr = dyn_cast<StringAttr>(attr))
+    return !strAttr.empty();
+  else if (auto arrayAttr = dyn_cast<ArrayAttr>(attr))
+    return !arrayAttr.empty();
+  return false;
+}
+
+} // namespace
+
 void ResultNamesUpdater::notifyOperationReplaced(
-    mlir::Operation *op, mlir::ValueRange replacement) {
-  if (!op->hasAttrOfType<mlir::ArrayAttr>("ResultNames"))
+    mlir::Operation *op, mlir::Operation *replacement) {
+  auto resultNamesArray = op->getAttrOfType<ArrayAttr>("ResultNames");
+  if (!resultNamesArray)
     return;
 
-  auto resultNamesArray = op->getAttrOfType<mlir::ArrayAttr>("ResultNames");
+  if (auto replResultNames =
+          replacement->getAttrOfType<ArrayAttr>("ResultNames");
+      replResultNames && llvm::all_of(replResultNames, isTensorName))
+    return;
 
+  replacement->setAttr("ResultNames", resultNamesArray);
+}
+
+void ResultNamesUpdater::notifyOperationReplaced(
+    Operation *op, ValueRange replacement) {
   // If the op is replaced by a single op, simply copy the attribute
-  mlir::Operation *replSingleOp = replacement.front().getDefiningOp();
-  if (replSingleOp &&
-      llvm::all_of(replacement, [replSingleOp](mlir::Value val) -> bool {
-        return val.getDefiningOp() == replSingleOp;
+  if (Operation *replOp = replacement.front().getDefiningOp();
+      replOp && llvm::all_of(replacement, [replOp](Value val) -> bool {
+        return val.getDefiningOp() == replOp;
       })) {
-    replSingleOp->setAttr("ResultNames", resultNamesArray);
+    notifyOperationReplaced(op, replOp);
     return;
   }
 
-  mlir::MLIRContext *ctx = op->getContext();
+  auto resultNamesArray = op->getAttrOfType<ArrayAttr>("ResultNames");
+  if (!resultNamesArray)
+    return;
+
+  MLIRContext *ctx = op->getContext();
   for (auto [name, value] : llvm::zip_equal(resultNamesArray, replacement)) {
-    if (mlir::OpResult replResult = mlir::dyn_cast<mlir::OpResult>(value)) {
-      mlir::Operation *replOp = replResult.getOwner();
+    if (auto replResult = dyn_cast<OpResult>(value)) {
+      Operation *replOp = replResult.getOwner();
 
       // Get new or existing ResultNames
-      mlir::SmallVector<mlir::Attribute> replResultNames(
-          replOp->getNumResults(), mlir::StringAttr::get(ctx));
-      if (auto existing = replOp->getAttrOfType<mlir::ArrayAttr>("ResultNames"))
-        replResultNames =
-            mlir::SmallVector<mlir::Attribute>(existing.getValue());
+      SmallVector<Attribute> replResultNames(
+          replOp->getNumResults(), StringAttr::get(ctx));
+      if (auto existing = replOp->getAttrOfType<ArrayAttr>("ResultNames"))
+        replResultNames = SmallVector<Attribute>(existing.getValue());
+
+      if (isTensorName(replResultNames[replResult.getResultNumber()]))
+        continue;
 
       // Replace the ResultName of current result
       replResultNames[replResult.getResultNumber()] = name;
-      replOp->setAttr(
-          "ResultNames", mlir::ArrayAttr::get(ctx, replResultNames));
+      replOp->setAttr("ResultNames", ArrayAttr::get(ctx, replResultNames));
     }
   }
 }

--- a/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
+++ b/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
@@ -18,7 +18,7 @@ bool isTensorName(Attribute attr) {
   if (auto strAttr = dyn_cast<StringAttr>(attr))
     return !strAttr.empty();
   else if (auto arrayAttr = dyn_cast<ArrayAttr>(attr))
-    return !arrayAttr.empty();
+    return !arrayAttr.empty() && isTensorName(arrayAttr[0]);
   return false;
 }
 

--- a/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
+++ b/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
@@ -25,7 +25,7 @@ bool isTensorName(Attribute attr) {
 } // namespace
 
 void ResultNamesUpdater::notifyOperationReplaced(
-    mlir::Operation *op, mlir::Operation *replacement) {
+    Operation *op, Operation *replacement) {
   auto resultNamesArray = op->getAttrOfType<ArrayAttr>("ResultNames");
   if (!resultNamesArray)
     return;

--- a/src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp
+++ b/src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp
@@ -9,6 +9,9 @@ namespace onnx_mlir {
 class ResultNamesUpdater : public mlir::RewriterBase::Listener {
 public:
   void notifyOperationReplaced(
+      mlir::Operation *op, mlir::Operation *replacement) override;
+
+  void notifyOperationReplaced(
       mlir::Operation *op, mlir::ValueRange replacement) override;
 };
 

--- a/test/mlir/onnx/onnx_resultnames_prop.mlir
+++ b/test/mlir/onnx/onnx_resultnames_prop.mlir
@@ -38,7 +38,7 @@ func.func @canonicalize(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK: "onnx.Add"(%arg0, %0)
 // CHECK-SAME: ResultNames = ["add0"]
 
-func.func @qdq_canonicalize(%arg0: tensor<1x128xf32>) -> tensor<1x1x128xf32> {
+func.func @remove_qdq_around_ops(%arg0: tensor<1x128xf32>) -> tensor<1x1x128xf32> {
   %0 = onnx.Constant {ResultNames = ["scale"]} dense<1.000000e+00> : tensor<f32>
   %1 = onnx.Constant {ResultNames = ["zp"]} dense<128> : tensor<ui8>
   %2 = onnx.Constant {ResultNames = ["shape"]} dense<[1, 1, 128]> : tensor<3xi64>
@@ -50,7 +50,7 @@ func.func @qdq_canonicalize(%arg0: tensor<1x128xf32>) -> tensor<1x1x128xf32> {
   return %7 : tensor<1x1x128xf32>
 }
 
-// CHECK-LABEL: @qdq_canonicalize
+// CHECK-LABEL: @remove_qdq_around_ops
 // CHECK: onnx.QuantizeLinear
 // CHECK-SAME: ResultNames = ["q0"]
 // CHECK-NOT: onnx.DequantizeLinear
@@ -58,6 +58,22 @@ func.func @qdq_canonicalize(%arg0: tensor<1x128xf32>) -> tensor<1x1x128xf32> {
 // CHECK-SAME: ResultNames = ["q1"]
 // CHECK-NOT: onnx.QuantizeLinear
 // CHECK: onnx.DequantizeLinear
+
+func.func @qdq_canonicalize(%arg0: tensor<1x128xf32>) -> tensor<1x128xf32> {
+  %0 = onnx.Constant {ResultNames = ["scale"]} dense<1.000000e+00> : tensor<f32>
+  %1 = onnx.Constant {ResultNames = ["zp"]} dense<128> : tensor<ui8>
+  %3 = "onnx.QuantizeLinear"(%arg0, %0, %1) {ResultNames = ["q0"], axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x128xui8>
+  %4 = "onnx.DequantizeLinear"(%3, %0, %1) {ResultNames = ["dq0"], axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x128xf32>
+  %6 = "onnx.QuantizeLinear"(%4, %0, %1) {ResultNames = ["q1"], axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x128xui8>
+  %7 = "onnx.DequantizeLinear"(%6, %0, %1) {ResultNames = ["dq1"], axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x128xf32>
+  return %7 : tensor<1x128xf32>
+}
+
+// CHECK-LABEL: @qdq_canonicalize
+// CHECK: onnx.QuantizeLinear
+// CHECK-SAME: ResultNames = ["q0"]
+// CHECK: onnx.DequantizeLinear
+// CHECK-SAME: ResultNames = ["dq1"]
 
 func.func @complex_names(%arg0: tensor<f32>) -> tensor<f32> {
   %0 = onnx.Constant {ResultNames = ["const0"]} dense<2.000000e+00> : tensor<f32>


### PR DESCRIPTION
- While copying TensorNames, we have to check if the replacement op already has ResultNames attribute, if yes, don't overwrite it with original op ResultNames.
- ~Should be careful while creating ops, it shouldn't directly copy attributes from an existing op, as it will copy the ResultNames along with it, and avoid populating new names.~
  - ~Fixed the above issue in QDQCanonicalize pass.~
- Always overwrite ResultNames when the replacement op is a newly created op. This is checked with `replOp.getUses().empty()`, as newly created op wouldn't have any uses yet.