### PR TITLE
Modify TransposeofConst constraint for per axis quantization

### DIFF
--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -111,13 +112,13 @@ bool valuesHaveSameDTypeForTransposeOfConst(
   if (!transposeOp)
     return false;
 
-  auto inShaped = dyn_cast<ShapedType>(input.getType());
-  auto outShaped = dyn_cast<ShapedType>(transposeResult.getType());
-  if (!inShaped || !outShaped)
+  auto inRanked = dyn_cast<RankedTensorType>(input.getType());
+  auto outRanked = dyn_cast<RankedTensorType>(transposeResult.getType());
+  if (!inRanked || !outRanked)
     return false;
 
-  Type inElem = inShaped.getElementType();
-  Type outElem = outShaped.getElementType();
+  Type inElem = inRanked.getElementType();
+  Type outElem = outRanked.getElementType();
 
   SmallVector<int64_t, 8> perm;
   if (transposeOp.getPermAttr()) {
@@ -126,23 +127,24 @@ bool valuesHaveSameDTypeForTransposeOfConst(
       perm.push_back(p);
   } else {
     // ONNX default: reverse dimension order.
-    for (int64_t r = inShaped.getRank() - 1; r >= 0; --r)
+    for (int64_t r = inRanked.getRank() - 1; r >= 0; --r)
       perm.push_back(r);
   }
-  if (static_cast<int64_t>(perm.size()) != inShaped.getRank())
+  // Ranked input: perm length must match tensor rank (ONNX Transpose).
+  if (static_cast<int64_t>(perm.size()) != inRanked.getRank())
     return false;
 
   Type expectedOutElem = inElem;
   if (auto perAxis =
           dyn_cast<mlir::quant::UniformQuantizedPerAxisType>(inElem)) {
     int32_t oldAxis = perAxis.getQuantizedDimension();
-    int32_t newAxis = oldAxis;
-    for (int64_t i = 0, e = static_cast<int64_t>(perm.size()); i < e; ++i) {
-      if (perm[static_cast<size_t>(i)] == oldAxis) {
-        newAxis = static_cast<int32_t>(i);
-        break;
-      }
-    }
+    if (oldAxis < 0 || oldAxis >= inRanked.getRank())
+      return false;
+    // ONNX: output axis i reads input axis perm[i]; inverse maps input axis
+    // -> output axis (same as ConvertToChannelLast::remapPerAxisQuantType).
+    SmallVector<int64_t> invPerm = invertPermutationVector(perm);
+    int32_t newAxis =
+        static_cast<int32_t>(invPerm[static_cast<size_t>(oldAxis)]);
     if (newAxis != oldAxis) {
       expectedOutElem =
           mlir::quant::UniformQuantizedPerAxisType::get(perAxis.getFlags(),

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -95,6 +95,19 @@ bool satisfiesExpansionBound(Value result) {
          getSizeInBytes(resultType);
 }
 
+/// Same as comparing element types, except we skip the check when either value
+/// is per-axis quantized: transpose const-prop uses the TransposeOp's result
+/// type (with updated quant axis) while the constant may still carry the
+/// pre-transpose quant type, so element types may not compare equal.
+bool valuesHaveSameDTypeUnlessPerAxisQuant(Value a, Value b) {
+  Type elemA = cast<ShapedType>(a.getType()).getElementType();
+  Type elemB = cast<ShapedType>(b.getType()).getElementType();
+  if (isa<mlir::quant::UniformQuantizedPerAxisType>(elemA) ||
+      isa<mlir::quant::UniformQuantizedPerAxisType>(elemB))
+    return true;
+  return elemA == elemB;
+}
+
 // We want to disable Constant Propagation when a user
 // manually specifies the "disable-constant-prop" flag.
 bool isConstantPropagationDisabled() {

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -95,17 +95,56 @@ bool satisfiesExpansionBound(Value result) {
          getSizeInBytes(resultType);
 }
 
-/// Same as comparing element types, except we skip the check when either value
-/// is per-axis quantized: transpose const-prop uses the TransposeOp's result
-/// type (with updated quant axis) while the constant may still carry the
-/// pre-transpose quant type, so element types may not compare equal.
-bool valuesHaveSameDTypeUnlessPerAxisQuant(Value a, Value b) {
-  Type elemA = cast<ShapedType>(a.getType()).getElementType();
-  Type elemB = cast<ShapedType>(b.getType()).getElementType();
-  if (isa<mlir::quant::UniformQuantizedPerAxisType>(elemA) ||
-      isa<mlir::quant::UniformQuantizedPerAxisType>(elemB))
-    return true;
-  return elemA == elemB;
+/// True if the transpose result's element type matches the constant input's
+/// element type after remapping per-axis quantization through `perm` (same
+/// rule as ConvertToChannelLast: output axis i reads input axis perm[i]).
+bool valuesHaveSameDTypeForTransposeOfConst(Value transposeResult, Value input) {
+  auto transposeOp = dyn_cast<ONNXTransposeOp>(transposeResult.getDefiningOp());
+  if (!transposeOp)
+    return false;
+
+  auto inShaped = dyn_cast<ShapedType>(input.getType());
+  auto outShaped = dyn_cast<ShapedType>(transposeResult.getType());
+  if (!inShaped || !outShaped)
+    return false;
+
+  Type inElem = inShaped.getElementType();
+  Type outElem = outShaped.getElementType();
+
+  SmallVector<int64_t, 8> perm;
+  if (transposeOp.getPermAttr()) {
+    for (int64_t p :
+        extractFromIntegerArrayAttr<int64_t>(transposeOp.getPermAttr()))
+      perm.push_back(p);
+  } else {
+    // ONNX default: reverse dimension order.
+    for (int64_t r = inShaped.getRank() - 1; r >= 0; --r)
+      perm.push_back(r);
+  }
+  if (static_cast<int64_t>(perm.size()) != inShaped.getRank())
+    return false;
+
+  Type expectedOutElem = inElem;
+  if (auto perAxis =
+          dyn_cast<mlir::quant::UniformQuantizedPerAxisType>(inElem)) {
+    int32_t oldAxis = perAxis.getQuantizedDimension();
+    int32_t newAxis = oldAxis;
+    for (int64_t i = 0, e = static_cast<int64_t>(perm.size()); i < e; ++i) {
+      if (perm[static_cast<size_t>(i)] == oldAxis) {
+        newAxis = static_cast<int32_t>(i);
+        break;
+      }
+    }
+    if (newAxis != oldAxis) {
+      expectedOutElem = mlir::quant::UniformQuantizedPerAxisType::get(
+          perAxis.getFlags(), perAxis.getStorageType(),
+          perAxis.getExpressedType(), perAxis.getScales(),
+          perAxis.getZeroPoints(), newAxis, perAxis.getStorageTypeMin(),
+          perAxis.getStorageTypeMax());
+    }
+  }
+
+  return expectedOutElem == outElem;
 }
 
 // We want to disable Constant Propagation when a user

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -98,7 +98,8 @@ bool satisfiesExpansionBound(Value result) {
 /// True if the transpose result's element type matches the constant input's
 /// element type after remapping per-axis quantization through `perm` (same
 /// rule as ConvertToChannelLast: output axis i reads input axis perm[i]).
-bool valuesHaveSameDTypeForTransposeOfConst(Value transposeResult, Value input) {
+bool valuesHaveSameDTypeForTransposeOfConst(
+    Value transposeResult, Value input) {
   auto transposeOp = dyn_cast<ONNXTransposeOp>(transposeResult.getDefiningOp());
   if (!transposeOp)
     return false;
@@ -136,11 +137,11 @@ bool valuesHaveSameDTypeForTransposeOfConst(Value transposeResult, Value input) 
       }
     }
     if (newAxis != oldAxis) {
-      expectedOutElem = mlir::quant::UniformQuantizedPerAxisType::get(
-          perAxis.getFlags(), perAxis.getStorageType(),
-          perAxis.getExpressedType(), perAxis.getScales(),
-          perAxis.getZeroPoints(), newAxis, perAxis.getStorageTypeMin(),
-          perAxis.getStorageTypeMax());
+      expectedOutElem =
+          mlir::quant::UniformQuantizedPerAxisType::get(perAxis.getFlags(),
+              perAxis.getStorageType(), perAxis.getExpressedType(),
+              perAxis.getScales(), perAxis.getZeroPoints(), newAxis,
+              perAxis.getStorageTypeMin(), perAxis.getStorageTypeMax());
     }
   }
 

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -106,6 +106,8 @@ bool satisfiesExpansionBound(Value result) {
 /// True if the transpose result's element type matches the constant input's
 /// element type after remapping per-axis quantization through `perm` (same
 /// rule as ConvertToChannelLast: output axis i reads input axis perm[i]).
+/// Requires an explicit `perm` attribute; ONNX's default (reverse axes) is
+/// expected to be materialized during import or canonicalization.
 bool valuesHaveSameDTypeForTransposeOfConst(
     Value transposeResult, Value input) {
   auto transposeOp = dyn_cast<ONNXTransposeOp>(transposeResult.getDefiningOp());
@@ -120,21 +122,17 @@ bool valuesHaveSameDTypeForTransposeOfConst(
   Type inElem = inRanked.getElementType();
   Type outElem = outRanked.getElementType();
 
+  if (!transposeOp.getPermAttr())
+    return false;
   SmallVector<int64_t, 8> perm;
-  if (transposeOp.getPermAttr()) {
-    for (int64_t p :
-        extractFromIntegerArrayAttr<int64_t>(transposeOp.getPermAttr()))
-      perm.push_back(p);
-  } else {
-    // ONNX default: reverse dimension order.
-    for (int64_t r = inRanked.getRank() - 1; r >= 0; --r)
-      perm.push_back(r);
-  }
+  for (int64_t p :
+      extractFromIntegerArrayAttr<int64_t>(transposeOp.getPermAttr()))
+    perm.push_back(p);
   // Ranked input: perm length must match tensor rank (ONNX Transpose).
   if (static_cast<int64_t>(perm.size()) != inRanked.getRank())
     return false;
 
-  Type expectedOutElem = inElem;
+  Type transposedInElem = inElem;
   if (auto perAxis =
           dyn_cast<mlir::quant::UniformQuantizedPerAxisType>(inElem)) {
     int32_t oldAxis = perAxis.getQuantizedDimension();
@@ -146,7 +144,7 @@ bool valuesHaveSameDTypeForTransposeOfConst(
     int32_t newAxis =
         static_cast<int32_t>(invPerm[static_cast<size_t>(oldAxis)]);
     if (newAxis != oldAxis) {
-      expectedOutElem =
+      transposedInElem =
           mlir::quant::UniformQuantizedPerAxisType::get(perAxis.getFlags(),
               perAxis.getStorageType(), perAxis.getExpressedType(),
               perAxis.getScales(), perAxis.getZeroPoints(), newAxis,
@@ -154,7 +152,7 @@ bool valuesHaveSameDTypeForTransposeOfConst(
     }
   }
 
-  return expectedOutElem == outElem;
+  return transposedInElem == outElem;
 }
 
 // We want to disable Constant Propagation when a user

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -101,9 +101,9 @@ def ValuesHaveSameDType : Constraint<
   CPred<"$0.getType().cast<mlir::ShapedType>().getElementType() == $1.getType().cast<mlir::ShapedType>().getElementType()">,
   "Values have same dtype">;
 
-def ValuesHaveSameDTypeUnlessPerAxisQuant : Constraint<
-  CPred<"valuesHaveSameDTypeUnlessPerAxisQuant($0, $1)">,
-  "Values have same dtype, or per-axis quantization on either value (skip strict dtype match)">;
+def TransposeConstPropTypesMatch : Constraint<
+  CPred<"valuesHaveSameDTypeForTransposeOfConst($0, $1)">,
+  "Transpose result dtype matches constant input after per-axis quant axis remap">;
 
 def IsMatMulIntegerLhsZero: Constraint<
     CPred<"isMatMulIntegerLhsZero($0, $1)">,
@@ -1145,7 +1145,7 @@ def TransposeofConst : NamedPat<"TransposeofConst",
     // To c' where c' is transposed attribute
     (CreateTransposeOfConst $resOp, $input),
     [(IsFromDenseONNXConstantOp:$input),
-     (ValuesHaveSameDTypeUnlessPerAxisQuant $resOp, $input)]>;
+     (TransposeConstPropTypesMatch $resOp, $input)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with ReverseSequence operations.

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -101,6 +101,10 @@ def ValuesHaveSameDType : Constraint<
   CPred<"$0.getType().cast<mlir::ShapedType>().getElementType() == $1.getType().cast<mlir::ShapedType>().getElementType()">,
   "Values have same dtype">;
 
+def ValuesHaveSameDTypeUnlessPerAxisQuant : Constraint<
+  CPred<"valuesHaveSameDTypeUnlessPerAxisQuant($0, $1)">,
+  "Values have same dtype, or per-axis quantization on either value (skip strict dtype match)">;
+
 def IsMatMulIntegerLhsZero: Constraint<
     CPred<"isMatMulIntegerLhsZero($0, $1)">,
     "MatMulInteger lhs matrix is zero for given zero point">;
@@ -1140,7 +1144,8 @@ def TransposeofConst : NamedPat<"TransposeofConst",
     (ONNXTransposeOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is transposed attribute
     (CreateTransposeOfConst $resOp, $input),
-    [(IsFromDenseONNXConstantOp:$input), (ValuesHaveSameDType $resOp, $input)]>;
+    [(IsFromDenseONNXConstantOp:$input),
+     (ValuesHaveSameDTypeUnlessPerAxisQuant $resOp, $input)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with ReverseSequence operations.

--- a/test/mlir/onnx/onnx_constprop_quant.mlir
+++ b/test/mlir/onnx/onnx_constprop_quant.mlir
@@ -501,3 +501,147 @@ func.func @transpose_per_axis_quant_mismatch_scales() -> tensor<2x1xf32> {
 // CHECK-LABEL: @transpose_per_axis_quant_mismatch_scales
 // CHECK:         onnx.Transpose
 // CHECK-SAME:      perm = [1, 0]
+
+
+// Reshape with quantized input but float output — should NOT be folded
+func.func @reshape_quantized_input_float_output() -> tensor<1x2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %shape = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+  %r = "onnx.Reshape"(%a_dq, %shape) {allowzero = 0 : si64} : (tensor<2xf32>, tensor<2xi64>) -> tensor<1x2xf32>
+
+  return %r : tensor<1x2xf32>
+}
+
+// CHECK-LABEL: @reshape_quantized_input_float_output
+// CHECK:         onnx.Reshape
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>, tensor<2xi64>) -> tensor<1x2xf32>
+
+
+// Reshape with matching input/output quantized types — should still be folded
+func.func @reshape_quantized_constant() -> tensor<1x2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %shape = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+  %r = "onnx.Reshape"(%a_dq, %shape) {allowzero = 0 : si64} : (tensor<2xf32>, tensor<2xi64>) -> tensor<1x2xf32>
+
+  %out_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %out_zp = onnx.Constant dense<0> : tensor<ui8>
+  %q = "onnx.QuantizeLinear"(%r, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x2xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+
+  return %final : tensor<1x2xf32>
+}
+
+// CHECK-LABEL: @reshape_quantized_constant
+// CHECK-NOT:     onnx.Reshape
+// CHECK:         onnx.Constant
+// CHECK:         quant.scast
+
+
+// Unsqueeze with quantized input but float output — should NOT be folded
+func.func @unsqueeze_quantized_input_float_output() -> tensor<1x2xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %axes = onnx.Constant dense<[0]> : tensor<1xi64>
+  %r = "onnx.Unsqueeze"(%a_dq, %axes) : (tensor<2xf32>, tensor<1xi64>) -> tensor<1x2xf32>
+
+  return %r : tensor<1x2xf32>
+}
+
+// CHECK-LABEL: @unsqueeze_quantized_input_float_output
+// CHECK:         onnx.Unsqueeze
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>, tensor<1xi64>) -> tensor<1x2xf32>
+
+
+// Squeeze with quantized input but float output — should NOT be folded
+func.func @squeeze_quantized_input_float_output() -> tensor<2xf32> {
+  %a = onnx.Constant dense<[[10, 20]]> : tensor<1x2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+
+  %axes = onnx.Constant dense<[0]> : tensor<1xi64>
+  %r = "onnx.Squeeze"(%a_dq, %axes) : (tensor<1x2xf32>, tensor<1xi64>) -> tensor<2xf32>
+
+  return %r : tensor<2xf32>
+}
+
+// CHECK-LABEL: @squeeze_quantized_input_float_output
+// CHECK:         onnx.Squeeze
+// CHECK-SAME:      (tensor<1x2x!quant.uniform<u8:f32, 5.000000e-01>>, tensor<1xi64>) -> tensor<2xf32>
+
+
+// Gather with quantized input but float output — should NOT be folded
+func.func @gather_quantized_input_float_output() -> tensor<1xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %indices = onnx.Constant dense<[0]> : tensor<1xi64>
+  %r = "onnx.Gather"(%a_dq, %indices) {axis = 0 : si64} : (tensor<2xf32>, tensor<1xi64>) -> tensor<1xf32>
+
+  return %r : tensor<1xf32>
+}
+
+// CHECK-LABEL: @gather_quantized_input_float_output
+// CHECK:         onnx.Gather
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>, tensor<1xi64>) -> tensor<1xf32>
+
+
+// Slice with quantized input but float output — should NOT be folded
+func.func @slice_quantized_input_float_output() -> tensor<1xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %starts = onnx.Constant dense<[0]> : tensor<1xi64>
+  %ends = onnx.Constant dense<[1]> : tensor<1xi64>
+  %axes = onnx.Constant dense<[0]> : tensor<1xi64>
+  %r = "onnx.Slice"(%a_dq, %starts, %ends, %axes, %axes) : (tensor<2xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xf32>
+
+  return %r : tensor<1xf32>
+}
+
+// CHECK-LABEL: @slice_quantized_input_float_output
+// CHECK:         onnx.Slice
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>
+
+
+// ReduceMean noop fold with quantized input — should NOT be folded.
+// The fold method returns getData() when there are no reduction axes and
+// noop_with_empty_axes is set; the IsIntOrFloatType guard prevents a type
+// mismatch between the quantized input and the float result.
+func.func @reduce_mean_noop_quantized_input_float_output() -> tensor<1xf32> {
+  %a = onnx.Constant dense<[10, 20]> : tensor<2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+
+  %none = "onnx.NoValue"() {value} : () -> none
+  %r = "onnx.ReduceMean"(%a_dq, %none) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2xf32>, none) -> tensor<1xf32>
+
+  return %r : tensor<1xf32>
+}
+
+// CHECK-LABEL: @reduce_mean_noop_quantized_input_float_output
+// CHECK:         onnx.ReduceMean
+// CHECK-SAME:      (tensor<2x!quant.uniform<u8:f32, 5.000000e-01>>

--- a/test/mlir/onnx/onnx_constprop_quant.mlir
+++ b/test/mlir/onnx/onnx_constprop_quant.mlir
@@ -1,10 +1,10 @@
 // Verify that quant-types followed by constprop-onnx does not crash or
 // miscompute. The IsIntOrFloatType constraint on element-wise const-prop
-// patterns causes them to skip quantized-typed constants, and the
-// ValuesHaveSameDType constraint on unary (like Transpose) patterns ensures
-// const-prop is skipped when input/output element types differ (e.g. one
-// side is quantized and the other is not, or different quantization
-// parameters).
+// patterns causes them to skip quantized-typed constants, and transpose
+// const-prop compares input/output dtypes after remapping per-axis
+// quantization through perm (TransposeConstPropTypesMatch); otherwise
+// const-prop is skipped when types differ (e.g. float vs quant, mismatched
+// scales, or per-axis vs incompatible output quant).
 
 // RUN: onnx-mlir-opt %s --quant-types --constprop-onnx | FileCheck %s
 
@@ -452,3 +452,52 @@ func.func @transpose_quantized_constant() -> tensor<2x1xf32> {
 // CHECK-NOT:     onnx.Transpose
 // CHECK:         onnx.Constant
 // CHECK:         quant.scast
+
+
+// Per-axis Q along input axis 1; after perm=[1,0] the quant axis becomes 0.
+// Input/output use the same per-axis scales — fold transpose into the constant.
+func.func @transpose_per_axis_quant_constant() -> tensor<2x1xf32> {
+  %a = onnx.Constant dense<[[10, 20]]> : tensor<1x2xui8>
+  %a_scale = onnx.Constant dense<[5.000000e-01, 5.000000e-01]> : tensor<2xf32>
+  %a_zp = onnx.Constant dense<[0, 0]> : tensor<2xui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<2xf32>, tensor<2xui8>) -> tensor<1x2xf32>
+
+  %t = "onnx.Transpose"(%a_dq) {perm = [1, 0]} : (tensor<1x2xf32>) -> tensor<2x1xf32>
+
+  %out_scale = onnx.Constant dense<[5.000000e-01, 5.000000e-01]> : tensor<2xf32>
+  %out_zp = onnx.Constant dense<[0, 0]> : tensor<2xui8>
+  %q = "onnx.QuantizeLinear"(%t, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1xf32>, tensor<2xf32>, tensor<2xui8>) -> tensor<2x1xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1xui8>, tensor<2xf32>, tensor<2xui8>) -> tensor<2x1xf32>
+
+  return %final : tensor<2x1xf32>
+}
+
+// CHECK-LABEL: @transpose_per_axis_quant_constant
+// CHECK-NOT:     onnx.Transpose
+// CHECK:         !quant.uniform<u8:f32:0, {5.000000e-01,5.000000e-01}>
+// CHECK:         quant.scast
+
+
+// Same per-axis input path, but output Q uses different per-axis scales than
+// the remapped input quant type — transpose const-prop must not fold.
+func.func @transpose_per_axis_quant_mismatch_scales() -> tensor<2x1xf32> {
+  %a = onnx.Constant dense<[[10, 20]]> : tensor<1x2xui8>
+  %a_scale = onnx.Constant dense<[5.000000e-01, 5.000000e-01]> : tensor<2xf32>
+  %a_zp = onnx.Constant dense<[0, 0]> : tensor<2xui8>
+
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<2xf32>, tensor<2xui8>) -> tensor<1x2xf32>
+
+  %t = "onnx.Transpose"(%a_dq) {perm = [1, 0]} : (tensor<1x2xf32>) -> tensor<2x1xf32>
+
+  %out_scale = onnx.Constant dense<[5.000000e-01, 2.500000e-01]> : tensor<2xf32>
+  %out_zp = onnx.Constant dense<[0, 0]> : tensor<2xui8>
+  %q = "onnx.QuantizeLinear"(%t, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x1xf32>, tensor<2xf32>, tensor<2xui8>) -> tensor<2x1xui8>
+  %final = "onnx.DequantizeLinear"(%q, %out_scale, %out_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x1xui8>, tensor<2xf32>, tensor<2xui8>) -> tensor<2x1xf32>
+
+  return %final : tensor<2x1xf32>
+}
+
+// CHECK-LABEL: @transpose_per_axis_quant_mismatch_scales
+// CHECK:         onnx.Transpose
+// CHECK-SAME:      perm = [1, 0]


### PR DESCRIPTION
This is needed for per axis quantization where the axis of input and output is not same. 
We compute the expected element type by computing the axis through perm attribute