### PR TITLE
fix: SequenceEmpty shape inference

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -1485,7 +1485,7 @@ def ONNXConcatOp:ONNX_Op<"Concat",
 }
 
 def ONNXConcatFromSequenceOp:ONNX_Op<"ConcatFromSequence",
-  [Pure, OpVersionTrait<11>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  [Pure, OpVersionTrait<11>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>, DeclareOpInterfaceMethods<ResultTypeInferenceOpInterface>]> {
   let summary = "ONNX ConcatFromSequence operation";
   let description = [{
   Concatenate a sequence of tensors into a single tensor.
@@ -8784,7 +8784,7 @@ def ONNXSeluOp:ONNX_Op<"Selu",
 }
 
 def ONNXSequenceAtOp:ONNX_Op<"SequenceAt",
-  [Pure, OpVersionTrait<11>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  [Pure, OpVersionTrait<11>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>, DeclareOpInterfaceMethods<ResultTypeInferenceOpInterface>]> {
   let summary = "ONNX SequenceAt operation";
   let description = [{
   Outputs a tensor copy from the tensor at 'position' in 'input_sequence'.
@@ -8816,7 +8816,7 @@ def ONNXSequenceAtOp:ONNX_Op<"SequenceAt",
 }
 
 def ONNXSequenceConstructOp:ONNX_Op<"SequenceConstruct",
-  [Pure, OpVersionTrait<11>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  [Pure, OpVersionTrait<11>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>, DeclareOpInterfaceMethods<ResultTypeInferenceOpInterface>]> {
   let summary = "ONNX SequenceConstruct operation";
   let description = [{
   Construct a tensor sequence containing 'inputs' tensors.
@@ -8974,7 +8974,7 @@ def ONNXSequenceLengthOp:ONNX_Op<"SequenceLength",
 }
 
 def ONNXSequenceMapOp:ONNX_Op<"SequenceMap",
-  [Pure, OpVersionTrait<17>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>, OpInterface<"HasOnnxSubgraphOpInterface">]> {
+  [Pure, OpVersionTrait<17>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>, DeclareOpInterfaceMethods<ResultTypeInferenceOpInterface>, OpInterface<"HasOnnxSubgraphOpInterface">]> {
   let summary = "ONNX SequenceMap operation";
   let description = [{
   Applies a sub-graph to each sample in the input sequence(s).
@@ -9752,7 +9752,7 @@ def ONNXSplitV11Op:ONNX_Op<"SplitV11",
 }
 
 def ONNXSplitToSequenceOp:ONNX_Op<"SplitToSequence",
-  [Pure, OpVersionTrait<11>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  [Pure, OpVersionTrait<11>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>, DeclareOpInterfaceMethods<ResultTypeInferenceOpInterface>]> {
   let summary = "ONNX SplitToSequence operation";
   let description = [{
   Split a tensor into a sequence of tensors, along the specified 'axis'.

--- a/src/Dialect/ONNX/ONNXOps/Sequence/Sequence.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Sequence/Sequence.cpp
@@ -10,6 +10,9 @@
 //
 // This file provides definition of ONNX dialect Sequence operations.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
@@ -126,8 +129,9 @@ LogicalResult ONNXSequenceEmptyOp::inferShapes(
 }
 
 std::vector<Type> ONNXSequenceEmptyOp::resultTypeInference() {
-  return {cast<ShapedType>(
-      SeqType::get(getResultElementTypeFromDtypeDefaultingToF32(*this), 0))};
+  Type scalarType = getResultElementTypeFromDtypeDefaultingToF32(*this);
+  ShapedType elementType = UnrankedTensorType::get(scalarType);
+  return {SeqType::get(elementType, 0)};
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/ONNXOps/Sequence/Sequence.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Sequence/Sequence.cpp
@@ -75,6 +75,20 @@ ShapedType sequenceAddType(
 // SequenceAtOp
 //===----------------------------------------------------------------------===//
 
+std::vector<Type> ONNXSequenceAtOp::resultTypeInference() {
+  // The output is the element type of the input sequence.  If the input
+  // sequence type is not yet resolved (e.g. NoneType at import time), fall
+  // back to tensor<*xf32> so that downstream code (e.g. the Decompose pass
+  // which runs before shape inference) always sees a valid ShapedType.
+  auto seqType = mlir::dyn_cast<SeqType>(getInputSequence().getType());
+  if (!seqType)
+    return {UnrankedTensorType::get(Builder(getContext()).getF32Type())};
+  auto shapedElem = mlir::dyn_cast<ShapedType>(seqType.getElementType());
+  if (!shapedElem)
+    return {UnrankedTensorType::get(Builder(getContext()).getF32Type())};
+  return {UnrankedTensorType::get(shapedElem.getElementType())};
+}
+
 LogicalResult ONNXSequenceAtOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   auto outputType = getResult().getType();
@@ -90,6 +104,19 @@ LogicalResult ONNXSequenceAtOp::inferShapes(
 //===----------------------------------------------------------------------===//
 // SequenceConstructOp
 //===----------------------------------------------------------------------===//
+
+std::vector<Type> ONNXSequenceConstructOp::resultTypeInference() {
+  // Derive the sequence element type from the first input.  If inputs are not
+  // yet typed (NoneType), fall back to f32.
+  auto types = getInputs().getTypes();
+  Type scalarType = Builder(getContext()).getF32Type();
+  if (!types.empty()) {
+    if (auto shapedType = mlir::dyn_cast<ShapedType>(types.front()))
+      scalarType = shapedType.getElementType();
+  }
+  ShapedType elemType = UnrankedTensorType::get(scalarType);
+  return {SeqType::get(elemType, static_cast<int64_t>(types.size()))};
+}
 
 LogicalResult ONNXSequenceConstructOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
@@ -192,6 +219,23 @@ LogicalResult ONNXSequenceInsertOp::inferShapes(
     getResult().setType(SeqType::get(seqTensorType, newLength));
   }
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// SequenceMapOp
+//===----------------------------------------------------------------------===//
+
+std::vector<Type> ONNXSequenceMapOp::resultTypeInference() {
+  // The body region outputs are tensors; each becomes the element type of the
+  // corresponding output sequence.  The output sequence length is unknown at
+  // import time (it equals the input sequence length, resolved during shape
+  // inference), so we use kDynamic.
+  Operation *terminator = getBody().back().getTerminator();
+  std::vector<Type> resultTypes;
+  for (Type ty : terminator->getOperandTypes())
+    resultTypes.push_back(
+        SeqType::get(mlir::cast<ShapedType>(ty), ShapedType::kDynamic));
+  return resultTypes;
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/ONNXOps/Sequence/SplitToSequence.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Sequence/SplitToSequence.cpp
@@ -20,6 +20,20 @@ using namespace mlir::OpTrait::util;
 using namespace onnx_mlir;
 
 //===----------------------------------------------------------------------===//
+// Type Inference
+//===----------------------------------------------------------------------===//
+
+std::vector<Type> ONNXSplitToSequenceOp::resultTypeInference() {
+  // At import time (before full shape inference) the output length and exact
+  // element shape are unknown.  Derive just the scalar dtype from the input.
+  Type scalarType = Builder(getContext()).getF32Type();
+  if (auto shapedInput = mlir::dyn_cast<ShapedType>(getInput().getType()))
+    scalarType = shapedInput.getElementType();
+  return {
+      SeqType::get(UnrankedTensorType::get(scalarType), ShapedType::kDynamic)};
+}
+
+//===----------------------------------------------------------------------===//
 // Verify
 //===----------------------------------------------------------------------===//
 

--- a/src/Dialect/ONNX/ONNXOps/Tensor/ConcatFromSequence.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/ConcatFromSequence.cpp
@@ -19,6 +19,21 @@ using namespace mlir::OpTrait::util;
 using namespace onnx_mlir;
 
 //===----------------------------------------------------------------------===//
+// Type Inference
+//===----------------------------------------------------------------------===//
+
+std::vector<Type> ONNXConcatFromSequenceOp::resultTypeInference() {
+  // The output is a tensor whose element type matches the sequence elements.
+  // At import time (before full shape inference) derive only the scalar dtype.
+  Type scalarType = Builder(getContext()).getF32Type();
+  if (auto seqType = mlir::dyn_cast<SeqType>(getInputSequence().getType())) {
+    if (auto shapedElem = mlir::dyn_cast<ShapedType>(seqType.getElementType()))
+      scalarType = shapedElem.getElementType();
+  }
+  return {UnrankedTensorType::get(scalarType)};
+}
+
+//===----------------------------------------------------------------------===//
 // Verify
 //===----------------------------------------------------------------------===//
 

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -3684,6 +3684,33 @@ func.func @test_seqence_3(%arg0: tensor<2x4x8xf32>, %arg1: tensor<3x6xf32>) -> !
 
 // -----
 
+// Test that SequenceEmpty (with explicit dtype) -> SequenceInsert -> SequenceAt
+// correctly propagates shape through the chain:
+//   - SequenceEmpty result stays !onnx.Seq<tensor<*xf32>> (element type is
+//     unranked because SequenceEmpty has no shape info, only dtype).
+//   - SequenceInsert sees an empty seq (length=0) and promotes the element
+//     type to the concrete shape of the inserted tensor.
+//   - SequenceAt propagates that element type to the output.
+//   - The function return type is refined from tensor<*xf32> to tensor<1x4xf32>.
+func.func @test_sequence_empty_insert_at(%arg0: tensor<1x4xf32>) -> tensor<*xf32> {
+  %0 = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+  %cst_none = "onnx.NoValue"() {value} : () -> none
+  %1 = "onnx.SequenceInsert"(%0, %arg0, %cst_none) : (!onnx.Seq<tensor<*xf32>>, tensor<1x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %cst_idx = onnx.Constant dense<0> : tensor<i64>
+  %2 = "onnx.SequenceAt"(%1, %cst_idx) : (!onnx.Seq<tensor<*xf32>>, tensor<i64>) -> tensor<*xf32>
+  onnx.Return %2 : tensor<*xf32>
+// CHECK-LABEL:  func @test_sequence_empty_insert_at
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4xf32>) -> tensor<1x4xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<0> : tensor<i64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.SequenceInsert"([[VAR_2_]], [[PARAM_0_]], [[VAR_1_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<1x4xf32>, none) -> !onnx.Seq<tensor<1x4xf32>>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.SequenceAt"([[VAR_3_]], [[VAR_0_]]) : (!onnx.Seq<tensor<1x4xf32>>, tensor<i64>) -> tensor<1x4xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<1x4xf32>
+}
+
+// -----
+
 // when the split input is none we always infer that the splits will have dim
 // size 1 on the split axis even if we know the output sequence will be empty
 func.func @test_splittosequence_0(%arg0: tensor<0x?x4xf32>) -> !onnx.Seq<tensor<*xf32>> {

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -3840,6 +3840,130 @@ func.func @test_splittosequence_9(%arg0: tensor<4x?x3xf32>) -> !onnx.Seq<tensor<
 // -----
 
 //===----------------------------------------------------------------------===//
+/// Test shape inference for SequenceAt.
+//===----------------------------------------------------------------------===//
+
+// SequenceAt from a ranked-element sequence: output refines to that element type.
+func.func @test_sequenceat_ranked(%arg0: tensor<3x4xf32>, %arg1: tensor<i64>) -> tensor<*xf32> {
+  %0 = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+  %cst = "onnx.NoValue"() {value} : () -> none
+  %1 = "onnx.SequenceInsert"(%0, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<3x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %2 = "onnx.SequenceAt"(%1, %arg1) : (!onnx.Seq<tensor<*xf32>>, tensor<i64>) -> tensor<*xf32>
+  onnx.Return %2 : tensor<*xf32>
+// CHECK-LABEL:  func @test_sequenceat_ranked
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf32>, [[PARAM_1_:%.+]]: tensor<i64>) -> tensor<3x4xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+// CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_1_:%.+]] = "onnx.SequenceInsert"([[VAR_0_]], [[PARAM_0_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<3x4xf32>, none) -> !onnx.Seq<tensor<3x4xf32>>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.SequenceAt"([[VAR_1_]], [[PARAM_1_]]) : (!onnx.Seq<tensor<3x4xf32>>, tensor<i64>) -> tensor<3x4xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<3x4xf32>
+}
+
+// -----
+
+// SequenceAt from an unranked-element sequence: output stays tensor<*xf32>.
+func.func @test_sequenceat_unranked(%arg0: tensor<*xf32>, %arg1: tensor<i64>) -> tensor<*xf32> {
+  %0 = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+  %cst = "onnx.NoValue"() {value} : () -> none
+  %1 = "onnx.SequenceInsert"(%0, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<*xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %2 = "onnx.SequenceAt"(%1, %arg1) : (!onnx.Seq<tensor<*xf32>>, tensor<i64>) -> tensor<*xf32>
+  onnx.Return %2 : tensor<*xf32>
+// CHECK-LABEL:  func @test_sequenceat_unranked
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<i64>) -> tensor<*xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+// CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_1_:%.+]] = "onnx.SequenceInsert"([[VAR_0_]], [[PARAM_0_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<*xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.SequenceAt"([[VAR_1_]], [[PARAM_1_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<i64>) -> tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<*xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Test shape inference for SequenceConstruct.
+//===----------------------------------------------------------------------===//
+
+// SequenceConstruct with identical shapes: exact shape is preserved.
+func.func @test_sequenceconstruct_homogeneous(%arg0: tensor<2x4xf32>, %arg1: tensor<2x4xf32>) -> !onnx.Seq<tensor<*xf32>> {
+  %0 = "onnx.SequenceConstruct"(%arg0, %arg1) : (tensor<2x4xf32>, tensor<2x4xf32>) -> !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
+// CHECK-LABEL:  func @test_sequenceconstruct_homogeneous
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4xf32>, [[PARAM_1_:%.+]]: tensor<2x4xf32>) -> !onnx.Seq<tensor<2x4xf32>> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.SequenceConstruct"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<2x4xf32>, tensor<2x4xf32>) -> !onnx.Seq<tensor<2x4xf32>>
+// CHECK:           onnx.Return [[VAR_0_]] : !onnx.Seq<tensor<2x4xf32>>
+}
+
+// -----
+
+// SequenceConstruct with same rank but differing first dim: that dim becomes dynamic.
+func.func @test_sequenceconstruct_dynamic_dim(%arg0: tensor<2x4xf32>, %arg1: tensor<3x4xf32>) -> !onnx.Seq<tensor<*xf32>> {
+  %0 = "onnx.SequenceConstruct"(%arg0, %arg1) : (tensor<2x4xf32>, tensor<3x4xf32>) -> !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
+// CHECK-LABEL:  func @test_sequenceconstruct_dynamic_dim
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4xf32>, [[PARAM_1_:%.+]]: tensor<3x4xf32>) -> !onnx.Seq<tensor<?x4xf32>> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.SequenceConstruct"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<2x4xf32>, tensor<3x4xf32>) -> !onnx.Seq<tensor<?x4xf32>>
+// CHECK:           onnx.Return [[VAR_0_]] : !onnx.Seq<tensor<?x4xf32>>
+}
+
+// -----
+
+// SequenceConstruct with different ranks: element type falls back to unranked.
+func.func @test_sequenceconstruct_different_ranks(%arg0: tensor<2x4xf32>, %arg1: tensor<2x4x8xf32>) -> !onnx.Seq<tensor<*xf32>> {
+  %0 = "onnx.SequenceConstruct"(%arg0, %arg1) : (tensor<2x4xf32>, tensor<2x4x8xf32>) -> !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
+// CHECK-LABEL:  func @test_sequenceconstruct_different_ranks
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4xf32>, [[PARAM_1_:%.+]]: tensor<2x4x8xf32>) -> !onnx.Seq<tensor<*xf32>> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.SequenceConstruct"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<2x4xf32>, tensor<2x4x8xf32>) -> !onnx.Seq<tensor<*xf32>>
+// CHECK:           onnx.Return [[VAR_0_]] : !onnx.Seq<tensor<*xf32>>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Test shape inference for ConcatFromSequence.
+//===----------------------------------------------------------------------===//
+
+// ConcatFromSequence: inferShapes is not yet implemented; output stays tensor<*xf32>.
+func.func @test_concatfromsequence(%arg0: tensor<3x4xf32>) -> tensor<*xf32> {
+  %0 = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+  %cst = "onnx.NoValue"() {value} : () -> none
+  %1 = "onnx.SequenceInsert"(%0, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<3x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %2 = "onnx.ConcatFromSequence"(%1) {axis = 0 : si64} : (!onnx.Seq<tensor<*xf32>>) -> tensor<*xf32>
+  onnx.Return %2 : tensor<*xf32>
+// CHECK-LABEL:  func @test_concatfromsequence
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf32>) -> tensor<*xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+// CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_1_:%.+]] = "onnx.SequenceInsert"([[VAR_0_]], [[PARAM_0_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<3x4xf32>, none) -> !onnx.Seq<tensor<3x4xf32>>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.ConcatFromSequence"([[VAR_1_]]) {axis = 0 : si64, new_axis = 0 : si64} : (!onnx.Seq<tensor<3x4xf32>>) -> tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<*xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Test shape inference for SequenceMap.
+//===----------------------------------------------------------------------===//
+
+// SequenceMap with an Identity body: shape inference for SequenceMap is not yet
+// implemented so the result type (set at import time by resultTypeInference) is
+// preserved unchanged through the pass.
+func.func @test_sequencemap(%arg0: !onnx.Seq<tensor<1x4xf32>>) -> !onnx.Seq<tensor<1x4xf32>> {
+  %0 = "onnx.SequenceMap"(%arg0) ({
+  ^bb0(%elem: tensor<1x4xf32>):
+    %id = "onnx.Identity"(%elem) : (tensor<1x4xf32>) -> tensor<1x4xf32>
+    onnx.Yield %id : tensor<1x4xf32>
+  }) : (!onnx.Seq<tensor<1x4xf32>>) -> !onnx.Seq<tensor<1x4xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<1x4xf32>>
+// CHECK-LABEL:  func @test_sequencemap
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: !onnx.Seq<tensor<1x4xf32>>) -> !onnx.Seq<tensor<1x4xf32>> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.SequenceMap"([[PARAM_0_]])
+// CHECK:           onnx.Return [[VAR_0_]] : !onnx.Seq<tensor<1x4xf32>>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 /// Test shape inference for RoiAlign.
 //===----------------------------------------------------------------------===//
 func.func @test_roialign(%arg0: tensor<1x2x4x8xf32>, %arg1: tensor<100x4xf32>, %arg2: tensor<100xi64>) -> tensor<*xf32> {

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -722,6 +722,7 @@ OpsWithResultTypeInference = [
     "Constant",
     "Cast",
     "CastLike",
+    "ConcatFromSequence",
     "ConstantOfShape",
     "EyeLike",
     "If",
@@ -731,7 +732,11 @@ OpsWithResultTypeInference = [
     "RandomUniform",
     "RandomUniformLike",
     "Scan",
+    "SequenceAt",
+    "SequenceConstruct",
     "SequenceEmpty",
+    "SequenceMap",
+    "SplitToSequence",
 ]
 
 FloatTypes = {"TensorOf<[F32]>"}


### PR DESCRIPTION
The `ONNXSequenceEmptyOp::resultTypeInference` tries to perform an invalid cast from SeqType to ShapeType.
The PR provide a fix for it and add a small lit test to cover the case.

The PR also provide all the missing `resulttypeInference` function for each Onnx Sequence ops.