### PR TITLE
For DMAC, do not convert gap to reducemean

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -134,7 +134,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
         opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
         opts.enableGroupQueryAttentionDecompose,
-        opts.enableSplitToSliceDecompose));
+        opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
@@ -147,7 +147,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
               opts.enableConvTranspose1dDecomposeToPhasedConv,
               opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
               opts.enableGroupQueryAttentionDecompose,
-              opts.enableSplitToSliceDecompose));
+              opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean));
     }
     // If quark quantized legalization is enabled, do a last const prop after it
     // so that we cover any remaining Cast -> Cast patterns that weren't covered
@@ -207,7 +207,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
         opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
         opts.enableGroupQueryAttentionDecompose,
-        opts.enableSplitToSliceDecompose));
+        opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -191,7 +191,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
 
   // Simplify shape-related ops.
   pm.addPass(onnx_mlir::createSimplifyShapeRelatedOpsPass(
-      opts.enableQuarkQuantizedLegalization));
+      opts.enableQuarkQuantizedLegalization, opts.enablGAPToReduceMean));
 
   // Canonicalizing Q-DQ related ops
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createQDQCanonicalizePass(

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -28,7 +28,7 @@ struct OnnxToMlirOptions {
 
   bool disableBatchNormDecompose = false;
   bool enablGAPToReduceMean = true;
-  
+
   bool disableRecomposeOption = false;
   bool enableONNXHybridPass = true;
   bool enableConvOptPass = true;

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -27,7 +27,8 @@ struct OnnxToMlirOptions {
   bool enableSplitToSliceDecompose = false;
 
   bool disableBatchNormDecompose = false;
-
+  bool enablGAPToReduceMean = true;
+  
   bool disableRecomposeOption = false;
   bool enableONNXHybridPass = true;
   bool enableConvOptPass = true;

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -27,13 +27,13 @@ struct OnnxToMlirOptions {
   bool enableSplitToSliceDecompose = false;
 
   bool disableBatchNormDecompose = false;
-  bool enablGAPToReduceMean = true;
-
   bool disableRecomposeOption = false;
   bool enableONNXHybridPass = true;
   bool enableConvOptPass = true;
   bool enableSimdDataLayout = false;
   bool disableSimdOption = false;
+  bool enablGAPToReduceMean = true;
+
   int onnxOpTransformThreshold = 3;
   bool onnxOpTransformReport = false;
   int repeatOnnxTransform = 0;

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -133,6 +133,11 @@ struct ONNXHybridTransformPass
       "enable-split-to-slice-decompose",
       llvm::cl::desc("Enable decomposition of Split to Slice"),
       ::llvm::cl::init(false)};
+  
+  Option<bool> enablGAPToReduceMean{*this,
+      "enable-globalaveragepool-to-reducemean",
+      llvm::cl::desc("Enable canonicalize from GlobalAveragePool to ReduceMean"),
+      ::llvm::cl::init(true)};
 
   FrozenRewritePatternSet patterns;
 
@@ -143,7 +148,8 @@ struct ONNXHybridTransformPass
       bool enableConvTranspose1dDecomposeToPhasedConv,
       bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
       bool enableGroupQueryAttentionDecompose,
-      bool enableSplitToSliceDecompose) {
+      bool enableSplitToSliceDecompose, 
+      bool enablGAPToReduceMean) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
@@ -156,6 +162,7 @@ struct ONNXHybridTransformPass
     this->enableGroupQueryAttentionDecompose =
         enableGroupQueryAttentionDecompose;
     this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
+    this->enablGAPToReduceMean = enablGAPToReduceMean;
   }
 
   ONNXHybridTransformPass(const ONNXHybridTransformPass &pass)
@@ -183,12 +190,17 @@ struct ONNXHybridTransformPass
 
     if (canonicalization) {
       // canonicalization (copied from mlir/lib/Transforms/Canonicalizer.cpp)
-      for (auto *dialect : context->getLoadedDialects())
+      for (auto *dialect : context->getLoadedDialects()){
         dialect->getCanonicalizationPatterns(cumulativePatterns);
+     }
       for (RegisteredOperationName op : context->getRegisteredOperations()) {
         // Since we are manipulating ONNXCastOp's, disable any canonicalization
         // for it.
         if (quarkQuantizedOpsLegalization && op.getStringRef() == "onnx.Cast") {
+          continue;
+        }
+        
+        if (!enablGAPToReduceMean && op.getStringRef() == "onnx.GlobalAveragePool") {
           continue;
         }
         op.getCanonicalizationPatterns(cumulativePatterns, context);
@@ -252,11 +264,11 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
-    bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose) {
+    bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose, bool enablGAPToReduceMean) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableMatmulNBitsDecompose, enableGroupQueryAttentionDecompose,
-      enableSplitToSliceDecompose);
+      enableSplitToSliceDecompose, enablGAPToReduceMean);
 }

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -133,10 +133,11 @@ struct ONNXHybridTransformPass
       "enable-split-to-slice-decompose",
       llvm::cl::desc("Enable decomposition of Split to Slice"),
       ::llvm::cl::init(false)};
-  
+
   Option<bool> enablGAPToReduceMean{*this,
       "enable-globalaveragepool-to-reducemean",
-      llvm::cl::desc("Enable canonicalize from GlobalAveragePool to ReduceMean"),
+      llvm::cl::desc(
+          "Enable canonicalize from GlobalAveragePool to ReduceMean"),
       ::llvm::cl::init(true)};
 
   FrozenRewritePatternSet patterns;
@@ -147,8 +148,7 @@ struct ONNXHybridTransformPass
       bool enableConvTransposeDecomposeToPhasedConv,
       bool enableConvTranspose1dDecomposeToPhasedConv,
       bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
-      bool enableGroupQueryAttentionDecompose,
-      bool enableSplitToSliceDecompose, 
+      bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose,
       bool enablGAPToReduceMean) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
@@ -190,17 +190,18 @@ struct ONNXHybridTransformPass
 
     if (canonicalization) {
       // canonicalization (copied from mlir/lib/Transforms/Canonicalizer.cpp)
-      for (auto *dialect : context->getLoadedDialects()){
+      for (auto *dialect : context->getLoadedDialects()) {
         dialect->getCanonicalizationPatterns(cumulativePatterns);
-     }
+      }
       for (RegisteredOperationName op : context->getRegisteredOperations()) {
         // Since we are manipulating ONNXCastOp's, disable any canonicalization
         // for it.
         if (quarkQuantizedOpsLegalization && op.getStringRef() == "onnx.Cast") {
           continue;
         }
-        
-        if (!enablGAPToReduceMean && op.getStringRef() == "onnx.GlobalAveragePool") {
+
+        if (!enablGAPToReduceMean &&
+            op.getStringRef() == "onnx.GlobalAveragePool") {
           continue;
         }
         op.getCanonicalizationPatterns(cumulativePatterns, context);
@@ -264,7 +265,8 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
-    bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose, bool enablGAPToReduceMean) {
+    bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose,
+    bool enablGAPToReduceMean) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,

--- a/src/Dialect/ONNX/Transforms/SimplifyShapeRelatedOps.cpp
+++ b/src/Dialect/ONNX/Transforms/SimplifyShapeRelatedOps.cpp
@@ -462,8 +462,8 @@ struct SimplifyShapeRelatedOpsPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SimplifyShapeRelatedOpsPass)
 
   SimplifyShapeRelatedOpsPass(
-      bool disableCastOpCanonicalizations)
-      : PassWrapper(), disableCastOpCanonicalizations(disableCastOpCanonicalizations) {}
+      bool disableCastOpCanonicalizations, bool enablGAPToReduceMean)
+      : PassWrapper(), disableCastOpCanonicalizations(disableCastOpCanonicalizations), enablGAPToReduceMean(enablGAPToReduceMean) {}
 
   StringRef getArgument() const override {
     return "simplify-shape-related-ops-onnx";
@@ -478,6 +478,7 @@ struct SimplifyShapeRelatedOpsPass
 private:
   void topDownShapeSimplification(MLIRContext *context, ModuleOp moduleOp);
   bool disableCastOpCanonicalizations;
+  bool enablGAPToReduceMean;
 };
 
 void SimplifyShapeRelatedOpsPass::topDownShapeSimplification(
@@ -529,9 +530,13 @@ void SimplifyShapeRelatedOpsPass::runOnOperation() {
     OpPassManager pm("builtin.module");
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
-    pm.addPass(mlir::createCanonicalizerPass(config,
-        /*disabledPatterns=*/{"GlobalAveragePoolPattern"},
-        /*enabledPatterns=*/{}));
+    if (!this->enablGAPToReduceMean) {
+      pm.addPass(mlir::createCanonicalizerPass(config,
+          /*disabledPatterns=*/{"GlobalAveragePoolPattern"},
+          /*enabledPatterns=*/{}));
+    } else {
+      pm.addPass(mlir::createCanonicalizerPass());
+    }
     if (failed(runPipeline(pm, moduleOp)))
       return signalPassFailure();
   }
@@ -544,8 +549,8 @@ namespace onnx_mlir {
 /*!
  * Create a SimplifyShapeRelatedOps pass.
  */
-std::unique_ptr<mlir::Pass> createSimplifyShapeRelatedOpsPass(bool disableCastOpCanonicalizations) {
-  return std::make_unique<SimplifyShapeRelatedOpsPass>(disableCastOpCanonicalizations);
+std::unique_ptr<mlir::Pass> createSimplifyShapeRelatedOpsPass(bool disableCastOpCanonicalizations, bool enablGAPToReduceMean) {
+  return std::make_unique<SimplifyShapeRelatedOpsPass>(disableCastOpCanonicalizations, enablGAPToReduceMean);
 }
 
 } // namespace onnx_mlir

--- a/src/Dialect/ONNX/Transforms/SimplifyShapeRelatedOps.cpp
+++ b/src/Dialect/ONNX/Transforms/SimplifyShapeRelatedOps.cpp
@@ -513,8 +513,11 @@ void SimplifyShapeRelatedOpsPass::topDownShapeSimplification(
   ONNXUnsqueezeOp::getCanonicalizationPatterns(patterns, context);
   ONNXUnsqueezeV11Op::getCanonicalizationPatterns(patterns, context);
 
+  GreedyRewriteConfig config;
+  config.useTopDownTraversal = true;
+
   // Simplify shape-related ops.
-  if (failed(applyPatternsGreedily(moduleOp, std::move(patterns))))
+  if (failed(applyPatternsGreedily(moduleOp, std::move(patterns), config)))
     signalPassFailure();
 }
 

--- a/src/Dialect/ONNX/Transforms/SimplifyShapeRelatedOps.cpp
+++ b/src/Dialect/ONNX/Transforms/SimplifyShapeRelatedOps.cpp
@@ -512,9 +512,6 @@ void SimplifyShapeRelatedOpsPass::topDownShapeSimplification(
   ONNXUnsqueezeOp::getCanonicalizationPatterns(patterns, context);
   ONNXUnsqueezeV11Op::getCanonicalizationPatterns(patterns, context);
 
-  GreedyRewriteConfig config;
-  config.useTopDownTraversal = true;
-
   // Simplify shape-related ops.
   if (failed(applyPatternsGreedily(moduleOp, std::move(patterns))))
     signalPassFailure();
@@ -528,10 +525,13 @@ void SimplifyShapeRelatedOpsPass::runOnOperation() {
   // so that all ops' shape are updated.
   for (unsigned i = 0; i < 3; ++i) {
     topDownShapeSimplification(context, moduleOp);
+    GreedyRewriteConfig config;
     OpPassManager pm("builtin.module");
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
-    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(mlir::createCanonicalizerPass(config,
+        /*disabledPatterns=*/{"GlobalAveragePoolPattern"},
+        /*enabledPatterns=*/{}));
     if (failed(runPipeline(pm, moduleOp)))
       return signalPassFailure();
   }

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -104,7 +104,8 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableInstanceNormDecompose = true,
     bool enableMatmulNBitsDecompose = false,
     bool enableGroupQueryAttentionDecompose = true,
-    bool enableSplitToSliceDecompose = false);
+    bool enableSplitToSliceDecompose = false,
+    bool enablGAPToReduceMean = true);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -89,7 +89,8 @@ std::unique_ptr<mlir::Pass> createInstrumentONNXSignaturePass(
 
 /// Pass for simplifying shape-related ONNX operations.
 std::unique_ptr<mlir::Pass> createSimplifyShapeRelatedOpsPass(
-    bool disableCastOpCanonicalizations = false, bool enablGAPToReduceMean = true);
+    bool disableCastOpCanonicalizations = false,
+    bool enablGAPToReduceMean = true);
 
 /// Pass for replacing ONNXReturnOp with func::ReturnOp.
 std::unique_ptr<mlir::Pass> createStandardFuncReturnPass();
@@ -104,8 +105,7 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableInstanceNormDecompose = true,
     bool enableMatmulNBitsDecompose = false,
     bool enableGroupQueryAttentionDecompose = true,
-    bool enableSplitToSliceDecompose = false,
-    bool enablGAPToReduceMean = true);
+    bool enableSplitToSliceDecompose = false, bool enablGAPToReduceMean = true);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -89,7 +89,7 @@ std::unique_ptr<mlir::Pass> createInstrumentONNXSignaturePass(
 
 /// Pass for simplifying shape-related ONNX operations.
 std::unique_ptr<mlir::Pass> createSimplifyShapeRelatedOpsPass(
-    bool disableCastOpCanonicalizations = false);
+    bool disableCastOpCanonicalizations = false, bool enablGAPToReduceMean = true);
 
 /// Pass for replacing ONNXReturnOp with func::ReturnOp.
 std::unique_ptr<mlir::Pass> createStandardFuncReturnPass();

--- a/test/mlir/onnx/onnx_globalaveragepool_reducemean_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_globalaveragepool_reducemean_canonicalize.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --canonicalize --qdq-canonicalize %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt -onnx-hybrid-transform="canonicalization=true enable-globalaveragepool-to-reducemean=false" %s -split-input-file | FileCheck %s
 
 func.func @test_global_average_pool(%arg0: tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32> {
    %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32>

--- a/test/mlir/onnx/onnx_globalaveragepool_reducemean_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_globalaveragepool_reducemean_canonicalize.mlir
@@ -1,0 +1,11 @@
+// RUN: onnx-mlir-opt --canonicalize --qdq-canonicalize %s -split-input-file | FileCheck %s
+
+func.func @test_global_average_pool(%arg0: tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32> {
+   %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32>
+   return %0 : tensor<1x3x1x1xf32>
+}
+
+// CHECK-LABEL: func.func @test_global_average_pool(%arg0: tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32>
+// CHECK-NOT: onnx.ReduceMeanV13
+// CHECK: return %0 : tensor<1x3x1x1xf32>
+


### PR DESCRIPTION
In DMAC, there is a kernel for globalaveragePool, and in flexml repo it also undo the conversion from gap->reducemean, it also wrongly undo the reducemean->gap if the original node is a reducemean. The dmac gap->reducemean undo pass will be fixed in another PR in flexml repo https://gitenterprise.xilinx.com/FaaSApps/vitis_flexml/pull/34181, which can be later on merged after current PR in onnx-mlir merged and synced with release branch in flexml repo.
