### PR TITLE
Guard constprop patterns for quant types

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Math/Reduction.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/Reduction.cpp
@@ -405,6 +405,11 @@ OpFoldResult ONNXReduceMeanOp::fold(FoldAdaptor adaptor) {
   if (failed(shapeHelper.computeShape()))
     return nullptr;
 
+  if (auto elemType =
+          mlir::cast<ShapedType>(getData().getType()).getElementType();
+      !mlir::isa<IntegerType, FloatType>(elemType))
+    return nullptr;
+
   const bool hasReduction =
       llvm::any_of(shapeHelper.isReductionAxis, [](bool axis) { return axis; });
 

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Squeeze.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Squeeze.cpp
@@ -208,6 +208,10 @@ OpFoldResult ONNXSqueezeOp::fold(FoldAdaptor adaptor) {
   if (!hasStaticShape(getSqueezed().getType()))
     return nullptr;
 
+  if (mlir::cast<ShapedType>(getData().getType()).getElementType() !=
+      mlir::cast<ShapedType>(getSqueezed().getType()).getElementType())
+    return nullptr;
+
   OnnxElementsAttrBuilder elementsBuilder(getContext());
   return elementsBuilder.reshape(mlir::cast<ElementsAttr>(adaptor.getData()),
       getShape(getSqueezed().getType()));
@@ -222,6 +226,10 @@ OpFoldResult ONNXSqueezeV11Op::fold(FoldAdaptor adaptor) {
   }
 
   if (!hasStaticShape(getSqueezed().getType()))
+    return nullptr;
+
+  if (mlir::cast<ShapedType>(getData().getType()).getElementType() !=
+      mlir::cast<ShapedType>(getSqueezed().getType()).getElementType())
     return nullptr;
 
   OnnxElementsAttrBuilder elementsBuilder(getContext());

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -425,6 +425,7 @@ def AddConstProp : NamedPat<"AddConstProp",
     (CreateAddOfTwoConst $addOp, $lhs, $rhs),
     // Additional constraints (dense)
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs),
      (SatisfiesExpansionBound:$addOp), (HasStaticShape:$addOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
@@ -450,6 +451,7 @@ def SubConstProp : NamedPat<"SubConstProp",
     // To c1-c2
     (CreateSubOfTwoConst $subOp, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs),
      (SatisfiesExpansionBound:$subOp), (HasStaticShape:$subOp)]>;
 
 // TODO: Expand $a to $result's shape instead of requiring ValuesHaveSameType.
@@ -469,7 +471,7 @@ def CastofConst : NamedPat<"CastofConst",
     (ONNXCastOp:$castOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $saturate, $to),
     // To (c)
     (CreateCastOfConst $castOp, $input, $saturate, $to),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for BitwiseNot
 def BitwiseNotConstProp : NamedPat<"BitwiseNotofConst",
@@ -477,7 +479,7 @@ def BitwiseNotConstProp : NamedPat<"BitwiseNotofConst",
     (ONNXBitwiseNotOp:$bitwiseNotOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To ~c
     (CreateBitwiseNotOfConst $bitwiseNotOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Abs
 def AbsConstProp : NamedPat<"AbsofConst",
@@ -485,7 +487,7 @@ def AbsConstProp : NamedPat<"AbsofConst",
     (ONNXAbsOp:$ceilOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateAbsOfConst $ceilOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Ceil
 def CeilConstProp : NamedPat<"CeilofConst",
@@ -493,7 +495,7 @@ def CeilConstProp : NamedPat<"CeilofConst",
     (ONNXCeilOp:$ceilOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateCeilOfConst $ceilOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Cos
 def CosConstProp : NamedPat<"CosofConst",
@@ -501,7 +503,7 @@ def CosConstProp : NamedPat<"CosofConst",
     (ONNXCosOp:$cosOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateCosOfConst $cosOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Erf
 def ErfConstProp : NamedPat<"ErfofConst",
@@ -509,7 +511,7 @@ def ErfConstProp : NamedPat<"ErfofConst",
     (ONNXErfOp:$erfOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateErfOfConst $erfOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Exp
 def ExpConstProp : NamedPat<"ExpofConst",
@@ -517,7 +519,7 @@ def ExpConstProp : NamedPat<"ExpofConst",
     (ONNXExpOp:$expOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateExpOfConst $expOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Floor
 def FloorConstProp : NamedPat<"FloorofConst",
@@ -525,7 +527,7 @@ def FloorConstProp : NamedPat<"FloorofConst",
     (ONNXFloorOp:$floorOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateFloorOfConst $floorOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Log
 def LogConstProp : NamedPat<"LogofConst",
@@ -533,7 +535,7 @@ def LogConstProp : NamedPat<"LogofConst",
     (ONNXLogOp:$logOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateLogOfConst $logOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Neg of constant is simply -const
 def NegofConst : NamedPat<"NegofConst",
@@ -541,7 +543,7 @@ def NegofConst : NamedPat<"NegofConst",
     (ONNXNegOp:$negOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To (-c)
     (CreateNegOfConst $negOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Not of constant is simply !const
 def NotofConst : NamedPat<"NotofConst",
@@ -557,7 +559,7 @@ def SinConstProp : NamedPat<"SinofConst",
     (ONNXSinOp:$sinOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateSinOfConst $sinOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Sigmoid
 def SigmoidConstProp : NamedPat<"SigmoidofConst",
@@ -565,7 +567,7 @@ def SigmoidConstProp : NamedPat<"SigmoidofConst",
     (ONNXSigmoidOp:$sigmoidOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateSigmoidOfConst $sigmoidOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Reciprocal
 def ReciprocalConstProp : NamedPat<"ReciprocalofConst",
@@ -573,7 +575,7 @@ def ReciprocalConstProp : NamedPat<"ReciprocalofConst",
     (ONNXReciprocalOp:$reciprocalOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateReciprocalOfConst $reciprocalOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Round
 def RoundConstProp : NamedPat<"RoundofConst",
@@ -581,7 +583,7 @@ def RoundConstProp : NamedPat<"RoundofConst",
     (ONNXRoundOp:$roundOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateRoundOfConst $roundOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Change a subtraction of a constant c by an addition of -c. Helpfull to combine
 // with other add optimizations.
@@ -590,7 +592,8 @@ def SubConstToNeg : NamedPat<"SubConstToNeg",
     (ONNXSubOp:$subOp $x, (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To x + (-c).
     (ONNXAddOp $x, (CreateNegOfConst $input, $input)),
-    [(IsNotAConstant:$x), (IsFromDenseONNXConstantOp:$input)]>;
+    [(IsNotAConstant:$x), (IsFromDenseONNXConstantOp:$input),
+     (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Sqrt
 def SqrtofConst : NamedPat<"SqrtofConst",
@@ -598,7 +601,7 @@ def SqrtofConst : NamedPat<"SqrtofConst",
     (ONNXSqrtOp:$sqrtOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To sqrt(c)
     (CreateSqrtOfConst $sqrtOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Relu
 def ReluofConst : NamedPat<"ReluofConst",
@@ -606,7 +609,7 @@ def ReluofConst : NamedPat<"ReluofConst",
     (ONNXReluOp:$reluOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To relu(c)
     (CreateReluOfConst $reluOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Reciprocal
 def ReciprocalOfConst : NamedPat<"ReciprocalOfConst",
@@ -614,7 +617,7 @@ def ReciprocalOfConst : NamedPat<"ReciprocalOfConst",
     (ONNXReciprocalOp:$reciprocalOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To reciprocal(c)
     (CreateReciprocalOfConst $reciprocalOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Round
 def RoundofConst : NamedPat<"RoundofConst",
@@ -622,7 +625,7 @@ def RoundofConst : NamedPat<"RoundofConst",
     (ONNXRoundOp:$reluOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To round_even(c)
     (CreateRoundOfConst $reluOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 //===----------------------------------------------------------------------===//
 // Const propagation patterns for variadic elementwise operations.
@@ -636,6 +639,7 @@ def MaxConstProp : NamedPat<"MaxConstProp",
     (CreateMaxOfConst $maxOp, $operandList),
     // Constraints
     [(IsVariadicOperandDenseONNXConstantOp:$operandList),
+     (IsIntOrFloatType:$maxOp),
      (SatisfiesExpansionBound:$maxOp), (HasStaticShape:$maxOp)]>;
 
 // Constant Propagation for Min
@@ -646,6 +650,7 @@ def MinConstProp : NamedPat<"MinConstProp",
     (CreateMinOfConst $minOp, $operandList),
     // Constraints
     [(IsVariadicOperandDenseONNXConstantOp:$operandList),
+     (IsIntOrFloatType:$minOp),
      (SatisfiesExpansionBound:$minOp), (HasStaticShape:$minOp)]>;
 
 // Constant Propagation for Sum
@@ -656,6 +661,7 @@ def SumConstProp : NamedPat<"SumConstProp",
     (CreateSumOfConst $sumOp, $operandList),
     // Constraints
     [(IsVariadicOperandDenseONNXConstantOp:$operandList),
+     (IsIntOrFloatType:$sumOp),
      (SatisfiesExpansionBound:$sumOp), (HasStaticShape:$sumOp)]>;
 
 //===----------------------------------------------------------------------===//
@@ -730,6 +736,7 @@ def MulConstProp : NamedPat<"MulConstProp",
     (CreateMulOfTwoConst $mulOp, $lhs, $rhs),
     // Multiplication constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs),
      (SatisfiesExpansionBound:$mulOp), (HasStaticShape:$mulOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
@@ -755,6 +762,7 @@ def DivConstProp : NamedPat<"DivConstProp",
     (CreateDivOfTwoConst $divOp, $lhs, $rhs),
     // Division constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs),
      (SatisfiesExpansionBound:$divOp), (HasStaticShape:$divOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
@@ -781,6 +789,7 @@ def BitwiseAndConstPropPattern : NamedPat<"BitwiseAndConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateBitwiseAndOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -793,6 +802,7 @@ def BitwiseOrConstPropPattern : NamedPat<"BitwiseOrConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateBitwiseOrOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -856,6 +866,7 @@ def LessConstPropPattern : NamedPat<"LessConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateLessOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -868,6 +879,7 @@ def GreaterConstPropPattern : NamedPat<"GreaterConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateGreaterOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -880,6 +892,7 @@ def LessOrEqualConstPropPattern : NamedPat<"LessOrEqualConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateLessOrEqualOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -892,6 +905,7 @@ def GreaterOrEqualConstPropPattern : NamedPat<"GreaterOrEqualConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateGreaterOrEqualOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -905,6 +919,7 @@ def ModConstPropPattern : NamedPat<"ModConstPropPattern",
       $fmod),
     (CreateModOfTwoConst  $modOp, $A, $B),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B),
+    (IsIntOrFloatType:$A),
     (SatisfiesExpansionBound:$modOp), (HasStaticShape:$modOp)]>;
 
 //===----------------------------------------------------------------------===//
@@ -926,7 +941,7 @@ def ClipConstProp : NamedPat<"ClipConstProp",
       (CreateONNXMaxOp $clipOp, $input, (CreateMinimumValueForClip $input, $min)),
       (CreateMaximumValueForClip $input, $max)),
     // Clip constraints
-    [(IsFromDenseONNXConstantOp:$input),
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
      (IsFromDenseONNXConstantOpOrNone:$min), (IsFromDenseONNXConstantOpOrNone:$max),
      (SatisfiesExpansionBound:$clipOp)]>;
 
@@ -945,6 +960,7 @@ def WhereConstProp : NamedPat<"WhereConstProp",
     // Where constraints
     [(IsFromDenseONNXConstantOp:$condition),
      (IsFromDenseONNXConstantOp:$X), (IsFromDenseONNXConstantOp:$Y),
+     (IsIntOrFloatType:$X),
      (SatisfiesExpansionBound:$whereOp), (HasStaticShape:$whereOp)]>;
 
 //===----------------------------------------------------------------------===//
@@ -958,7 +974,8 @@ def ReduceSumConstProp : NamedPat<"ReduceSumConstProp",
         $_,
         $_),
     (CreateReduceSumConst $reduceSumOp, $data, $axes),
-    [(IsFromDenseONNXConstantOp:$data), (IsFromDenseONNXConstantOpOrNone:$axes)]
+    [(IsFromDenseONNXConstantOp:$data), (IsIntOrFloatType:$data),
+     (IsFromDenseONNXConstantOpOrNone:$axes)]
     >;
 
 def ReduceProdConstProp : NamedPat<"ReduceProdConstProp",
@@ -968,7 +985,8 @@ def ReduceProdConstProp : NamedPat<"ReduceProdConstProp",
         $_,
         $_),
     (CreateReduceProdConst $reduceProdOp, $data, $axes),
-    [(IsFromDenseONNXConstantOp:$data), (IsFromDenseONNXConstantOpOrNone:$axes)]
+    [(IsFromDenseONNXConstantOp:$data), (IsIntOrFloatType:$data),
+     (IsFromDenseONNXConstantOpOrNone:$axes)]
     >;
 
 def ReduceMinConstProp : NamedPat<"ReduceMinConstProp",
@@ -978,7 +996,8 @@ def ReduceMinConstProp : NamedPat<"ReduceMinConstProp",
         $_,
         $_),
     (CreateReduceMinConst $reduceMinOp, $data, $axes),
-    [(IsFromDenseONNXConstantOp:$data), (IsFromDenseONNXConstantOpOrNone:$axes)]
+    [(IsFromDenseONNXConstantOp:$data), (IsIntOrFloatType:$data),
+     (IsFromDenseONNXConstantOpOrNone:$axes)]
     >;
 
 def ReduceMaxConstProp : NamedPat<"ReduceMaxConstProp",
@@ -988,7 +1007,8 @@ def ReduceMaxConstProp : NamedPat<"ReduceMaxConstProp",
         $_,
         $_),
     (CreateReduceMaxConst $reduceMaxOp, $data, $axes),
-    [(IsFromDenseONNXConstantOp:$data), (IsFromDenseONNXConstantOpOrNone:$axes)]
+    [(IsFromDenseONNXConstantOp:$data), (IsIntOrFloatType:$data),
+     (IsFromDenseONNXConstantOpOrNone:$axes)]
     >;
 
 def ReduceMeanConstProp : NamedPat<"ReduceMeanConstProp",
@@ -998,7 +1018,8 @@ def ReduceMeanConstProp : NamedPat<"ReduceMeanConstProp",
         $_,
         $_),
     (CreateReduceMeanConst $reduceMeanOp, $data, $axes),
-    [(IsFromDenseONNXConstantOp:$data), (IsFromDenseONNXConstantOpOrNone:$axes)]
+    [(IsFromDenseONNXConstantOp:$data), (IsIntOrFloatType:$data),
+     (IsFromDenseONNXConstantOpOrNone:$axes)]
     >;
 
 //===----------------------------------------------------------------------===//
@@ -1034,6 +1055,7 @@ def MatMulOfConsts : NamedPat<"MatMulOfConsts",
     ),
     (CreateMatMulOfConsts $resOp, $A, $B),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B),
+     (IsIntOrFloatType:$A),
      (SatisfiesExpansionBound:$resOp)]
     >;
 
@@ -1087,6 +1109,7 @@ def GemmConstProp : NamedPat<"GemmConstProp",
       $C, $alpha, $beta, $transA, $transB),
     (CreateGemmOfConsts $gemmOp, $A, $B, $C),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B),
+     (IsIntOrFloatType:$A),
      (IsFromDenseONNXConstantOpOrNone:$C),
      (SatisfiesExpansionBound:$gemmOp), (HasStaticShape:$gemmOp)]>;
 
@@ -1264,7 +1287,7 @@ def RangeConstProp : NamedPat<"RangeConstProp",
 def NonZeroOfConst : NamedPat<"NonZeroOfConst",
     (ONNXNonZeroOp:$nonZeroOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateNonZeroOfConst $nonZeroOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns for ScatterND.
@@ -1294,6 +1317,7 @@ def PowConstProp : NamedPat<"PowConstProp",
     (CreatePowOfTwoConst $powOp, $lhs, $rhs),
     // Power constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs),
      (SatisfiesExpansionBound:$powOp), (ValuesHaveSameDType $lhs, $rhs),
      (HasStaticShape:$powOp)]>;
 

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -479,7 +479,8 @@ def BitwiseNotConstProp : NamedPat<"BitwiseNotofConst",
     (ONNXBitwiseNotOp:$bitwiseNotOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To ~c
     (CreateBitwiseNotOfConst $bitwiseNotOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $bitwiseNotOp, $input)]>;
 
 // Constant Propagation for Abs
 def AbsConstProp : NamedPat<"AbsofConst",
@@ -487,7 +488,8 @@ def AbsConstProp : NamedPat<"AbsofConst",
     (ONNXAbsOp:$ceilOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateAbsOfConst $ceilOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $ceilOp, $input)]>;
 
 // Constant Propagation for Ceil
 def CeilConstProp : NamedPat<"CeilofConst",
@@ -495,7 +497,8 @@ def CeilConstProp : NamedPat<"CeilofConst",
     (ONNXCeilOp:$ceilOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateCeilOfConst $ceilOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $ceilOp, $input)]>;
 
 // Constant Propagation for Cos
 def CosConstProp : NamedPat<"CosofConst",
@@ -503,7 +506,8 @@ def CosConstProp : NamedPat<"CosofConst",
     (ONNXCosOp:$cosOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateCosOfConst $cosOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $cosOp, $input)]>;
 
 // Constant Propagation for Erf
 def ErfConstProp : NamedPat<"ErfofConst",
@@ -511,7 +515,8 @@ def ErfConstProp : NamedPat<"ErfofConst",
     (ONNXErfOp:$erfOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateErfOfConst $erfOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $erfOp, $input)]>;
 
 // Constant Propagation for Exp
 def ExpConstProp : NamedPat<"ExpofConst",
@@ -519,7 +524,8 @@ def ExpConstProp : NamedPat<"ExpofConst",
     (ONNXExpOp:$expOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateExpOfConst $expOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $expOp, $input)]>;
 
 // Constant Propagation for Floor
 def FloorConstProp : NamedPat<"FloorofConst",
@@ -527,7 +533,8 @@ def FloorConstProp : NamedPat<"FloorofConst",
     (ONNXFloorOp:$floorOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateFloorOfConst $floorOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $floorOp, $input)]>;
 
 // Constant Propagation for Log
 def LogConstProp : NamedPat<"LogofConst",
@@ -535,7 +542,8 @@ def LogConstProp : NamedPat<"LogofConst",
     (ONNXLogOp:$logOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateLogOfConst $logOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $logOp, $input)]>;
 
 // Neg of constant is simply -const
 def NegofConst : NamedPat<"NegofConst",
@@ -543,7 +551,8 @@ def NegofConst : NamedPat<"NegofConst",
     (ONNXNegOp:$negOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To (-c)
     (CreateNegOfConst $negOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $negOp, $input)]>;
 
 // Not of constant is simply !const
 def NotofConst : NamedPat<"NotofConst",
@@ -551,7 +560,8 @@ def NotofConst : NamedPat<"NotofConst",
     (ONNXNotOp:$notOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To !c
     (CreateNotOfConst $notOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input),
+     (ValuesHaveSameDType $notOp, $input)]>;
 
 // Constant Propagation for Sin
 def SinConstProp : NamedPat<"SinofConst",
@@ -559,7 +569,8 @@ def SinConstProp : NamedPat<"SinofConst",
     (ONNXSinOp:$sinOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateSinOfConst $sinOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $sinOp, $input)]>;
 
 // Constant Propagation for Sigmoid
 def SigmoidConstProp : NamedPat<"SigmoidofConst",
@@ -567,7 +578,8 @@ def SigmoidConstProp : NamedPat<"SigmoidofConst",
     (ONNXSigmoidOp:$sigmoidOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateSigmoidOfConst $sigmoidOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $sigmoidOp, $input)]>;
 
 // Constant Propagation for Reciprocal
 def ReciprocalConstProp : NamedPat<"ReciprocalofConst",
@@ -575,7 +587,8 @@ def ReciprocalConstProp : NamedPat<"ReciprocalofConst",
     (ONNXReciprocalOp:$reciprocalOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateReciprocalOfConst $reciprocalOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $reciprocalOp, $input)]>;
 
 // Constant Propagation for Round
 def RoundConstProp : NamedPat<"RoundofConst",
@@ -583,7 +596,8 @@ def RoundConstProp : NamedPat<"RoundofConst",
     (ONNXRoundOp:$roundOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateRoundOfConst $roundOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $roundOp, $input)]>;
 
 // Change a subtraction of a constant c by an addition of -c. Helpfull to combine
 // with other add optimizations.
@@ -601,7 +615,8 @@ def SqrtofConst : NamedPat<"SqrtofConst",
     (ONNXSqrtOp:$sqrtOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To sqrt(c)
     (CreateSqrtOfConst $sqrtOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $sqrtOp, $input)]>;
 
 // Constant Propagation for Relu
 def ReluofConst : NamedPat<"ReluofConst",
@@ -609,7 +624,8 @@ def ReluofConst : NamedPat<"ReluofConst",
     (ONNXReluOp:$reluOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To relu(c)
     (CreateReluOfConst $reluOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $reluOp, $input)]>;
 
 // Constant Propagation for Reciprocal
 def ReciprocalOfConst : NamedPat<"ReciprocalOfConst",
@@ -617,7 +633,8 @@ def ReciprocalOfConst : NamedPat<"ReciprocalOfConst",
     (ONNXReciprocalOp:$reciprocalOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To reciprocal(c)
     (CreateReciprocalOfConst $reciprocalOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $reciprocalOp, $input)]>;
 
 // Constant Propagation for Round
 def RoundofConst : NamedPat<"RoundofConst",
@@ -625,7 +642,8 @@ def RoundofConst : NamedPat<"RoundofConst",
     (ONNXRoundOp:$reluOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To round_even(c)
     (CreateRoundOfConst $reluOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
+     (ValuesHaveSameDType $reluOp, $input)]>;
 
 //===----------------------------------------------------------------------===//
 // Const propagation patterns for variadic elementwise operations.
@@ -1122,7 +1140,7 @@ def TransposeofConst : NamedPat<"TransposeofConst",
     (ONNXTransposeOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is transposed attribute
     (CreateTransposeOfConst $resOp, $input),
-    [(IsFromDenseONNXConstantOp:$input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (ValuesHaveSameDType $resOp, $input)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with ReverseSequence operations.

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -425,7 +425,7 @@ def AddConstProp : NamedPat<"AddConstProp",
     (CreateAddOfTwoConst $addOp, $lhs, $rhs),
     // Additional constraints (dense)
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$addOp), (HasStaticShape:$addOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
@@ -451,7 +451,7 @@ def SubConstProp : NamedPat<"SubConstProp",
     // To c1-c2
     (CreateSubOfTwoConst $subOp, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$subOp), (HasStaticShape:$subOp)]>;
 
 // TODO: Expand $a to $result's shape instead of requiring ValuesHaveSameType.
@@ -479,8 +479,7 @@ def BitwiseNotConstProp : NamedPat<"BitwiseNotofConst",
     (ONNXBitwiseNotOp:$bitwiseNotOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To ~c
     (CreateBitwiseNotOfConst $bitwiseNotOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $bitwiseNotOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Abs
 def AbsConstProp : NamedPat<"AbsofConst",
@@ -488,8 +487,7 @@ def AbsConstProp : NamedPat<"AbsofConst",
     (ONNXAbsOp:$ceilOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateAbsOfConst $ceilOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $ceilOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Ceil
 def CeilConstProp : NamedPat<"CeilofConst",
@@ -497,8 +495,7 @@ def CeilConstProp : NamedPat<"CeilofConst",
     (ONNXCeilOp:$ceilOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateCeilOfConst $ceilOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $ceilOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Cos
 def CosConstProp : NamedPat<"CosofConst",
@@ -506,8 +503,7 @@ def CosConstProp : NamedPat<"CosofConst",
     (ONNXCosOp:$cosOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateCosOfConst $cosOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $cosOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Erf
 def ErfConstProp : NamedPat<"ErfofConst",
@@ -515,8 +511,7 @@ def ErfConstProp : NamedPat<"ErfofConst",
     (ONNXErfOp:$erfOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateErfOfConst $erfOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $erfOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Exp
 def ExpConstProp : NamedPat<"ExpofConst",
@@ -524,8 +519,7 @@ def ExpConstProp : NamedPat<"ExpofConst",
     (ONNXExpOp:$expOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateExpOfConst $expOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $expOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Floor
 def FloorConstProp : NamedPat<"FloorofConst",
@@ -533,8 +527,7 @@ def FloorConstProp : NamedPat<"FloorofConst",
     (ONNXFloorOp:$floorOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateFloorOfConst $floorOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $floorOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Log
 def LogConstProp : NamedPat<"LogofConst",
@@ -542,8 +535,7 @@ def LogConstProp : NamedPat<"LogofConst",
     (ONNXLogOp:$logOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateLogOfConst $logOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $logOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Neg of constant is simply -const
 def NegofConst : NamedPat<"NegofConst",
@@ -551,8 +543,7 @@ def NegofConst : NamedPat<"NegofConst",
     (ONNXNegOp:$negOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To (-c)
     (CreateNegOfConst $negOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $negOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Not of constant is simply !const
 def NotofConst : NamedPat<"NotofConst",
@@ -560,8 +551,7 @@ def NotofConst : NamedPat<"NotofConst",
     (ONNXNotOp:$notOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To !c
     (CreateNotOfConst $notOp, $input),
-    [(IsFromDenseONNXConstantOp:$input),
-     (ValuesHaveSameDType $notOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Sin
 def SinConstProp : NamedPat<"SinofConst",
@@ -569,8 +559,7 @@ def SinConstProp : NamedPat<"SinofConst",
     (ONNXSinOp:$sinOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateSinOfConst $sinOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $sinOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Sigmoid
 def SigmoidConstProp : NamedPat<"SigmoidofConst",
@@ -578,8 +567,7 @@ def SigmoidConstProp : NamedPat<"SigmoidofConst",
     (ONNXSigmoidOp:$sigmoidOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateSigmoidOfConst $sigmoidOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $sigmoidOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Reciprocal
 def ReciprocalConstProp : NamedPat<"ReciprocalofConst",
@@ -587,8 +575,7 @@ def ReciprocalConstProp : NamedPat<"ReciprocalofConst",
     (ONNXReciprocalOp:$reciprocalOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c
     (CreateReciprocalOfConst $reciprocalOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $reciprocalOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Round
 def RoundConstProp : NamedPat<"RoundofConst",
@@ -596,8 +583,7 @@ def RoundConstProp : NamedPat<"RoundofConst",
     (ONNXRoundOp:$roundOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To new_c.
     (CreateRoundOfConst $roundOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $roundOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Change a subtraction of a constant c by an addition of -c. Helpfull to combine
 // with other add optimizations.
@@ -615,8 +601,7 @@ def SqrtofConst : NamedPat<"SqrtofConst",
     (ONNXSqrtOp:$sqrtOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To sqrt(c)
     (CreateSqrtOfConst $sqrtOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $sqrtOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Relu
 def ReluofConst : NamedPat<"ReluofConst",
@@ -624,8 +609,7 @@ def ReluofConst : NamedPat<"ReluofConst",
     (ONNXReluOp:$reluOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To relu(c)
     (CreateReluOfConst $reluOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $reluOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Reciprocal
 def ReciprocalOfConst : NamedPat<"ReciprocalOfConst",
@@ -633,8 +617,7 @@ def ReciprocalOfConst : NamedPat<"ReciprocalOfConst",
     (ONNXReciprocalOp:$reciprocalOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To reciprocal(c)
     (CreateReciprocalOfConst $reciprocalOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $reciprocalOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 // Constant Propagation for Round
 def RoundofConst : NamedPat<"RoundofConst",
@@ -642,8 +625,7 @@ def RoundofConst : NamedPat<"RoundofConst",
     (ONNXRoundOp:$reluOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To round_even(c)
     (CreateRoundOfConst $reluOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input),
-     (ValuesHaveSameDType $reluOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsIntOrFloatType:$input)]>;
 
 //===----------------------------------------------------------------------===//
 // Const propagation patterns for variadic elementwise operations.
@@ -754,7 +736,7 @@ def MulConstProp : NamedPat<"MulConstProp",
     (CreateMulOfTwoConst $mulOp, $lhs, $rhs),
     // Multiplication constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$mulOp), (HasStaticShape:$mulOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
@@ -780,7 +762,7 @@ def DivConstProp : NamedPat<"DivConstProp",
     (CreateDivOfTwoConst $divOp, $lhs, $rhs),
     // Division constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$divOp), (HasStaticShape:$divOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
@@ -807,7 +789,7 @@ def BitwiseAndConstPropPattern : NamedPat<"BitwiseAndConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateBitwiseAndOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -820,7 +802,7 @@ def BitwiseOrConstPropPattern : NamedPat<"BitwiseOrConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateBitwiseOrOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -833,6 +815,7 @@ def AndConstPropPattern : NamedPat<"AndConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateAndOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -845,6 +828,7 @@ def OrConstPropPattern : NamedPat<"OrConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateOrOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -857,6 +841,7 @@ def XorConstPropPattern : NamedPat<"XorConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateXorOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -872,7 +857,8 @@ def EqualConstProp : NamedPat<"EqualConstProp",
     (CreateEqualOfTwoConst $result, $lhs, $rhs),
     // constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs), (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
+     (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagation for ONNXLessOp
@@ -884,7 +870,7 @@ def LessConstPropPattern : NamedPat<"LessConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateLessOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -897,7 +883,7 @@ def GreaterConstPropPattern : NamedPat<"GreaterConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateGreaterOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -910,7 +896,7 @@ def LessOrEqualConstPropPattern : NamedPat<"LessOrEqualConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateLessOrEqualOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -923,7 +909,7 @@ def GreaterOrEqualConstPropPattern : NamedPat<"GreaterOrEqualConstPropPattern",
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateGreaterOrEqualOfTwoConst $result, $lhs, $rhs),
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$result), (HasStaticShape:$result)]>;
 
 //===----------------------------------------------------------------------===//
@@ -937,7 +923,7 @@ def ModConstPropPattern : NamedPat<"ModConstPropPattern",
       $fmod),
     (CreateModOfTwoConst  $modOp, $A, $B),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B),
-    (IsIntOrFloatType:$A),
+    (IsIntOrFloatType:$A), (IsIntOrFloatType:$B),
     (SatisfiesExpansionBound:$modOp), (HasStaticShape:$modOp)]>;
 
 //===----------------------------------------------------------------------===//
@@ -978,7 +964,7 @@ def WhereConstProp : NamedPat<"WhereConstProp",
     // Where constraints
     [(IsFromDenseONNXConstantOp:$condition),
      (IsFromDenseONNXConstantOp:$X), (IsFromDenseONNXConstantOp:$Y),
-     (IsIntOrFloatType:$X),
+     (IsIntOrFloatType:$X), (IsIntOrFloatType:$Y),
      (SatisfiesExpansionBound:$whereOp), (HasStaticShape:$whereOp)]>;
 
 //===----------------------------------------------------------------------===//
@@ -1073,7 +1059,7 @@ def MatMulOfConsts : NamedPat<"MatMulOfConsts",
     ),
     (CreateMatMulOfConsts $resOp, $A, $B),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B),
-     (IsIntOrFloatType:$A),
+     (IsIntOrFloatType:$A), (IsIntOrFloatType:$B),
      (SatisfiesExpansionBound:$resOp)]
     >;
 
@@ -1127,7 +1113,7 @@ def GemmConstProp : NamedPat<"GemmConstProp",
       $C, $alpha, $beta, $transA, $transB),
     (CreateGemmOfConsts $gemmOp, $A, $B, $C),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B),
-     (IsIntOrFloatType:$A),
+     (IsIntOrFloatType:$A), (IsIntOrFloatType:$B),
      (IsFromDenseONNXConstantOpOrNone:$C),
      (SatisfiesExpansionBound:$gemmOp), (HasStaticShape:$gemmOp)]>;
 
@@ -1151,7 +1137,8 @@ def ReverseSequenceofConst : NamedPat<"ReverseSequenceofConst",
     (ONNXReverseSequenceOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_),
                       (ONNXConstantOp:$sequence_lens $_, $_, $_, $_, $_, $_, $_, $_), $batch_axis, $time_axis),
     (CreateReverseSequenceOfConst $resOp, $input, $sequence_lens),
-    [(IsFromDenseONNXConstantOp:$input),(IsFromDenseONNXConstantOp:$sequence_lens)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsFromDenseONNXConstantOp:$sequence_lens),
+     (ValuesHaveSameDType $resOp, $input)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Unsqueeze operations.
@@ -1162,14 +1149,16 @@ def UnsqueezeofConst : NamedPat<"UnsqueezeofConst",
     (ONNXUnsqueezeOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
     (CreateUnsqueezeOfConst $resOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp)]>;
+    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp),
+     (ValuesHaveSameDType $resOp, $input)]>;
 
 def UnsqueezeV11ofConst : NamedPat<"UnsqueezeV11ofConst",
     // From Unsqueeze (c, axis)
     (ONNXUnsqueezeV11Op:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
     (CreateUnsqueezeOfConst $resOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp)]>;
+    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp),
+     (ValuesHaveSameDType $resOp, $input)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Squeeze operations.
@@ -1180,14 +1169,16 @@ def SqueezeofConst : NamedPat<"SqueezeofConst",
     (ONNXSqueezeOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
     (CreateSqueezeOfConst $resOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp)]>;
+    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp),
+     (ValuesHaveSameDType $resOp, $input)]>;
 
 def SqueezeV11ofConst : NamedPat<"SqueezeV11ofConst",
     // From Squeeze (c, axis)
     (ONNXSqueezeV11Op:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
     (CreateSqueezeOfConst $resOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp)]>;
+    [(IsFromDenseONNXConstantOp:$input), (HasStaticShape:$resOp),
+     (ValuesHaveSameDType $resOp, $input)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Slice operations.
@@ -1201,7 +1192,8 @@ def SliceofConst : NamedPat<"SliceofConst",
     (CreateSliceOfConst $resOp, $input),
     [(IsFromDenseONNXConstantOp:$input), (IsFromDenseONNXConstantOp:$starts),
      (IsFromDenseONNXConstantOp:$ends), (IsFromDenseONNXConstantOpOrNone:$axes),
-     (IsFromDenseONNXConstantOpOrNone:$steps), (HasStaticShape:$resOp)]>;
+     (IsFromDenseONNXConstantOpOrNone:$steps), (HasStaticShape:$resOp),
+     (ValuesHaveSameDType $resOp, $input)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns for Pad.
@@ -1216,7 +1208,7 @@ def PadOfConst : NamedPat<"PadOfConst",
     (CreatePadOfConst $resOp, $input, $constant_value),
     [(IsFromDenseONNXConstantOp:$pads),
      (IsFromDenseONNXConstantOpOrNone:$constant_value),
-     (IsNoneType:$axes),
+     (IsNoneType:$axes), (IsIntOrFloatType:$input),
      (EqualString<"constant"> $mode)]>;
 
 //===----------------------------------------------------------------------===//
@@ -1226,7 +1218,8 @@ def PadOfConst : NamedPat<"PadOfConst",
 def ConcatofConst : NamedPat<"ConcatofConst",
   (ONNXConcatOp:$resOp $input, $axis),
   (CreateConcatOfConst $resOp, $input, $axis),
-  [(IsVariadicOperandDenseONNXConstantOp:$input), (IsRankedShapedType:$resOp)]
+  [(IsVariadicOperandDenseONNXConstantOp:$input), (IsRankedShapedType:$resOp),
+   (IsIntOrFloatType:$resOp)]
 >;
 
 //===----------------------------------------------------------------------===//
@@ -1240,7 +1233,7 @@ def ExpandofConst : NamedPat<"ExpandofConst",
     // To c where c is the expanded value.
     (CreateExpandOfConst $resOp, $input),
     [(IsFromDenseONNXConstantOp:$input), (IsFromDenseONNXConstantOp:$shape),
-     (HasStaticShape:$resOp),
+     (HasStaticShape:$resOp), (ValuesHaveSameDType $resOp, $input),
      (SatisfiesExpansionBound:$resOp)]>;
 
 //===----------------------------------------------------------------------===//
@@ -1254,7 +1247,8 @@ def GatherofConst : NamedPat<"GatherofConst",
                          $_),
     // To c' where c' is the gathered value.
     (CreateGatherOfConst $resOp, $input, $indices),
-    [(IsFromDenseONNXConstantOp:$input), (IsFromDenseONNXConstantOp:$indices)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsFromDenseONNXConstantOp:$indices),
+     (ValuesHaveSameDType $resOp, $input)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Reshape operations.
@@ -1268,7 +1262,7 @@ def ReshapeofConst : NamedPat<"ReshapeofConst",
     // To c where c is the reshaped value.
     (CreateReshapeOfConst $resOp, $input),
     [(IsFromDenseONNXConstantOp:$input), (IsFromDenseONNXConstantOp:$shape),
-     (HasStaticShape:$resOp)]>;
+     (HasStaticShape:$resOp), (ValuesHaveSameDType $resOp, $input)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with ConstantOfShape operations.
@@ -1280,7 +1274,7 @@ def ConstantOfShapeofConst : NamedPat<"ConstantOfShapeofConst",
     // To c where c is the expanded value.
     (CreateConstantOfShapeOfConst $resOp, $shape, $value),
     [(IsFromDenseONNXConstantOp:$shape),
-     (HasStaticShape:$resOp)]>;
+     (HasStaticShape:$resOp), (IsIntOrFloatType:$resOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns for Range.
@@ -1296,7 +1290,9 @@ def RangeConstProp : NamedPat<"RangeConstProp",
     // dim size max(ceil((c1 - c0) / c2), 0).
     (CreateRangeOfThreeConst $rangeOp, $start, $limit, $delta),
     [(IsFromDenseONNXConstantOp:$start), (IsFromDenseONNXConstantOp:$limit),
-     (IsFromDenseONNXConstantOp:$delta), (HasStaticShape:$rangeOp)]>;
+     (IsFromDenseONNXConstantOp:$delta), (HasStaticShape:$rangeOp),
+     (IsIntOrFloatType:$start), (IsIntOrFloatType:$limit),
+     (IsIntOrFloatType:$delta)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns for NonZero.
@@ -1321,6 +1317,7 @@ def ScatterNDOfConst : NamedPat<"ScatterNDOfConst",
     [(IsFromDenseONNXConstantOp:$data),
      (IsFromDenseONNXConstantOp:$indices),
      (IsFromDenseONNXConstantOp:$updates),
+     (IsIntOrFloatType:$data), (IsIntOrFloatType:$updates),
      (EqualString<"none"> $reduction)]>;
 
 //===----------------------------------------------------------------------===//
@@ -1335,7 +1332,7 @@ def PowConstProp : NamedPat<"PowConstProp",
     (CreatePowOfTwoConst $powOp, $lhs, $rhs),
     // Power constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsIntOrFloatType:$lhs),
+     (IsIntOrFloatType:$lhs), (IsIntOrFloatType:$rhs),
      (SatisfiesExpansionBound:$powOp), (ValuesHaveSameDType $lhs, $rhs),
      (HasStaticShape:$powOp)]>;
 

--- a/test/mlir/onnx/onnx_constprop_quant.mlir
+++ b/test/mlir/onnx/onnx_constprop_quant.mlir
@@ -1,10 +1,9 @@
 // Verify that quant-types followed by constprop-onnx does not crash or
 // miscompute. The IsIntOrFloatType constraint on element-wise const-prop
-// patterns causes them to skip quantized-typed constants, and the
-// ValuesHaveSameDType constraint on unary (like Transpose) patterns ensures
-// const-prop is skipped when input/output element types differ (e.g. one
-// side is quantized and the other is not, or different quantization
-// parameters).
+// patterns causes them to skip quantized-typed constants. For rearrangement
+// ops (like Transpose), the ValuesHaveSameDType constraint ensures const-prop
+// is skipped when input/output element types differ (e.g. one side is
+// quantized and the other is not, or different quantization parameters).
 
 // RUN: onnx-mlir-opt %s --quant-types --constprop-onnx | FileCheck %s
 
@@ -191,7 +190,8 @@ func.func @reduce_sum_quantized_constant() -> tensor<1xf32> {
 // CHECK:         quant.scast
 
 
-// Unary ops with quantized input (from DQL) but no Q on output — should NOT be folded.
+// Unary ops with quantized input (from DQL) but no Q on output — should NOT
+// be folded because IsIntOrFloatType blocks quantized inputs.
 
 func.func @neg_quantized_input_float_output() -> tensor<2xf32> {
   %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
@@ -452,3 +452,125 @@ func.func @transpose_quantized_constant() -> tensor<2x1xf32> {
 // CHECK-NOT:     onnx.Transpose
 // CHECK:         onnx.Constant
 // CHECK:         quant.scast
+
+
+// Reshape with quantized input but float output — should NOT be folded
+func.func @reshape_quantized_input_float_output() -> tensor<1x2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %shape = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+  %r = "onnx.Reshape"(%a_dq, %shape) {allowzero = 0 : si64} : (tensor<2xf32>, tensor<2xi64>) -> tensor<1x2xf32>
+
+  return %r : tensor<1x2xf32>
+}
+
+// CHECK-LABEL: @reshape_quantized_input_float_output
+// CHECK:         onnx.Reshape
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>, tensor<2xi64>) -> tensor<1x2xf32>
+
+
+// Reshape with matching input/output quantized types — should still be folded
+func.func @reshape_quantized_constant() -> tensor<1x2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %shape = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+  %r = "onnx.Reshape"(%a_dq, %shape) {allowzero = 0 : si64} : (tensor<2xf32>, tensor<2xi64>) -> tensor<1x2xf32>
+
+  %out_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %out_zp = onnx.Constant dense<0> : tensor<ui8>
+  %q = "onnx.QuantizeLinear"(%r, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x2xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+
+  return %final : tensor<1x2xf32>
+}
+
+// CHECK-LABEL: @reshape_quantized_constant
+// CHECK-NOT:     onnx.Reshape
+// CHECK:         onnx.Constant
+// CHECK:         quant.scast
+
+
+// Unsqueeze with quantized input but float output — should NOT be folded
+func.func @unsqueeze_quantized_input_float_output() -> tensor<1x2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %axes = onnx.Constant dense<[0]> : tensor<1xi64>
+  %r = "onnx.Unsqueeze"(%a_dq, %axes) : (tensor<2xf32>, tensor<1xi64>) -> tensor<1x2xf32>
+
+  return %r : tensor<1x2xf32>
+}
+
+// CHECK-LABEL: @unsqueeze_quantized_input_float_output
+// CHECK:         onnx.Unsqueeze
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>, tensor<1xi64>) -> tensor<1x2xf32>
+
+
+// Squeeze with quantized input but float output — should NOT be folded
+func.func @squeeze_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[[10, 20]]> : tensor<1x2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+
+  %axes = onnx.Constant dense<[0]> : tensor<1xi64>
+  %r = "onnx.Squeeze"(%a_dq, %axes) : (tensor<1x2xf32>, tensor<1xi64>) -> tensor<2xf32>
+
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @squeeze_quantized_input_float_output
+// CHECK:         onnx.Squeeze
+// CHECK-SAME:      (tensor<1x2x!quant.uniform<u8:f32, 5.000000e-01>>, tensor<1xi64>) -> tensor<2xf32>
+
+
+// Gather with quantized input but float output — should NOT be folded
+func.func @gather_quantized_input_float_output() -> tensor<1xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %indices = onnx.Constant dense<[0]> : tensor<1xi64>
+  %r = "onnx.Gather"(%a_dq, %indices) {axis = 0 : si64} : (tensor<2xf32>, tensor<1xi64>) -> tensor<1xf32>
+
+  return %r : tensor<1xf32>
+}
+
+// CHECK-LABEL: @gather_quantized_input_float_output
+// CHECK:         onnx.Gather
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>, tensor<1xi64>) -> tensor<1xf32>
+
+
+// Slice with quantized input but float output — should NOT be folded
+func.func @slice_quantized_input_float_output() -> tensor<1xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %starts = onnx.Constant dense<[0]> : tensor<1xi64>
+  %ends = onnx.Constant dense<[1]> : tensor<1xi64>
+  %axes = onnx.Constant dense<[0]> : tensor<1xi64>
+  %r = "onnx.Slice"(%a_dq, %starts, %ends, %axes, %axes) : (tensor<2xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xf32>
+
+  return %r : tensor<1xf32>
+}
+
+// CHECK-LABEL: @slice_quantized_input_float_output
+// CHECK:         onnx.Slice
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>

--- a/test/mlir/onnx/onnx_constprop_quant.mlir
+++ b/test/mlir/onnx/onnx_constprop_quant.mlir
@@ -574,3 +574,25 @@ func.func @slice_quantized_input_float_output() -> tensor<1xf32> {
 // CHECK-LABEL: @slice_quantized_input_float_output
 // CHECK:         onnx.Slice
 // CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>
+
+
+// ReduceMean noop fold with quantized input — should NOT be folded.
+// The fold method returns getData() when there are no reduction axes and
+// noop_with_empty_axes is set; the IsIntOrFloatType guard prevents a type
+// mismatch between the quantized input and the float result.
+func.func @reduce_mean_noop_quantized_input_float_output() -> tensor<1xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %none = "onnx.NoValue"() {value} : () -> none
+  %r = "onnx.ReduceMean"(%a_dq, %none) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2xf32>, none) -> tensor<1xf32>
+
+  return %r : tensor<1xf32>
+}
+
+// CHECK-LABEL: @reduce_mean_noop_quantized_input_float_output
+// CHECK:         onnx.ReduceMean
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>

--- a/test/mlir/onnx/onnx_constprop_quant.mlir
+++ b/test/mlir/onnx/onnx_constprop_quant.mlir
@@ -1,8 +1,11 @@
 // Verify that quant-types followed by constprop-onnx does not crash or
 // miscompute. The IsIntOrFloatType constraint on element-wise const-prop
-// patterns causes them to skip quantized-typed constants, leaving the ops
-// intact. Data-movement patterns (e.g. Transpose) are NOT guarded because
-// rearranging storage values preserves quantized semantics.
+// patterns causes them to skip quantized-typed constants, and the
+// ValuesHaveSameDType constraint on unary (like Transpose) patterns ensures
+// const-prop is skipped when input/output element types differ (e.g. one
+// side is quantized and the other is not, or different quantization
+// parameters).
+
 // RUN: onnx-mlir-opt %s --quant-types --constprop-onnx | FileCheck %s
 
 func.func @add_two_quantized_constants() -> tensor<2xf32> {
@@ -188,7 +191,246 @@ func.func @reduce_sum_quantized_constant() -> tensor<1xf32> {
 // CHECK:         quant.scast
 
 
-// Transpose — should still be folded
+// Unary ops with quantized input (from DQL) but no Q on output — should NOT be folded.
+
+func.func @neg_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Neg"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @neg_quantized_input_float_output
+// CHECK:         onnx.Neg
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @relu_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Relu"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @relu_quantized_input_float_output
+// CHECK:         onnx.Relu
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @abs_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Abs"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @abs_quantized_input_float_output
+// CHECK:         onnx.Abs
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @ceil_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Ceil"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @ceil_quantized_input_float_output
+// CHECK:         onnx.Ceil
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @floor_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Floor"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @floor_quantized_input_float_output
+// CHECK:         onnx.Floor
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @round_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Round"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @round_quantized_input_float_output
+// CHECK:         onnx.Round
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @cos_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Cos"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @cos_quantized_input_float_output
+// CHECK:         onnx.Cos
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @sin_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Sin"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @sin_quantized_input_float_output
+// CHECK:         onnx.Sin
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @erf_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Erf"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @erf_quantized_input_float_output
+// CHECK:         onnx.Erf
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @exp_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Exp"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @exp_quantized_input_float_output
+// CHECK:         onnx.Exp
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @log_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Log"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @log_quantized_input_float_output
+// CHECK:         onnx.Log
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @sigmoid_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Sigmoid"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @sigmoid_quantized_input_float_output
+// CHECK:         onnx.Sigmoid
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @sqrt_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Sqrt"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @sqrt_quantized_input_float_output
+// CHECK:         onnx.Sqrt
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+func.func @reciprocal_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%a, %s, %z) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %r = "onnx.Reciprocal"(%dq) : (tensor<2xf32>) -> tensor<2xf32>
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @reciprocal_quantized_input_float_output
+// CHECK:         onnx.Reciprocal
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2xf32>
+
+
+// Transpose with quantized input but no Q on output — should NOT be folded
+func.func @transpose_quantized_input_float_output() -> tensor<2x1xf32> {
+  %a = onnx.Constant dense<[[10, 20]]> : tensor<1x2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+
+  %t = "onnx.Transpose"(%a_dq) {perm = [1, 0]} : (tensor<1x2xf32>) -> tensor<2x1xf32>
+
+  return %t : tensor<2x1xf32>
+}
+
+// CHECK-LABEL: @transpose_quantized_input_float_output
+// CHECK:         onnx.Transpose
+// CHECK-SAME:      (tensor<1x2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2x1xf32>
+
+
+// Transpose with different input/output quantized types — should NOT be folded
+func.func @transpose_quantized_dtype_mismatch() -> tensor<2x1xf32> {
+  %a = onnx.Constant dense<[[10, 20]]> : tensor<1x2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+
+  %t = "onnx.Transpose"(%a_dq) {perm = [1, 0]} : (tensor<1x2xf32>) -> tensor<2x1xf32>
+
+  %out_scale = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %out_zp = onnx.Constant dense<0> : tensor<ui8>
+  %q = "onnx.QuantizeLinear"(%t, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1xf32>, tensor<f32>, tensor<ui8>) -> tensor<2x1xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x1xf32>
+
+  return %final : tensor<2x1xf32>
+}
+
+// CHECK-LABEL: @transpose_quantized_dtype_mismatch
+// CHECK:         onnx.Transpose
+// CHECK-SAME:      (tensor<1x2x!quant.uniform<u8:f32, 5.000000e-01>>) -> tensor<2x1x!quant.uniform<u8:f32, 2.500000e-01>>
+
+
+// Transpose with matching input/output quantized types — should still be folded
 func.func @transpose_quantized_constant() -> tensor<2x1xf32> {
   %a = onnx.Constant dense<[[10, 20]]> : tensor<1x2xui8>
   %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>

--- a/test/mlir/onnx/onnx_constprop_quant.mlir
+++ b/test/mlir/onnx/onnx_constprop_quant.mlir
@@ -1,0 +1,212 @@
+// Verify that quant-types followed by constprop-onnx does not crash or
+// miscompute. The IsIntOrFloatType constraint on element-wise const-prop
+// patterns causes them to skip quantized-typed constants, leaving the ops
+// intact. Data-movement patterns (e.g. Transpose) are NOT guarded because
+// rearranging storage values preserves quantized semantics.
+// RUN: onnx-mlir-opt %s --quant-types --constprop-onnx | FileCheck %s
+
+func.func @add_two_quantized_constants() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %b = onnx.Constant dense<[6, 12]> : tensor<2xui8>
+  %b_scale = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %b_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %b_dq = "onnx.DequantizeLinear"(%b, %b_scale, %b_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %add = "onnx.Add"(%a_dq, %b_dq) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+
+  %out_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %out_zp = onnx.Constant dense<0> : tensor<ui8>
+  %q = "onnx.QuantizeLinear"(%add, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2xf32>, tensor<f32>, tensor<ui8>) -> tensor<2xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  return %final : tensor<2xf32>
+}
+
+// CHECK-LABEL: @add_two_quantized_constants
+// CHECK:         onnx.Constant {value = dense<[10, 20]> : tensor<2xui8>} : tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>
+// CHECK:         onnx.Constant {value = dense<[6, 12]> : tensor<2xui8>} : tensor<2x!quant.uniform<u8:f32, 2.500000e-01>>
+// CHECK:         onnx.Add
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>, tensor<2x!quant.uniform<u8:f32, 2.500000e-01>>)
+
+
+func.func @mul_two_quantized_constants() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %b = onnx.Constant dense<[8, 4]> : tensor<2xui8>
+  %b_scale = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %b_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %b_dq = "onnx.DequantizeLinear"(%b, %b_scale, %b_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %mul = "onnx.Mul"(%a_dq, %b_dq) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+
+  %out_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %out_zp = onnx.Constant dense<0> : tensor<ui8>
+  %q = "onnx.QuantizeLinear"(%mul, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2xf32>, tensor<f32>, tensor<ui8>) -> tensor<2xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  return %final : tensor<2xf32>
+}
+
+// CHECK-LABEL: @mul_two_quantized_constants
+// CHECK:         onnx.Constant {value = dense<[10, 20]> : tensor<2xui8>} : tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>
+// CHECK:         onnx.Constant {value = dense<[8, 4]> : tensor<2xui8>} : tensor<2x!quant.uniform<u8:f32, 2.500000e-01>>
+// CHECK:         onnx.Mul
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>, tensor<2x!quant.uniform<u8:f32, 2.500000e-01>>)
+
+
+func.func @sub_two_quantized_constants() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[20, 40]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %b = onnx.Constant dense<[6, 12]> : tensor<2xui8>
+  %b_scale = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %b_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %b_dq = "onnx.DequantizeLinear"(%b, %b_scale, %b_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %sub = "onnx.Sub"(%a_dq, %b_dq) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+
+  %out_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %out_zp = onnx.Constant dense<0> : tensor<ui8>
+  %q = "onnx.QuantizeLinear"(%sub, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2xf32>, tensor<f32>, tensor<ui8>) -> tensor<2xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  return %final : tensor<2xf32>
+}
+
+// CHECK-LABEL: @sub_two_quantized_constants
+// CHECK:         onnx.Sub
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>, tensor<2x!quant.uniform<u8:f32, 2.500000e-01>>)
+
+
+func.func @neg_quantized_constant() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %neg = "onnx.Neg"(%a_dq) : (tensor<2xf32>) -> tensor<2xf32>
+
+  %out_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %out_zp = onnx.Constant dense<0> : tensor<ui8>
+  %q = "onnx.QuantizeLinear"(%neg, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2xf32>, tensor<f32>, tensor<ui8>) -> tensor<2xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  return %final : tensor<2xf32>
+}
+
+// CHECK-LABEL: @neg_quantized_constant
+// CHECK:         onnx.Neg
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>)
+// CHECK:         quant.scast
+
+
+func.func @relu_quantized_constant() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %relu = "onnx.Relu"(%a_dq) : (tensor<2xf32>) -> tensor<2xf32>
+
+  %out_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %out_zp = onnx.Constant dense<0> : tensor<ui8>
+  %q = "onnx.QuantizeLinear"(%relu, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2xf32>, tensor<f32>, tensor<ui8>) -> tensor<2xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  return %final : tensor<2xf32>
+}
+
+// CHECK-LABEL: @relu_quantized_constant
+// CHECK:         onnx.Relu
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>)
+// CHECK:         quant.scast
+
+
+func.func @matmul_two_quantized_constants() -> tensor<2x2xf32> {
+  %a = onnx.Constant dense<[[10, 20], [30, 40]]> : tensor<2x2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %b = onnx.Constant dense<[[2, 4], [6, 8]]> : tensor<2x2xui8>
+  %b_scale = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %b_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+  %b_dq = "onnx.DequantizeLinear"(%b, %b_scale, %b_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+
+  %matmul = "onnx.MatMul"(%a_dq, %b_dq) : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+
+  %out_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %out_zp = onnx.Constant dense<0> : tensor<ui8>
+  %q = "onnx.QuantizeLinear"(%matmul, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<2x2xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+
+  return %final : tensor<2x2xf32>
+}
+
+// CHECK-LABEL: @matmul_two_quantized_constants
+// CHECK:         onnx.Constant {value = dense<{{.*}}> : tensor<2x2xui8>} : tensor<2x2x!quant.uniform<u8:f32, 5.000000e-01>>
+// CHECK:         onnx.Constant {value = dense<{{.*}}> : tensor<2x2xui8>} : tensor<2x2x!quant.uniform<u8:f32, 2.500000e-01>>
+// CHECK:         onnx.MatMul
+
+
+func.func @reduce_sum_quantized_constant() -> tensor<1xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %axes = onnx.Constant dense<[0]> : tensor<1xi64>
+  %reduce = "onnx.ReduceSum"(%a_dq, %axes) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2xf32>, tensor<1xi64>) -> tensor<1xf32>
+
+  %out_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %out_zp = onnx.Constant dense<0> : tensor<ui8>
+  %q = "onnx.QuantizeLinear"(%reduce, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1xf32>, tensor<f32>, tensor<ui8>) -> tensor<1xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<1xui8>, tensor<f32>, tensor<ui8>) -> tensor<1xf32>
+
+  return %final : tensor<1xf32>
+}
+
+// CHECK-LABEL: @reduce_sum_quantized_constant
+// CHECK:         onnx.ReduceSum
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>
+// CHECK:         quant.scast
+
+
+// Transpose — should still be folded
+func.func @transpose_quantized_constant() -> tensor<2x1xf32> {
+  %a = onnx.Constant dense<[[10, 20]]> : tensor<1x2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+
+  %t = "onnx.Transpose"(%a_dq) {perm = [1, 0]} : (tensor<1x2xf32>) -> tensor<2x1xf32>
+
+  %out_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %out_zp = onnx.Constant dense<0> : tensor<ui8>
+  %q = "onnx.QuantizeLinear"(%t, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1xf32>, tensor<f32>, tensor<ui8>) -> tensor<2x1xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x1xf32>
+
+  return %final : tensor<2x1xf32>
+}
+
+// CHECK-LABEL: @transpose_quantized_constant
+// CHECK-NOT:     onnx.Transpose
+// CHECK:         onnx.Constant
+// CHECK:         quant.scast


### PR DESCRIPTION
- Added testcases to verify that the constprop followed by quant-types do not crash or otherwise produce incorrect results.

PS: Mostly done by cursor-agent with very few manual modifications.