### PR TITLE
Added softmax pattern for negative indexing

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -9371,6 +9371,7 @@ def ONNXSliceOp:ONNX_Op<"Slice",
 
 def ONNXSoftmaxOp:ONNX_Op<"Softmax",
   [Pure, OpVersionTrait<13>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Softmax operation";
   let description = [{
   The operator computes the normalized exponential values for the given input:

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2585,6 +2585,28 @@ struct PullReluLikeOpsThroughSplitPattern
   }
 };
 
+struct SoftmaxNegativeAxisPattern : public OpRewritePattern<ONNXSoftmaxOp> {
+  using OpRewritePattern<ONNXSoftmaxOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(
+      ONNXSoftmaxOp softmaxOp, PatternRewriter &rewriter) const final {
+
+    auto inputType = dyn_cast<RankedTensorType>(softmaxOp.getInput().getType());
+    if (!inputType)
+      return rewriter.notifyMatchFailure(
+          softmaxOp, "Input is not a ranked tensor");
+
+    const int64_t axis = softmaxOp.getAxis();
+    const int64_t rank = inputType.getRank();
+
+    if (axis >= 0)
+      return failure(); // nothing to do.
+    assert(-rank <= axis && "axis is out of range");
+    rewriter.modifyOpInPlace(
+        softmaxOp, [&]() { softmaxOp.setAxis(rank + axis); });
+    return success();
+  }
+};
+
 /*
  * Push down the transpose after scale (mul op), so the scale can be fused to
  * Layernorm.
@@ -3403,6 +3425,12 @@ void ONNXShapeTransformOp::getCanonicalizationPatterns(
 void ONNXSizeOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<SizeToConstantPattern>(context);
+}
+
+/// on the ONNXSoftmaxOp.
+void ONNXSoftmaxOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<SoftmaxNegativeAxisPattern>(context);
 }
 
 /// on the ONNXSoftmaxV11Op.

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -1536,6 +1536,19 @@ func.func @test_softmax_v11_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
 
 // -----
 
+func.func @test_softmax_negative_axis(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+  %0 = "onnx.Softmax"(%arg0) {axis = -1 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
+  onnx.Return %0 : tensor<10x20x30xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_negative_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Softmax"([[PARAM_0_]]) {axis = 2 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<10x20x30xf32>
+// CHECK:         }
+}
+
+// -----
+
 #transpose = affine_map<(d0, d1, d2, d3) -> (d2, d0, d1, d3)>
 #reshape =  affine_map<(d0, d1) -> (d0 floordiv 32, d0 mod 32, d1 floordiv 64, d1 mod 64)>
 func.func @shape_transform_compose(%arg0: tensor<128x128xf32>) -> tensor<2x4x32x64xf32> {

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -547,6 +547,7 @@ OpsWithCanonicalizer = [
     "Shape",
     "Split",
     "Size",
+    "Softmax",
     "SoftmaxV11",
     "SpaceToDepth",
     "Squeeze",


### PR DESCRIPTION
Hi, I've added a small canonicalization pattern which turn negative index on the axis attribute of softmax to the "normal" absolute indexing. There is a LIT test demonstrating what exactly I mean.