### PR TITLE
[AIESW-28263] Fix bias shape mismatch in MulAdd to DepthwiseConv conversion

### DIFF
--- a/src/Dialect/ONNX/Transforms/xmc/ConvertMulToDepthwiseConv2dPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ConvertMulToDepthwiseConv2dPass.cpp
@@ -324,9 +324,57 @@ struct MulAddToDepthwiseConvPattern : public OpRewritePattern<ONNXAddOp> {
     auto convOutputType =
         RankedTensorType::get(inputShape, inputType.getElementType());
 
+    // Reshape bias constant to [C] to satisfy onnx.Conv verifier:
+    // bias dim must equal first dim of weights (inputChannel).
+    // isPerChannelBias accepts [C], [1,C,1,1], or [1] - normalize to [C].
+    auto biasType = cast<RankedTensorType>(bias.getType());
+    auto biasShape = biasType.getShape();
+    Value convBias = bias;
+    if (!(biasShape.size() == 1 && biasShape[0] == inputChannel)) {
+      auto biasConstOp = bias.getDefiningOp<ONNXConstantOp>();
+      if (!biasConstOp)
+        return failure();
+      auto denseAttr = dyn_cast<DenseElementsAttr>(biasConstOp.getValueAttr());
+      if (!denseAttr)
+        return failure();
+
+      Type storageElemType = biasType.getElementType();
+      if (auto qType = dyn_cast<quant::QuantizedType>(storageElemType))
+        storageElemType = qType.getStorageType();
+
+      if (biasShape.size() == 1 && biasShape[0] == 1 && inputChannel > 1) {
+        // Scalar bias [1]: create splat [C] with the same value
+        auto flatStorageType =
+            RankedTensorType::get({inputChannel}, storageElemType);
+        auto flatAttr = DenseElementsAttr::get(
+            flatStorageType, denseAttr.getSplatValue<Attribute>());
+        auto flatResultType =
+            RankedTensorType::get({inputChannel}, biasType.getElementType());
+        convBias =
+            rewriter
+                .create<ONNXConstantOp>(loc, flatResultType, mlir::ValueRange{},
+                    mlir::ArrayRef<mlir::NamedAttribute>{
+                        rewriter.getNamedAttr("value", flatAttr)})
+                .getResult();
+      } else {
+        // [1,C,1,1] or other -> reshape dense attr to [C]
+        auto flatStorageType =
+            RankedTensorType::get({inputChannel}, storageElemType);
+        auto flatAttr = denseAttr.reshape(flatStorageType);
+        auto flatResultType =
+            RankedTensorType::get({inputChannel}, biasType.getElementType());
+        convBias =
+            rewriter
+                .create<ONNXConstantOp>(loc, flatResultType, mlir::ValueRange{},
+                    mlir::ArrayRef<mlir::NamedAttribute>{
+                        rewriter.getNamedAttr("value", flatAttr)})
+                .getResult();
+      }
+    }
+
     // Create Conv op with bias
     auto convOp = rewriter.create<ONNXConvOp>(loc, convOutputType, input,
-        newWeight, /*bias=*/bias,
+        newWeight, /*bias=*/convBias,
         /*auto_pad=*/rewriter.getStringAttr("NOTSET"),
         /*dilations=*/dilations,
         /*group=*/group,


### PR DESCRIPTION
Reshape bias constant to [C] before passing to onnx.Conv to satisfy the verifier requirement that bias dim must equal the first dimension of weights. Previously, bias shapes like [1,C,1,1] or [1] were accepted by isPerChannelBias but passed directly to Conv, causing a verification error. Now scalar [1] bias is replicated to [C] and [1,C,1,1] bias is reshaped to [C] at the constant level without creating runtime Reshape ops.