### PR TITLE
Invert excluded-ops for ONNX to TOSA conversion

### DIFF
--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -119,8 +119,8 @@ public:
       llvm::cl::desc("If enabled, convert onnx.slice only if all steps are 1"),
       llvm::cl::ZeroOrMore, llvm::cl::init(false)};
   ListOption<std::string> excludedOps{*this, "excluded-ops",
-      llvm::cl::desc("ONNX op names to exclude from TOSA conversion "
-                     "(e.g. Gather,Cast)"),
+      llvm::cl::desc("TOSA op names to exclude from conversion "
+                     "(e.g. gather, cast)"),
       llvm::cl::ZeroOrMore};
 };
 
@@ -198,7 +198,7 @@ void FrontendToTosaLoweringPass::runOnOperation() {
       mlir::arith::ArithDialect, mlir::shape::ShapeDialect>();
 
   for (const std::string &opName : excludedOps)
-    target.addLegalOp(OperationName("onnx." + opName, context));
+    target.addIllegalOp(OperationName("tosa." + opName, context));
 
   // Define patterns
   populateONNXToTOSAConversionPattern(target, patterns, typeConverter, context,

--- a/test/mlir/conversion/onnx_to_tosa/Math/DisableCastLowering.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/DisableCastLowering.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa=excluded-ops=Cast -cse %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa=excluded-ops=cast -cse %s -split-input-file | FileCheck %s
 
 func.func @test_cast_f32_i8(%arg0: tensor<13x21x1xf32>) -> tensor<13x21x1xi8> {
   %0 = "onnx.Cast"(%arg0) {to = i8} : (tensor<13x21x1xf32>) -> tensor<13x21x1xi8>

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
@@ -1,5 +1,5 @@
 // RUN: onnx-mlir-opt --convert-onnx-to-tosa -cse %s -split-input-file | FileCheck %s
-// RUN: onnx-mlir-opt --convert-onnx-to-tosa="excluded-ops=Gather" -cse %s -split-input-file | FileCheck %s --check-prefix=EXCLUDE
+// RUN: onnx-mlir-opt --convert-onnx-to-tosa="excluded-ops=gather" -cse %s -split-input-file | FileCheck %s --check-prefix=EXCLUDE
 
 func.func @test_gather_axis0(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
   %indices = "onnx.Constant"() {value = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>} : () -> tensor<2x2xi64>
@@ -162,8 +162,8 @@ func.func @test_gather_like_slice(%arg0 : tensor<3x3xf32>) -> tensor<3xf32> {
 // CHECK:         return %[[VAL_2]]
 
 // EXCLUDE-LABEL:   func.func @test_gather_like_slice(
-// EXCLUDE:           onnx.Gather
-// EXCLUDE-NOT:       tosa.slice
+// EXCLUDE-NOT:       onnx.Gather
+// EXCLUDE:           tosa.slice
 }
 
 // -----
@@ -179,8 +179,8 @@ func.func @test_gather_like_slice_positive_integer(%arg0 : tensor<3x3xf32>) -> t
 // CHECK:         return %[[VAL_2]]
 
 // EXCLUDE-LABEL:   func.func @test_gather_like_slice_positive_integer(
-// EXCLUDE:           onnx.Gather
-// EXCLUDE-NOT:       tosa.slice
+// EXCLUDE-NOT:       onnx.Gather
+// EXCLUDE:           tosa.slice
 }
 
 // -----
@@ -196,8 +196,8 @@ func.func @test_gather_like_slice_negative_integer(%arg0 : tensor<3x3xf32>) -> t
 // CHECK:         return %[[VAL_2]]
 
 // EXCLUDE-LABEL:   func.func @test_gather_like_slice_negative_integer(
-// EXCLUDE:           onnx.Gather
-// EXCLUDE-NOT:       tosa.slice
+// EXCLUDE-NOT:       onnx.Gather
+// EXCLUDE:           tosa.slice
 }
 
 // -----


### PR DESCRIPTION
Instead of marking onnx.Gather as legal, we want to mark tosa.gather as illegal. This way, the conversion from onnx.Gather to tosa.slice still matches