### PR TITLE
Transpose should not be moved through boundary scast [AIESW-28266]

### DIFF
--- a/src/Dialect/ONNX/Transforms/xmc/ONNXTransposeOptimizationPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ONNXTransposeOptimizationPass.cpp
@@ -881,8 +881,9 @@ struct PushTransposeThroughSCast
     if (!perm)
       return failure();
 
-    if (llvm::any_of(op->getUsers(),
-            [](Operation *op) { return isa<ONNXDequantizeLinearOp>(op); }))
+    if (llvm::any_of(op->getUsers(), [](Operation *op) {
+          return isa<ONNXDequantizeLinearOp, func::ReturnOp>(op);
+        }))
       return rewriter.notifyMatchFailure(
           op, "Not pushing through boundary scast");
 

--- a/src/Dialect/ONNX/Transforms/xmc/ONNXTransposeOptimizationPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ONNXTransposeOptimizationPass.cpp
@@ -881,6 +881,11 @@ struct PushTransposeThroughSCast
     if (!perm)
       return failure();
 
+    if (llvm::any_of(op->getUsers(),
+            [](Operation *op) { return isa<ONNXDequantizeLinearOp>(op); }))
+      return rewriter.notifyMatchFailure(
+          op, "Not pushing through boundary scast");
+
     auto outputType = mlir::cast<RankedTensorType>(op.getType());
 
     // The new scast takes the transpose's input directly, so its output must

--- a/test/mlir/onnx/xmc/onnx_transpose_optimization.mlir
+++ b/test/mlir/onnx/xmc/onnx_transpose_optimization.mlir
@@ -1303,23 +1303,6 @@ func.func @test_no_push_transpose_through_boundary_scast(
 
 // -----
 
-// Test: scast with mixed users including DequantizeLinear - should NOT push transpose
-// CHECK-LABEL: func @test_no_push_transpose_through_boundary_scast_mixed_users
-func.func @test_no_push_transpose_through_boundary_scast_mixed_users(
-    %arg0: tensor<1x3x4x4x!quant.uniform<i8:f32, 0.05:0>>,
-    %scale: tensor<f32>,
-    %zp: tensor<i8>) -> (tensor<1x4x4x3xf32>, tensor<1x4x4x3xi8>) {
-  // CHECK: "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]}
-  // CHECK: quant.scast
-  // CHECK: "onnx.DequantizeLinear"
-  %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x3x4x4x!quant.uniform<i8:f32, 0.05:0>>) -> tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>>
-  %1 = quant.scast %0 : tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>> to tensor<1x4x4x3xi8>
-  %2 = "onnx.DequantizeLinear"(%1, %scale, %zp) : (tensor<1x4x4x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1x4x4x3xf32>
-  return %2, %1 : tensor<1x4x4x3xf32>, tensor<1x4x4x3xi8>
-}
-
-// -----
-
 // Test: scast without transpose input should NOT be modified
 // CHECK-LABEL: func @test_no_push_scast_without_transpose
 func.func @test_no_push_scast_without_transpose(%arg0: tensor<1x3x4x4x!quant.uniform<i8:f32, 0.05:0>>) -> tensor<1x3x4x4xi8> {

--- a/test/mlir/onnx/xmc/onnx_transpose_optimization.mlir
+++ b/test/mlir/onnx/xmc/onnx_transpose_optimization.mlir
@@ -1255,7 +1255,8 @@ func.func @test_push_transpose_through_scast_to_storage(%arg0: tensor<1x3x4x4x!q
   // CHECK-SAME: perm = [0, 2, 3, 1]
   %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x3x4x4x!quant.uniform<i8:f32, 0.05:0>>) -> tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>>
   %1 = quant.scast %0 : tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>> to tensor<1x4x4x3xi8>
-  return %1 : tensor<1x4x4x3xi8>
+  %2 = "onnx.Identity"(%1) : (tensor<1x4x4x3xi8>) -> tensor<1x4x4x3xi8>
+  return %2 : tensor<1x4x4x3xi8>
 }
 
 // -----
@@ -1268,7 +1269,8 @@ func.func @test_push_transpose_through_scast_to_quant(%arg0: tensor<1x3x4x4xi8>)
   // CHECK-SAME: perm = [0, 2, 3, 1]
   %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x3x4x4xi8>) -> tensor<1x4x4x3xi8>
   %1 = quant.scast %0 : tensor<1x4x4x3xi8> to tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>>
-  return %1 : tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>>
+  %2 = "onnx.Identity"(%1) : (tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>>) -> tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>>
+  return %2 : tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>>
 }
 
 // -----
@@ -1281,7 +1283,8 @@ func.func @test_push_transpose_through_scast_i8(%arg0: tensor<1x32x7x7x!quant.un
   // CHECK-SAME: perm = [0, 2, 3, 1]
   %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x32x7x7x!quant.uniform<i8:f32, 0.00842:0>>) -> tensor<1x7x7x32x!quant.uniform<i8:f32, 0.00842:0>>
   %1 = quant.scast %0 : tensor<1x7x7x32x!quant.uniform<i8:f32, 0.00842:0>> to tensor<1x7x7x32xi8>
-  return %1 : tensor<1x7x7x32xi8>
+  %2 = "onnx.Identity"(%1) : (tensor<1x7x7x32xi8>) -> tensor<1x7x7x32xi8>
+  return %2 : tensor<1x7x7x32xi8>
 }
 
 // -----
@@ -1299,6 +1302,20 @@ func.func @test_no_push_transpose_through_boundary_scast(
   %1 = quant.scast %0 : tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>> to tensor<1x4x4x3xi8>
   %2 = "onnx.DequantizeLinear"(%1, %scale, %zp) : (tensor<1x4x4x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1x4x4x3xf32>
   return %2 : tensor<1x4x4x3xf32>
+}
+
+// -----
+
+// Test: scast whose result is returned is a boundary - should NOT push transpose through
+// CHECK-LABEL: func @test_no_push_transpose_through_scast_at_return
+func.func @test_no_push_transpose_through_scast_at_return(
+    %arg0: tensor<1x3x4x4x!quant.uniform<i8:f32, 0.05:0>>) -> tensor<1x4x4x3xi8> {
+  // CHECK: "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]}
+  // CHECK: quant.scast
+  // CHECK: return
+  %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x3x4x4x!quant.uniform<i8:f32, 0.05:0>>) -> tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>>
+  %1 = quant.scast %0 : tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>> to tensor<1x4x4x3xi8>
+  return %1 : tensor<1x4x4x3xi8>
 }
 
 // -----

--- a/test/mlir/onnx/xmc/onnx_transpose_optimization.mlir
+++ b/test/mlir/onnx/xmc/onnx_transpose_optimization.mlir
@@ -1286,6 +1286,40 @@ func.func @test_push_transpose_through_scast_i8(%arg0: tensor<1x32x7x7x!quant.un
 
 // -----
 
+// Test: scast feeding DequantizeLinear is a boundary - should NOT push transpose through
+// CHECK-LABEL: func @test_no_push_transpose_through_boundary_scast
+func.func @test_no_push_transpose_through_boundary_scast(
+    %arg0: tensor<1x3x4x4x!quant.uniform<i8:f32, 0.05:0>>,
+    %scale: tensor<f32>,
+    %zp: tensor<i8>) -> tensor<1x4x4x3xf32> {
+  // CHECK: "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]}
+  // CHECK: quant.scast
+  // CHECK: "onnx.DequantizeLinear"
+  %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x3x4x4x!quant.uniform<i8:f32, 0.05:0>>) -> tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>>
+  %1 = quant.scast %0 : tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>> to tensor<1x4x4x3xi8>
+  %2 = "onnx.DequantizeLinear"(%1, %scale, %zp) : (tensor<1x4x4x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1x4x4x3xf32>
+  return %2 : tensor<1x4x4x3xf32>
+}
+
+// -----
+
+// Test: scast with mixed users including DequantizeLinear - should NOT push transpose
+// CHECK-LABEL: func @test_no_push_transpose_through_boundary_scast_mixed_users
+func.func @test_no_push_transpose_through_boundary_scast_mixed_users(
+    %arg0: tensor<1x3x4x4x!quant.uniform<i8:f32, 0.05:0>>,
+    %scale: tensor<f32>,
+    %zp: tensor<i8>) -> (tensor<1x4x4x3xf32>, tensor<1x4x4x3xi8>) {
+  // CHECK: "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]}
+  // CHECK: quant.scast
+  // CHECK: "onnx.DequantizeLinear"
+  %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x3x4x4x!quant.uniform<i8:f32, 0.05:0>>) -> tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>>
+  %1 = quant.scast %0 : tensor<1x4x4x3x!quant.uniform<i8:f32, 0.05:0>> to tensor<1x4x4x3xi8>
+  %2 = "onnx.DequantizeLinear"(%1, %scale, %zp) : (tensor<1x4x4x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1x4x4x3xf32>
+  return %2, %1 : tensor<1x4x4x3xf32>, tensor<1x4x4x3xi8>
+}
+
+// -----
+
 // Test: scast without transpose input should NOT be modified
 // CHECK-LABEL: func @test_no_push_scast_without_transpose
 func.func @test_no_push_scast_without_transpose(%arg0: tensor<1x3x4x4x!quant.uniform<i8:f32, 0.05:0>>) -> tensor<1x3x4x4xi8> {


### PR DESCRIPTION
Add a check while moving transpose through scast that it's not a boundary scast. If it's a boundary, don't push transpose through scast.