### PR TITLE
Add TensorName inference infrastructure

### DIFF
--- a/src/Compiler/CompilerDialects.cpp
+++ b/src/Compiler/CompilerDialects.cpp
@@ -7,6 +7,7 @@
 #include "CompilerDialects.hpp"
 
 #include "src/Compiler/CompilerOptions.hpp"
+#include "src/Interface/TensorNameInference.hpp"
 #ifdef ONNX_MLIR_ENABLE_KRNL
 #include "src/Dialect/Krnl/KrnlOps.hpp"
 #endif
@@ -53,6 +54,9 @@ DialectRegistry registerDialects(ArrayRef<accel::Accelerator::Kind> accels) {
   // Register interface needed by both old and new buffer deallocation pass.
   memref::registerAllocationOpInterfaceExternalModels(registry);
   arith::registerBufferDeallocationOpInterfaceExternalModels(registry);
+
+  // Register TensorName inference
+  registerTensorNameInferenceExternalModels(registry);
 
   return registry;
 }

--- a/src/Dialect/ONNX/CMakeLists.txt
+++ b/src/Dialect/ONNX/CMakeLists.txt
@@ -25,6 +25,7 @@ add_onnx_mlir_library(OMONNXOps
   ONNXOps/Canonicalize.cpp
   ONNXOps/ShapeHelper.cpp
   ONNXTypes.cpp
+  TensorName.cpp
 
   # Support for shape inference and verifiers
   ONNXOps/Additional/AMDQuark.cpp

--- a/src/Dialect/ONNX/CMakeLists.txt
+++ b/src/Dialect/ONNX/CMakeLists.txt
@@ -126,6 +126,7 @@ add_onnx_mlir_library(OMONNXOps
   OMONNXCanonicalizeIncGen
   OMResultTypeInferenceOpInterfaceIncGen
   OMShapeInferenceOpInterfaceIncGen
+  OMTensorNameInferenceIncGen
 
   LINK_LIBS PRIVATE
   OMDiagnostic
@@ -134,6 +135,7 @@ add_onnx_mlir_library(OMONNXOps
   OMMlirDialects
   OMMlirUtilities
   OMShapeHelperOpInterface
+  OMTensorNameInference
   OMONNXElementsAttr
   onnx
   MLIRFuncDialect

--- a/src/Dialect/ONNX/TensorName.cpp
+++ b/src/Dialect/ONNX/TensorName.cpp
@@ -3,10 +3,14 @@
 #include <memory>
 #include <numeric>
 
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/TypeUtilities.h"
+#include <llvm/ADT/SmallVectorExtras.h>
+#include <llvm/Support/ErrorHandling.h>
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/TypeUtilities.h>
+
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/TensorName.hpp"
+#include "src/Interface/TensorNameInference.hpp"
 
 using namespace mlir;
 
@@ -33,6 +37,8 @@ std::unique_ptr<Transform> Transform::fromAttr(ArrayAttr arrayAttr) {
 }
 
 std::unique_ptr<Transform> Transform::fromOp(Operation *op) {
+  if (auto nameInf = dyn_cast<mlir::TensorNameInference>(op))
+    return nameInf.inferTensorNameTransform();
   return {};
 }
 
@@ -93,11 +99,6 @@ ReshapeTransform::ReshapeTransform(
     ArrayRef<int64_t> inShape, ArrayRef<int64_t> outShape)
     : Transform(Kind::Reshape, inShape, outShape) {}
 
-ReshapeTransform::ReshapeTransform(ONNXReshapeOp reshapeOp)
-    : ReshapeTransform(
-          cast<RankedTensorType>(reshapeOp.getData().getType()).getShape(),
-          cast<RankedTensorType>(reshapeOp.getResult().getType()).getShape()) {}
-
 ReshapeTransform::ReshapeTransform(ArrayAttr attr)
     : ReshapeTransform(arrayToVector(cast<ArrayAttr>(attr[1])),
           arrayToVector(cast<ArrayAttr>(attr[2]))) {}
@@ -117,13 +118,6 @@ std::unique_ptr<Transform> ReshapeTransform::invert() const {
 TransposeTransform::TransposeTransform(ArrayRef<int64_t> inShape,
     ArrayRef<int64_t> perm, ArrayRef<int64_t> outShape)
     : Transform(Kind::Transpose, inShape, outShape), perm(perm) {}
-
-TransposeTransform::TransposeTransform(ONNXTransposeOp transposeOp)
-    : TransposeTransform(
-          cast<RankedTensorType>(transposeOp.getData().getType()).getShape(),
-          arrayToVector(transposeOp.getPermAttr()),
-          cast<RankedTensorType>(transposeOp.getResult().getType())
-              .getShape()) {}
 
 TransposeTransform::TransposeTransform(ArrayAttr attr)
     : TransposeTransform(arrayToVector(cast<ArrayAttr>(attr[1])),
@@ -154,25 +148,6 @@ PadTransform::PadTransform(ArrayRef<int64_t> inShape, ArrayRef<int64_t> starts,
     ArrayRef<int64_t> outShape)
     : Transform(Kind::Pad, inShape, outShape), starts(starts), ends(ends),
       axes(axes), constant(constant) {}
-
-PadTransform::PadTransform(ONNXPadOp padOp)
-    : Transform(Kind::Pad,
-          cast<RankedTensorType>(padOp.getData().getType()).getShape(),
-          cast<RankedTensorType>(padOp.getOutput().getType()).getShape()),
-      axes(axesToVector(padOp.getAxes(), inShape.size())) {
-  // In Pad op, pads = [x1_start, x2_start, ..., x1_end, x2_end, ...]
-  auto pads = valToVector(padOp.getPads());
-  auto splitAt = pads.size() / 2;
-  starts = SmallVector<int64_t>(pads.begin(), pads.begin() + splitAt);
-  ends = SmallVector<int64_t>(pads.begin() + splitAt, pads.end());
-
-  auto constVal = padOp.getConstantValue();
-  if (!isa<NoneType>(constVal.getType())) {
-    if (auto constOp = constVal.getDefiningOp<ONNXConstantOp>()) {
-      constant = constOp.getValueAttr();
-    }
-  }
-}
 
 PadTransform::PadTransform(ArrayAttr attr)
     : PadTransform(arrayToVector(cast<ArrayAttr>(attr[1])),
@@ -210,18 +185,6 @@ SliceTransform::SliceTransform(ArrayRef<int64_t> inShape,
     ArrayRef<int64_t> outShape)
     : Transform(Kind::Slice, inShape, outShape), starts(starts), ends(ends),
       axes(axes) {}
-
-SliceTransform::SliceTransform(ONNXSliceOp sliceOp)
-    : Transform(Kind::Slice,
-          cast<RankedTensorType>(sliceOp.getData().getType()).getShape(),
-          cast<RankedTensorType>(sliceOp.getOutput().getType()).getShape()),
-      starts(valToVector(sliceOp.getStarts())),
-      ends(valToVector(sliceOp.getEnds())),
-      axes(axesToVector(sliceOp.getAxes(), inShape.size())) {
-  // Clip end values
-  for (const auto &[ax, en] : llvm::zip_equal(axes, ends))
-    en = std::min(en, inShape[ax]);
-}
 
 SliceTransform::SliceTransform(ArrayAttr attr)
     : SliceTransform(arrayToVector(cast<ArrayAttr>(attr[1])),

--- a/src/Dialect/ONNX/TensorName.cpp
+++ b/src/Dialect/ONNX/TensorName.cpp
@@ -60,8 +60,7 @@ SmallVector<int64_t> Transform::denseToVector(DenseIntElementsAttr denseAttr) {
 }
 
 SmallVector<int64_t> Transform::valToVector(Value val) {
-  auto constOp = val.getDefiningOp<ONNXConstantOp>();
-  if (!constOp) {
+  if (auto constOp = val.getDefiningOp<ONNXConstantOp>()) {
     if (auto arrayAttr = dyn_cast<ArrayAttr>(constOp.getValueAttr()))
       return arrayToVector(arrayAttr);
     else if (auto denseAttr =

--- a/src/Dialect/ONNX/TensorName.cpp
+++ b/src/Dialect/ONNX/TensorName.cpp
@@ -32,7 +32,7 @@ std::unique_ptr<Transform> Transform::fromAttr(ArrayAttr arrayAttr) {
   return {};
 }
 
-SmallVector<std::unique_ptr<Transform>> Transform::fromOp(Operation *op) {
+std::unique_ptr<Transform> Transform::fromOp(Operation *op) {
   return {};
 }
 
@@ -250,6 +250,24 @@ std::unique_ptr<Transform> SliceTransform::invert() const {
       outShape, starts, padEnds, axes, Attribute(), inShape);
 }
 
+// == List == //
+
+ListTransform::ListTransform(
+    SmallVector<std::unique_ptr<Transform>> &&transforms)
+    : Transform(Kind::List, {}, {}), transforms(std::move(transforms)) {}
+
+mlir::Attribute ListTransform::toAttr(MLIRContext * /*context*/) const {
+  llvm_unreachable(
+      "ListTransform should not be directly converted to attribute");
+}
+
+std::unique_ptr<Transform> ListTransform::invert() const {
+  SmallVector<std::unique_ptr<Transform>> trans;
+  for (const auto &transform : llvm::reverse(transforms))
+    trans.push_back(transform->invert());
+  return std::make_unique<ListTransform>(std::move(trans));
+}
+
 // == TensorName == //
 
 TensorName::TensorName(std::string name) : name(std::move(name)) {}
@@ -294,11 +312,10 @@ TensorName TensorName::inferWithUse(Value value) {
     return tname;
 
   Operation *op = *value.user_begin();
-  if (auto transforms = Transform::fromOp(op); transforms.size()) {
+  if (auto transform = Transform::fromOp(op)) {
     tname = inferWithUse(op->getResult(0));
     if (tname) {
-      for (auto &transform : llvm::reverse(transforms))
-        tname.push_back(transform->invert());
+      tname.push_back(transform->invert());
       (void)tname.setTo(value);
     }
   }
@@ -312,16 +329,25 @@ TensorName TensorName::inferWithDef(Value value) {
     return tname;
 
   Operation *op = value.getDefiningOp();
-  if (auto transforms = Transform::fromOp(op); transforms.size()) {
+  if (auto transform = Transform::fromOp(op)) {
     tname = inferWithDef(op->getOperand(0));
     if (tname) {
-      for (auto &transform : transforms)
-        tname.push_back(std::move(transform));
+      tname.push_back(std::move(transform));
       (void)tname.setTo(value);
     }
   }
 
   return tname;
+}
+
+void TensorName::push_back(std::unique_ptr<Transform> transform) {
+  if (auto *list = dyn_cast<ListTransform>(transform.get())) {
+    for (auto &it : list->transforms) {
+      transforms.push_back(std::move(it));
+    }
+    return;
+  }
+  transforms.push_back(std::move(transform));
 }
 
 Attribute TensorName::toAttr(MLIRContext *context) const {

--- a/src/Dialect/ONNX/TensorName.cpp
+++ b/src/Dialect/ONNX/TensorName.cpp
@@ -32,37 +32,8 @@ std::unique_ptr<Transform> Transform::fromAttr(ArrayAttr arrayAttr) {
   return {};
 }
 
-template <>
-SmallVector<std::unique_ptr<Transform>> Transform::fromOp<ONNXReshapeOp>(
-    ONNXReshapeOp reshapeOp) {
-  SmallVector<std::unique_ptr<Transform>> transforms;
-  transforms.push_back(std::make_unique<ReshapeTransform>(reshapeOp));
-  return transforms;
-}
-
-template <>
-SmallVector<std::unique_ptr<Transform>> Transform::fromOp<ONNXTransposeOp>(
-    ONNXTransposeOp transposeOp) {
-  SmallVector<std::unique_ptr<Transform>> transforms;
-  transforms.push_back(std::make_unique<TransposeTransform>(transposeOp));
-  return transforms;
-}
-
-template <>
-SmallVector<std::unique_ptr<Transform>> Transform::fromOp<ONNXPadOp>(
-    ONNXPadOp padOp) {
-  SmallVector<std::unique_ptr<Transform>> transforms;
-  if (padOp.getMode() == "constant")
-    transforms.push_back(std::make_unique<PadTransform>(padOp));
-  return transforms;
-}
-
-template <>
-SmallVector<std::unique_ptr<Transform>> Transform::fromOp<ONNXSliceOp>(
-    ONNXSliceOp sliceOp) {
-  SmallVector<std::unique_ptr<Transform>> transforms;
-  transforms.push_back(std::make_unique<SliceTransform>(sliceOp));
-  return transforms;
+SmallVector<std::unique_ptr<Transform>> Transform::fromOp(Operation *op) {
+  return {};
 }
 
 SmallVector<int64_t> Transform::arrayToVector(ArrayAttr arrayAttr) {

--- a/src/Dialect/ONNX/TensorName.cpp
+++ b/src/Dialect/ONNX/TensorName.cpp
@@ -31,6 +31,10 @@ std::unique_ptr<Transform> Transform::fromAttr(ArrayAttr arrayAttr) {
         return std::make_unique<PadTransform>(arrayAttr);
       else if (transType == "Slice")
         return std::make_unique<SliceTransform>(arrayAttr);
+      else if (transType == "Dequantize")
+        return std::make_unique<DequantizeTransform>(arrayAttr);
+      else if (transType == "Quantize")
+        return std::make_unique<QuantizeTransform>(arrayAttr);
     }
   }
   return {};
@@ -210,6 +214,67 @@ std::unique_ptr<Transform> SliceTransform::invert() const {
 
   return std::make_unique<PadTransform>(
       outShape, starts, padEnds, axes, Attribute(), inShape);
+}
+
+// == QDQ == //
+
+template <Transform::Kind QDQType>
+QDQTransform<QDQType>::QDQTransform(mlir::ArrayRef<int64_t> shape, double scale,
+    int64_t zeroPoint, mlir::Type scaleType, mlir::Type zpType)
+    : Transform(QDQType, shape, shape), scale(scale), zeroPoint(zeroPoint),
+      scaleType(scaleType), zpType(zpType) {}
+
+template <Transform::Kind QDQType>
+QDQTransform<QDQType>::QDQTransform(mlir::ArrayAttr attr)
+    : QDQTransform(arrayToVector(cast<ArrayAttr>(attr[1])),
+          cast<FloatAttr>(attr[2]).getValueAsDouble(),
+          cast<IntegerAttr>(attr[3]).getInt(),
+          cast<FloatAttr>(attr[2]).getType(),
+          cast<IntegerAttr>(attr[3]).getType()) {}
+
+template <Transform::Kind QDQType>
+mlir::Attribute QDQTransform<QDQType>::toAttr(
+    mlir::MLIRContext *context) const {
+  StringRef transType = "Unknown";
+  if constexpr (QDQType == Transform::Kind::Dequantize)
+    transType = "Dequantize";
+  else if constexpr (QDQType == Transform::Kind::Dequantize)
+    transType = "Quantize";
+  return ArrayAttr::get(context, {
+                                     StringAttr::get(context, transType),
+                                     vecToAttr(context, inShape),
+                                     FloatAttr::get(scaleType, scale),
+                                     IntegerAttr::get(zpType, zeroPoint),
+                                 });
+}
+
+template <Transform::Kind QDQType>
+std::unique_ptr<Transform> QDQTransform<QDQType>::invert() const {
+  if constexpr (QDQType == Transform::Kind::Dequantize)
+    return std::make_unique<QuantizeTransform>(
+        inShape, scale, zeroPoint, scaleType, zpType);
+  else if constexpr (QDQType == Transform::Kind::Dequantize)
+    return std::make_unique<DequantizeTransform>(
+        inShape, scale, zeroPoint, scaleType, zpType);
+  return nullptr;
+}
+
+template <Transform::Kind QDQType>
+mlir::Type QDQTransform<QDQType>::getFromDType() const {
+  if constexpr (QDQType == Transform::Kind::Dequantize)
+    return zpType;
+  else if constexpr (QDQType == Transform::Kind::Quantize)
+    return scaleType;
+  return nullptr;
+}
+
+template <Transform::Kind QDQType>
+mlir::Type QDQTransform<QDQType>::getToDType() const {
+  if constexpr (QDQType == Transform::Kind::Dequantize)
+    return scaleType;
+  else if constexpr (QDQType == Transform::Kind::Quantize)
+    return zpType;
+  return nullptr;
 }
 
 // == List == //

--- a/src/Dialect/ONNX/TensorName.cpp
+++ b/src/Dialect/ONNX/TensorName.cpp
@@ -1,0 +1,394 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#include <memory>
+#include <numeric>
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/TensorName.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+Transform::Transform(
+    Transform::Kind k, ArrayRef<int64_t> inShape, ArrayRef<int64_t> outShape)
+    : kind(k), inShape(inShape), outShape(outShape) {}
+
+std::unique_ptr<Transform> Transform::fromAttr(ArrayAttr arrayAttr) {
+  if (arrayAttr.size()) {
+    if (auto transType = dyn_cast<StringAttr>(arrayAttr[0])) {
+      if (transType == "Reshape")
+        return std::make_unique<ReshapeTransform>(arrayAttr);
+      else if (transType == "Transpose")
+        return std::make_unique<TransposeTransform>(arrayAttr);
+      else if (transType == "Pad")
+        return std::make_unique<PadTransform>(arrayAttr);
+      else if (transType == "Slice")
+        return std::make_unique<SliceTransform>(arrayAttr);
+    }
+  }
+  return {};
+}
+
+template <>
+SmallVector<std::unique_ptr<Transform>> Transform::fromOp<ONNXReshapeOp>(
+    ONNXReshapeOp reshapeOp) {
+  SmallVector<std::unique_ptr<Transform>> transforms;
+  transforms.push_back(std::make_unique<ReshapeTransform>(reshapeOp));
+  return transforms;
+}
+
+template <>
+SmallVector<std::unique_ptr<Transform>> Transform::fromOp<ONNXTransposeOp>(
+    ONNXTransposeOp transposeOp) {
+  SmallVector<std::unique_ptr<Transform>> transforms;
+  transforms.push_back(std::make_unique<TransposeTransform>(transposeOp));
+  return transforms;
+}
+
+template <>
+SmallVector<std::unique_ptr<Transform>> Transform::fromOp<ONNXPadOp>(
+    ONNXPadOp padOp) {
+  SmallVector<std::unique_ptr<Transform>> transforms;
+  if (padOp.getMode() == "constant")
+    transforms.push_back(std::make_unique<PadTransform>(padOp));
+  return transforms;
+}
+
+template <>
+SmallVector<std::unique_ptr<Transform>> Transform::fromOp<ONNXSliceOp>(
+    ONNXSliceOp sliceOp) {
+  SmallVector<std::unique_ptr<Transform>> transforms;
+  transforms.push_back(std::make_unique<SliceTransform>(sliceOp));
+  return transforms;
+}
+
+SmallVector<int64_t> Transform::arrayToVector(ArrayAttr arrayAttr) {
+  SmallVector<int64_t> vector;
+  for (const APInt intVal : arrayAttr.getAsValueRange<IntegerAttr>())
+    vector.push_back(intVal.getSExtValue());
+  return vector;
+}
+
+SmallVector<int64_t> Transform::denseToVector(DenseIntElementsAttr denseAttr) {
+  if (denseAttr.isSplat()) {
+    SmallVector<int64_t> vector(denseAttr.getNumElements());
+    for (int64_t &v : vector)
+      v = denseAttr.getSplatValue<int64_t>();
+    return vector;
+  }
+  return SmallVector<int64_t>(denseAttr.getValues<int64_t>());
+}
+
+SmallVector<int64_t> Transform::valToVector(Value val) {
+  auto constOp = val.getDefiningOp<ONNXConstantOp>();
+  if (!constOp) {
+    if (auto arrayAttr = dyn_cast<ArrayAttr>(constOp.getValueAttr()))
+      return arrayToVector(arrayAttr);
+    else if (auto denseAttr =
+                 dyn_cast<DenseIntElementsAttr>(constOp.getValueAttr()))
+      return denseToVector(denseAttr);
+  }
+  return {};
+}
+
+SmallVector<int64_t> Transform::axesToVector(Value val, size_t rank) {
+  if (isa<NoneType>(val.getType())) {
+    SmallVector<int64_t> axes(rank);
+    std::iota(axes.begin(), axes.end(), 0);
+    return axes;
+  } else {
+    SmallVector<int64_t> axes = valToVector(val);
+    for (int64_t &ax : axes)
+      if (ax < 0 && rank > 0)
+        ax += rank;
+    return axes;
+  }
+}
+
+ArrayAttr Transform::vecToAttr(MLIRContext *context, ArrayRef<int64_t> vector) {
+  auto vecOfAttr =
+      llvm::map_to_vector(vector, [context](int64_t v) -> Attribute {
+        return IntegerAttr::get(IntegerType::get(context, 64), APInt(64, v));
+      });
+  return ArrayAttr::get(context, vecOfAttr);
+}
+
+// == Reshape == //
+
+ReshapeTransform::ReshapeTransform(
+    ArrayRef<int64_t> inShape, ArrayRef<int64_t> outShape)
+    : Transform(Kind::Reshape, inShape, outShape) {}
+
+ReshapeTransform::ReshapeTransform(ONNXReshapeOp reshapeOp)
+    : ReshapeTransform(
+          cast<RankedTensorType>(reshapeOp.getData().getType()).getShape(),
+          cast<RankedTensorType>(reshapeOp.getResult().getType()).getShape()) {}
+
+ReshapeTransform::ReshapeTransform(ArrayAttr attr)
+    : ReshapeTransform(arrayToVector(cast<ArrayAttr>(attr[1])),
+          arrayToVector(cast<ArrayAttr>(attr[2]))) {}
+
+Attribute ReshapeTransform::toAttr(MLIRContext *context) const {
+  return ArrayAttr::get(
+      context, {StringAttr::get(context, "Reshape"),
+                   vecToAttr(context, inShape), vecToAttr(context, outShape)});
+}
+
+std::unique_ptr<Transform> ReshapeTransform::invert() const {
+  return std::make_unique<ReshapeTransform>(outShape, inShape);
+}
+
+// == Transpose == //
+
+TransposeTransform::TransposeTransform(ArrayRef<int64_t> inShape,
+    ArrayRef<int64_t> perm, ArrayRef<int64_t> outShape)
+    : Transform(Kind::Transpose, inShape, outShape), perm(perm) {}
+
+TransposeTransform::TransposeTransform(ONNXTransposeOp transposeOp)
+    : TransposeTransform(
+          cast<RankedTensorType>(transposeOp.getData().getType()).getShape(),
+          arrayToVector(transposeOp.getPermAttr()),
+          cast<RankedTensorType>(transposeOp.getResult().getType())
+              .getShape()) {}
+
+TransposeTransform::TransposeTransform(ArrayAttr attr)
+    : TransposeTransform(arrayToVector(cast<ArrayAttr>(attr[1])),
+          arrayToVector(cast<ArrayAttr>(attr[2])),
+          arrayToVector(cast<ArrayAttr>(attr[3]))) {}
+
+Attribute TransposeTransform::toAttr(MLIRContext *context) const {
+  return ArrayAttr::get(context, {
+                                     StringAttr::get(context, "Transpose"),
+                                     vecToAttr(context, inShape),
+                                     vecToAttr(context, perm),
+                                     vecToAttr(context, outShape),
+                                 });
+}
+
+std::unique_ptr<Transform> TransposeTransform::invert() const {
+  SmallVector<int64_t> invPerm(perm.size());
+  for (const auto [i, p] : llvm::enumerate(perm))
+    invPerm[p] = i;
+
+  return std::make_unique<TransposeTransform>(outShape, invPerm, inShape);
+}
+
+// == Pad == //
+
+PadTransform::PadTransform(ArrayRef<int64_t> inShape, ArrayRef<int64_t> starts,
+    ArrayRef<int64_t> ends, ArrayRef<int64_t> axes, Attribute constant,
+    ArrayRef<int64_t> outShape)
+    : Transform(Kind::Pad, inShape, outShape), starts(starts), ends(ends),
+      axes(axes), constant(constant) {}
+
+PadTransform::PadTransform(ONNXPadOp padOp)
+    : Transform(Kind::Pad,
+          cast<RankedTensorType>(padOp.getData().getType()).getShape(),
+          cast<RankedTensorType>(padOp.getOutput().getType()).getShape()),
+      axes(axesToVector(padOp.getAxes(), inShape.size())) {
+  // In Pad op, pads = [x1_start, x2_start, ..., x1_end, x2_end, ...]
+  auto pads = valToVector(padOp.getPads());
+  auto splitAt = pads.size() / 2;
+  starts = SmallVector<int64_t>(pads.begin(), pads.begin() + splitAt);
+  ends = SmallVector<int64_t>(pads.begin() + splitAt, pads.end());
+
+  auto constVal = padOp.getConstantValue();
+  if (!isa<NoneType>(constVal.getType())) {
+    if (auto constOp = constVal.getDefiningOp<ONNXConstantOp>()) {
+      constant = constOp.getValueAttr();
+    }
+  }
+}
+
+PadTransform::PadTransform(ArrayAttr attr)
+    : PadTransform(arrayToVector(cast<ArrayAttr>(attr[1])),
+          arrayToVector(cast<ArrayAttr>(attr[2])),
+          arrayToVector(cast<ArrayAttr>(attr[3])),
+          arrayToVector(cast<ArrayAttr>(attr[4])), attr[5],
+          arrayToVector(cast<ArrayAttr>(attr[6]))) {}
+
+Attribute PadTransform::toAttr(MLIRContext *context) const {
+  return ArrayAttr::get(
+      context, {
+                   StringAttr::get(context, "Pad"),
+                   vecToAttr(context, inShape),
+                   vecToAttr(context, starts),
+                   vecToAttr(context, ends),
+                   vecToAttr(context, axes),
+                   constant ? constant : UnitAttr::get(context),
+                   vecToAttr(context, outShape),
+               });
+}
+
+std::unique_ptr<Transform> PadTransform::invert() const {
+  SmallVector<int64_t> sliceEnds(ends.size());
+  for (const auto &[ax, pe, se] : llvm::zip_equal(axes, ends, sliceEnds))
+    se = outShape[ax] - pe;
+
+  return std::make_unique<SliceTransform>(
+      outShape, starts, sliceEnds, axes, inShape);
+}
+
+// == Slice == //
+
+SliceTransform::SliceTransform(ArrayRef<int64_t> inShape,
+    ArrayRef<int64_t> starts, ArrayRef<int64_t> ends, ArrayRef<int64_t> axes,
+    ArrayRef<int64_t> outShape)
+    : Transform(Kind::Slice, inShape, outShape), starts(starts), ends(ends),
+      axes(axes) {}
+
+SliceTransform::SliceTransform(ONNXSliceOp sliceOp)
+    : Transform(Kind::Slice,
+          cast<RankedTensorType>(sliceOp.getData().getType()).getShape(),
+          cast<RankedTensorType>(sliceOp.getOutput().getType()).getShape()),
+      starts(valToVector(sliceOp.getStarts())),
+      ends(valToVector(sliceOp.getEnds())),
+      axes(axesToVector(sliceOp.getAxes(), inShape.size())) {
+  // Clip end values
+  for (const auto &[ax, en] : llvm::zip_equal(axes, ends))
+    en = std::min(en, inShape[ax]);
+}
+
+SliceTransform::SliceTransform(ArrayAttr attr)
+    : SliceTransform(arrayToVector(cast<ArrayAttr>(attr[1])),
+          arrayToVector(cast<ArrayAttr>(attr[2])),
+          arrayToVector(cast<ArrayAttr>(attr[3])),
+          arrayToVector(cast<ArrayAttr>(attr[4])),
+          arrayToVector(cast<ArrayAttr>(attr[5]))) {}
+
+Attribute SliceTransform::toAttr(MLIRContext *context) const {
+  return ArrayAttr::get(context, {
+                                     StringAttr::get(context, "Slice"),
+                                     vecToAttr(context, inShape),
+                                     vecToAttr(context, starts),
+                                     vecToAttr(context, ends),
+                                     vecToAttr(context, axes),
+                                     vecToAttr(context, outShape),
+                                 });
+}
+
+std::unique_ptr<Transform> SliceTransform::invert() const {
+  SmallVector<int64_t> padEnds(ends.size());
+  for (const auto &[ax, se, pe] : llvm::zip_equal(axes, ends, padEnds))
+    pe = inShape[ax] - se;
+
+  return std::make_unique<PadTransform>(
+      outShape, starts, padEnds, axes, Attribute(), inShape);
+}
+
+// == TensorName == //
+
+TensorName::TensorName(std::string name) : name(std::move(name)) {}
+
+TensorName::TensorName(Value value) {
+  if (auto opRes = dyn_cast<OpResult>(value)) {
+    auto resultNames =
+        opRes.getOwner()->getAttrOfType<ArrayAttr>("ResultNames");
+    if (resultNames && resultNames.size() > opRes.getResultNumber()) {
+      auto resultName = resultNames[opRes.getResultNumber()];
+      if (auto strAttr = dyn_cast<StringAttr>(resultName))
+        name = strAttr.getValue().str();
+      else if (auto arrayAttr = dyn_cast<ArrayAttr>(resultName)) {
+        name = cast<StringAttr>(arrayAttr[0]).getValue().str();
+        for (size_t i = 1; i < arrayAttr.size(); i++) {
+          transforms.push_back(
+              Transform::fromAttr(cast<ArrayAttr>(arrayAttr[i])));
+        }
+      }
+    }
+  } else if (auto blkArg = dyn_cast<BlockArgument>(value)) {
+    auto *parentOp = blkArg.getOwner()->getParentOp();
+    if (auto funcOp = dyn_cast<func::FuncOp>(parentOp)) {
+      auto argIndex = blkArg.getArgNumber();
+      if (auto strAttr =
+              funcOp.getArgAttrOfType<StringAttr>(argIndex, "onnx.name"))
+        name = strAttr.getValue().str();
+    }
+  }
+}
+
+TensorName TensorName::infer(Value value) {
+  if (TensorName tname = inferWithUse(value))
+    return tname;
+
+  return inferWithDef(value);
+}
+
+TensorName TensorName::inferWithUse(Value value) {
+  TensorName tname(value);
+  if (tname || !value.hasOneUse() || value.use_begin()->getOperandNumber() != 0)
+    return tname;
+
+  Operation *op = *value.user_begin();
+  if (auto transforms = Transform::fromOp(op); transforms.size()) {
+    tname = inferWithUse(op->getResult(0));
+    if (tname) {
+      for (auto &transform : llvm::reverse(transforms))
+        tname.push_back(transform->invert());
+      (void)tname.setTo(value);
+    }
+  }
+
+  return tname;
+}
+
+TensorName TensorName::inferWithDef(Value value) {
+  TensorName tname(value);
+  if (tname)
+    return tname;
+
+  Operation *op = value.getDefiningOp();
+  if (auto transforms = Transform::fromOp(op); transforms.size()) {
+    tname = inferWithDef(op->getOperand(0));
+    if (tname) {
+      for (auto &transform : transforms)
+        tname.push_back(std::move(transform));
+      (void)tname.setTo(value);
+    }
+  }
+
+  return tname;
+}
+
+Attribute TensorName::toAttr(MLIRContext *context) const {
+  Attribute tnameAttr = StringAttr::get(context, llvm::Twine(name));
+  if (!transforms.empty()) {
+    SmallVector<Attribute> arrayAttr({tnameAttr});
+    for (const auto &t : transforms)
+      arrayAttr.push_back(t->toAttr(context));
+    tnameAttr = ArrayAttr::get(context, arrayAttr);
+  }
+  return tnameAttr;
+}
+
+LogicalResult TensorName::setTo(Value value) const {
+  if (auto result = dyn_cast<OpResult>(value)) {
+    MLIRContext *ctx = value.getContext();
+    Operation *op = result.getOwner();
+    unsigned idx = result.getResultNumber();
+
+    SmallVector<Attribute> resultNames(
+        op->getNumResults(), StringAttr::get(ctx));
+    if (auto resultNamesAttr = op->getAttrOfType<ArrayAttr>("ResultNames")) {
+      // The existing ResultNames array may have fewer entries than the op has
+      // results (e.g. when a prior setTo only populated a subset, or the
+      // attribute was carried from an op with a different result count).
+      // Copy what we have and leave the rest as the default empty StringAttr.
+      auto existing = resultNamesAttr.getValue();
+      for (unsigned i = 0, e = std::min((unsigned)existing.size(),
+                               (unsigned)resultNames.size());
+           i < e; ++i)
+        resultNames[i] = existing[i];
+    }
+
+    resultNames[idx] = toAttr(ctx);
+    op->setAttr("ResultNames", ArrayAttr::get(ctx, resultNames));
+    return success();
+  }
+  return failure();
+}
+
+} // namespace onnx_mlir

--- a/src/Dialect/ONNX/TensorName.cpp
+++ b/src/Dialect/ONNX/TensorName.cpp
@@ -306,7 +306,7 @@ TensorName TensorName::inferWithDef(Value value) {
 void TensorName::push_back(std::unique_ptr<Transform> transform) {
   if (auto *list = dyn_cast<ListTransform>(transform.get())) {
     for (auto &it : list->transforms) {
-      transforms.push_back(std::move(it));
+      push_back(std::move(it));
     }
     return;
   }

--- a/src/Dialect/ONNX/TensorName.cpp
+++ b/src/Dialect/ONNX/TensorName.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<Transform> Transform::fromAttr(ArrayAttr arrayAttr) {
 }
 
 std::unique_ptr<Transform> Transform::fromOp(Operation *op) {
-  if (auto nameInf = dyn_cast<mlir::TensorNameInference>(op))
+  if (auto nameInf = dyn_cast_if_present<mlir::TensorNameInference>(op))
     return nameInf.inferTensorNameTransform();
   return {};
 }

--- a/src/Dialect/ONNX/TensorName.hpp
+++ b/src/Dialect/ONNX/TensorName.hpp
@@ -48,10 +48,8 @@ public:
   virtual mlir::Attribute toAttr(mlir::MLIRContext *context) const = 0;
 
   // Op conversions
-  template <typename OpTy = mlir::Operation *>
-  static mlir::SmallVector<std::unique_ptr<Transform>> fromOp(OpTy /*op*/) {
-    return {};
-  }
+  static mlir::SmallVector<std::unique_ptr<Transform>> fromOp(
+      mlir::Operation *op);
   // virtual mlir::Operation *toOp(
   //     mlir::OpBuilder &builder, mlir::Value) const = 0;
 

--- a/src/Dialect/ONNX/TensorName.hpp
+++ b/src/Dialect/ONNX/TensorName.hpp
@@ -38,6 +38,7 @@ public:
     Slice,
     Dequantize,
     Quantize,
+    List,
   };
 
   Transform(Kind k, mlir::ArrayRef<int64_t> inShape,
@@ -48,8 +49,7 @@ public:
   virtual mlir::Attribute toAttr(mlir::MLIRContext *context) const = 0;
 
   // Op conversions
-  static mlir::SmallVector<std::unique_ptr<Transform>> fromOp(
-      mlir::Operation *op);
+  static std::unique_ptr<Transform> fromOp(mlir::Operation *op);
   // virtual mlir::Operation *toOp(
   //     mlir::OpBuilder &builder, mlir::Value) const = 0;
 
@@ -181,6 +181,27 @@ private:
   mlir::SmallVector<int64_t> axes;
 };
 
+/// A convenience transform to hold multiple transforms
+class ListTransform : public Transform {
+public:
+  ListTransform(mlir::SmallVector<std::unique_ptr<Transform>> &&transforms);
+
+  mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
+
+  // mlir::Operation *toOp(
+  //     mlir::OpBuilder &builder, mlir::Value value) const override;
+
+  [[nodiscard]] std::unique_ptr<Transform> invert() const override;
+
+  static bool classof(const Transform *transform) {
+    return transform->getKind() == Kind::List;
+  }
+
+private:
+  friend class TensorName;
+  mlir::SmallVector<std::unique_ptr<Transform>> transforms;
+};
+
 /// A TensorName represents the name of a tensor along with the sequence of
 /// transformations that have been applied to it.
 class TensorName {
@@ -210,9 +231,7 @@ public:
   }
 
   /// Add new transform at the end of list of tranforms
-  void push_back(std::unique_ptr<Transform> transform) {
-    transforms.push_back(std::move(transform));
-  }
+  void push_back(std::unique_ptr<Transform> transform);
 
   /// Attribute conversion
   [[nodiscard]] mlir::Attribute toAttr(mlir::MLIRContext *context) const;

--- a/src/Dialect/ONNX/TensorName.hpp
+++ b/src/Dialect/ONNX/TensorName.hpp
@@ -90,7 +90,6 @@ public:
   ReshapeTransform(mlir::ArrayAttr attr);
   mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
 
-  ReshapeTransform(mlir::ONNXReshapeOp reshapeOp);
   // mlir::Operation *toOp(
   //     mlir::OpBuilder &builder, mlir::Value value) const override;
 
@@ -109,7 +108,6 @@ public:
   TransposeTransform(mlir::ArrayAttr attr);
   mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
 
-  TransposeTransform(mlir::ONNXTransposeOp transposeOp);
   // mlir::Operation *toOp(
   //     mlir::OpBuilder &builder, mlir::Value value) const override;
 
@@ -133,7 +131,6 @@ public:
   PadTransform(mlir::ArrayAttr attr);
   mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
 
-  PadTransform(mlir::ONNXPadOp padOp);
   // mlir::Operation *toOp(
   //     mlir::OpBuilder &builder, mlir::Value value) const override;
 
@@ -162,7 +159,6 @@ public:
   SliceTransform(mlir::ArrayAttr attr);
   mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
 
-  SliceTransform(mlir::ONNXSliceOp sliceOp);
   // mlir::Operation *toOp(
   //     mlir::OpBuilder &builder, mlir::Value value) const override;
 

--- a/src/Dialect/ONNX/TensorName.hpp
+++ b/src/Dialect/ONNX/TensorName.hpp
@@ -46,7 +46,8 @@ public:
 
   // Attribute conversions
   static std::unique_ptr<Transform> fromAttr(mlir::ArrayAttr arrayAttr);
-  virtual mlir::Attribute toAttr(mlir::MLIRContext *context) const = 0;
+  [[nodiscard]] virtual mlir::Attribute toAttr(
+      mlir::MLIRContext *context) const = 0;
 
   // Op conversions
   static std::unique_ptr<Transform> fromOp(mlir::Operation *op);
@@ -86,7 +87,8 @@ public:
       mlir::ArrayRef<int64_t> inShape, mlir::ArrayRef<int64_t> outShape);
 
   ReshapeTransform(mlir::ArrayAttr attr);
-  mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
+  [[nodiscard]] mlir::Attribute toAttr(
+      mlir::MLIRContext *context) const override;
 
   [[nodiscard]] std::unique_ptr<Transform> invert() const override;
 
@@ -101,9 +103,11 @@ public:
       mlir::ArrayRef<int64_t> perm, mlir::ArrayRef<int64_t> outShape);
 
   TransposeTransform(mlir::ArrayAttr attr);
-  mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
+  [[nodiscard]] mlir::Attribute toAttr(
+      mlir::MLIRContext *context) const override;
 
   [[nodiscard]] std::unique_ptr<Transform> invert() const override;
+
   static bool classof(const Transform *transform) {
     return transform->getKind() == Kind::Transpose;
   }
@@ -121,9 +125,11 @@ public:
       mlir::Attribute constant, mlir::ArrayRef<int64_t> outShape);
 
   PadTransform(mlir::ArrayAttr attr);
-  mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
+  [[nodiscard]] mlir::Attribute toAttr(
+      mlir::MLIRContext *context) const override;
 
   [[nodiscard]] std::unique_ptr<Transform> invert() const override;
+
   static bool classof(const Transform *transform) {
     return transform->getKind() == Kind::Pad;
   }
@@ -146,9 +152,11 @@ public:
       mlir::ArrayRef<int64_t> axes, mlir::ArrayRef<int64_t> outShape);
 
   SliceTransform(mlir::ArrayAttr attr);
-  mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
+  [[nodiscard]] mlir::Attribute toAttr(
+      mlir::MLIRContext *context) const override;
 
   [[nodiscard]] std::unique_ptr<Transform> invert() const override;
+
   static bool classof(const Transform *transform) {
     return transform->getKind() == Kind::Slice;
   }

--- a/src/Dialect/ONNX/TensorName.hpp
+++ b/src/Dialect/ONNX/TensorName.hpp
@@ -50,8 +50,6 @@ public:
 
   // Op conversions
   static std::unique_ptr<Transform> fromOp(mlir::Operation *op);
-  // virtual mlir::Operation *toOp(
-  //     mlir::OpBuilder &builder, mlir::Value) const = 0;
 
   /// Creates a new transform which is inversion of the current transform
   [[nodiscard]] virtual std::unique_ptr<Transform> invert() const = 0;
@@ -90,9 +88,6 @@ public:
   ReshapeTransform(mlir::ArrayAttr attr);
   mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
 
-  // mlir::Operation *toOp(
-  //     mlir::OpBuilder &builder, mlir::Value value) const override;
-
   [[nodiscard]] std::unique_ptr<Transform> invert() const override;
 
   static bool classof(const Transform *transform) {
@@ -107,9 +102,6 @@ public:
 
   TransposeTransform(mlir::ArrayAttr attr);
   mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
-
-  // mlir::Operation *toOp(
-  //     mlir::OpBuilder &builder, mlir::Value value) const override;
 
   [[nodiscard]] std::unique_ptr<Transform> invert() const override;
   static bool classof(const Transform *transform) {
@@ -130,9 +122,6 @@ public:
 
   PadTransform(mlir::ArrayAttr attr);
   mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
-
-  // mlir::Operation *toOp(
-  //     mlir::OpBuilder &builder, mlir::Value value) const override;
 
   [[nodiscard]] std::unique_ptr<Transform> invert() const override;
   static bool classof(const Transform *transform) {
@@ -159,9 +148,6 @@ public:
   SliceTransform(mlir::ArrayAttr attr);
   mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
 
-  // mlir::Operation *toOp(
-  //     mlir::OpBuilder &builder, mlir::Value value) const override;
-
   [[nodiscard]] std::unique_ptr<Transform> invert() const override;
   static bool classof(const Transform *transform) {
     return transform->getKind() == Kind::Slice;
@@ -183,9 +169,6 @@ public:
   ListTransform(mlir::SmallVector<std::unique_ptr<Transform>> &&transforms);
 
   mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
-
-  // mlir::Operation *toOp(
-  //     mlir::OpBuilder &builder, mlir::Value value) const override;
 
   [[nodiscard]] std::unique_ptr<Transform> invert() const override;
 

--- a/src/Dialect/ONNX/TensorName.hpp
+++ b/src/Dialect/ONNX/TensorName.hpp
@@ -1,0 +1,237 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+/// This files defines the TensorName structure.
+/// TensorName tracks the original name of a tensor along with a sequence of
+/// transformations (reshape, transpose, pad, slice) that have been applied to
+/// it.
+/// Then TensorName API abstracts the underlying storage mechanism (attributes
+/// on operations).
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <llvm/Support/Casting.h>
+#include <llvm/Support/raw_ostream.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/Attributes.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Support/LLVM.h>
+
+#include <src/Dialect/ONNX/ONNXOps.hpp>
+
+namespace onnx_mlir {
+
+/// Base class that represents Transformations applied on an original ONNX
+/// Tensor to obtain respective tensor in the modified graph
+class Transform {
+public:
+  /// Enum to allow LLVM-style casting with isa<>, dyn_cast<> etc.
+  enum class Kind {
+    Reshape,
+    Transpose,
+    Pad,
+    Slice,
+    Dequantize,
+    Quantize,
+  };
+
+  Transform(Kind k, mlir::ArrayRef<int64_t> inShape,
+      mlir::ArrayRef<int64_t> outShape);
+
+  // Attribute conversions
+  static std::unique_ptr<Transform> fromAttr(mlir::ArrayAttr arrayAttr);
+  virtual mlir::Attribute toAttr(mlir::MLIRContext *context) const = 0;
+
+  // Op conversions
+  template <typename OpTy = mlir::Operation *>
+  static mlir::SmallVector<std::unique_ptr<Transform>> fromOp(OpTy /*op*/) {
+    return {};
+  }
+  // virtual mlir::Operation *toOp(
+  //     mlir::OpBuilder &builder, mlir::Value) const = 0;
+
+  /// Creates a new transform which is inversion of the current transform
+  [[nodiscard]] virtual std::unique_ptr<Transform> invert() const = 0;
+
+  virtual ~Transform() = default;
+
+  /// Utility methods to be used by sub-classes
+  static mlir::SmallVector<int64_t> arrayToVector(mlir::ArrayAttr arrayAttr);
+  static mlir::SmallVector<int64_t> denseToVector(
+      mlir::DenseIntElementsAttr denseAttr);
+  static mlir::SmallVector<int64_t> valToVector(mlir::Value val);
+  static mlir::SmallVector<int64_t> axesToVector(mlir::Value val, size_t rank);
+  static mlir::ArrayAttr vecToAttr(
+      mlir::MLIRContext *context, mlir::ArrayRef<int64_t> vector);
+
+  [[nodiscard]] Kind getKind() const { return kind; };
+
+  [[nodiscard]] mlir::ArrayRef<int64_t> getInShape() const { return inShape; }
+  [[nodiscard]] mlir::ArrayRef<int64_t> getOutShape() const { return outShape; }
+
+private:
+  const Kind kind;
+
+protected:
+  friend class TensorName;
+
+  mlir::SmallVector<int64_t> inShape;
+  mlir::SmallVector<int64_t> outShape;
+};
+
+class ReshapeTransform : public Transform {
+public:
+  ReshapeTransform(
+      mlir::ArrayRef<int64_t> inShape, mlir::ArrayRef<int64_t> outShape);
+
+  ReshapeTransform(mlir::ArrayAttr attr);
+  mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
+
+  ReshapeTransform(mlir::ONNXReshapeOp reshapeOp);
+  // mlir::Operation *toOp(
+  //     mlir::OpBuilder &builder, mlir::Value value) const override;
+
+  [[nodiscard]] std::unique_ptr<Transform> invert() const override;
+
+  static bool classof(const Transform *transform) {
+    return transform->getKind() == Kind::Reshape;
+  }
+};
+
+class TransposeTransform : public Transform {
+public:
+  TransposeTransform(mlir::ArrayRef<int64_t> inShape,
+      mlir::ArrayRef<int64_t> perm, mlir::ArrayRef<int64_t> outShape);
+
+  TransposeTransform(mlir::ArrayAttr attr);
+  mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
+
+  TransposeTransform(mlir::ONNXTransposeOp transposeOp);
+  // mlir::Operation *toOp(
+  //     mlir::OpBuilder &builder, mlir::Value value) const override;
+
+  [[nodiscard]] std::unique_ptr<Transform> invert() const override;
+  static bool classof(const Transform *transform) {
+    return transform->getKind() == Kind::Transpose;
+  }
+
+  [[nodiscard]] mlir::ArrayRef<int64_t> getPerm() const { return perm; }
+
+private:
+  mlir::SmallVector<int64_t> perm;
+};
+
+class PadTransform : public Transform {
+public:
+  PadTransform(mlir::ArrayRef<int64_t> inShape, mlir::ArrayRef<int64_t> starts,
+      mlir::ArrayRef<int64_t> ends, mlir::ArrayRef<int64_t> axes,
+      mlir::Attribute constant, mlir::ArrayRef<int64_t> outShape);
+
+  PadTransform(mlir::ArrayAttr attr);
+  mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
+
+  PadTransform(mlir::ONNXPadOp padOp);
+  // mlir::Operation *toOp(
+  //     mlir::OpBuilder &builder, mlir::Value value) const override;
+
+  [[nodiscard]] std::unique_ptr<Transform> invert() const override;
+  static bool classof(const Transform *transform) {
+    return transform->getKind() == Kind::Pad;
+  }
+
+  [[nodiscard]] mlir::ArrayRef<int64_t> getStarts() const { return starts; }
+  [[nodiscard]] mlir::ArrayRef<int64_t> getEnds() const { return ends; }
+  [[nodiscard]] mlir::ArrayRef<int64_t> getAxes() const { return axes; }
+
+private:
+  mlir::SmallVector<int64_t> starts;
+  mlir::SmallVector<int64_t> ends;
+  mlir::SmallVector<int64_t> axes;
+  mlir::Attribute constant;
+};
+
+class SliceTransform : public Transform {
+public:
+  SliceTransform(mlir::ArrayRef<int64_t> inShape,
+      mlir::ArrayRef<int64_t> starts, mlir::ArrayRef<int64_t> ends,
+      mlir::ArrayRef<int64_t> axes, mlir::ArrayRef<int64_t> outShape);
+
+  SliceTransform(mlir::ArrayAttr attr);
+  mlir::Attribute toAttr(mlir::MLIRContext *context) const override;
+
+  SliceTransform(mlir::ONNXSliceOp sliceOp);
+  // mlir::Operation *toOp(
+  //     mlir::OpBuilder &builder, mlir::Value value) const override;
+
+  [[nodiscard]] std::unique_ptr<Transform> invert() const override;
+  static bool classof(const Transform *transform) {
+    return transform->getKind() == Kind::Slice;
+  }
+
+  [[nodiscard]] mlir::ArrayRef<int64_t> getStarts() const { return starts; }
+  [[nodiscard]] mlir::ArrayRef<int64_t> getEnds() const { return ends; }
+  [[nodiscard]] mlir::ArrayRef<int64_t> getAxes() const { return axes; }
+
+private:
+  mlir::SmallVector<int64_t> starts;
+  mlir::SmallVector<int64_t> ends;
+  mlir::SmallVector<int64_t> axes;
+};
+
+/// A TensorName represents the name of a tensor along with the sequence of
+/// transformations that have been applied to it.
+class TensorName {
+public:
+  TensorName(std::string name);
+
+  /// Constructs TensorName from MLIR value by extracting information from
+  /// the "ResultNames" attribute or the function argument attribute.
+  /// Does NOT `infer` the transforms.
+  explicit TensorName(mlir::Value value);
+
+  /// Infer the TensorName based on transforms
+  static TensorName infer(mlir::Value value);
+
+  /// True if TensorName corresponds to a valid tensor in ONNX
+  explicit operator bool() const { return !name.empty(); }
+
+  /// Get original name of the tensor
+  [[nodiscard]] mlir::StringRef getNameStr() const { return name; }
+
+  /// List of transforms to be applied
+  [[nodiscard]] mlir::SmallVector<Transform *> getTransforms() const {
+    return llvm::map_to_vector(
+        transforms, [](const std::unique_ptr<Transform> &uptr) -> Transform * {
+          return uptr.get();
+        });
+  }
+
+  /// Add new transform at the end of list of tranforms
+  void push_back(std::unique_ptr<Transform> transform) {
+    transforms.push_back(std::move(transform));
+  }
+
+  /// Attribute conversion
+  [[nodiscard]] mlir::Attribute toAttr(mlir::MLIRContext *context) const;
+
+  /// Set the TensorName to value by setting attribute to defining op
+  mlir::LogicalResult setTo(mlir::Value value) const;
+
+  static TensorName inferWithUse(mlir::Value value);
+  static TensorName inferWithDef(mlir::Value value);
+
+private:
+  /// The original name of this tensor (e.g. the edge name in the ONNX model).
+  std::string name;
+
+  /// The list of transformations that need to be applied on top of the
+  /// original tensor.
+  mlir::SmallVector<std::unique_ptr<Transform>> transforms;
+};
+
+} // namespace onnx_mlir

--- a/src/Dialect/ONNX/TensorName.hpp
+++ b/src/Dialect/ONNX/TensorName.hpp
@@ -171,6 +171,43 @@ private:
   mlir::SmallVector<int64_t> axes;
 };
 
+template <Transform::Kind QDQType>
+class QDQTransform : public Transform {
+public:
+  QDQTransform(mlir::ArrayRef<int64_t> shape, double scale, int64_t zeroPoint,
+      mlir::Type scaleType, mlir::Type zpType);
+
+  QDQTransform(mlir::ArrayAttr attr);
+  [[nodiscard]] mlir::Attribute toAttr(
+      mlir::MLIRContext *context) const override;
+
+  [[nodiscard]] std::unique_ptr<Transform> invert() const override;
+
+  static bool classof(const Transform *transform) {
+    return transform->getKind() == QDQType;
+  }
+
+  [[nodiscard]] float getScale() const { return scale; }
+  [[nodiscard]] int64_t getZeroPoint() const { return zeroPoint; }
+  [[nodiscard]] mlir::Type getScaleType() const { return scaleType; }
+  [[nodiscard]] mlir::Type getZpType() const { return zpType; }
+
+  [[nodiscard]] mlir::Type getFromDType() const;
+  [[nodiscard]] mlir::Type getToDType() const;
+
+private:
+  double scale;
+  int64_t zeroPoint;
+  mlir::Type scaleType;
+  mlir::Type zpType;
+};
+
+// template class QDQTransform<Transform::Kind::Dequantize>;
+// template class QDQTransform<Transform::Kind::Quantize>;
+
+using DequantizeTransform = QDQTransform<Transform::Kind::Dequantize>;
+using QuantizeTransform = QDQTransform<Transform::Kind::Quantize>;
+
 /// A convenience transform to hold multiple transforms
 class ListTransform : public Transform {
 public:

--- a/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
+++ b/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
@@ -1,12 +1,14 @@
 // Copyright (C) 2022 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #include <deque>
+#include <memory>
 #include <unordered_set>
 
 #include <llvm/ADT/STLExtras.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Value.h>
+#include <mlir/Pass/Pass.h>
 #include <mlir/Support/LLVM.h>
 
 #include "src/Dialect/ONNX/TensorName.hpp"
@@ -109,6 +111,24 @@ void ResultNamesUpdater::notifyOperationReplaced(
           inferenceVals.end(), defOp->operand_begin(), defOp->operand_end());
   }
   inferTensorNames(inferenceVals);
+}
+
+class InferTensorNamesPass
+    : public PassWrapper<InferTensorNamesPass, OperationPass<func::FuncOp>> {
+public:
+  StringRef getArgument() const override { return "onnx-infer-tensornames"; }
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    func->walk([](Operation *op) {
+      for (auto result : op->getResults())
+        TensorName::infer(result);
+    });
+  }
+};
+
+std::unique_ptr<mlir::Pass> createInferTensorNames() {
+  return std::make_unique<InferTensorNamesPass>();
 }
 
 } // namespace onnx_mlir

--- a/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
+++ b/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
@@ -1,50 +1,114 @@
 // Copyright (C) 2022 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 
+#include <deque>
+#include <unordered_set>
+
 #include <llvm/ADT/STLExtras.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Support/LLVM.h>
 
+#include "src/Dialect/ONNX/TensorName.hpp"
 #include "src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp"
+
+using namespace mlir;
+
+template <>
+struct std::hash<Value> {
+  size_t operator()(Value value) const { return hash_value(value); }
+};
 
 namespace onnx_mlir {
 
-void ResultNamesUpdater::notifyOperationReplaced(
-    mlir::Operation *op, mlir::ValueRange replacement) {
-  if (!op->hasAttrOfType<mlir::ArrayAttr>("ResultNames"))
-    return;
+namespace {
 
-  auto resultNamesArray = op->getAttrOfType<mlir::ArrayAttr>("ResultNames");
+void inferTensorNames(ValueRange replOperands) {
+  // Collect the values that don't have TensorNames
+  std::unordered_set<Value> workList;
+  {
+    std::deque<Value> stack(replOperands.begin(), replOperands.end());
 
-  // If the op is replaced by a single op, simply copy the attribute
-  mlir::Operation *replSingleOp = replacement.front().getDefiningOp();
-  if (replSingleOp &&
-      llvm::all_of(replacement, [replSingleOp](mlir::Value val) -> bool {
-        return val.getDefiningOp() == replSingleOp;
-      })) {
-    replSingleOp->setAttr("ResultNames", resultNamesArray);
-    return;
+    // Process stack entries, adding values to worklist
+    while (!stack.empty()) {
+      Value value = stack.front();
+      stack.pop_front();
+      if (!TensorName(value) && workList.insert(value).second) {
+        if (Operation *defOp = value.getDefiningOp())
+          for (Value operand : defOp->getOperands())
+            stack.push_back(operand);
+      }
+    }
   }
 
-  mlir::MLIRContext *ctx = op->getContext();
+  // Process worklist
+  size_t wlen;
+  do {
+    wlen = workList.size();
+    for (Value value : workList) {
+      if (auto tname = TensorName::infer(value)) {
+        workList.erase(value);
+        break;
+      }
+    }
+  } while (workList.size() > 0 && wlen > workList.size());
+}
+
+} // namespace
+
+void ResultNamesUpdater::notifyOperationReplaced(
+    Operation *op, Operation *replacement) {
+  if (!op->hasAttrOfType<ArrayAttr>("ResultNames"))
+    return;
+
+  // First, copy the ResultNames attribute for the last value
+  auto resultNamesArray = op->getAttrOfType<ArrayAttr>("ResultNames");
+  replacement->setAttr("ResultNames", resultNamesArray);
+
+  // Infer the TensorNames for defining values
+  inferTensorNames(replacement->getOperands());
+}
+
+void ResultNamesUpdater::notifyOperationReplaced(
+    Operation *op, ValueRange replacement) {
+  if (!op->hasAttrOfType<ArrayAttr>("ResultNames"))
+    return;
+
+  // If the op is replaced by a single op, use the simpler method
+  if (Operation *replSingleOp = replacement.front().getDefiningOp();
+      replSingleOp &&
+      llvm::all_of(replacement, [replSingleOp](Value value) -> bool {
+        return value.getDefiningOp() == replSingleOp;
+      }))
+    return notifyOperationReplaced(op, replSingleOp);
+
+  // First, copy the ResultNames attribute for the last value
+  auto resultNamesArray = op->getAttrOfType<ArrayAttr>("ResultNames");
+  MLIRContext *ctx = op->getContext();
   for (auto [name, value] : llvm::zip_equal(resultNamesArray, replacement)) {
-    if (mlir::OpResult replResult = mlir::dyn_cast<mlir::OpResult>(value)) {
-      mlir::Operation *replOp = replResult.getOwner();
+    if (OpResult replResult = dyn_cast<OpResult>(value)) {
+      Operation *replOp = replResult.getOwner();
 
       // Get new or existing ResultNames
-      mlir::SmallVector<mlir::Attribute> replResultNames(
-          replOp->getNumResults(), mlir::StringAttr::get(ctx));
-      if (auto existing = replOp->getAttrOfType<mlir::ArrayAttr>("ResultNames"))
-        replResultNames =
-            mlir::SmallVector<mlir::Attribute>(existing.getValue());
+      SmallVector<Attribute> replResultNames(
+          replOp->getNumResults(), StringAttr::get(ctx));
+      if (auto existing = replOp->getAttrOfType<ArrayAttr>("ResultNames"))
+        replResultNames = SmallVector<Attribute>(existing.getValue());
 
       // Replace the ResultName of current result
       replResultNames[replResult.getResultNumber()] = name;
-      replOp->setAttr(
-          "ResultNames", mlir::ArrayAttr::get(ctx, replResultNames));
+      replOp->setAttr("ResultNames", ArrayAttr::get(ctx, replResultNames));
     }
   }
+
+  // Infer the TensorNames of defining values
+  SmallVector<Value> inferenceVals;
+  for (Value value : replacement) {
+    if (Operation *defOp = value.getDefiningOp())
+      inferenceVals.insert(
+          inferenceVals.end(), defOp->operand_begin(), defOp->operand_end());
+  }
+  inferTensorNames(inferenceVals);
 }
 
 } // namespace onnx_mlir

--- a/src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp
+++ b/src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp
@@ -9,6 +9,8 @@ namespace onnx_mlir {
 class ResultNamesUpdater : public mlir::RewriterBase::Listener {
 public:
   void notifyOperationReplaced(
+      mlir::Operation *op, mlir::Operation *replacement) override;
+  void notifyOperationReplaced(
       mlir::Operation *op, mlir::ValueRange replacement) override;
 };
 

--- a/src/Interface/CMakeLists.txt
+++ b/src/Interface/CMakeLists.txt
@@ -5,6 +5,7 @@ add_onnx_mlir_interface(ShapeHelperOpInterface)
 add_onnx_mlir_interface(ResultTypeInferenceOpInterface)
 add_onnx_mlir_interface(HasOnnxSubgraphOpInterface)
 add_onnx_mlir_interface(SpecializedKernelOpInterface)
+add_onnx_mlir_interface(TensorNameInference)
 
 add_onnx_mlir_library(OMShapeInferenceOpInterface
   ShapeInferenceOpInterface.cpp
@@ -61,3 +62,14 @@ add_onnx_mlir_library(OMSpecializedKernelOpInterface
   MLIRIR
   LLVMSupport
   )
+
+add_onnx_mlir_library(OMTensorNameInference
+	TensorNameInference.cpp
+
+	DEPENDS
+	OMTensorNameInferenceIncGen
+
+	LINK_LIBS PUBLIC
+	MLIRIR
+	LLVMSupport
+)

--- a/src/Interface/TensorNameInference.cpp
+++ b/src/Interface/TensorNameInference.cpp
@@ -19,12 +19,14 @@ ReshapeOpTensorNameInference::inferTensorNameTransform(
     mlir::Operation *op) const {
   auto reshapeOp = cast<ONNXReshapeOp>(op);
 
-  auto inShape =
-      cast<RankedTensorType>(reshapeOp.getData().getType()).getShape();
-  auto outShape =
-      cast<RankedTensorType>(reshapeOp.getResult().getType()).getShape();
+  // Validate if shapes are static
+  auto inType = cast<RankedTensorType>(reshapeOp.getOperand(0).getType());
+  auto outType = cast<RankedTensorType>(reshapeOp.getResult().getType());
+  if (!inType.hasStaticShape() || !outType.hasStaticShape())
+    return nullptr;
 
-  return std::make_unique<ReshapeTransform>(inShape, outShape);
+  return std::make_unique<ReshapeTransform>(
+      inType.getShape(), outType.getShape());
 }
 
 std::unique_ptr<Transform>
@@ -32,18 +34,27 @@ TransposeOpTensorNameInference::inferTensorNameTransform(
     mlir::Operation *op) const {
   auto transposeOp = cast<ONNXTransposeOp>(op);
 
-  auto inShape =
-      cast<RankedTensorType>(transposeOp.getData().getType()).getShape();
-  auto perm = Transform::arrayToVector(transposeOp.getPermAttr());
-  auto outShape =
-      cast<RankedTensorType>(transposeOp.getResult().getType()).getShape();
+  // Validate if shapes are static
+  auto inType = cast<RankedTensorType>(transposeOp.getOperand().getType());
+  auto outType = cast<RankedTensorType>(transposeOp.getResult().getType());
+  if (!inType.hasStaticShape() || !outType.hasStaticShape())
+    return nullptr;
 
-  return std::make_unique<TransposeTransform>(inShape, perm, outShape);
+  auto perm = Transform::arrayToVector(transposeOp.getPermAttr());
+
+  return std::make_unique<TransposeTransform>(
+      inType.getShape(), perm, outType.getShape());
 }
 
 std::unique_ptr<Transform> PadOpTensorNameInference::inferTensorNameTransform(
     mlir::Operation *op) const {
   auto padOp = cast<ONNXPadOp>(op);
+
+  // Validate if shapes are static
+  auto inType = cast<RankedTensorType>(padOp.getOperand(0).getType());
+  auto outType = cast<RankedTensorType>(padOp.getResult().getType());
+  if (!inType.hasStaticShape() || !outType.hasStaticShape())
+    return nullptr;
 
   // Only mode = "constant" is supported
   if (padOp.getMode() != "constant")
@@ -54,44 +65,48 @@ std::unique_ptr<Transform> PadOpTensorNameInference::inferTensorNameTransform(
   Attribute constant = constOp.getValueAttr();
   if (!constant)
     return nullptr;
+
+  // Validate if pads is constant
   auto pads = Transform::valToVector(padOp.getPads());
   if (pads.size() == 0)
     return nullptr;
 
-  auto inShape = cast<RankedTensorType>(padOp.getData().getType()).getShape();
   auto splitAt = pads.size() / 2;
   auto starts = SmallVector<int64_t>(pads.begin(), pads.begin() + splitAt);
   auto ends = SmallVector<int64_t>(pads.begin() + splitAt, pads.end());
-  auto axes = Transform::axesToVector(padOp.getAxes(), inShape.size());
-  auto outShape =
-      cast<RankedTensorType>(padOp.getOutput().getType()).getShape();
+  auto axes = Transform::axesToVector(padOp.getAxes(), inType.getRank());
 
   return std::make_unique<PadTransform>(
-      inShape, starts, ends, axes, constant, outShape);
+      inType.getShape(), starts, ends, axes, constant, outType.getShape());
 }
 
 std::unique_ptr<Transform> SliceOpTensorNameInference::inferTensorNameTransform(
     mlir::Operation *op) const {
   auto sliceOp = cast<ONNXSliceOp>(op);
 
-  auto inShape = cast<RankedTensorType>(sliceOp.getData().getType()).getShape();
+  // Validate if shapes are static
+  auto inType = cast<RankedTensorType>(sliceOp.getOperand(0).getType());
+  auto outType = cast<RankedTensorType>(sliceOp.getResult().getType());
+  if (!inType.hasStaticShape() || !outType.hasStaticShape())
+    return nullptr;
+
+  // Validate if starts & ends are constant and steps is always 1
   auto starts = Transform::valToVector(sliceOp.getStarts());
   auto ends = Transform::valToVector(sliceOp.getEnds());
-  auto axes = Transform::axesToVector(sliceOp.getAxes(), inShape.size());
-  auto outShape =
-      cast<RankedTensorType>(sliceOp.getResult().getType()).getShape();
-
+  auto steps = Transform::valToVector(sliceOp.getSteps());
   if (starts.size() == 0 || ends.size() == 0 ||
-      llvm::any_of(Transform::valToVector(sliceOp.getSteps()),
-          [](int64_t s) { return s != 1; }))
+      llvm::any_of(steps, [](int64_t s) { return s != 1; }))
     return nullptr;
+
+  auto inShape = inType.getShape();
+  auto axes = Transform::axesToVector(sliceOp.getAxes(), inShape.size());
 
   // Clip end values
   for (const auto &[ax, en] : llvm::zip_equal(axes, ends))
     en = std::min(en, inShape[ax]);
 
   return std::make_unique<SliceTransform>(
-      inShape, starts, ends, axes, outShape);
+      inShape, starts, ends, axes, outType.getShape());
 }
 
 void registerTensorNameInferenceExternalModels(

--- a/src/Interface/TensorNameInference.cpp
+++ b/src/Interface/TensorNameInference.cpp
@@ -47,16 +47,18 @@ std::unique_ptr<Transform> PadOpTensorNameInference::inferTensorNameTransform(
 
   // Only mode = "constant" is supported
   if (padOp.getMode() != "constant")
-    return {};
+    return nullptr;
   auto constOp = padOp.getConstantValue().getDefiningOp<ONNXConstantOp>();
   if (!constOp)
-    return {};
+    return nullptr;
   Attribute constant = constOp.getValueAttr();
   if (!constant)
-    return {};
+    return nullptr;
+  auto pads = Transform::valToVector(padOp.getPads());
+  if (pads.size() == 0)
+    return nullptr;
 
   auto inShape = cast<RankedTensorType>(padOp.getData().getType()).getShape();
-  auto pads = Transform::valToVector(padOp.getPads());
   auto splitAt = pads.size() / 2;
   auto starts = SmallVector<int64_t>(pads.begin(), pads.begin() + splitAt);
   auto ends = SmallVector<int64_t>(pads.begin() + splitAt, pads.end());
@@ -78,6 +80,11 @@ std::unique_ptr<Transform> SliceOpTensorNameInference::inferTensorNameTransform(
   auto axes = Transform::axesToVector(sliceOp.getAxes(), inShape.size());
   auto outShape =
       cast<RankedTensorType>(sliceOp.getResult().getType()).getShape();
+
+  if (starts.size() == 0 || ends.size() == 0 ||
+      llvm::any_of(Transform::valToVector(sliceOp.getSteps()),
+          [](int64_t s) { return s != 1; }))
+    return nullptr;
 
   // Clip end values
   for (const auto &[ax, en] : llvm::zip_equal(axes, ends))

--- a/src/Interface/TensorNameInference.cpp
+++ b/src/Interface/TensorNameInference.cpp
@@ -87,4 +87,15 @@ std::unique_ptr<Transform> SliceOpTensorNameInference::inferTensorNameTransform(
       inShape, starts, ends, axes, outShape);
 }
 
+void registerTensorNameInferenceExternalModels(
+    mlir::DialectRegistry &registry) {
+  registry.addExtension<ONNXDialect>(
+      +[](MLIRContext *ctx, ONNXDialect * /*dialect*/) {
+        ONNXTransposeOp::attachInterface<TransposeOpTensorNameInference>(*ctx);
+        ONNXReshapeOp::attachInterface<ReshapeOpTensorNameInference>(*ctx);
+        ONNXPadOp::attachInterface<PadOpTensorNameInference>(*ctx);
+        ONNXSliceOp::attachInterface<SliceOpTensorNameInference>(*ctx);
+      });
+}
+
 } // namespace onnx_mlir

--- a/src/Interface/TensorNameInference.cpp
+++ b/src/Interface/TensorNameInference.cpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "src/Interface/TensorNameInference.hpp"
+
+namespace mlir {
+
+#include "src/Interface/TensorNameInference.cpp.inc"
+
+}
+
+#include "src/Dialect/ONNX/TensorName.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+std::unique_ptr<Transform>
+ReshapeOpTensorNameInference::inferTensorNameTransform(
+    mlir::Operation *op) const {
+  return {};
+}
+
+std::unique_ptr<Transform>
+TransposeOpTensorNameInference::inferTensorNameTransform(
+    mlir::Operation *op) const {
+  return {};
+}
+
+std::unique_ptr<Transform> SliceOpTensorNameInference::inferTensorNameTransform(
+    mlir::Operation *op) const {
+  return {};
+}
+
+std::unique_ptr<Transform> PadOpTensorNameInference::inferTensorNameTransform(
+    mlir::Operation *op) const {
+  return {};
+}
+
+} // namespace onnx_mlir

--- a/src/Interface/TensorNameInference.cpp
+++ b/src/Interface/TensorNameInference.cpp
@@ -17,23 +17,74 @@ namespace onnx_mlir {
 std::unique_ptr<Transform>
 ReshapeOpTensorNameInference::inferTensorNameTransform(
     mlir::Operation *op) const {
-  return {};
+  auto reshapeOp = cast<ONNXReshapeOp>(op);
+
+  auto inShape =
+      cast<RankedTensorType>(reshapeOp.getData().getType()).getShape();
+  auto outShape =
+      cast<RankedTensorType>(reshapeOp.getResult().getType()).getShape();
+
+  return std::make_unique<ReshapeTransform>(inShape, outShape);
 }
 
 std::unique_ptr<Transform>
 TransposeOpTensorNameInference::inferTensorNameTransform(
     mlir::Operation *op) const {
-  return {};
-}
+  auto transposeOp = cast<ONNXTransposeOp>(op);
 
-std::unique_ptr<Transform> SliceOpTensorNameInference::inferTensorNameTransform(
-    mlir::Operation *op) const {
-  return {};
+  auto inShape =
+      cast<RankedTensorType>(transposeOp.getData().getType()).getShape();
+  auto perm = Transform::arrayToVector(transposeOp.getPermAttr());
+  auto outShape =
+      cast<RankedTensorType>(transposeOp.getResult().getType()).getShape();
+
+  return std::make_unique<TransposeTransform>(inShape, perm, outShape);
 }
 
 std::unique_ptr<Transform> PadOpTensorNameInference::inferTensorNameTransform(
     mlir::Operation *op) const {
-  return {};
+  auto padOp = cast<ONNXPadOp>(op);
+
+  // Only mode = "constant" is supported
+  if (padOp.getMode() != "constant")
+    return {};
+  auto constOp = padOp.getConstantValue().getDefiningOp<ONNXConstantOp>();
+  if (!constOp)
+    return {};
+  Attribute constant = constOp.getValueAttr();
+  if (!constant)
+    return {};
+
+  auto inShape = cast<RankedTensorType>(padOp.getData().getType()).getShape();
+  auto pads = Transform::valToVector(padOp.getPads());
+  auto splitAt = pads.size() / 2;
+  auto starts = SmallVector<int64_t>(pads.begin(), pads.begin() + splitAt);
+  auto ends = SmallVector<int64_t>(pads.begin() + splitAt, pads.end());
+  auto axes = Transform::axesToVector(padOp.getAxes(), inShape.size());
+  auto outShape =
+      cast<RankedTensorType>(padOp.getOutput().getType()).getShape();
+
+  return std::make_unique<PadTransform>(
+      inShape, starts, ends, axes, constant, outShape);
+}
+
+std::unique_ptr<Transform> SliceOpTensorNameInference::inferTensorNameTransform(
+    mlir::Operation *op) const {
+  auto sliceOp = cast<ONNXSliceOp>(op);
+
+  auto inShape = cast<RankedTensorType>(sliceOp.getData().getType()).getShape();
+  auto starts = Transform::valToVector(sliceOp.getStarts());
+  auto ends = Transform::valToVector(sliceOp.getEnds());
+  auto axes = Transform::axesToVector(sliceOp.getAxes(), inShape.size());
+  auto outShape =
+      cast<RankedTensorType>(sliceOp.getResult().getType()).getShape();
+
+  // Clip end values
+  for (const auto &[ax, en] : llvm::zip_equal(axes, ends))
+    en = std::min(en, inShape[ax]);
+
+  return std::make_unique<SliceTransform>(
+      inShape, starts, ends, axes, outShape);
 }
 
 } // namespace onnx_mlir

--- a/src/Interface/TensorNameInference.hpp
+++ b/src/Interface/TensorNameInference.hpp
@@ -2,6 +2,10 @@
 
 #pragma once
 
+#include <memory>
+
+#include <mlir/IR/DialectRegistry.h>
+
 #include "src/Dialect/ONNX/TensorName.hpp"
 #include "src/Interface/TensorNameInference.hpp.inc"
 
@@ -38,5 +42,7 @@ public:
   std::unique_ptr<onnx_mlir::Transform> inferTensorNameTransform(
       mlir::Operation *op) const;
 };
+
+void registerTensorNameInferenceExternalModels(mlir::DialectRegistry &registry);
 
 } // namespace onnx_mlir

--- a/src/Interface/TensorNameInference.hpp
+++ b/src/Interface/TensorNameInference.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "src/Dialect/ONNX/TensorName.hpp"
+#include "src/Interface/TensorNameInference.hpp.inc"
+
+namespace onnx_mlir {
+
+class ReshapeOpTensorNameInference
+    : public mlir::TensorNameInference::ExternalModel<
+          ReshapeOpTensorNameInference, mlir::ONNXReshapeOp> {
+public:
+  std::unique_ptr<onnx_mlir::Transform> inferTensorNameTransform(
+      mlir::Operation *op) const;
+};
+
+class TransposeOpTensorNameInference
+    : public mlir::TensorNameInference::ExternalModel<
+          TransposeOpTensorNameInference, mlir::ONNXTransposeOp> {
+public:
+  std::unique_ptr<onnx_mlir::Transform> inferTensorNameTransform(
+      mlir::Operation *op) const;
+};
+
+class SliceOpTensorNameInference
+    : public mlir::TensorNameInference::ExternalModel<
+          SliceOpTensorNameInference, mlir::ONNXSliceOp> {
+public:
+  std::unique_ptr<onnx_mlir::Transform> inferTensorNameTransform(
+      mlir::Operation *op) const;
+};
+
+class PadOpTensorNameInference
+    : public mlir::TensorNameInference::ExternalModel<PadOpTensorNameInference,
+          mlir::ONNXPadOp> {
+public:
+  std::unique_ptr<onnx_mlir::Transform> inferTensorNameTransform(
+      mlir::Operation *op) const;
+};
+
+} // namespace onnx_mlir

--- a/src/Interface/TensorNameInference.hpp
+++ b/src/Interface/TensorNameInference.hpp
@@ -23,17 +23,17 @@ public:
       mlir::Operation *op) const;
 };
 
-class SliceOpTensorNameInference
-    : public mlir::TensorNameInference::ExternalModel<
-          SliceOpTensorNameInference, mlir::ONNXSliceOp> {
+class PadOpTensorNameInference
+    : public mlir::TensorNameInference::ExternalModel<PadOpTensorNameInference,
+          mlir::ONNXPadOp> {
 public:
   std::unique_ptr<onnx_mlir::Transform> inferTensorNameTransform(
       mlir::Operation *op) const;
 };
 
-class PadOpTensorNameInference
-    : public mlir::TensorNameInference::ExternalModel<PadOpTensorNameInference,
-          mlir::ONNXPadOp> {
+class SliceOpTensorNameInference
+    : public mlir::TensorNameInference::ExternalModel<
+          SliceOpTensorNameInference, mlir::ONNXSliceOp> {
 public:
   std::unique_ptr<onnx_mlir::Transform> inferTensorNameTransform(
       mlir::Operation *op) const;

--- a/src/Interface/TensorNameInference.td
+++ b/src/Interface/TensorNameInference.td
@@ -4,7 +4,7 @@ include "mlir/IR/OpBase.td"
 
 def TensorNameInference : OpInterface<"TensorNameInference"> {
   let methods = [
-    InterfaceMethod<"Return list of Transforms representing the Op",
+    InterfaceMethod<"Return Transform representing the Op",
                     "std::unique_ptr<onnx_mlir::Transform>",
                     "inferTensorNameTransform">
     ];

--- a/src/Interface/TensorNameInference.td
+++ b/src/Interface/TensorNameInference.td
@@ -1,0 +1,12 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+include "mlir/IR/OpBase.td"
+
+def TensorNameInference : OpInterface<"TensorNameInference"> {
+  let methods = [
+    InterfaceMethod<"Return list of Transforms representing the Op",
+                    "std::unique_ptr<onnx_mlir::Transform>",
+                    "inferTensorNameTransform">
+    ];
+  let cppNamespace = "::mlir";
+}

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -71,6 +71,8 @@ std::unique_ptr<mlir::Pass> createQuantTypesPass();
 
 std::unique_ptr<mlir::Pass> createFixNegScalePass();
 
+std::unique_ptr<mlir::Pass> createInferTensorNames();
+
 #ifdef ONNX_MLIR_ENABLE_KRNL
 /// Pass for instrument the ops in specific stage.
 std::unique_ptr<mlir::Pass> createInstrumentPass();

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -353,6 +353,7 @@ void registerOMPasses(int optLevel) {
   mlir::registerPass(createQuantTypesPass);
   mlir::registerPass(createONNXCSEPass);
   mlir::registerPass(createFixNegScalePass);
+  mlir::registerPass(createInferTensorNames);
 
   mlir::PassPipelineRegistration<>("xmc-passes", "Run all XMC xcompiler passes",
       [](mlir::OpPassManager &pm) { addXmcMlirPasses(pm); });

--- a/test/mlir/onnx/onnx_tensornames_inference.mlir
+++ b/test/mlir/onnx/onnx_tensornames_inference.mlir
@@ -1,0 +1,157 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+// RUN: onnx-mlir-opt %s -onnx-infer-tensornames | FileCheck %s
+
+func.func @reshape_result(%arg0: tensor<1x768x128xf32> {onnx.name = "input"}) -> tensor<1x12x64x128xf32> {
+  %0 = onnx.Constant dense<[1, 12, 64, 128]> : tensor<4xi64>
+  %1 = "onnx.Reshape"(%arg0, %0) {allowzero = 0 : si64} : (tensor<1x768x128xf32>, tensor<4xi64>) -> tensor<1x12x64x128xf32>
+  return %1 : tensor<1x12x64x128xf32>
+}
+
+// CHECK-LABEL: @reshape_result
+// CHECK: onnx.Reshape
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["input", ["Reshape", [1, 768, 128], [1, 12, 64, 128]]]]
+
+func.func @reshape_operand(%arg0: tensor<1x768x128xf32>) -> tensor<1x12x64x128xf32> {
+  %0 = onnx.Constant dense<[1, 12, 64, 128]> : tensor<4xi64>
+  %1 = "onnx.Identity"(%arg0) : (tensor<1x768x128xf32>) -> tensor<1x768x128xf32>
+  %2 = "onnx.Reshape"(%1, %0) {ResultNames = ["output"], allowzero = 0 : si64} : (tensor<1x768x128xf32>, tensor<4xi64>) -> tensor<1x12x64x128xf32>
+  return %2 : tensor<1x12x64x128xf32>
+}
+
+// CHECK-LABEL: @reshape_operand
+// CHECK: onnx.Identity
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["output", ["Reshape", [1, 12, 64, 128], [1, 768, 128]]]]
+
+func.func @transpose_result(%arg0: tensor<1x128x768xf32> {onnx.name = "input"}) -> tensor<1x768x128xf32> {
+  %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 1]} : (tensor<1x128x768xf32>) -> tensor<1x768x128xf32>
+  return %0: tensor<1x768x128xf32>
+}
+
+// CHECK-LABEL: @transpose_result
+// CHECK: onnx.Transpose
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["input", ["Transpose", [1, 128, 768], [0, 2, 1], [1, 768, 128]]]]
+
+func.func @transpose_operand(%arg0: tensor<1x128x768xf32>) -> tensor<1x768x128xf32> {
+  %0 = "onnx.Identity"(%arg0) : (tensor<1x128x768xf32>) -> tensor<1x128x768xf32>
+  %1 = "onnx.Transpose"(%0) {ResultNames = ["output"], perm = [0, 2, 1]} : (tensor<1x128x768xf32>) -> tensor<1x768x128xf32>
+  return %1: tensor<1x768x128xf32>
+}
+
+// CHECK-LABEL: @transpose_operand
+// CHECK: onnx.Identity
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["output", ["Transpose", [1, 768, 128], [0, 2, 1], [1, 128, 768]]]]
+
+func.func @pad_result(%arg0: tensor<1x3xf32> {onnx.name = "input"}) -> tensor<1x8xf32> {
+  %0 = onnx.Constant dense<0.000000e+00> : tensor<f32>
+  %1 = onnx.Constant dense<[4, 1]> : tensor<2xi64>
+  %2 = onnx.Constant dense<-1> : tensor<1xi64>
+  %3 = "onnx.Pad"(%arg0, %1, %0, %2) {mode = "constant"} : (tensor<1x3xf32>, tensor<2xi64>, tensor<f32>, tensor<1xi64>) -> tensor<1x8xf32>
+  return %3 : tensor<1x8xf32>
+}
+
+// CHECK-LABEL: @pad_result
+// CHECK: onnx.Pad
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["input", ["Pad", [1, 3], [4], [1], [1], dense<0.000000e+00> : tensor<f32>, [1, 8]]]]
+
+func.func @pad_operand(%arg0: tensor<1x3xf32>) -> tensor<1x8xf32> {
+  %0 = "onnx.Identity"(%arg0) : (tensor<1x3xf32>) -> tensor<1x3xf32>
+  %1 = onnx.Constant dense<0.0> : tensor<f32>
+  %2 = onnx.Constant dense<[4, 1]> : tensor<2xi64>
+  %3 = onnx.Constant dense<-1> : tensor<1xi64>
+  %4 = "onnx.Pad"(%0, %2, %1, %3) {ResultNames = ["output"]} : (tensor<1x3xf32>, tensor<2xi64>, tensor<f32>, tensor<1xi64>) -> tensor<1x8xf32>
+  return %4 : tensor<1x8xf32>
+}
+
+// CHECK-LABEL: @pad_operand
+// CHECK: onnx.Identity
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["output", ["Slice", [1, 8], [4], [7], [1], [1, 3]]]]
+// ResultNames shouldn't be inferred for constants
+// CHECK-NEXT: onnx.Constant dense
+// CHECK-NEXT: onnx.Constant dense
+// CHECK-NEXT: onnx.Constant dense
+
+func.func @slice_result(%arg0: tensor<1x8xf32> {onnx.name = "input"}) -> tensor<1x4xf32> {
+  %1 = onnx.Constant dense<4> : tensor<1xi64>
+  %2 = onnx.Constant dense<9223372036854775807> : tensor<1xi64>
+  %3 = onnx.Constant dense<-1> : tensor<1xi64>
+  %4 = onnx.Constant dense<1> : tensor<1xi64>
+  %5 = "onnx.Slice"(%arg0, %1, %2, %3, %4) : (tensor<1x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x4xf32>
+  return %5 : tensor<1x4xf32>
+}
+
+// CHECK-LABEL: @slice_result
+// CHECK: onnx.Slice
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["input", ["Slice", [1, 8], [4], [8], [1], [1, 4]]]]
+
+func.func @slice_operand(%arg0: tensor<1x8xf32>) -> tensor<1x3xf32> {
+  %0 = "onnx.Identity"(%arg0) : (tensor<1x8xf32>) -> tensor<1x8xf32>
+  %1 = onnx.Constant dense<2> : tensor<1xi64>
+  %2 = onnx.Constant dense<5> : tensor<1xi64>
+  %3 = onnx.Constant dense<-1> : tensor<1xi64>
+  %4 = onnx.Constant dense<1> : tensor<1xi64>
+  %5 = "onnx.Slice"(%0, %1, %2, %3, %4) {ResultNames = ["output"]} : (tensor<1x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x3xf32>
+  return %5 : tensor<1x3xf32>
+}
+
+// CHECK-LABEL: @slice_operand
+// CHECK: onnx.Identity
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["output", ["Pad", [1, 3], [2], [3], [1], unit, [1, 8]]]]
+
+func.func @transpose_reshape(%arg0: tensor<1x128x768xf32> {onnx.name = "input"}) -> tensor<1x12x64x128xf32> {
+  %0 = onnx.Constant dense<[1, 12, 64, 128]> : tensor<4xi64>
+  %1 = "onnx.Transpose"(%arg0) {perm = [0, 2, 1]} : (tensor<1x128x768xf32>) -> tensor<1x768x128xf32>
+  %2 = "onnx.Reshape"(%1, %0) {allowzero = 0 : si64} : (tensor<1x768x128xf32>, tensor<4xi64>) -> tensor<1x12x64x128xf32>
+  return %2 : tensor<1x12x64x128xf32>
+}
+
+// CHECK-LABEL: @transpose_reshape
+// CHECK: onnx.Transpose
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["input", ["Transpose", [1, 128, 768], [0, 2, 1], [1, 768, 128]]]]
+// CHECK-NEXT: onnx.Reshape
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["input", ["Transpose", [1, 128, 768], [0, 2, 1], [1, 768, 128]], ["Reshape", [1, 768, 128], [1, 12, 64, 128]]]]
+
+func.func @conv_double_shielding(%arg0: tensor<1x320x64x64xf32> {onnx.name = "input"}) -> tensor<1x320x64x64xf32> {
+  %0 = onnx.Constant {ResultNames = ["bias"]} dense_resource<__elided__> : tensor<320xf32>
+  %1 = onnx.Constant {ResultNames = ["wgt"]} dense_resource<__elided__> : tensor<320x320x3x3xf32>
+  %2 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x320x64x64xf32>) -> tensor<1x64x64x320xf32>
+  %3 = "onnx.Transpose"(%2) {perm = [0, 3, 1, 2]} : (tensor<1x64x64x320xf32>) -> tensor<1x320x64x64xf32>
+  %4 = "onnx.Transpose"(%1) {perm = [3, 2, 1, 0]} : (tensor<320x320x3x3xf32>) -> tensor<3x3x320x320xf32>
+  %5 = "onnx.Transpose"(%4) {perm = [3, 2, 1, 0]} : (tensor<3x3x320x320xf32>) -> tensor<320x320x3x3xf32>
+  %6 = "onnx.Conv"(%3, %5, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x320x64x64xf32>, tensor<320x320x3x3xf32>, tensor<320xf32>) -> tensor<1x320x64x64xf32>
+  %7 = "onnx.Transpose"(%6) {perm = [0, 2, 3, 1]} : (tensor<1x320x64x64xf32>) -> tensor<1x64x64x320xf32>
+  %8 = "onnx.Transpose"(%7) {ResultNames = ["conv"], perm = [0, 3, 1, 2]} : (tensor<1x64x64x320xf32>) -> tensor<1x320x64x64xf32>
+  return %8 : tensor<1x320x64x64xf32>
+}
+
+// CHECK-LABEL: @conv_double_shielding
+// CHECK: onnx.Transpose
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["input", ["Transpose", [1, 320, 64, 64], [0, 2, 3, 1], [1, 64, 64, 320]]]]
+// CHECK-NEXT: onnx.Transpose
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["input", ["Transpose", [1, 320, 64, 64], [0, 2, 3, 1], [1, 64, 64, 320]], ["Transpose", [1, 64, 64, 320], [0, 3, 1, 2], [1, 320, 64, 64]]]]
+// CHECK-NEXT: onnx.Transpose
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["wgt", ["Transpose", [320, 320, 3, 3], [3, 2, 1, 0], [3, 3, 320, 320]]]]
+// CHECK-NEXT: onnx.Transpose
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["wgt", ["Transpose", [320, 320, 3, 3], [3, 2, 1, 0], [3, 3, 320, 320]], ["Transpose", [3, 3, 320, 320], [3, 2, 1, 0], [320, 320, 3, 3]]]]
+// CHECK-NEXT: onnx.Conv
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["conv", ["Transpose", [1, 320, 64, 64], [0, 2, 3, 1], [1, 64, 64, 320]], ["Transpose", [1, 64, 64, 320], [0, 3, 1, 2], [1, 320, 64, 64]]]]
+// CHECK-NEXT: onnx.Transpose
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["conv", ["Transpose", [1, 320, 64, 64], [0, 2, 3, 1], [1, 64, 64, 320]]]]
+// CHECK-NEXT: onnx.Transpose
+// CHECK-SAME: ResultNames = ["conv"]


### PR DESCRIPTION
- Add TensorNameInference OpInterface, that can be implemented for ops outside onnx-mlir
  - Currently implemented for onnx.{Reshape, Transpose, Pad, Slice}
- Add TensorName and Transform classes
- Update ResultNamesUpdater to use TensorNames
