### PR TITLE
add XFEGroupNormalization and NCD (3D) test coverage for normalization ops

### DIFF
--- a/src/Builder/OpBuildTable.inc
+++ b/src/Builder/OpBuildTable.inc
@@ -236,6 +236,7 @@ dialect_op_version_map_["com.amd.xfe"]["BatchNormalization"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["InstanceNormalization"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["DepthToSpace"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["SpaceToDepth"] = {1};
+dialect_op_version_map_["com.amd.xfe"]["GroupNormalization"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["Resize"] = {1};
 dialect_op_version_map_["com.amd.quark"]["BFPQuantizeDequantize"] = {1};
 dialect_op_version_map_["com.amd.xcompiler"]["FusedEltwise"] = {1};
@@ -252,6 +253,7 @@ dialect_op_version_map_["com.amd.xfe"]["BatchNormalization"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["InstanceNormalization"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["DepthToSpace"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["SpaceToDepth"] = {1};
+dialect_op_version_map_["com.amd.xfe"]["GroupNormalization"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["Resize"] = {1};
 import_handler_map_[""]["Abs"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXAbsOp>;
@@ -777,6 +779,8 @@ import_handler_map_["com.amd.xfe"]["GlobalAveragePool"] =
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFEGlobalAveragePoolOp>;
 import_handler_map_["com.amd.xfe"]["GlobalMaxPool"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFEGlobalMaxPoolOp>;
+import_handler_map_["com.amd.xfe"]["GroupNormalization"] = 
+   &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFEGroupNormalizationOp>;
 import_handler_map_["com.amd.xfe"]["InstanceNormalization"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFEInstanceNormalizationOp>;
 import_handler_map_["com.amd.xfe"]["MatMulBias"] = 
@@ -817,6 +821,8 @@ import_handler_map_["com.amd.xfe"]["DepthToSpace"] =
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFEDepthToSpaceOp>;
 import_handler_map_["com.amd.xfe"]["SpaceToDepth"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFESpaceToDepthOp>;
+import_handler_map_["com.amd.xfe"]["GroupNormalization"] = 
+   &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFEGroupNormalizationOp>;
 import_handler_map_["com.amd.xfe"]["Resize"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFEResizeOp>;
 dialect_op_opsets_map_[""]["Abs"] = {13, 6, 1};
@@ -1050,6 +1056,7 @@ dialect_op_opsets_map_["com.amd.xfe"]["ConvTranspose"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["DepthToSpace"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["GlobalAveragePool"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["GlobalMaxPool"] = {1};
+dialect_op_opsets_map_["com.amd.xfe"]["GroupNormalization"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["InstanceNormalization"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["MatMulBias"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["MaxPool"] = {1};
@@ -1070,4 +1077,5 @@ dialect_op_opsets_map_["com.amd.xfe"]["BatchNormalization"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["InstanceNormalization"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["DepthToSpace"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["SpaceToDepth"] = {1};
+dialect_op_opsets_map_["com.amd.xfe"]["GroupNormalization"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["Resize"] = {1};

--- a/src/Dialect/ONNX/ONNXOps/Additional/XFE.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XFE.cpp
@@ -81,6 +81,12 @@ LogicalResult XFESpaceToDepthOp::inferShapes(
       this->getOperation(), doShapeInference);
 }
 
+LogicalResult XFEGroupNormalizationOp::inferShapes(
+    std::function<void(Region &)> doShapeInference) {
+  return XFEGroupNormalizationOpShapeInference(
+      this->getOperation(), doShapeInference);
+}
+
 LogicalResult XFEResizeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   return XFEResizeOpShapeInference(this->getOperation(), doShapeInference);
@@ -132,6 +138,10 @@ LogicalResult XFEDepthToSpaceOp::verify() {
 
 LogicalResult XFESpaceToDepthOp::verify() {
   return XFESpaceToDepthOpVerify(this->getOperation());
+}
+
+LogicalResult XFEGroupNormalizationOp::verify() {
+  return XFEGroupNormalizationOpVerify(this->getOperation());
 }
 
 LogicalResult XFEResizeOp::verify() {

--- a/src/Dialect/ONNX/ONNXOps/Additional/XFEShapeInference.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XFEShapeInference.cpp
@@ -672,6 +672,35 @@ LogicalResult XFEInstanceNormalizationOpShapeInference(
   return success();
 }
 
+LogicalResult XFEGroupNormalizationOpShapeInference(
+    Operation *op, std::function<void(Region &)> doShapeInference) {
+  auto gnOp = dyn_cast<XFEGroupNormalizationOp>(op);
+  if (!gnOp)
+    return failure();
+
+  Value input = gnOp.getX();
+  if (!hasShapeAndRank(input))
+    return success();
+
+  auto inputType = mlir::cast<ShapedType>(input.getType());
+  auto inputShape = inputType.getShape();
+
+  if (inputShape.size() < 3)
+    return op->emitError(
+        "GroupNormalizationChannelLast requires at least 3D input tensor");
+
+  SmallVector<int64_t, 6> outputShape(inputShape.begin(), inputShape.end());
+
+  Type elementType = inputType.getElementType();
+  if (auto existingType = dyn_cast<ShapedType>(gnOp.getY().getType())) {
+    elementType = existingType.getElementType();
+  }
+  auto resultType = RankedTensorType::get(outputShape, elementType);
+  gnOp.getY().setType(resultType);
+
+  return success();
+}
+
 LogicalResult XFEDepthToSpaceOpShapeInference(
     Operation *op, std::function<void(Region &)> doShapeInference) {
   auto d2sOp = dyn_cast<XFEDepthToSpaceOp>(op);

--- a/src/Dialect/ONNX/ONNXOps/Additional/XFEShapeInference.hpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XFEShapeInference.hpp
@@ -58,6 +58,10 @@ LogicalResult XFEDepthToSpaceOpShapeInference(
 LogicalResult XFESpaceToDepthOpShapeInference(
     Operation *op, std::function<void(Region &)> doShapeInference);
 
+// Shape inference for GroupNormalization
+LogicalResult XFEGroupNormalizationOpShapeInference(
+    Operation *op, std::function<void(Region &)> doShapeInference);
+
 // Shape inference for Resize
 LogicalResult XFEResizeOpShapeInference(
     Operation *op, std::function<void(Region &)> doShapeInference);

--- a/src/Dialect/ONNX/ONNXOps/Additional/XFEVerify.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XFEVerify.cpp
@@ -152,6 +152,9 @@ LogicalResult XFEChannelWiseQuantizationVerify(Operation *op) {
   } else if (auto normOp = dyn_cast<XFEInstanceNormalizationOp>(op)) {
     inputTensor = normOp.getInput();
     inputName = "input";
+  } else if (auto gnOp = dyn_cast<XFEGroupNormalizationOp>(op)) {
+    inputTensor = gnOp.getX();
+    inputName = "input X";
   } else if (auto d2sOp = dyn_cast<XFEDepthToSpaceOp>(op)) {
     inputTensor = d2sOp.getInput();
     inputName = "input";
@@ -329,6 +332,30 @@ LogicalResult XFEInstanceNormalizationOpVerify(Operation *op) {
   if (inputShape.size() < 3)
     return op->emitError(
         "InstanceNormalizationChannelLast requires at least 3D input tensor");
+
+  return XFEChannelWiseQuantizationVerify(op);
+}
+
+LogicalResult XFEGroupNormalizationOpVerify(Operation *op) {
+  auto gnOp = dyn_cast<XFEGroupNormalizationOp>(op);
+  if (!gnOp)
+    return failure();
+
+  Value input = gnOp.getX();
+  if (!hasShapeAndRank(input))
+    return success();
+
+  auto inputType = mlir::cast<ShapedType>(input.getType());
+  auto inputShape = inputType.getShape();
+  if (inputShape.size() < 3)
+    return op->emitError(
+        "GroupNormalizationChannelLast requires at least 3D input tensor");
+
+  int64_t C = inputShape[inputShape.size() - 1];
+  int64_t numGroups = gnOp.getNumGroups();
+  if (C != ShapedType::kDynamic && numGroups > 0 && C % numGroups != 0)
+    return op->emitError("number of channels (")
+           << C << ") must be divisible by num_groups (" << numGroups << ")";
 
   return XFEChannelWiseQuantizationVerify(op);
 }

--- a/src/Dialect/ONNX/ONNXOps/Additional/XFEVerify.hpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/XFEVerify.hpp
@@ -47,6 +47,9 @@ LogicalResult XFEDepthToSpaceOpVerify(Operation *op);
 // Verify for SpaceToDepth
 LogicalResult XFESpaceToDepthOpVerify(Operation *op);
 
+// Verify for GroupNormalization
+LogicalResult XFEGroupNormalizationOpVerify(Operation *op);
+
 // Verify for Resize
 LogicalResult XFEResizeOpVerify(Operation *op);
 

--- a/src/Dialect/ONNX/Transforms/ConvertToChannelLast.cpp
+++ b/src/Dialect/ONNX/Transforms/ConvertToChannelLast.cpp
@@ -21,6 +21,7 @@
 // - GlobalMaxPool -> XFEGlobalMaxPool
 // - BatchNormalizationInferenceMode -> XFEBatchNormalization
 // - InstanceNormalization -> XFEInstanceNormalization
+// - GroupNormalization -> XFEGroupNormalization
 // - DepthToSpace -> XFEDepthToSpace
 // - SpaceToDepth -> XFESpaceToDepth
 //
@@ -642,6 +643,54 @@ struct InstanceNormToChannelLastPattern
   }
 };
 
+// Pattern to convert GroupNormalization to XFEGroupNormalization
+struct GroupNormToChannelLastPattern
+    : public OpRewritePattern<ONNXGroupNormalizationOp> {
+  using OpRewritePattern<ONNXGroupNormalizationOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXGroupNormalizationOp gnOp, PatternRewriter &rewriter) const override {
+    Location loc = gnOp.getLoc();
+    Value input = gnOp.getX();
+    Value scale = gnOp.getScale();
+    Value bias = gnOp.getBias();
+
+    auto inputType = mlir::dyn_cast<RankedTensorType>(input.getType());
+    if (!inputType || inputType.getRank() < 3)
+      return failure();
+
+    int64_t rank = inputType.getRank();
+
+    // Transpose input to channel-last
+    Value inputChannelLast = createInputTranspose(
+        rewriter, loc, input, rank, inputType.getElementType());
+
+    // Create XFEGroupNormalization operation
+    auto origOutputType = mlir::cast<ShapedType>(gnOp.getType());
+    Type outputElementType = origOutputType.getElementType();
+    auto gnChannelLastOp = rewriter.create<XFEGroupNormalizationOp>(loc,
+        UnrankedTensorType::get(outputElementType), inputChannelLast, scale,
+        bias, gnOp.getEpsilonAttr(), gnOp.getNumGroupsAttr());
+
+    transferOnnxNodeName(gnOp, gnChannelLastOp);
+
+    if (failed(gnChannelLastOp.inferShapes(nullptr))) {
+      return failure();
+    }
+
+    // Transpose output back to NCHW
+    auto xfeOutputType =
+        mlir::cast<ShapedType>(gnChannelLastOp.getY().getType());
+    auto transposeOutputType = RankedTensorType::get(
+        origOutputType.getShape(), xfeOutputType.getElementType());
+    Value outputNCHW = createOutputTranspose(
+        rewriter, loc, gnChannelLastOp.getY(), transposeOutputType, rank);
+
+    rewriter.replaceOp(gnOp, outputNCHW);
+    return success();
+  }
+};
+
 // Pattern to convert DepthToSpace to XFEDepthToSpace
 struct DepthToSpaceToChannelLastPattern
     : public OpRewritePattern<ONNXDepthToSpaceOp> {
@@ -1028,6 +1077,7 @@ struct ConvertToChannelLastPass : public PassWrapper<ConvertToChannelLastPass,
     patterns.add<GlobalMaxPoolToChannelLastPattern>(context);
     patterns.add<BatchNormToChannelLastPattern>(context);
     patterns.add<InstanceNormToChannelLastPattern>(context);
+    patterns.add<GroupNormToChannelLastPattern>(context);
     patterns.add<DepthToSpaceToChannelLastPattern>(context);
     patterns.add<SpaceToDepthToChannelLastPattern>(context);
     patterns.add<ResizeToChannelLastPattern>(context);

--- a/src/Dialect/ONNX/XFEOps.td
+++ b/src/Dialect/ONNX/XFEOps.td
@@ -265,6 +265,40 @@ def XFEGlobalMaxPoolOp:ONNX_Op<"XFEGlobalMaxPool",
   let hasVerifier = 1;
 }
 
+def XFEGroupNormalizationOp:ONNX_Op<"XFEGroupNormalization",
+  [Pure, OpVersionTrait<1>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let summary = "GroupNormalization operation";
+  let description = [{
+  Group normalization with channel-last layout (channels innermost). Carries out group normalization with input/output tensors in channel-last format instead of NCHW. Divides channels into groups and normalizes within each group per instance.
+  }];
+  let arguments = (ins AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[quant_QuantizedType]>]>:$X,
+    AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[quant_QuantizedType]>]>:$scale,
+    AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[quant_QuantizedType]>]>:$bias,
+    DefaultValuedAttr<F32Attr, "1e-05">:$epsilon,
+    SI64Attr:$num_groups);
+  let results = (outs AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[quant_QuantizedType]>]>:$Y);
+  let extraClassDeclaration = [{
+    static int getNumberOfOperands() {
+      return 3;
+    }
+    static int getNumberOfResults() {
+      return 1;
+    }
+    static std::vector<int> getTypeMap() {
+      return {30};
+    }
+  }];
+  let extraClassDefinition = [{
+    onnx_mlir::ONNXOpShapeHelper * $cppClass::getShapeHelper(mlir::Operation *op, llvm::ArrayRef<mlir::Value> oper, 
+        onnx_mlir::IndexExprBuilder *ieb, onnx_mlir::IndexExprScope *scope) {
+      // TODO: Implement specific shape helper for this custom op
+      // For now, returning nullptr - shape inference will use default behavior
+      return nullptr;
+    }
+  }];
+  let hasVerifier = 1;
+}
+
 def XFEInstanceNormalizationOp:ONNX_Op<"XFEInstanceNormalization",
   [Pure, OpVersionTrait<1>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
   let summary = "InstanceNormalization operation";

--- a/test/mlir/onnx/onnx_convert_to_channel_last.mlir
+++ b/test/mlir/onnx/onnx_convert_to_channel_last.mlir
@@ -234,7 +234,7 @@ func.func @test_global_maxpool_to_channel_last(%arg0: tensor<1x512x7x7xf32>) -> 
 /// Normalization Conversion Tests
 //===----------------------------------------------------------------------===//
 
-// COM: Test InstanceNormalization to InstanceNormalizationChannelLast conversion
+// COM: Test InstanceNormalization to InstanceNormalizationChannelLast conversion (4D NCHW)
 // CHECK-LABEL: func.func @test_instance_norm_to_channel_last
 func.func @test_instance_norm_to_channel_last(%arg0: tensor<1x64x28x28xf32>, %arg1: tensor<64xf32>, %arg2: tensor<64xf32>) -> tensor<1x64x28x28xf32> {
   %0 = "onnx.InstanceNormalization"(%arg0, %arg1, %arg2) {epsilon = 1.0e-05 : f32} : (tensor<1x64x28x28xf32>, tensor<64xf32>, tensor<64xf32>) -> tensor<1x64x28x28xf32>
@@ -244,6 +244,62 @@ func.func @test_instance_norm_to_channel_last(%arg0: tensor<1x64x28x28xf32>, %ar
   // CHECK: [[NORM_CHANNEL_LAST:%.+]] = "onnx.XFEInstanceNormalization"([[INPUT_CHANNEL_LAST]], %arg1, %arg2) {epsilon = 9.99999974E-6 : f32} : (tensor<1x28x28x64xf32>, tensor<64xf32>, tensor<64xf32>) -> tensor<1x28x28x64xf32>
   // CHECK: [[OUTPUT_NCHW:%.+]] = "onnx.Transpose"([[NORM_CHANNEL_LAST]]) {perm = [0, 3, 1, 2]} : (tensor<1x28x28x64xf32>) -> tensor<1x64x28x28xf32>
   // CHECK: onnx.Return [[OUTPUT_NCHW]] : tensor<1x64x28x28xf32>
+}
+
+// -----
+
+// COM: Test InstanceNormalization NCD (3D) conversion
+// CHECK-LABEL: func.func @test_instance_norm_3d_ncd
+func.func @test_instance_norm_3d_ncd(%arg0: tensor<1x32x128xf32>, %arg1: tensor<32xf32>, %arg2: tensor<32xf32>) -> tensor<1x32x128xf32> {
+  %0 = "onnx.InstanceNormalization"(%arg0, %arg1, %arg2) {epsilon = 1.0e-05 : f32} : (tensor<1x32x128xf32>, tensor<32xf32>, tensor<32xf32>) -> tensor<1x32x128xf32>
+  onnx.Return %0 : tensor<1x32x128xf32>
+
+  // CHECK: [[INPUT_NDC:%.+]] = "onnx.Transpose"(%arg0) {perm = [0, 2, 1]} : (tensor<1x32x128xf32>) -> tensor<1x128x32xf32>
+  // CHECK: [[NORM_NDC:%.+]] = "onnx.XFEInstanceNormalization"([[INPUT_NDC]], %arg1, %arg2) {epsilon = 9.99999974E-6 : f32} : (tensor<1x128x32xf32>, tensor<32xf32>, tensor<32xf32>) -> tensor<1x128x32xf32>
+  // CHECK: [[OUTPUT_NCD:%.+]] = "onnx.Transpose"([[NORM_NDC]]) {perm = [0, 2, 1]} : (tensor<1x128x32xf32>) -> tensor<1x32x128xf32>
+  // CHECK: onnx.Return [[OUTPUT_NCD]] : tensor<1x32x128xf32>
+}
+
+// -----
+
+// COM: Test BatchNormalization NCD (3D) conversion
+// CHECK-LABEL: func.func @test_batchnorm_3d_ncd
+func.func @test_batchnorm_3d_ncd(%arg0: tensor<1x64x256xf32>, %arg1: tensor<64xf32>, %arg2: tensor<64xf32>, %arg3: tensor<64xf32>, %arg4: tensor<64xf32>) -> tensor<1x64x256xf32> {
+  %0 = "onnx.BatchNormalizationInferenceMode"(%arg0, %arg1, %arg2, %arg3, %arg4) {epsilon = 1.0e-05 : f32, momentum = 0.9 : f32} : (tensor<1x64x256xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) -> tensor<1x64x256xf32>
+  onnx.Return %0 : tensor<1x64x256xf32>
+
+  // CHECK: [[INPUT_NDC:%.+]] = "onnx.Transpose"(%arg0) {perm = [0, 2, 1]} : (tensor<1x64x256xf32>) -> tensor<1x256x64xf32>
+  // CHECK: [[BN_NDC:%.+]] = "onnx.XFEBatchNormalization"([[INPUT_NDC]], %arg1, %arg2, %arg3, %arg4) {epsilon = 9.99999974E-6 : f32, momentum = 0.899999976 : f32} : (tensor<1x256x64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) -> tensor<1x256x64xf32>
+  // CHECK: [[OUTPUT_NCD:%.+]] = "onnx.Transpose"([[BN_NDC]]) {perm = [0, 2, 1]} : (tensor<1x256x64xf32>) -> tensor<1x64x256xf32>
+  // CHECK: onnx.Return [[OUTPUT_NCD]] : tensor<1x64x256xf32>
+}
+
+// -----
+
+// COM: Test GroupNormalization 4D NCHW conversion
+// CHECK-LABEL: func.func @test_groupnorm_4d_nchw
+func.func @test_groupnorm_4d_nchw(%arg0: tensor<1x64x28x28xf32>, %arg1: tensor<64xf32>, %arg2: tensor<64xf32>) -> tensor<1x64x28x28xf32> {
+  %0 = "onnx.GroupNormalization"(%arg0, %arg1, %arg2) {epsilon = 1.0e-05 : f32, num_groups = 4 : si64} : (tensor<1x64x28x28xf32>, tensor<64xf32>, tensor<64xf32>) -> tensor<1x64x28x28xf32>
+  onnx.Return %0 : tensor<1x64x28x28xf32>
+
+  // CHECK: [[INPUT_NHWC:%.+]] = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<1x64x28x28xf32>) -> tensor<1x28x28x64xf32>
+  // CHECK: [[GN_NHWC:%.+]] = "onnx.XFEGroupNormalization"([[INPUT_NHWC]], %arg1, %arg2) {epsilon = 9.99999974E-6 : f32, num_groups = 4 : si64} : (tensor<1x28x28x64xf32>, tensor<64xf32>, tensor<64xf32>) -> tensor<1x28x28x64xf32>
+  // CHECK: [[OUTPUT_NCHW:%.+]] = "onnx.Transpose"([[GN_NHWC]]) {perm = [0, 3, 1, 2]} : (tensor<1x28x28x64xf32>) -> tensor<1x64x28x28xf32>
+  // CHECK: onnx.Return [[OUTPUT_NCHW]] : tensor<1x64x28x28xf32>
+}
+
+// -----
+
+// COM: Test GroupNormalization 3D NCD conversion
+// CHECK-LABEL: func.func @test_groupnorm_3d_ncd
+func.func @test_groupnorm_3d_ncd(%arg0: tensor<1x32x128xf32>, %arg1: tensor<32xf32>, %arg2: tensor<32xf32>) -> tensor<1x32x128xf32> {
+  %0 = "onnx.GroupNormalization"(%arg0, %arg1, %arg2) {epsilon = 1.0e-05 : f32, num_groups = 8 : si64} : (tensor<1x32x128xf32>, tensor<32xf32>, tensor<32xf32>) -> tensor<1x32x128xf32>
+  onnx.Return %0 : tensor<1x32x128xf32>
+
+  // CHECK: [[INPUT_NDC:%.+]] = "onnx.Transpose"(%arg0) {perm = [0, 2, 1]} : (tensor<1x32x128xf32>) -> tensor<1x128x32xf32>
+  // CHECK: [[GN_NDC:%.+]] = "onnx.XFEGroupNormalization"([[INPUT_NDC]], %arg1, %arg2) {epsilon = 9.99999974E-6 : f32, num_groups = 8 : si64} : (tensor<1x128x32xf32>, tensor<32xf32>, tensor<32xf32>) -> tensor<1x128x32xf32>
+  // CHECK: [[OUTPUT_NCD:%.+]] = "onnx.Transpose"([[GN_NDC]]) {perm = [0, 2, 1]} : (tensor<1x128x32xf32>) -> tensor<1x32x128xf32>
+  // CHECK: onnx.Return [[OUTPUT_NCD]] : tensor<1x32x128xf32>
 }
 
 // -----

--- a/utils/xfe_ops_schema.yaml
+++ b/utils/xfe_ops_schema.yaml
@@ -617,6 +617,57 @@
   max_output: 1
 
 # ==============================================================================
+# GroupNormalization: Group normalization with channel-last layout
+# Normalizes per group of channels: y = scale * (x - mean) / sqrt(variance + epsilon) + B
+# ==============================================================================
+- name: GroupNormalization
+  domain: com.amd.xfe
+  since_version: 1
+  support_level: COMMON
+  description: 'Group normalization with channel-last layout (channels innermost). Carries out group normalization with input/output tensors in channel-last format instead of NCHW. Divides channels into groups and normalizes within each group per instance.'
+  meta_attributes:
+  - onnx_opset: 21
+  - verify: True
+  - fold: False
+  inputs:
+  - name: X
+    description: Input data tensor with channel-last layout (batch, spatial_dims..., channels)
+    type_str: T
+  - name: scale
+    description: 1D scale tensor of size C (number of channels)
+    type_str: T
+  - name: bias
+    description: 1D bias tensor of size C (number of channels)
+    type_str: T
+  outputs:
+  - name: Y
+    description: Output data tensor with channel-last layout, same shape as input
+    type_str: T
+  attributes:
+  - name: epsilon
+    description: Small value to add to variance to avoid division by zero
+    type: float
+    default_value: 1e-05
+  - name: num_groups
+    description: Number of groups to divide channels into for normalization
+    type: int
+    required: true
+  type_constraints:
+  - type_param: T
+    description: Constrain input and output types to float tensors.
+    allowed_types:
+    - tensor(float16)
+    - tensor(float)
+    - tensor(double)
+    - tensor(bfloat16)
+    - tensor(int8)
+    - tensor(uint8)
+  min_input: 3
+  max_input: 3
+  min_output: 1
+  max_output: 1
+
+# ==============================================================================
 # Resize: Resize tensor with channel-last layout
 # Supports nearest, linear, and cubic interpolation modes
 # ==============================================================================


### PR DESCRIPTION


- Add XFEGroupNormalizationOp with schema, tablegen, shape inference, and verification
- Add GroupNormToChannelLastPattern in ConvertToChannelLast.cpp supporting both 4D NCHW and 3D NCD layouts
- Add NCD (3D) test cases for InstanceNorm, BatchNorm, and GroupNorm channel-last conversion
- Register GroupNormalization in OpBuildTable.inc for ONNX model import