### PR TITLE
[AIESW-28267] Fix quantized type handling

### DIFF
--- a/src/Dialect/ONNX/Transforms/xmc/TransferDepthwiseConv2dWithChannelMultiplierPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/TransferDepthwiseConv2dWithChannelMultiplierPass.cpp
@@ -133,106 +133,117 @@ SmallVector<T> extractSplitBias(
 }
 
 /// Create a constant op with the given values and shape (templatized for
-/// different types)
+/// different types).
+/// `storageElementType` is used for the DenseElementsAttr (e.g., ui8, i8).
+/// `resultElementType` is used for the ONNXConstantOp result type (may be
+/// quantized, e.g., !quant.uniform<ui8:f32, ...>).
 template <typename T>
 Value createConstant(PatternRewriter &rewriter, Location loc,
-    ArrayRef<T> values, ArrayRef<int64_t> shape, Type elementType) {
-  auto tensorType = RankedTensorType::get(shape, elementType);
+    ArrayRef<T> values, ArrayRef<int64_t> shape, Type storageElementType,
+    Type resultElementType) {
+  auto storageTensorType = RankedTensorType::get(shape, storageElementType);
+  auto resultTensorType = RankedTensorType::get(shape, resultElementType);
   DenseElementsAttr attr;
 
   if constexpr (std::is_floating_point_v<T>) {
-    attr = DenseFPElementsAttr::get(tensorType, values);
+    attr = DenseFPElementsAttr::get(storageTensorType, values);
   } else {
-    attr = DenseIntElementsAttr::get(tensorType, values);
+    attr = DenseIntElementsAttr::get(storageTensorType, values);
   }
 
-  return rewriter.create<ONNXConstantOp>(loc, tensorType, Attribute(), attr,
-      FloatAttr(), ArrayAttr(), IntegerAttr(), ArrayAttr(), StringAttr(),
+  return rewriter.create<ONNXConstantOp>(loc, resultTensorType, Attribute(),
+      attr, FloatAttr(), ArrayAttr(), IntegerAttr(), ArrayAttr(), StringAttr(),
       ArrayAttr());
 }
 
-/// Create split weight constant based on element type
+/// Create split weight constant based on element type.
+/// `resultElementType` is the full element type for the result (may include
+/// quantization info). The storage type is derived from denseWeightAttr.
 Value createSplitWeightConstant(PatternRewriter &rewriter, Location loc,
     DenseElementsAttr denseWeightAttr, int64_t cmIdx, int64_t inputChannels,
-    int64_t weightsPerChannel, ArrayRef<int64_t> splitWeightShape) {
-  Type elementType = denseWeightAttr.getElementType();
+    int64_t weightsPerChannel, ArrayRef<int64_t> splitWeightShape,
+    Type resultElementType) {
+  Type storageType = denseWeightAttr.getElementType();
 
-  if (elementType.isF32()) {
+  if (storageType.isF32()) {
     auto splitWeights = extractSplitWeights<float>(
         denseWeightAttr, cmIdx, inputChannels, weightsPerChannel);
-    return createConstant<float>(
-        rewriter, loc, splitWeights, splitWeightShape, elementType);
-  } else if (elementType.isF64()) {
+    return createConstant<float>(rewriter, loc, splitWeights, splitWeightShape,
+        storageType, resultElementType);
+  } else if (storageType.isF64()) {
     auto splitWeights = extractSplitWeights<double>(
         denseWeightAttr, cmIdx, inputChannels, weightsPerChannel);
-    return createConstant<double>(
-        rewriter, loc, splitWeights, splitWeightShape, elementType);
-  } else if (elementType.isSignedInteger(8)) {
+    return createConstant<double>(rewriter, loc, splitWeights, splitWeightShape,
+        storageType, resultElementType);
+  } else if (storageType.isSignedInteger(8)) {
     auto splitWeights = extractSplitWeights<int8_t>(
         denseWeightAttr, cmIdx, inputChannels, weightsPerChannel);
-    return createConstant<int8_t>(
-        rewriter, loc, splitWeights, splitWeightShape, elementType);
-  } else if (elementType.isUnsignedInteger(8)) {
+    return createConstant<int8_t>(rewriter, loc, splitWeights, splitWeightShape,
+        storageType, resultElementType);
+  } else if (storageType.isUnsignedInteger(8)) {
     auto splitWeights = extractSplitWeights<uint8_t>(
         denseWeightAttr, cmIdx, inputChannels, weightsPerChannel);
-    return createConstant<uint8_t>(
-        rewriter, loc, splitWeights, splitWeightShape, elementType);
-  } else if (elementType.isSignedInteger(16)) {
+    return createConstant<uint8_t>(rewriter, loc, splitWeights,
+        splitWeightShape, storageType, resultElementType);
+  } else if (storageType.isSignedInteger(16)) {
     auto splitWeights = extractSplitWeights<int16_t>(
         denseWeightAttr, cmIdx, inputChannels, weightsPerChannel);
-    return createConstant<int16_t>(
-        rewriter, loc, splitWeights, splitWeightShape, elementType);
-  } else if (elementType.isUnsignedInteger(16)) {
+    return createConstant<int16_t>(rewriter, loc, splitWeights,
+        splitWeightShape, storageType, resultElementType);
+  } else if (storageType.isUnsignedInteger(16)) {
     auto splitWeights = extractSplitWeights<uint16_t>(
         denseWeightAttr, cmIdx, inputChannels, weightsPerChannel);
-    return createConstant<uint16_t>(
-        rewriter, loc, splitWeights, splitWeightShape, elementType);
+    return createConstant<uint16_t>(rewriter, loc, splitWeights,
+        splitWeightShape, storageType, resultElementType);
   }
 
   return Value(); // Unsupported type
 }
 
-/// Create split bias constant based on element type
+/// Create split bias constant based on element type.
+/// `resultElementType` is the full element type for the result (may include
+/// quantization info). The storage type is derived from denseBiasAttr.
 Value createSplitBiasConstant(PatternRewriter &rewriter, Location loc,
-    DenseElementsAttr denseBiasAttr, int64_t cmIdx, int64_t inputChannels) {
-  Type elementType = denseBiasAttr.getElementType();
+    DenseElementsAttr denseBiasAttr, int64_t cmIdx, int64_t inputChannels,
+    Type resultElementType) {
+  Type storageType = denseBiasAttr.getElementType();
   SmallVector<int64_t> biasShape = {inputChannels};
 
-  if (elementType.isF32()) {
+  if (storageType.isF32()) {
     auto biasValues =
         extractSplitBias<float>(denseBiasAttr, cmIdx, inputChannels);
     return createConstant<float>(
-        rewriter, loc, biasValues, biasShape, elementType);
-  } else if (elementType.isF64()) {
+        rewriter, loc, biasValues, biasShape, storageType, resultElementType);
+  } else if (storageType.isF64()) {
     auto biasValues =
         extractSplitBias<double>(denseBiasAttr, cmIdx, inputChannels);
     return createConstant<double>(
-        rewriter, loc, biasValues, biasShape, elementType);
-  } else if (elementType.isSignedInteger(8)) {
+        rewriter, loc, biasValues, biasShape, storageType, resultElementType);
+  } else if (storageType.isSignedInteger(8)) {
     auto biasValues =
         extractSplitBias<int8_t>(denseBiasAttr, cmIdx, inputChannels);
     return createConstant<int8_t>(
-        rewriter, loc, biasValues, biasShape, elementType);
-  } else if (elementType.isUnsignedInteger(8)) {
+        rewriter, loc, biasValues, biasShape, storageType, resultElementType);
+  } else if (storageType.isUnsignedInteger(8)) {
     auto biasValues =
         extractSplitBias<uint8_t>(denseBiasAttr, cmIdx, inputChannels);
     return createConstant<uint8_t>(
-        rewriter, loc, biasValues, biasShape, elementType);
-  } else if (elementType.isSignedInteger(16)) {
+        rewriter, loc, biasValues, biasShape, storageType, resultElementType);
+  } else if (storageType.isSignedInteger(16)) {
     auto biasValues =
         extractSplitBias<int16_t>(denseBiasAttr, cmIdx, inputChannels);
     return createConstant<int16_t>(
-        rewriter, loc, biasValues, biasShape, elementType);
-  } else if (elementType.isUnsignedInteger(16)) {
+        rewriter, loc, biasValues, biasShape, storageType, resultElementType);
+  } else if (storageType.isUnsignedInteger(16)) {
     auto biasValues =
         extractSplitBias<uint16_t>(denseBiasAttr, cmIdx, inputChannels);
     return createConstant<uint16_t>(
-        rewriter, loc, biasValues, biasShape, elementType);
-  } else if (elementType.isInteger(32)) {
+        rewriter, loc, biasValues, biasShape, storageType, resultElementType);
+  } else if (storageType.isInteger(32)) {
     auto biasValues =
         extractSplitBias<int32_t>(denseBiasAttr, cmIdx, inputChannels);
     return createConstant<int32_t>(
-        rewriter, loc, biasValues, biasShape, elementType);
+        rewriter, loc, biasValues, biasShape, storageType, resultElementType);
   }
 
   return Value(); // Unsupported type
@@ -342,10 +353,11 @@ struct SplitDepthwiseConvPattern : public OpRewritePattern<ONNXConvOp> {
     onnx_mlir::OnnxBuilder onnxBuilder(rewriter, loc);
 
     for (int64_t cmIdx = 0; cmIdx < channelMultiplier; cmIdx++) {
-      // Create split weight constant using templatized helper
-      Value splitWeight =
-          createSplitWeightConstant(rewriter, loc, denseWeightAttr, cmIdx,
-              inputChannels, weightsPerChannel, splitWeightShape);
+      // Create split weight constant using templatized helper.
+      // Pass the full weight element type (may be quantized) for the result.
+      Value splitWeight = createSplitWeightConstant(rewriter, loc,
+          denseWeightAttr, cmIdx, inputChannels, weightsPerChannel,
+          splitWeightShape, weightType.getElementType());
       if (!splitWeight) {
         LLVM_DEBUG(
             llvm::dbgs() << "Unsupported weight element type, skipping\n");
@@ -355,8 +367,9 @@ struct SplitDepthwiseConvPattern : public OpRewritePattern<ONNXConvOp> {
       // Create split bias if present
       Value splitBias;
       if (hasBias && denseBiasAttr) {
-        splitBias = createSplitBiasConstant(
-            rewriter, loc, denseBiasAttr, cmIdx, inputChannels);
+        auto biasType = cast<RankedTensorType>(origBias.getType());
+        splitBias = createSplitBiasConstant(rewriter, loc, denseBiasAttr, cmIdx,
+            inputChannels, biasType.getElementType());
         if (!splitBias) {
           LLVM_DEBUG(
               llvm::dbgs() << "Unsupported bias element type, skipping\n");
@@ -505,10 +518,11 @@ struct SplitXFEDepthwiseConvPattern : public OpRewritePattern<XFEConvOp> {
     onnx_mlir::OnnxBuilder onnxBuilder(rewriter, loc);
 
     for (int64_t cmIdx = 0; cmIdx < channelMultiplier; cmIdx++) {
-      // Create split weight constant using templatized helper
-      Value splitWeight =
-          createSplitWeightConstant(rewriter, loc, denseWeightAttr, cmIdx,
-              inputChannels, weightsPerChannel, splitWeightShape);
+      // Create split weight constant using templatized helper.
+      // Pass the full weight element type (may be quantized) for the result.
+      Value splitWeight = createSplitWeightConstant(rewriter, loc,
+          denseWeightAttr, cmIdx, inputChannels, weightsPerChannel,
+          splitWeightShape, weightType.getElementType());
       if (!splitWeight) {
         LLVM_DEBUG(
             llvm::dbgs() << "Unsupported weight element type, skipping\n");
@@ -518,8 +532,9 @@ struct SplitXFEDepthwiseConvPattern : public OpRewritePattern<XFEConvOp> {
       // Create split bias if present
       Value splitBias;
       if (hasBias && denseBiasAttr) {
-        splitBias = createSplitBiasConstant(
-            rewriter, loc, denseBiasAttr, cmIdx, inputChannels);
+        auto biasType = cast<RankedTensorType>(origBias.getType());
+        splitBias = createSplitBiasConstant(rewriter, loc, denseBiasAttr, cmIdx,
+            inputChannels, biasType.getElementType());
         if (!splitBias) {
           LLVM_DEBUG(
               llvm::dbgs() << "Unsupported bias element type, skipping\n");

--- a/src/Dialect/ONNX/Transforms/xmc/TransferReduceMeanSumToConvPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/TransferReduceMeanSumToConvPass.cpp
@@ -54,6 +54,13 @@ bool isChannelWiseReduction(llvm::ArrayRef<int64_t> axes, int64_t rank) {
   return axis == 1; // NCHW: channel is at index 1
 }
 
+/// Check if element type is valid for onnx.Conv (float or quantized).
+/// Integer types like i64 (from Shape/Cast ops) are not supported by Conv.
+bool isConvCompatibleElementType(mlir::Type elementType) {
+  return mlir::isa<mlir::FloatType>(elementType) ||
+         mlir::isa<mlir::quant::QuantizedType>(elementType);
+}
+
 /// Create constant tensor with given shape and value.
 /// Supports float, integer, and quantized element types.
 /// For quantized types, the float value is quantized using the type's
@@ -315,6 +322,12 @@ struct ReduceMeanToConvPattern : public OpRewritePattern<ONNXReduceMeanOp> {
     if (inputShape.empty() || inputShape.size() < 2)
       return mlir::failure();
 
+    // onnx.Conv only supports float/quantized types, not integer types.
+    auto inputElemType =
+        mlir::cast<mlir::ShapedType>(input.getType()).getElementType();
+    if (!isConvCompatibleElementType(inputElemType))
+      return mlir::failure();
+
     int64_t rank = inputShape.size();
     int64_t inputChannel = inputShape[1]; // NCHW: channel is at index 1
 
@@ -372,6 +385,12 @@ struct ReduceSumToConvPattern : public OpRewritePattern<ONNXReduceSumOp> {
     // Get input shape
     auto inputShape = getShape(input);
     if (inputShape.empty() || inputShape.size() < 2)
+      return mlir::failure();
+
+    // onnx.Conv only supports float/quantized types, not integer types.
+    auto inputElemType =
+        mlir::cast<mlir::ShapedType>(input.getType()).getElementType();
+    if (!isConvCompatibleElementType(inputElemType))
       return mlir::failure();
 
     int64_t rank = inputShape.size();
@@ -463,6 +482,12 @@ struct ReduceMeanMulToConvPattern : public OpRewritePattern<ONNXMulOp> {
     if (inputShape.empty() || inputShape.size() < 2)
       return mlir::failure();
 
+    // onnx.Conv only supports float/quantized types, not integer types.
+    auto inputElemType =
+        mlir::cast<mlir::ShapedType>(input.getType()).getElementType();
+    if (!isConvCompatibleElementType(inputElemType))
+      return mlir::failure();
+
     int64_t rank = inputShape.size();
     int64_t inputChannel = inputShape[1]; // NCHW: channel is at index 1
 
@@ -515,6 +540,12 @@ struct ReduceMeanReluToConvPattern : public OpRewritePattern<ONNXReluOp> {
     mlir::Value input = reduceMean.getData();
     auto inputShape = getShape(input);
     if (inputShape.empty() || inputShape.size() < 2)
+      return mlir::failure();
+
+    // onnx.Conv only supports float/quantized types, not integer types.
+    auto inputElemType =
+        mlir::cast<mlir::ShapedType>(input.getType()).getElementType();
+    if (!isConvCompatibleElementType(inputElemType))
       return mlir::failure();
 
     int64_t rank = inputShape.size();

--- a/test/mlir/onnx/xmc/TransferReduceMeanSumToConv.mlir
+++ b/test/mlir/onnx/xmc/TransferReduceMeanSumToConv.mlir
@@ -134,3 +134,61 @@ func.func @reduce_sum_large_channel(%arg0: tensor<1x64x32x32x!quant.uniform<i8:f
 }
 // CHECK: "onnx.Conv"
 // CHECK-NOT: onnx.ReduceSum
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative Tests: Integer element types (should NOT convert)
+// Conv only supports float/quantized types, not integer types like i64.
+// These patterns arise from Cast/IsNaN counting in instance normalization.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @reduce_mean_i64_input_no_convert
+// NCHW: tensor<1x8x4x4xi64> - integer element type
+// Should NOT convert because onnx.Conv does not support i64
+func.func @reduce_mean_i64_input_no_convert(%arg0: tensor<1x8x4x4xi64>) -> tensor<1x1x4x4xi64> {
+    %0 = onnx.Constant dense<[1]> : tensor<1xi64>
+    %1 = "onnx.ReduceMean"(%arg0, %0) {keepdims = 1 : si64} : (tensor<1x8x4x4xi64>, tensor<1xi64>) -> tensor<1x1x4x4xi64>
+    return %1 : tensor<1x1x4x4xi64>
+}
+// CHECK: "onnx.ReduceMean"
+// CHECK-NOT: onnx.Conv
+
+// -----
+
+// CHECK-LABEL: @reduce_sum_i64_input_no_convert
+// NCHW: tensor<1x8x4x4xi64> - integer element type
+// Should NOT convert because onnx.Conv does not support i64
+func.func @reduce_sum_i64_input_no_convert(%arg0: tensor<1x8x4x4xi64>) -> tensor<1x1x4x4xi64> {
+    %0 = onnx.Constant dense<[1]> : tensor<1xi64>
+    %1 = "onnx.ReduceSum"(%arg0, %0) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x8x4x4xi64>, tensor<1xi64>) -> tensor<1x1x4x4xi64>
+    return %1 : tensor<1x1x4x4xi64>
+}
+// CHECK: "onnx.ReduceSum"
+// CHECK-NOT: onnx.Conv
+
+// -----
+
+// CHECK-LABEL: @reduce_mean_i32_input_no_convert
+// NCHW: tensor<1x4x4x4xi32> - integer element type
+// Should NOT convert because onnx.Conv does not support i32
+func.func @reduce_mean_i32_input_no_convert(%arg0: tensor<1x4x4x4xi32>) -> tensor<1x1x4x4xi32> {
+    %0 = onnx.Constant dense<[1]> : tensor<1xi64>
+    %1 = "onnx.ReduceMean"(%arg0, %0) {keepdims = 1 : si64} : (tensor<1x4x4x4xi32>, tensor<1xi64>) -> tensor<1x1x4x4xi32>
+    return %1 : tensor<1x1x4x4xi32>
+}
+// CHECK: "onnx.ReduceMean"
+// CHECK-NOT: onnx.Conv
+
+// -----
+
+// CHECK-LABEL: @reduce_mean_f32_input_should_convert
+// NCHW: tensor<1x8x4x4xf32> - float element type
+// Should convert because onnx.Conv supports f32
+func.func @reduce_mean_f32_input_should_convert(%arg0: tensor<1x8x4x4xf32>) -> tensor<1x1x4x4xf32> {
+    %0 = onnx.Constant dense<[1]> : tensor<1xi64>
+    %1 = "onnx.ReduceMean"(%arg0, %0) {keepdims = 1 : si64} : (tensor<1x8x4x4xf32>, tensor<1xi64>) -> tensor<1x1x4x4xf32>
+    return %1 : tensor<1x1x4x4xf32>
+}
+// CHECK: "onnx.Conv"
+// CHECK-NOT: onnx.ReduceMean

--- a/test/mlir/onnx/xmc/transfer_depthwise_conv2d_with_channel_multiplier.mlir
+++ b/test/mlir/onnx/xmc/transfer_depthwise_conv2d_with_channel_multiplier.mlir
@@ -338,4 +338,107 @@ module {
   // CHECK: onnx.Conv
   // CHECK: onnx.Conv
   // CHECK: onnx.Concat
+
+  // =========================================================================
+  // Quantized type tests - Verify storage vs quantized type handling
+  // The fix ensures split weight/bias constants use the full quantized type
+  // (e.g., !quant.uniform<i8:f32, ...>) for the result, not just the storage
+  // type (e.g., i8).
+  // =========================================================================
+
+  // Test 15: Quantized depthwise conv with channel_multiplier=2 (NCHW, ui8)
+  // Input: [1, 4, 8, 8] (NCHW), group=4, output_channels=8
+  // channel_multiplier = 8/4 = 2
+  // Verifies that split weight constants preserve the full quantized type
+  // (e.g., !quant.uniform<u8:f32, ...>) instead of using just the storage type (ui8).
+  func.func @test_depthwise_conv_cm2_quant_ui8(%arg0: tensor<1x4x8x8x!quant.uniform<u8:f32, 0.1:128>>) -> tensor<1x8x8x8x!quant.uniform<u8:f32, 0.1:128>> {
+    %weights = "onnx.Constant"() {value = dense<128> : tensor<8x1x3x3xui8>} : () -> tensor<8x1x3x3x!quant.uniform<u8:f32, 0.05:128>>
+    %none = "onnx.NoValue"() {value} : () -> none
+    %0 = "onnx.Conv"(%arg0, %weights, %none) {
+      auto_pad = "NOTSET",
+      dilations = [1, 1],
+      group = 4 : si64,
+      kernel_shape = [3, 3],
+      pads = [1, 1, 1, 1],
+      strides = [1, 1]
+    } : (tensor<1x4x8x8x!quant.uniform<u8:f32, 0.1:128>>, tensor<8x1x3x3x!quant.uniform<u8:f32, 0.05:128>>, none) -> tensor<1x8x8x8x!quant.uniform<u8:f32, 0.1:128>>
+    return %0 : tensor<1x8x8x8x!quant.uniform<u8:f32, 0.1:128>>
+  }
+  // CHECK-LABEL: func.func @test_depthwise_conv_cm2_quant_ui8
+  // CHECK: onnx.Constant
+  // CHECK: onnx.NoValue
+  // CHECK: onnx.Conv
+  // CHECK-SAME: group = 4
+  // CHECK: onnx.Conv
+  // CHECK-SAME: group = 4
+  // CHECK: onnx.Concat
+  // CHECK-SAME: axis = 1
+
+  // Test 16: Quantized depthwise conv with bias and channel_multiplier=2 (NCHW, ui8)
+  // Bias uses quantized i32 type, verifying both weight and bias type handling
+  func.func @test_depthwise_conv_cm2_quant_ui8_bias(%arg0: tensor<1x4x8x8x!quant.uniform<u8:f32, 0.1:128>>) -> tensor<1x8x8x8x!quant.uniform<u8:f32, 0.1:128>> {
+    %weights = "onnx.Constant"() {value = dense<128> : tensor<8x1x3x3xui8>} : () -> tensor<8x1x3x3x!quant.uniform<u8:f32, 0.05:128>>
+    %bias = "onnx.Constant"() {value = dense<0> : tensor<8xi32>} : () -> tensor<8x!quant.uniform<i32:f32, 0.005:0>>
+    %0 = "onnx.Conv"(%arg0, %weights, %bias) {
+      auto_pad = "NOTSET",
+      dilations = [1, 1],
+      group = 4 : si64,
+      kernel_shape = [3, 3],
+      pads = [1, 1, 1, 1],
+      strides = [1, 1]
+    } : (tensor<1x4x8x8x!quant.uniform<u8:f32, 0.1:128>>, tensor<8x1x3x3x!quant.uniform<u8:f32, 0.05:128>>, tensor<8x!quant.uniform<i32:f32, 0.005:0>>) -> tensor<1x8x8x8x!quant.uniform<u8:f32, 0.1:128>>
+    return %0 : tensor<1x8x8x8x!quant.uniform<u8:f32, 0.1:128>>
+  }
+  // CHECK-LABEL: func.func @test_depthwise_conv_cm2_quant_ui8_bias
+  // CHECK: onnx.Constant
+  // CHECK: onnx.Conv
+  // CHECK: onnx.Conv
+  // CHECK: onnx.Concat
+  // CHECK-SAME: axis = 1
+
+  // Test 17: XFE quantized depthwise conv with channel_multiplier=2 (NHWC, ui8)
+  // Input: [1, 8, 8, 4] (NHWC), group=4, output_channels=8
+  // Verifies that XFEConv split preserves quantized types for weight constants.
+  func.func @test_xfe_depthwise_conv_cm2_quant_ui8(%arg0: tensor<1x8x8x4x!quant.uniform<u8:f32, 0.1:128>>) -> tensor<1x8x8x8x!quant.uniform<u8:f32, 0.1:128>> {
+    %weights = "onnx.Constant"() {value = dense<128> : tensor<8x1x3x3xui8>} : () -> tensor<8x1x3x3x!quant.uniform<u8:f32, 0.05:128>>
+    %none = "onnx.NoValue"() {value} : () -> none
+    %0 = "onnx.XFEConv"(%arg0, %weights, %none) {
+      auto_pad = "NOTSET",
+      dilations = [1, 1],
+      group = 4 : si64,
+      kernel_shape = [3, 3],
+      pads = [1, 1, 1, 1],
+      strides = [1, 1]
+    } : (tensor<1x8x8x4x!quant.uniform<u8:f32, 0.1:128>>, tensor<8x1x3x3x!quant.uniform<u8:f32, 0.05:128>>, none) -> tensor<1x8x8x8x!quant.uniform<u8:f32, 0.1:128>>
+    return %0 : tensor<1x8x8x8x!quant.uniform<u8:f32, 0.1:128>>
+  }
+  // CHECK-LABEL: func.func @test_xfe_depthwise_conv_cm2_quant_ui8
+  // CHECK: onnx.Constant
+  // CHECK: onnx.NoValue
+  // CHECK: onnx.XFEConv
+  // CHECK: onnx.XFEConv
+  // CHECK: onnx.Concat
+  // CHECK-SAME: axis = 3
+
+  // Test 18: XFE quantized depthwise conv with bias and channel_multiplier=3 (NHWC, ui8)
+  func.func @test_xfe_depthwise_conv_cm3_quant_bias(%arg0: tensor<1x8x8x2x!quant.uniform<u8:f32, 0.1:128>>) -> tensor<1x8x8x6x!quant.uniform<u8:f32, 0.1:128>> {
+    %weights = "onnx.Constant"() {value = dense<128> : tensor<6x1x3x3xui8>} : () -> tensor<6x1x3x3x!quant.uniform<u8:f32, 0.05:128>>
+    %bias = "onnx.Constant"() {value = dense<0> : tensor<6xi32>} : () -> tensor<6x!quant.uniform<i32:f32, 0.005:0>>
+    %0 = "onnx.XFEConv"(%arg0, %weights, %bias) {
+      auto_pad = "NOTSET",
+      dilations = [1, 1],
+      group = 2 : si64,
+      kernel_shape = [3, 3],
+      pads = [1, 1, 1, 1],
+      strides = [1, 1]
+    } : (tensor<1x8x8x2x!quant.uniform<u8:f32, 0.1:128>>, tensor<6x1x3x3x!quant.uniform<u8:f32, 0.05:128>>, tensor<6x!quant.uniform<i32:f32, 0.005:0>>) -> tensor<1x8x8x6x!quant.uniform<u8:f32, 0.1:128>>
+    return %0 : tensor<1x8x8x6x!quant.uniform<u8:f32, 0.1:128>>
+  }
+  // CHECK-LABEL: func.func @test_xfe_depthwise_conv_cm3_quant_bias
+  // CHECK: onnx.Constant
+  // CHECK: onnx.XFEConv
+  // CHECK: onnx.XFEConv
+  // CHECK: onnx.XFEConv
+  // CHECK: onnx.Concat
+  // CHECK-SAME: axis = 3
 }


### PR DESCRIPTION

Two issues fixed:

1. TransferReduceMeanSumToConvPass: Add element type guard to skip ReduceMean/ReduceSum ops with integer inputs (e.g., i64 from Cast/IsNaN counting patterns in instance normalization). onnx.Conv only supports float/quantized types.

2. TransferDepthwiseConv2dWithChannelMultiplierPass: Fix storage vs quantized type mismatch when splitting weights. DenseElementsAttr returns storage type (e.g., ui8) but ONNXConstantOp result needs the full quantized type (e.g., !quant.uniform<ui8:f32, ...>). Split createConstant to use storage type for data and full type for the op result.