### PR TITLE
[AIESW-28320] : 'onnx.RMSLayerNormalization' op operand type issue

### DIFF
--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -600,12 +600,12 @@ def ONNXRMSLayerNormalizationOp:ONNX_Op<"RMSLayerNormalization",
         `Y` and `X` have the same shape.
   }];
   let arguments = (ins AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, TensorOf<[quant_QuantizedType]>]>:$X,
-    AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>]>:$Scale,
-    AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, NoneType]>:$B,
+    AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, TensorOf<[quant_QuantizedType]>]>:$Scale,
+    AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, NoneType, TensorOf<[quant_QuantizedType]>]>:$B,
     DefaultValuedAttr<SI64Attr, "-1">:$axis,
     DefaultValuedAttr<F32Attr, "1e-05">:$epsilon,
     DefaultValuedAttr<SI64Attr, "1">:$stash_type);
-  let results = (outs AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>]>:$Y,
+  let results = (outs AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, TensorOf<[quant_QuantizedType]>]>:$Y,
     AnyTypeOf<[TensorOf<[F32]>, TensorOf<[BF16]>, NoneType]>:$InvStdDev);
   let extraClassDeclaration = [{
     static int getNumberOfOperands() {

--- a/test/mlir/onnx/onnx_quanttypes.mlir
+++ b/test/mlir/onnx/onnx_quanttypes.mlir
@@ -251,3 +251,24 @@ func.func @q_dq_q_dq(%arg0: tensor<1x64x128x128xf32>, %arg1: tensor<1x64x128x128
 // CHECK-SAME: tensor<1x64x128x128x!quant.uniform<u8:f32, 0.039215687662363052:127>> to tensor<1x64x128x128xui8>
 // CHECK-NEXT: quant.scast
 // CHECK-SAME: tensor<1x64x128x128xui8> to tensor<1x64x128x128x!quant.uniform<u8:f32, 0.023221839219331741:52>>
+
+// Test that RMSLayerNormalization accepts quantized Scale and produces quantized Y
+// after the quant-types pass folds DQ into the operand type.
+func.func @rmslayernorm_quant_types(%arg0: tensor<1x128x2880xi16>) -> tensor<1x128x2880xi16> {
+  %zp_x = onnx.Constant dense<8361> : tensor<i16>
+  %sc_x = onnx.Constant dense<9.59339377E-4> : tensor<f32>
+  %zp_s = onnx.Constant dense<0> : tensor<i16>
+  %sc_s = onnx.Constant dense<1.000000e-04> : tensor<f32>
+  %zp_y = onnx.Constant dense<8361> : tensor<i16>
+  %sc_y = onnx.Constant dense<9.59339377E-4> : tensor<f32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %dq_x = "onnx.DequantizeLinear"(%arg0, %sc_x, %zp_x) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x2880xi16>, tensor<f32>, tensor<i16>) -> tensor<1x128x2880xf32>
+  %scale_const = onnx.Constant dense<1.0> : tensor<2880xf32>
+  %Y, %InvStdDev = "onnx.RMSLayerNormalization"(%dq_x, %scale_const, %none) {axis = -1 : si64, epsilon = 1.0E-5 : f32, stash_type = 1 : si64} : (tensor<1x128x2880xf32>, tensor<2880xf32>, none) -> (tensor<1x128x2880xf32>, none)
+  %q_y = "onnx.QuantizeLinear"(%Y, %sc_y, %zp_y) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x2880xf32>, tensor<f32>, tensor<i16>) -> tensor<1x128x2880xi16>
+  return %q_y : tensor<1x128x2880xi16>
+}
+
+// CHECK-LABEL: @rmslayernorm_quant_types
+// CHECK: "onnx.RMSLayerNormalization"
+// CHECK-SAME: !quant.uniform<i16:f32,


### PR DESCRIPTION
The inputs already support quantized types, but the result $Y doesn't — so when the quant-types pass converts the output type to quantized, the ODS result verifier rejects it.
Added quant support for output.