### PR TITLE
Support mixed head-split transpose patterns (matmul + MHA)

### DIFF
--- a/src/Dialect/ONNX/Transforms/xmc/OptimizeSliceReshapeTransposeBlockPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/OptimizeSliceReshapeTransposeBlockPass.cpp
@@ -1,12 +1,14 @@
 // Copyright (C) 2022 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // This pass mirrors xcompiler dev OptimizeSliceReshapeTransposeBlockPass
-// (get_template_block / get_template_block_mha + optimize_block / optimize_block_mha):
+// (get_template_block / get_template_block_mha + optimize_block /
+// optimize_block_mha):
 //
-// Matmul (get_template_block filter): rank-3 reshape inputs; transpose orders are
+// Matmul (get_template_block filter): rank-3 reshape inputs; transpose orders
+// are
 //   exactly {0,2,1,3}, {0,2,3,1}, {0,2,1,3} on branches 0,1,2 (middle branch is
-//   {0,2,3,1}). optimize_block fuses reshape+transpose then slices; only the middle
-//   branch gets extra transpose {0,1,3,2} after its strided_slice.
+//   {0,2,3,1}). optimize_block fuses reshape+transpose then slices; only the
+//   middle branch gets extra transpose {0,1,3,2} after its strided_slice.
 //
 // MHA (get_template_block_mha): same ranks; all three transposes {0,2,1,3}.
 //   optimize_block_mha does not add that extra transpose.
@@ -15,7 +17,8 @@
 //   input -> [slice_0, slice_1, slice_2] -> [reshape_0, reshape_1, reshape_2]
 //          -> [transpose_0, transpose_1, transpose_2] -> consumer
 // Into:
-//   input -> reshape -> transpose {0,2,1,3} -> [slice_x, slice_y, (+ maybe Transpose)]
+//   input -> reshape -> transpose {0,2,1,3} -> [slice_x, slice_y, (+ maybe
+//   Transpose)]
 //
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -65,10 +68,10 @@ Value createConstantI64Array(
   return rewriter.create<ONNXConstantOp>(loc, Attribute(), denseAttr);
 }
 
-/// Reshape output layout: axis 0=N, 1=S, 2=H, 3=D. ONNX Transpose: output dim i maps
-/// from input dim perm[i]. Valid "head-split" patterns put N,H first and S,D last:
-/// perm[0]==0, perm[1]==2, and {perm[2],perm[3]} == {1,3}.
-/// Sets \p needsSwapSdOnOutput when the branch output had (N,H,D,S) vs fused (N,H,S,D).
+/// Reshape output layout: axis 0=N, 1=S, 2=H, 3=D. ONNX Transpose: output dim i
+/// maps from input dim perm[i]. Valid "head-split" patterns put N,H first and
+/// S,D last: perm[0]==0, perm[1]==2, and {perm[2],perm[3]} == {1,3}. Sets \p
+/// needsSwapSdOnOutput when the branch output had (N,H,D,S) vs fused (N,H,S,D).
 static bool parseHeadSplitTranspose(
     ArrayAttr permAttr, bool &needsSwapSdOnOutput) {
   if (!permAttr || permAttr.size() != 4)
@@ -90,7 +93,8 @@ static bool parseHeadSplitTranspose(
   return false;
 }
 
-/// Read one element from a 1-D onnx.Constant tensor (typical slice starts/steps).
+/// Read one element from a 1-D onnx.Constant tensor (typical slice
+/// starts/steps).
 static bool tryGet1DConstI64Element(Value v, size_t index, int64_t &out) {
   Operation *def = v.getDefiningOp();
   if (!def)
@@ -140,8 +144,8 @@ struct MatchedPattern {
   bool needsSwapSdOnOutput[3] = {false, false, false};
 };
 
-/// Map xcompiler branch order: matmul {0213,0231,0213}; MHA three {0213}; sort by
-/// channel begin (`starts[2]`).
+/// Map xcompiler branch order: matmul {0213,0231,0213}; MHA three {0213}; sort
+/// by channel begin (`starts[2]`).
 static LogicalResult canonializeThreeChains(SmallVector<ChainSlot, 3> &chains,
     MatchedPattern &pattern, Value sliceInput) {
   if (chains.size() != 3)
@@ -154,7 +158,8 @@ static LogicalResult canonializeThreeChains(SmallVector<ChainSlot, 3> &chains,
 
   int64_t keys[3];
   for (int i = 0; i < 3; ++i) {
-    FailureOr<int64_t> k = getChannelSliceStartKey(chains[static_cast<unsigned>(i)].slice);
+    FailureOr<int64_t> k =
+        getChannelSliceStartKey(chains[static_cast<unsigned>(i)].slice);
     if (failed(k))
       return failure();
     keys[i] = *k;
@@ -400,8 +405,8 @@ public:
           stepsConst);
 
       Value repl = newSliceOp.getResult();
-      // Branch that used {0,2,3,1} had layout (N,H,D,S); slice above is (N,H,S,D).
-      // Swap last two dims to match original consumers.
+      // Branch that used {0,2,3,1} had layout (N,H,D,S); slice above is
+      // (N,H,S,D). Swap last two dims to match original consumers.
       if (pattern.needsSwapSdOnOutput[i]) {
         sliceVals.assign({nDim, numHeadsPerSlice, dDim, sDim});
         auto swappedType = RankedTensorType::get(sliceVals, elementType);

--- a/src/Dialect/ONNX/Transforms/xmc/OptimizeSliceReshapeTransposeBlockPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/OptimizeSliceReshapeTransposeBlockPass.cpp
@@ -1,11 +1,22 @@
 // Copyright (C) 2022 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
-// This pass optimizes the Slice-Reshape-Transpose block for MHA (Multi-Head
-// Attention) patterns. Transforms:
+// This pass mirrors xcompiler dev OptimizeSliceReshapeTransposeBlockPass
+// (get_template_block / get_template_block_mha + optimize_block / optimize_block_mha):
+//
+// Matmul (get_template_block filter): rank-3 reshape inputs; transpose orders are
+//   exactly {0,2,1,3}, {0,2,3,1}, {0,2,1,3} on branches 0,1,2 (middle branch is
+//   {0,2,3,1}). optimize_block fuses reshape+transpose then slices; only the middle
+//   branch gets extra transpose {0,1,3,2} after its strided_slice.
+//
+// MHA (get_template_block_mha): same ranks; all three transposes {0,2,1,3}.
+//   optimize_block_mha does not add that extra transpose.
+//
+// Transform (common):
 //   input -> [slice_0, slice_1, slice_2] -> [reshape_0, reshape_1, reshape_2]
 //          -> [transpose_0, transpose_1, transpose_2] -> consumer
 // Into:
-//   input -> reshape -> transpose -> [slice_0, slice_1, slice_2] -> consumer
+//   input -> reshape -> transpose {0,2,1,3} -> [slice_x, slice_y, (+ maybe Transpose)]
+//
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -18,10 +29,10 @@
 #include "src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp"
 #include "src/Pass/Passes.hpp"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "optimize-slice-reshape-transpose-block"
+#include <utility>
 
 using namespace mlir;
 
@@ -31,13 +42,9 @@ namespace {
 // Helper Functions
 //===----------------------------------------------------------------------===//
 
-/// Helper to get shape from a ranked tensor type
-SmallVector<int64_t> getShapeFromType(Type type) {
-  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
-    auto shape = tensorType.getShape();
-    return SmallVector<int64_t>(shape.begin(), shape.end());
-  }
-  return {};
+static size_t getRank(Type type) {
+  auto ranked = dyn_cast<RankedTensorType>(type);
+  return ranked ? ranked.getRank() : 0;
 }
 
 /// Helper to get element type from a tensor type
@@ -58,20 +65,71 @@ Value createConstantI64Array(
   return rewriter.create<ONNXConstantOp>(loc, Attribute(), denseAttr);
 }
 
-/// Check if the transpose order matches expected pattern
-bool isExpectedTransposeOrder(
-    ArrayAttr permAttr, ArrayRef<int64_t> expectedOrder) {
-  if (!permAttr || permAttr.size() != expectedOrder.size())
+/// Reshape output layout: axis 0=N, 1=S, 2=H, 3=D. ONNX Transpose: output dim i maps
+/// from input dim perm[i]. Valid "head-split" patterns put N,H first and S,D last:
+/// perm[0]==0, perm[1]==2, and {perm[2],perm[3]} == {1,3}.
+/// Sets \p needsSwapSdOnOutput when the branch output had (N,H,D,S) vs fused (N,H,S,D).
+static bool parseHeadSplitTranspose(
+    ArrayAttr permAttr, bool &needsSwapSdOnOutput) {
+  if (!permAttr || permAttr.size() != 4)
     return false;
-
-  for (size_t i = 0; i < expectedOrder.size(); ++i) {
-    if (cast<IntegerAttr>(permAttr[i]).getInt() != expectedOrder[i])
-      return false;
+  int64_t p0 = cast<IntegerAttr>(permAttr[0]).getInt();
+  int64_t p1 = cast<IntegerAttr>(permAttr[1]).getInt();
+  int64_t p2 = cast<IntegerAttr>(permAttr[2]).getInt();
+  int64_t p3 = cast<IntegerAttr>(permAttr[3]).getInt();
+  if (p0 != 0 || p1 != 2)
+    return false;
+  if (p2 == 1 && p3 == 3) {
+    needsSwapSdOnOutput = false;
+    return true;
   }
-  return true;
+  if (p2 == 3 && p3 == 1) {
+    needsSwapSdOnOutput = true;
+    return true;
+  }
+  return false;
 }
 
-/// Structure to hold the matched pattern
+/// Read one element from a 1-D onnx.Constant tensor (typical slice starts/steps).
+static bool tryGet1DConstI64Element(Value v, size_t index, int64_t &out) {
+  Operation *def = v.getDefiningOp();
+  if (!def)
+    return false;
+  auto cst = dyn_cast<ONNXConstantOp>(def);
+  if (!cst || !cst.getValueAttr())
+    return false;
+  auto dense = dyn_cast<DenseIntElementsAttr>(cst.getValueAttr());
+  if (!dense || dense.getType().getRank() != 1)
+    return false;
+  int64_t dim = dense.getType().getDimSize(0);
+  if (index >= static_cast<size_t>(dim))
+    return false;
+  size_t i = 0;
+  for (int64_t el : dense.getValues<int64_t>()) {
+    if (i == index) {
+      out = el;
+      return true;
+    }
+    ++i;
+  }
+  return false;
+}
+
+/// Channel-axis start for a typical rank-3 QKV slice (`starts[2]`).
+static FailureOr<int64_t> getChannelSliceStartKey(ONNXSliceOp slice) {
+  int64_t key = 0;
+  if (!tryGet1DConstI64Element(slice.getStarts(), 2, key))
+    return failure();
+  return key;
+}
+
+struct ChainSlot {
+  ONNXSliceOp slice;
+  ONNXReshapeOp reshape;
+  ONNXTransposeOp transpose;
+  bool needsSwapSdOnOutput = false;
+};
+
 struct MatchedPattern {
   ONNXSliceOp slices[3];
   ONNXReshapeOp reshapes[3];
@@ -79,17 +137,83 @@ struct MatchedPattern {
   Value commonInput;
   SmallVector<int64_t> reshapeShape;
   SmallVector<int64_t> inputShape;
+  bool needsSwapSdOnOutput[3] = {false, false, false};
 };
+
+/// Map xcompiler branch order: matmul {0213,0231,0213}; MHA three {0213}; sort by
+/// channel begin (`starts[2]`).
+static LogicalResult canonializeThreeChains(SmallVector<ChainSlot, 3> &chains,
+    MatchedPattern &pattern, Value sliceInput) {
+  if (chains.size() != 3)
+    return failure();
+  int swapCount = 0;
+  for (const auto &c : chains)
+    swapCount += c.needsSwapSdOnOutput ? 1 : 0;
+  if (swapCount > 1)
+    return failure();
+
+  int64_t keys[3];
+  for (int i = 0; i < 3; ++i) {
+    FailureOr<int64_t> k = getChannelSliceStartKey(chains[static_cast<unsigned>(i)].slice);
+    if (failed(k))
+      return failure();
+    keys[i] = *k;
+  }
+
+  unsigned order[3];
+  if (swapCount == 0) {
+    // Sort chain indices 0..2 by keys (fixed 3-element ordering network).
+    unsigned a = 0, b = 1, c = 2;
+    if (keys[a] > keys[b])
+      std::swap(a, b);
+    if (keys[b] > keys[c])
+      std::swap(b, c);
+    if (keys[a] > keys[b])
+      std::swap(a, b);
+    order[0] = a;
+    order[1] = b;
+    order[2] = c;
+  } else {
+    unsigned mid = 0, side0 = 0, side1 = 0;
+    bool seenSide = false;
+    for (unsigned i = 0; i < 3; ++i) {
+      if (chains[i].needsSwapSdOnOutput)
+        mid = i;
+      else if (!seenSide) {
+        side0 = i;
+        seenSide = true;
+      } else {
+        side1 = i;
+      }
+    }
+    if (keys[side0] <= keys[side1])
+      order[0] = side0, order[1] = mid, order[2] = side1;
+    else
+      order[0] = side1, order[1] = mid, order[2] = side0;
+  }
+
+  pattern.commonInput = sliceInput;
+  for (int i = 0; i < 3; ++i) {
+    const ChainSlot &c = chains[order[i]];
+    pattern.slices[i] = c.slice;
+    pattern.reshapes[i] = c.reshape;
+    pattern.transposes[i] = c.transpose;
+    pattern.needsSwapSdOnOutput[i] = c.needsSwapSdOnOutput;
+  }
+
+  // Matmul: canonical slot 1 is {0,2,3,1}; MHA: no swap flags.
+  return swapCount == static_cast<int>(pattern.needsSwapSdOnOutput[1])
+             ? success()
+             : failure();
+}
 
 /// Try to match the MHA Slice-Reshape-Transpose pattern starting from a
 /// transpose
 LogicalResult matchPattern(
     ONNXTransposeOp transposeOp, MatchedPattern &pattern) {
-  // Check transpose order - must be {0, 2, 1, 3}
-  auto permAttr = transposeOp.getPermAttr();
-  if (!isExpectedTransposeOrder(permAttr, {0, 2, 1, 3})) {
+  [[maybe_unused]] bool anchorSwapIgnored = false;
+  if (!parseHeadSplitTranspose(transposeOp.getPermAttr(), anchorSwapIgnored))
     return failure();
-  }
 
   // Get the reshape op feeding this transpose
   auto reshapeOp = transposeOp.getData().getDefiningOp<ONNXReshapeOp>();
@@ -119,10 +243,8 @@ LogicalResult matchPattern(
     return failure();
   }
 
-  // Verify each slice -> reshape -> transpose chain has correct structure
-  int validChains = 0;
+  SmallVector<ChainSlot, 3> chains;
   for (auto sibSlice : siblingSlices) {
-    // Check single use to reshape
     if (!sibSlice.getResult().hasOneUse())
       continue;
 
@@ -131,31 +253,54 @@ LogicalResult matchPattern(
     if (!sibReshape || !sibReshape.getResult().hasOneUse())
       continue;
 
+    if (getRank(sibReshape.getData().getType()) != 3)
+      continue;
+
     auto sibTranspose =
         dyn_cast<ONNXTransposeOp>(*sibReshape.getResult().getUsers().begin());
     if (!sibTranspose)
       continue;
 
-    // Check transpose order is {0, 2, 1, 3}
-    if (!isExpectedTransposeOrder(sibTranspose.getPermAttr(), {0, 2, 1, 3}))
+    bool branchSwap = false;
+    if (!parseHeadSplitTranspose(sibTranspose.getPermAttr(), branchSwap))
       continue;
 
-    // Store in pattern
-    pattern.slices[validChains] = sibSlice;
-    pattern.reshapes[validChains] = sibReshape;
-    pattern.transposes[validChains] = sibTranspose;
-    validChains++;
+    ChainSlot slot;
+    slot.slice = sibSlice;
+    slot.reshape = sibReshape;
+    slot.transpose = sibTranspose;
+    slot.needsSwapSdOnOutput = branchSwap;
+    chains.push_back(slot);
   }
 
-  // Store common input and shapes
-  pattern.commonInput = sliceInput;
-  pattern.inputShape = getShapeFromType(sliceInput.getType());
-  pattern.reshapeShape =
-      getShapeFromType(pattern.reshapes[0].getResult().getType());
-
-  // Verify input shape is 3D and reshape shape is 4D
-  if (pattern.inputShape.size() != 3 || pattern.reshapeShape.size() != 4) {
+  if (chains.size() != 3)
     return failure();
+  if (failed(canonializeThreeChains(chains, pattern, sliceInput)))
+    return failure();
+
+  auto inTy = dyn_cast<RankedTensorType>(sliceInput.getType());
+  auto out0Ty =
+      dyn_cast<RankedTensorType>(pattern.reshapes[0].getResult().getType());
+  if (!inTy || !out0Ty || inTy.getRank() != 3 || out0Ty.getRank() != 4)
+    return failure();
+
+  pattern.inputShape.assign(inTy.getShape().begin(), inTy.getShape().end());
+  pattern.reshapeShape.assign(
+      out0Ty.getShape().begin(), out0Ty.getShape().end());
+
+  int64_t headDim = pattern.reshapeShape[3];
+  int64_t c = pattern.inputShape[2];
+  if (headDim == 0 || c % headDim != 0)
+    return failure();
+  if ((c / headDim) % 3 != 0)
+    return failure();
+
+  ArrayRef<int64_t> rshape = out0Ty.getShape();
+  for (int i = 1; i < 3; ++i) {
+    auto ri =
+        dyn_cast<RankedTensorType>(pattern.reshapes[i].getResult().getType());
+    if (!ri || ri.getShape() != rshape)
+      return failure();
   }
 
   return success();
@@ -194,8 +339,9 @@ public:
     auto &reshapeShape = pattern.reshapeShape;
 
     int64_t headDim = reshapeShape[3];
+    int64_t fusedHeads = inputShape[2] / headDim;
     SmallVector<int64_t> newReshapeShape = {
-        inputShape[0], inputShape[1], inputShape[2] / headDim, headDim};
+        inputShape[0], inputShape[1], fusedHeads, headDim};
 
     // Set insertion point before the first slice
     rewriter.setInsertionPoint(pattern.slices[0]);
@@ -226,34 +372,44 @@ public:
     // transpose)
     int64_t numHeadsPerSlice = newTransposeShape[1] / 3;
 
-    // Create new slices and collect replacement values
+    static const int64_t kSliceSteps[] = {1, 1, 1, 1};
+    static const int64_t kSliceAxes[] = {0, 1, 2, 3};
+    Value stepsConst = createConstantI64Array(rewriter, loc, kSliceSteps);
+    Value axesConst = createConstantI64Array(rewriter, loc, kSliceAxes);
+
+    const int64_t nDim = newTransposeShape[0];
+    const int64_t sDim = newTransposeShape[2];
+    const int64_t dDim = newTransposeShape[3];
+
+    SmallVector<int64_t, 4> sliceVals;
     SmallVector<Value> newSliceResults;
     for (int i = 0; i < 3; i++) {
-      // New slice parameters on the transposed tensor
-      SmallVector<int64_t> newStarts = {0, i * numHeadsPerSlice, 0, 0};
-      SmallVector<int64_t> newEnds = {newTransposeShape[0],
-          (i + 1) * numHeadsPerSlice, newTransposeShape[2],
-          newTransposeShape[3]};
-      SmallVector<int64_t> newSteps = {1, 1, 1, 1};
-      SmallVector<int64_t> newAxes = {0, 1, 2, 3};
+      const int64_t h0 = i * numHeadsPerSlice;
+      const int64_t h1 = (i + 1) * numHeadsPerSlice;
+      sliceVals.assign({0, h0, 0, 0});
+      Value startsConst = createConstantI64Array(rewriter, loc, sliceVals);
+      sliceVals.assign({nDim, h1, sDim, dDim});
+      Value endsConst = createConstantI64Array(rewriter, loc, sliceVals);
 
-      // Create constants for slice parameters
-      Value startsConst = createConstantI64Array(rewriter, loc, newStarts);
-      Value endsConst = createConstantI64Array(rewriter, loc, newEnds);
-      Value stepsConst = createConstantI64Array(rewriter, loc, newSteps);
-      Value axesConst = createConstantI64Array(rewriter, loc, newAxes);
-
-      // Calculate new slice output shape preserving element type
-      SmallVector<int64_t> newSliceShape = {newTransposeShape[0],
-          numHeadsPerSlice, newTransposeShape[2], newTransposeShape[3]};
-      auto newSliceType = RankedTensorType::get(newSliceShape, elementType);
+      sliceVals.assign({nDim, numHeadsPerSlice, sDim, dDim});
+      auto newSliceType = RankedTensorType::get(sliceVals, elementType);
 
       // Create new slice op
       auto newSliceOp = rewriter.create<ONNXSliceOp>(loc, newSliceType,
           newTransposeOp.getResult(), startsConst, endsConst, axesConst,
           stepsConst);
 
-      newSliceResults.push_back(newSliceOp.getResult());
+      Value repl = newSliceOp.getResult();
+      // Branch that used {0,2,3,1} had layout (N,H,D,S); slice above is (N,H,S,D).
+      // Swap last two dims to match original consumers.
+      if (pattern.needsSwapSdOnOutput[i]) {
+        sliceVals.assign({nDim, numHeadsPerSlice, dDim, sDim});
+        auto swappedType = RankedTensorType::get(sliceVals, elementType);
+        repl = rewriter.create<ONNXTransposeOp>(
+            loc, swappedType, repl, rewriter.getI64ArrayAttr({0, 1, 3, 2}));
+      }
+
+      newSliceResults.push_back(repl);
     }
 
     // Replace uses and erase old ops

--- a/test/mlir/onnx/xmc/optimize_slice_reshape_transpose_block.mlir
+++ b/test/mlir/onnx/xmc/optimize_slice_reshape_transpose_block.mlir
@@ -2,11 +2,18 @@
 
 // RUN: onnx-mlir-opt --split-input-file --optimize-slice-reshape-transpose-block %s | FileCheck %s
 
+// Covers OptimizeSliceReshapeTransposeBlockPass: rank-3 reshape inputs, same 4D reshape
+// on each branch, head-split transposes {0,2,1,3} and/or {0,2,3,1}. Branch order is
+// canonicalized using slice starts[2] (must be onnx.Constant). MHA: all {0,2,1,3}.
+// Matmul template: {0,2,1,3}, {0,2,3,1}, {0,2,1,3}; middle output gets extra
+// Transpose {0,1,3,2} after slicing.
+
 module {
-  // Test 1: MHA pattern with 3 parallel slice-reshape-transpose chains
+  // Test 1: MHA — three chains all use perm [0, 2, 1, 3]; no post-slice transpose.
   // Input shape: [16, 225, 576] -> 3 slices of [16, 225, 192] each
   // Each slice -> reshape [16, 225, 12, 16] -> transpose {0, 2, 1, 3} -> [16, 12, 225, 16]
-  // Should be optimized to: reshape -> transpose -> 3 slices
+  // Optimized: reshape [16,225,36,16] -> transpose {0,2,1,3} -> three slices on fused H.
+  // CHECK-LABEL: func.func @mha_slice_reshape_transpose
   func.func @mha_slice_reshape_transpose(%arg0: tensor<16x225x576xf32>) -> (tensor<16x12x225x16xf32>, tensor<16x12x225x16xf32>, tensor<16x12x225x16xf32>) {
     // Slice parameters for Q, K, V
     %starts0 = "onnx.Constant"() {value = dense<[0, 0, 0]> : tensor<3xi64>} : () -> tensor<3xi64>
@@ -39,13 +46,49 @@ module {
   // Single reshape -> single transpose -> 3 slices (instead of 3x slice->reshape->transpose)
   // CHECK: %[[RESHAPE:.*]] = "onnx.Reshape"(%arg0
   // CHECK-SAME: -> tensor<16x225x36x16xf32>
-  // CHECK: %[[TRANSPOSE:.*]] = "onnx.Transpose"(%[[RESHAPE]])
-  // CHECK-SAME: perm = [0, 2, 1, 3]
+  // CHECK: %[[TRANSPOSE:.*]] = "onnx.Transpose"(%[[RESHAPE]]) {perm = [0, 2, 1, 3]}
   // CHECK: "onnx.Slice"(%[[TRANSPOSE]]
   // CHECK: "onnx.Slice"(%[[TRANSPOSE]]
   // CHECK: "onnx.Slice"(%[[TRANSPOSE]]
+  // CHECK-NOT: {perm = [0, 1, 3, 2]}
+  // CHECK-LABEL: func.func @matmul_mixed_transpose_qkv
 
-  // Test 2: MHA pattern with quantized element type
+  // Test 2: Matmul-style — middle branch perm [0, 2, 3, 1] -> extra Transpose [0, 1, 3, 2] after its slice.
+  func.func @matmul_mixed_transpose_qkv(%arg0: tensor<16x225x576xf32>) -> (tensor<16x12x225x16xf32>, tensor<16x12x16x225xf32>, tensor<16x12x225x16xf32>) {
+    %starts0 = "onnx.Constant"() {value = dense<[0, 0, 0]> : tensor<3xi64>} : () -> tensor<3xi64>
+    %ends0 = "onnx.Constant"() {value = dense<[16, 225, 192]> : tensor<3xi64>} : () -> tensor<3xi64>
+    %starts1 = "onnx.Constant"() {value = dense<[0, 0, 192]> : tensor<3xi64>} : () -> tensor<3xi64>
+    %ends1 = "onnx.Constant"() {value = dense<[16, 225, 384]> : tensor<3xi64>} : () -> tensor<3xi64>
+    %starts2 = "onnx.Constant"() {value = dense<[0, 0, 384]> : tensor<3xi64>} : () -> tensor<3xi64>
+    %ends2 = "onnx.Constant"() {value = dense<[16, 225, 576]> : tensor<3xi64>} : () -> tensor<3xi64>
+    %axes = "onnx.Constant"() {value = dense<[0, 1, 2]> : tensor<3xi64>} : () -> tensor<3xi64>
+    %steps = "onnx.Constant"() {value = dense<[1, 1, 1]> : tensor<3xi64>} : () -> tensor<3xi64>
+    %reshape_shape = "onnx.Constant"() {value = dense<[16, 225, 12, 16]> : tensor<4xi64>} : () -> tensor<4xi64>
+
+    %slice0 = "onnx.Slice"(%arg0, %starts0, %ends0, %axes, %steps) : (tensor<16x225x576xf32>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<16x225x192xf32>
+    %reshape0 = "onnx.Reshape"(%slice0, %reshape_shape) {allowzero = 0 : si64} : (tensor<16x225x192xf32>, tensor<4xi64>) -> tensor<16x225x12x16xf32>
+    %transpose0 = "onnx.Transpose"(%reshape0) {perm = [0, 2, 1, 3]} : (tensor<16x225x12x16xf32>) -> tensor<16x12x225x16xf32>
+
+    %slice1 = "onnx.Slice"(%arg0, %starts1, %ends1, %axes, %steps) : (tensor<16x225x576xf32>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<16x225x192xf32>
+    %reshape1 = "onnx.Reshape"(%slice1, %reshape_shape) {allowzero = 0 : si64} : (tensor<16x225x192xf32>, tensor<4xi64>) -> tensor<16x225x12x16xf32>
+    %transpose1 = "onnx.Transpose"(%reshape1) {perm = [0, 2, 3, 1]} : (tensor<16x225x12x16xf32>) -> tensor<16x12x16x225xf32>
+
+    %slice2 = "onnx.Slice"(%arg0, %starts2, %ends2, %axes, %steps) : (tensor<16x225x576xf32>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<16x225x192xf32>
+    %reshape2 = "onnx.Reshape"(%slice2, %reshape_shape) {allowzero = 0 : si64} : (tensor<16x225x192xf32>, tensor<4xi64>) -> tensor<16x225x12x16xf32>
+    %transpose2 = "onnx.Transpose"(%reshape2) {perm = [0, 2, 1, 3]} : (tensor<16x225x12x16xf32>) -> tensor<16x12x225x16xf32>
+
+    return %transpose0, %transpose1, %transpose2 : tensor<16x12x225x16xf32>, tensor<16x12x16x225xf32>, tensor<16x12x225x16xf32>
+  }
+  // Common fused reshape/transpose; exactly one fixup transpose on the middle path.
+  // CHECK: %[[RESHAPE_M:.*]] = "onnx.Reshape"(%arg0
+  // CHECK-SAME: -> tensor<16x225x36x16xf32>
+  // CHECK: %[[TRANSPOSE_M:.*]] = "onnx.Transpose"(%[[RESHAPE_M]]) {perm = [0, 2, 1, 3]}
+  // CHECK: "onnx.Slice"(%[[TRANSPOSE_M]]
+  // CHECK: "onnx.Slice"(%[[TRANSPOSE_M]]
+  // CHECK: %{{.+}} = "onnx.Transpose"({{.+}}) {perm = [0, 1, 3, 2]}
+  // CHECK: "onnx.Slice"(%[[TRANSPOSE_M]]
+
+  // Test 3: MHA with quantized element type (same as Test 1).
   // CHECK-LABEL: func.func @mha_slice_reshape_transpose_quant
   func.func @mha_slice_reshape_transpose_quant(%arg0: tensor<16x225x576x!quant.uniform<i8:f32, 0.1:0>>) -> (tensor<16x12x225x16x!quant.uniform<i8:f32, 0.1:0>>, tensor<16x12x225x16x!quant.uniform<i8:f32, 0.1:0>>, tensor<16x12x225x16x!quant.uniform<i8:f32, 0.1:0>>) {
     // Slice parameters for Q, K, V
@@ -79,8 +122,7 @@ module {
   // Quantized: Single reshape -> single transpose -> 3 slices, element type preserved
   // CHECK: %[[RESHAPE_Q:.*]] = "onnx.Reshape"(%arg0
   // CHECK-SAME: -> tensor<16x225x36x16x!quant.uniform<i8:f32, 1.000000e-01>>
-  // CHECK: %[[TRANSPOSE_Q:.*]] = "onnx.Transpose"(%[[RESHAPE_Q]])
-  // CHECK-SAME: perm = [0, 2, 1, 3]
+  // CHECK: %[[TRANSPOSE_Q:.*]] = "onnx.Transpose"(%[[RESHAPE_Q]]) {perm = [0, 2, 1, 3]}
   // CHECK: "onnx.Slice"(%[[TRANSPOSE_Q]]
   // CHECK: "onnx.Slice"(%[[TRANSPOSE_Q]]
   // CHECK: "onnx.Slice"(%[[TRANSPOSE_Q]]


### PR DESCRIPTION
Generalize OptimizeSliceReshapeTransposeBlockPass to handle both MHA ({0,2,1,3} on all branches) and matmul-style patterns where the middle branch uses {0,2,3,1}. Canonicalize chain ordering by channel slice start, and emit an extra Transpose {0,1,3,2} fixup on branches that need S/D swapped. Add matmul-style test case.