### PR TITLE
Add Pattern 5: Replace quantized Expand with Eltwise ADD

### DIFF
--- a/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
@@ -17,6 +17,11 @@
 //      LeakyRelu are fused into a single onnx.XCOMPILERFusedEltwise.
 // 3. BFloat16 with ReLU (4 combinations)
 // 4. Post-Quantized ReLU for IPU Strix (2 combinations)
+// 5. Replace Expand with Eltwise ADD
+//    - Quantized Expand ops are replaced by XCOMPILERFusedEltwise ADD with a
+//      zero constant at the target shape. For 4D (NCHW) inputs, only fires
+//      when W (dim index 2) is 1; non-4D inputs have no spatial constraint.
+//      Mirrors xcompiler's ReplaceQDQExpandToEltwisePass.
 //
 // Note: This pass assumes quant-types pass has already run, so operations
 // already have !quant.uniform types instead of explicit Q/DQ operations.
@@ -769,6 +774,81 @@ struct FusePostQuantizedReLUStrix : public OpRewritePattern<ONNXReluOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// Pattern 5: Replace Expand with Eltwise ADD
+// Quantized Expand(input, shape) -> XCOMPILERFusedEltwise(input, zeros, "ADD")
+// For 4D (NCHW) inputs:
+//   - W (dim[3]) == 1 is required (mirrors QDQ version, NHWC dim[2]).
+//   - C (dim[1]) == 1 is also required (mirrors fixed-point version, NHWC
+//   dim[3]).
+// Non-4D inputs have no spatial constraint.
+//===----------------------------------------------------------------------===//
+
+struct ReplaceExpandWithEltwise : public OpRewritePattern<ONNXExpandOp> {
+  using OpRewritePattern<ONNXExpandOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXExpandOp expandOp, PatternRewriter &rewriter) const override {
+    Value input = expandOp.getInput();
+    Type resultType = expandOp.getOutput().getType();
+
+    if (!isQuantizedType(input.getType()) || !isQuantizedType(resultType))
+      return rewriter.notifyMatchFailure(expandOp, "not quantized");
+
+    auto inputRankedType = mlir::dyn_cast<RankedTensorType>(input.getType());
+    auto outputRankedType = mlir::dyn_cast<RankedTensorType>(resultType);
+    if (!inputRankedType || !outputRankedType)
+      return rewriter.notifyMatchFailure(expandOp, "not ranked tensors");
+
+    auto inputShape = inputRankedType.getShape();
+
+    // For 4D (NCHW) tensors, require both C==1 (dim[1]) and W==1 (dim[3]).
+    // NHWC equivalents: W=dim[2], C=dim[3] in xcompiler's fixed-point version.
+    // Non-4D tensors are accepted without spatial-dim constraints.
+    if (inputShape.size() == 4 && (inputShape[1] != 1 || inputShape[3] != 1))
+      return rewriter.notifyMatchFailure(
+          expandOp, "4D input requires C (dim[1]) == 1 and W (dim[3]) == 1");
+
+    LLVM_DEBUG(llvm::dbgs() << "Replacing quantized Expand with eltwise ADD: "
+                            << expandOp->getName() << "\n");
+
+    auto outputShape = outputRankedType.getShape();
+    Type elemType = outputRankedType.getElementType();
+
+    // Build a zero constant with the output shape and storage type.
+    Type storageType = elemType;
+    if (auto qType =
+            mlir::dyn_cast<mlir::quant::UniformQuantizedType>(elemType))
+      storageType = qType.getStorageType();
+
+    auto zeroAttr =
+        DenseElementsAttr::get(RankedTensorType::get(outputShape, storageType),
+            rewriter.getZeroAttr(storageType));
+
+    auto valueNamedAttr = rewriter.getNamedAttr("value", zeroAttr);
+    auto zeroConst = rewriter.create<ONNXConstantOp>(expandOp.getLoc(),
+        outputRankedType, mlir::ValueRange{},
+        mlir::ArrayRef<mlir::NamedAttribute>{valueNamedAttr});
+
+    auto fusedOp = rewriter.create<XCOMPILERFusedEltwiseOp>(expandOp.getLoc(),
+        resultType, input, zeroConst.getResult(),
+        /*clip_max=*/IntegerAttr(),
+        /*clip_min=*/IntegerAttr(),
+        /*enable_lut_sigmoid=*/rewriter.getBoolAttr(false),
+        /*leakyrelu_alpha=*/FloatAttr(),
+        /*mul_y=*/FloatAttr(),
+        /*nonlinear=*/rewriter.getStringAttr("NONE"),
+        /*nonlinear_in_scales=*/FloatAttr(),
+        /*nonlinear_in_zeropoints=*/IntegerAttr(),
+        /*prelu_in=*/IntegerAttr(),
+        /*prelu_shift=*/IntegerAttr(),
+        /*type=*/rewriter.getStringAttr("ADD"));
+
+    rewriter.replaceOp(expandOp, fusedOp.getResult());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Pass Definition
 //===----------------------------------------------------------------------===//
 
@@ -891,6 +971,12 @@ struct ReplaceQDQEltwisePass
       patterns.add<FusePostQuantizedReLUStrix<ONNXAddOp>>(context, true);
       patterns.add<FusePostQuantizedReLUStrix<ONNXMulOp>>(context, true);
     }
+
+    //========================================================================
+    // Pattern 5: Replace Expand with Eltwise ADD
+    //========================================================================
+
+    patterns.add<ReplaceExpandWithEltwise>(context);
 
     //========================================================================
     // Apply patterns with greedy rewriter

--- a/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
+++ b/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
@@ -695,3 +695,110 @@ func.func @test_multiple_fusions(
   // CHECK-SAME: type = "MUL"
   // CHECK: return %[[FUSED_ADD]], %[[FUSED_MUL]]
 }
+
+// -----
+// Test Pattern 5: Replace quantized Expand with Eltwise ADD (4D, C=1, W=1)
+// Input shape [1,1,1,1] -> Expand to [1,1,32,32]
+// Should create XCOMPILERFusedEltwise(input, zeros, type="ADD")
+// CHECK-LABEL: func.func @test_expand_to_eltwise_4d
+func.func @test_expand_to_eltwise_4d(
+    %arg0: tensor<1x1x1x1x!quant.uniform<u8:f32, 0.05:128>>)
+    -> tensor<1x1x32x32x!quant.uniform<u8:f32, 0.05:128>> {
+  %shape = "onnx.Constant"() {value = dense<[1, 1, 32, 32]> : tensor<4xi64>} : () -> tensor<4xi64>
+  %expand = "onnx.Expand"(%arg0, %shape) :
+      (tensor<1x1x1x1x!quant.uniform<u8:f32, 0.05:128>>, tensor<4xi64>)
+      -> tensor<1x1x32x32x!quant.uniform<u8:f32, 0.05:128>>
+  return %expand : tensor<1x1x32x32x!quant.uniform<u8:f32, 0.05:128>>
+
+  // CHECK: %[[ZEROS:.*]] = onnx.Constant {value = dense<0> : tensor<1x1x32x32xui8>}
+  // CHECK: %[[FUSED:.*]] = "onnx.XCOMPILERFusedEltwise"(%arg0, %[[ZEROS]])
+  // CHECK-SAME: nonlinear = "NONE"
+  // CHECK-SAME: type = "ADD"
+  // CHECK: return %[[FUSED]]
+}
+
+// -----
+// Test Pattern 5: Replace quantized Expand with i8 quantized type (4D, C=1, W=1)
+// CHECK-LABEL: func.func @test_expand_to_eltwise_i8
+func.func @test_expand_to_eltwise_i8(
+    %arg0: tensor<1x1x1x1x!quant.uniform<i8:f32, 0.03:0>>)
+    -> tensor<1x1x16x16x!quant.uniform<i8:f32, 0.03:0>> {
+  %shape = "onnx.Constant"() {value = dense<[1, 1, 16, 16]> : tensor<4xi64>} : () -> tensor<4xi64>
+  %expand = "onnx.Expand"(%arg0, %shape) :
+      (tensor<1x1x1x1x!quant.uniform<i8:f32, 0.03:0>>, tensor<4xi64>)
+      -> tensor<1x1x16x16x!quant.uniform<i8:f32, 0.03:0>>
+  return %expand : tensor<1x1x16x16x!quant.uniform<i8:f32, 0.03:0>>
+
+  // CHECK: %[[ZEROS:.*]] = onnx.Constant {value = dense<0> : tensor<1x1x16x16xi8>}
+  // CHECK: %[[FUSED:.*]] = "onnx.XCOMPILERFusedEltwise"(%arg0, %[[ZEROS]])
+  // CHECK-SAME: nonlinear = "NONE"
+  // CHECK-SAME: type = "ADD"
+  // CHECK: return %[[FUSED]]
+}
+
+// -----
+// Negative: Pattern 5 should NOT fire when 4D input has W (dim 3) != 1
+// CHECK-LABEL: func.func @test_expand_no_match_w_not_one
+func.func @test_expand_no_match_w_not_one(
+    %arg0: tensor<1x1x1x4x!quant.uniform<u8:f32, 0.05:128>>)
+    -> tensor<1x1x8x4x!quant.uniform<u8:f32, 0.05:128>> {
+  %shape = "onnx.Constant"() {value = dense<[1, 1, 8, 4]> : tensor<4xi64>} : () -> tensor<4xi64>
+  %expand = "onnx.Expand"(%arg0, %shape) :
+      (tensor<1x1x1x4x!quant.uniform<u8:f32, 0.05:128>>, tensor<4xi64>)
+      -> tensor<1x1x8x4x!quant.uniform<u8:f32, 0.05:128>>
+  return %expand : tensor<1x1x8x4x!quant.uniform<u8:f32, 0.05:128>>
+
+  // CHECK: "onnx.Expand"
+  // CHECK-NOT: "onnx.XCOMPILERFusedEltwise"
+}
+
+// -----
+// Negative: Pattern 5 should NOT fire when 4D input has C (dim 1) != 1
+// CHECK-LABEL: func.func @test_expand_no_match_c_not_one
+func.func @test_expand_no_match_c_not_one(
+    %arg0: tensor<1x16x1x1x!quant.uniform<u8:f32, 0.05:128>>)
+    -> tensor<1x16x32x32x!quant.uniform<u8:f32, 0.05:128>> {
+  %shape = "onnx.Constant"() {value = dense<[1, 16, 32, 32]> : tensor<4xi64>} : () -> tensor<4xi64>
+  %expand = "onnx.Expand"(%arg0, %shape) :
+      (tensor<1x16x1x1x!quant.uniform<u8:f32, 0.05:128>>, tensor<4xi64>)
+      -> tensor<1x16x32x32x!quant.uniform<u8:f32, 0.05:128>>
+  return %expand : tensor<1x16x32x32x!quant.uniform<u8:f32, 0.05:128>>
+
+  // CHECK: "onnx.Expand"
+  // CHECK-NOT: "onnx.XCOMPILERFusedEltwise"
+}
+
+// -----
+// Negative: Pattern 5 should NOT fire on non-quantized Expand
+// CHECK-LABEL: func.func @test_expand_float_not_replaced
+func.func @test_expand_float_not_replaced(
+    %arg0: tensor<1x16x1x1xf32>)
+    -> tensor<1x16x32x32xf32> {
+  %shape = "onnx.Constant"() {value = dense<[1, 16, 32, 32]> : tensor<4xi64>} : () -> tensor<4xi64>
+  %expand = "onnx.Expand"(%arg0, %shape) :
+      (tensor<1x16x1x1xf32>, tensor<4xi64>)
+      -> tensor<1x16x32x32xf32>
+  return %expand : tensor<1x16x32x32xf32>
+
+  // CHECK: "onnx.Expand"
+  // CHECK-NOT: "onnx.XCOMPILERFusedEltwise"
+}
+
+// -----
+// Test Pattern 5: Non-4D tensor (3D) should also be replaced
+// CHECK-LABEL: func.func @test_expand_to_eltwise_3d
+func.func @test_expand_to_eltwise_3d(
+    %arg0: tensor<1x1x8x!quant.uniform<i8:f32, 0.02:0>>)
+    -> tensor<4x16x8x!quant.uniform<i8:f32, 0.02:0>> {
+  %shape = "onnx.Constant"() {value = dense<[4, 16, 8]> : tensor<3xi64>} : () -> tensor<3xi64>
+  %expand = "onnx.Expand"(%arg0, %shape) :
+      (tensor<1x1x8x!quant.uniform<i8:f32, 0.02:0>>, tensor<3xi64>)
+      -> tensor<4x16x8x!quant.uniform<i8:f32, 0.02:0>>
+  return %expand : tensor<4x16x8x!quant.uniform<i8:f32, 0.02:0>>
+
+  // CHECK: %[[ZEROS:.*]] = onnx.Constant {value = dense<0> : tensor<4x16x8xi8>}
+  // CHECK: %[[FUSED:.*]] = "onnx.XCOMPILERFusedEltwise"(%arg0, %[[ZEROS]])
+  // CHECK-SAME: nonlinear = "NONE"
+  // CHECK-SAME: type = "ADD"
+  // CHECK: return %[[FUSED]]
+}


### PR DESCRIPTION
Quantized Expand ops with trailing spatial dims of 1 are replaced by XCOMPILERFusedEltwise ADD with a zero constant at the target shape. Mirrors xcompiler's ReplaceExpandToEltwisePass/ReplaceQDQExpandToEltwisePass.
