### PR TITLE
feat: add option to disable ConcatFuse pattern that creates onnx.ConcatShapeTranspose operation

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -136,7 +136,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableMatmulNBitsDecompose,
         opts.enableGroupQueryAttentionDecompose,
         opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
-        opts.enablGAPToReduceMean));
+        opts.enableGAPToReduceMean));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
@@ -151,7 +151,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
               opts.enableMatmulNBitsDecompose,
               opts.enableGroupQueryAttentionDecompose,
               opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
-              opts.enablGAPToReduceMean));
+              opts.enableGAPToReduceMean));
     }
     // If quark quantized legalization is enabled, do a last const prop after it
     // so that we cover any remaining Cast -> Cast patterns that weren't covered
@@ -195,7 +195,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
 
   // Simplify shape-related ops.
   pm.addPass(onnx_mlir::createSimplifyShapeRelatedOpsPass(
-      opts.enableQuarkQuantizedLegalization, opts.enablGAPToReduceMean));
+      opts.enableQuarkQuantizedLegalization, opts.enableGAPToReduceMean));
 
   // Canonicalizing Q-DQ related ops
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createQDQCanonicalizePass(
@@ -213,7 +213,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableMatmulNBitsDecompose,
         opts.enableGroupQueryAttentionDecompose,
         opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
-        opts.enablGAPToReduceMean));
+        opts.enableGAPToReduceMean));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -121,7 +121,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
       opts.enableConvTranspose1dDecomposeToPhasedConv,
       opts.enableInstanceNormDecompose, opts.enableGroupNormDecompose,
       opts.enableMatmulNBitsDecompose, opts.enableGroupQueryAttentionDecompose,
-      opts.enableSplitToSliceDecompose));
+      opts.enableSplitToSliceDecompose, opts.enableConcatFuse));
   if (!opts.disableRecomposeOption)
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::createRecomposeONNXToONNXPass(/*target=*/""));
@@ -135,7 +135,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableInstanceNormDecompose, opts.enableGroupNormDecompose,
         opts.enableMatmulNBitsDecompose,
         opts.enableGroupQueryAttentionDecompose,
-        opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean));
+        opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
+        opts.enablGAPToReduceMean));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
@@ -149,7 +150,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
               opts.enableInstanceNormDecompose, opts.enableGroupNormDecompose,
               opts.enableMatmulNBitsDecompose,
               opts.enableGroupQueryAttentionDecompose,
-              opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean));
+              opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
+              opts.enablGAPToReduceMean));
     }
     // If quark quantized legalization is enabled, do a last const prop after it
     // so that we cover any remaining Cast -> Cast patterns that weren't covered
@@ -210,7 +212,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableInstanceNormDecompose, opts.enableGroupNormDecompose,
         opts.enableMatmulNBitsDecompose,
         opts.enableGroupQueryAttentionDecompose,
-        opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean));
+        opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
+        opts.enablGAPToReduceMean));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -34,7 +34,7 @@ struct OnnxToMlirOptions {
   bool enableConvOptPass = true;
   bool enableSimdDataLayout = false;
   bool disableSimdOption = false;
-  bool enablGAPToReduceMean = true;
+  bool enableGAPToReduceMean = true;
 
   int onnxOpTransformThreshold = 3;
   bool onnxOpTransformReport = false;

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -21,6 +21,7 @@ struct OnnxToMlirOptions {
   bool enableGroupNormDecompose = true;
   bool enableMatmulNBitsDecompose = false;
   bool enableGroupQueryAttentionDecompose = true;
+  bool enableConcatFuse = true;
   bool enableRemoveDqQAroundOp = false;
   bool enableRemoveBinary = false;
   bool enableFusePadIntoAvgpool = false;

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -4496,7 +4496,7 @@ struct DecomposeONNXToONNXPass
       bool enableGroupNormDecompose = true,
       bool enableMatmulNBitsDecompose = false,
       bool enableGroupQueryAttentionDecompose = true,
-      bool enableSplitToSliceDecompose = false) {
+      bool enableSplitToSliceDecompose = false, bool enableConcatFuse = true) {
     this->target = target;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
     this->enableConvTransposeDecomposeToPhasedConv =
@@ -4509,6 +4509,7 @@ struct DecomposeONNXToONNXPass
     this->enableGroupQueryAttentionDecompose =
         enableGroupQueryAttentionDecompose;
     this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
+    this->enableConcatFuse = enableConcatFuse;
   }
 
   DecomposeONNXToONNXPass(const DecomposeONNXToONNXPass &pass)
@@ -4528,6 +4529,7 @@ struct DecomposeONNXToONNXPass
         pass.enableGroupQueryAttentionDecompose.getValue();
     this->enableSplitToSliceDecompose =
         pass.enableSplitToSliceDecompose.getValue();
+    this->enableConcatFuse = pass.enableConcatFuse.getValue();
   }
 
   StringRef getArgument() const override { return "decompose-onnx"; }
@@ -4583,6 +4585,10 @@ struct DecomposeONNXToONNXPass
       llvm::cl::desc("Enable decomposition of Split to Slice operations"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableConcatFuse{*this, "enable-concat-fuse",
+      llvm::cl::desc("Enable ConcatFusePattern rewriter"),
+      ::llvm::cl::init(true)};
+
   void runOnOperation() final;
 
   typedef PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>>
@@ -4597,7 +4603,8 @@ void DecomposeONNXToONNXPass::runOnOperation() {
       enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableGroupNormDecompose, enableMatmulNBitsDecompose,
-      enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose);
+      enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
+      enableConcatFuse);
   patterns.insert<ReplaceCastLikeByCastPattern>(context);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
@@ -4620,7 +4627,7 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableGroupNormDecompose,
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
-    bool enableSplitToSliceDecompose) {
+    bool enableSplitToSliceDecompose, bool enableConcatFuse) {
   MLIRContext *context = patterns.getContext();
   populateWithGenerated(patterns);
   if (enableConvTransposeDecompose)
@@ -4638,7 +4645,8 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
   if (enableSplitToSliceDecompose)
     patterns.insert<SplitToSlicePattern>(context);
   patterns.insert<onnx_mlir::DecomposeEinsumPattern>(context);
-  patterns.insert<ConcatFusePattern>(context);
+  if (enableConcatFuse)
+    patterns.insert<ConcatFusePattern>(context);
   patterns.insert<DecomposeHardSwishPattern>(context);
   // Decompose CustomOp FusedMatMul introduced by onnxruntime:
   // https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.FusedMatMul
@@ -4684,10 +4692,11 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createDecomposeONNXToONNXPass(
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableGroupNormDecompose,
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
-    bool enableSplitToSliceDecompose) {
+    bool enableSplitToSliceDecompose, bool enableConcatFuse) {
   return std::make_unique<DecomposeONNXToONNXPass>(target,
       enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableGroupNormDecompose, enableMatmulNBitsDecompose,
-      enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose);
+      enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
+      enableConcatFuse);
 }

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -32,7 +32,7 @@ void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableGroupNormDecompose,
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
-    bool enableSplitToSliceDecompose = false);
+    bool enableSplitToSliceDecompose, bool enableConcatFuse);
 
 } // namespace onnx_mlir
 #endif

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -143,7 +143,7 @@ struct ONNXHybridTransformPass
       llvm::cl::desc("Enable ConcatFusePattern in decomposition pass"),
       ::llvm::cl::init(true)};
 
-  Option<bool> enablGAPToReduceMean{*this,
+  Option<bool> enableGAPToReduceMean{*this,
       "enable-globalaveragepool-to-reducemean",
       llvm::cl::desc(
           "Enable canonicalize from GlobalAveragePool to ReduceMean"),
@@ -159,7 +159,7 @@ struct ONNXHybridTransformPass
       bool enableInstanceNormDecompose, bool enableGroupNormDecompose,
       bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
       bool enableSplitToSliceDecompose, bool enableConcatFuse,
-      bool enablGAPToReduceMean) {
+      bool enableGAPToReduceMean) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
@@ -174,7 +174,7 @@ struct ONNXHybridTransformPass
         enableGroupQueryAttentionDecompose;
     this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
     this->enableConcatFuse = enableConcatFuse;
-    this->enablGAPToReduceMean = enablGAPToReduceMean;
+    this->enableGAPToReduceMean = enableGAPToReduceMean;
   }
 
   ONNXHybridTransformPass(const ONNXHybridTransformPass &pass)
@@ -212,7 +212,7 @@ struct ONNXHybridTransformPass
           continue;
         }
 
-        if (!enablGAPToReduceMean &&
+        if (!enableGAPToReduceMean &&
             op.getStringRef() == "onnx.GlobalAveragePool") {
           continue;
         }
@@ -280,12 +280,12 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableInstanceNormDecompose, bool enableGroupNormDecompose,
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
     bool enableSplitToSliceDecompose, bool enableConcatFuse,
-    bool enablGAPToReduceMean) {
+    bool enableGAPToReduceMean) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableGroupNormDecompose, enableMatmulNBitsDecompose,
       enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
-      enableConcatFuse, enablGAPToReduceMean);
+      enableConcatFuse, enableGAPToReduceMean);
 }

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -139,6 +139,10 @@ struct ONNXHybridTransformPass
       llvm::cl::desc("Enable decomposition of Split to Slice"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableConcatFuse{*this, "enable-concat-fuse",
+      llvm::cl::desc("Enable ConcatFusePattern in decomposition pass"),
+      ::llvm::cl::init(true)};
+
   Option<bool> enablGAPToReduceMean{*this,
       "enable-globalaveragepool-to-reducemean",
       llvm::cl::desc(
@@ -154,7 +158,8 @@ struct ONNXHybridTransformPass
       bool enableConvTranspose1dDecomposeToPhasedConv,
       bool enableInstanceNormDecompose, bool enableGroupNormDecompose,
       bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
-      bool enableSplitToSliceDecompose, bool enablGAPToReduceMean) {
+      bool enableSplitToSliceDecompose, bool enableConcatFuse,
+      bool enablGAPToReduceMean) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
@@ -168,6 +173,7 @@ struct ONNXHybridTransformPass
     this->enableGroupQueryAttentionDecompose =
         enableGroupQueryAttentionDecompose;
     this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
+    this->enableConcatFuse = enableConcatFuse;
     this->enablGAPToReduceMean = enablGAPToReduceMean;
   }
 
@@ -225,7 +231,7 @@ struct ONNXHybridTransformPass
           enableConvTranspose1dDecomposeToPhasedConv,
           enableInstanceNormDecompose, enableGroupNormDecompose,
           enableMatmulNBitsDecompose, enableGroupQueryAttentionDecompose,
-          enableSplitToSliceDecompose);
+          enableSplitToSliceDecompose, enableConcatFuse);
     }
 
     if (recomposition) {
@@ -273,12 +279,13 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableGroupNormDecompose,
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
-    bool enableSplitToSliceDecompose, bool enablGAPToReduceMean) {
+    bool enableSplitToSliceDecompose, bool enableConcatFuse,
+    bool enablGAPToReduceMean) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableGroupNormDecompose, enableMatmulNBitsDecompose,
       enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
-      enablGAPToReduceMean);
+      enableConcatFuse, enablGAPToReduceMean);
 }

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -45,7 +45,7 @@ std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
     bool enableGroupNormDecompose = true,
     bool enableMatmulNBitsDecompose = false,
     bool enableGroupQueryAttentionDecompose = true,
-    bool enableSplitToSliceDecompose = false);
+    bool enableSplitToSliceDecompose = false, bool enableConcatFuse = false);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "");
 
@@ -107,7 +107,8 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableGroupNormDecompose = true,
     bool enableMatmulNBitsDecompose = false,
     bool enableGroupQueryAttentionDecompose = true,
-    bool enableSplitToSliceDecompose = false, bool enablGAPToReduceMean = true);
+    bool enableSplitToSliceDecompose = false, bool enableConcatFuse = true,
+    bool enablGAPToReduceMean = true);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -522,56 +522,6 @@ func.func @test_scatter(%arg0: tensor<64x25600xf32>, %arg1: tensor<64x100xi64>, 
 
 // -----
 
-func.func @concat_fuse_0(%arg0: tensor<?x20xf32>, %arg1: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<50x?xf32>)
-{
-    %1 = "onnx.Concat"(%arg0, %arg1) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
-    %2 = "onnx.Transpose"(%1) {perm = [1, 0]} : (tensor<?x50xf32>) -> tensor<50x?xf32>
-    %3 = "onnx.Shape"(%1) : (tensor<?x50xf32>) -> tensor<2xi64>
-    onnx.Return %3, %2 : tensor<2xi64>, tensor<50x?xf32>
-// CHECK-LABEL:  func.func @concat_fuse_0
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x20xf32>, [[PARAM_1_:%.+]]: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<50x?xf32>) {
-// CHECK:           [[shape_:%.+]], [[VAR_transposed_:%.+]] = "onnx.ConcatShapeTranspose"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64, perm = [1, 0], start = 0 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> (tensor<2xi64>, tensor<50x?xf32>)
-// CHECK:           onnx.Return [[shape_]], [[VAR_transposed_]] : tensor<2xi64>, tensor<50x?xf32>
-// CHECK:         }
-}
-
-// -----
-
-func.func @test_concatfuse_1(%arg0: tensor<?x20xf32>, %arg1: tensor<?x30xf32>) -> (tensor<?x50xf32>, tensor<2xi64>, tensor<50x?xf32>)
-{
-    %1 = "onnx.Concat"(%arg0, %arg1) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
-    %2 = "onnx.Transpose"(%1) {perm = [1, 0]} : (tensor<?x50xf32>) -> tensor<50x?xf32>
-    %3 = "onnx.Shape"(%1) : (tensor<?x50xf32>) -> tensor<2xi64>
-    %4 = "onnx.Sin"(%1) : (tensor<?x50xf32>) -> tensor<?x50xf32>
-    onnx.Return %4, %3, %2 : tensor<?x50xf32>, tensor<2xi64>, tensor<50x?xf32>
-// CHECK-LABEL:  func.func @test_concatfuse_1
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x20xf32>, [[PARAM_1_:%.+]]: tensor<?x30xf32>) -> (tensor<?x50xf32>, tensor<2xi64>, tensor<50x?xf32>) {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Transpose"([[VAR_0_]]) {perm = [1, 0]} : (tensor<?x50xf32>) -> tensor<50x?xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Shape"([[VAR_0_]]) {start = 0 : si64} : (tensor<?x50xf32>) -> tensor<2xi64>
-// CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Sin"([[VAR_0_]]) : (tensor<?x50xf32>) -> tensor<?x50xf32>
-// CHECK:           onnx.Return [[VAR_3_]], [[VAR_2_]], [[VAR_1_]] : tensor<?x50xf32>, tensor<2xi64>, tensor<50x?xf32>
-}
-
-// -----
-
-func.func @test_concatfuse_2(%arg0: tensor<?x20xf32>, %arg1: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<?x50xf32>)
-{
-    %1 = "onnx.Concat"(%arg0, %arg1) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
-    %3 = "onnx.Shape"(%1) : (tensor<?x50xf32>) -> tensor<2xi64>
-    %4 = "onnx.Sin"(%1) : (tensor<?x50xf32>) -> tensor<?x50xf32>
-    onnx.Return %3, %4 : tensor<2xi64>, tensor<?x50xf32>
-// CHECK-LABEL:  func.func @test_concatfuse_2
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x20xf32>, [[PARAM_1_:%.+]]: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<?x50xf32>) {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[VAR_0_]]) {start = 0 : si64} : (tensor<?x50xf32>) -> tensor<2xi64>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Sin"([[VAR_0_]]) : (tensor<?x50xf32>) -> tensor<?x50xf32>
-// CHECK:           onnx.Return [[VAR_1_]], [[VAR_2_]] : tensor<2xi64>, tensor<?x50xf32>
-// CHECK:         }
-}
-
-// -----
-
 func.func @test_constantofshape_1(%arg0: tensor<?xi64>) -> tensor<*xi32> {
   %0 = onnx.ConstantOfShape(%arg0) {value = dense<1> : tensor<1xi32>} : (tensor<?xi64>) -> tensor<*xi32>
   return %0 : tensor<*xi32>

--- a/test/mlir/onnx/onnx_decompose_concat_fuse.mlir
+++ b/test/mlir/onnx/onnx_decompose_concat_fuse.mlir
@@ -1,0 +1,58 @@
+// RUN: onnx-mlir-opt --shape-inference --decompose-onnx=enable-concat-fuse=true %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --decompose-onnx=enable-concat-fuse=false %s -split-input-file | FileCheck %s --check-prefix=DISABLED-CHECK --check-prefix=COMMON-CHECK
+
+func.func @concat_fuse_0(%arg0: tensor<?x20xf32>, %arg1: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<50x?xf32>)
+{
+    %1 = "onnx.Concat"(%arg0, %arg1) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
+    %2 = "onnx.Transpose"(%1) {perm = [1, 0]} : (tensor<?x50xf32>) -> tensor<50x?xf32>
+    %3 = "onnx.Shape"(%1) : (tensor<?x50xf32>) -> tensor<2xi64>
+    onnx.Return %3, %2 : tensor<2xi64>, tensor<50x?xf32>
+// CHECK-LABEL:  func.func @concat_fuse_0
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x20xf32>, [[PARAM_1_:%.+]]: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<50x?xf32>) {
+// CHECK:           [[shape_:%.+]], [[VAR_transposed_:%.+]] = "onnx.ConcatShapeTranspose"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64, perm = [1, 0], start = 0 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> (tensor<2xi64>, tensor<50x?xf32>)
+// CHECK:           onnx.Return [[shape_]], [[VAR_transposed_]] : tensor<2xi64>, tensor<50x?xf32>
+// CHECK:         }
+
+// DISABLED-CHECK-LABEL:  func.func @concat_fuse_0
+// DISABLED-CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x20xf32>, [[PARAM_1_:%.+]]: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<50x?xf32>) {
+// DISABLED-CHECK:           [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
+// DISABLED-CHECK:           [[VAR_1_:%.+]] = "onnx.Transpose"([[VAR_0_]]) {perm = [1, 0]} : (tensor<?x50xf32>) -> tensor<50x?xf32>
+// DISABLED-CHECK:           [[VAR_2_:%.+]] = "onnx.Shape"([[VAR_0_]]) {start = 0 : si64} : (tensor<?x50xf32>) -> tensor<2xi64>
+// DISABLED-CHECK:           onnx.Return [[VAR_2_]], [[VAR_1_]] : tensor<2xi64>, tensor<50x?xf32>
+// DISABLED-CHECK:         }
+}
+
+// -----
+
+func.func @test_concatfuse_1(%arg0: tensor<?x20xf32>, %arg1: tensor<?x30xf32>) -> (tensor<?x50xf32>, tensor<2xi64>, tensor<50x?xf32>)
+{
+    %1 = "onnx.Concat"(%arg0, %arg1) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
+    %2 = "onnx.Transpose"(%1) {perm = [1, 0]} : (tensor<?x50xf32>) -> tensor<50x?xf32>
+    %3 = "onnx.Shape"(%1) : (tensor<?x50xf32>) -> tensor<2xi64>
+    %4 = "onnx.Sin"(%1) : (tensor<?x50xf32>) -> tensor<?x50xf32>
+    onnx.Return %4, %3, %2 : tensor<?x50xf32>, tensor<2xi64>, tensor<50x?xf32>
+// COMMON-CHECK-LABEL:  func.func @test_concatfuse_1
+// COMMON-CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x20xf32>, [[PARAM_1_:%.+]]: tensor<?x30xf32>) -> (tensor<?x50xf32>, tensor<2xi64>, tensor<50x?xf32>) {
+// COMMON-CHECK:           [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
+// COMMON-CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Transpose"([[VAR_0_]]) {perm = [1, 0]} : (tensor<?x50xf32>) -> tensor<50x?xf32>
+// COMMON-CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Shape"([[VAR_0_]]) {start = 0 : si64} : (tensor<?x50xf32>) -> tensor<2xi64>
+// COMMON-CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Sin"([[VAR_0_]]) : (tensor<?x50xf32>) -> tensor<?x50xf32>
+// COMMON-CHECK:           onnx.Return [[VAR_3_]], [[VAR_2_]], [[VAR_1_]] : tensor<?x50xf32>, tensor<2xi64>, tensor<50x?xf32>
+}
+
+// -----
+
+func.func @test_concatfuse_2(%arg0: tensor<?x20xf32>, %arg1: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<?x50xf32>)
+{
+    %1 = "onnx.Concat"(%arg0, %arg1) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
+    %3 = "onnx.Shape"(%1) : (tensor<?x50xf32>) -> tensor<2xi64>
+    %4 = "onnx.Sin"(%1) : (tensor<?x50xf32>) -> tensor<?x50xf32>
+    onnx.Return %3, %4 : tensor<2xi64>, tensor<?x50xf32>
+// COMMON-CHECK-LABEL:  func.func @test_concatfuse_2
+// COMMON-CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x20xf32>, [[PARAM_1_:%.+]]: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<?x50xf32>) {
+// COMMON-CHECK:           [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
+// COMMON-CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[VAR_0_]]) {start = 0 : si64} : (tensor<?x50xf32>) -> tensor<2xi64>
+// COMMON-CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Sin"([[VAR_0_]]) : (tensor<?x50xf32>) -> tensor<?x50xf32>
+// COMMON-CHECK:           onnx.Return [[VAR_1_]], [[VAR_2_]] : tensor<2xi64>, tensor<?x50xf32>
+// COMMON-CHECK:         }
+}


### PR DESCRIPTION
**Why?** We need to disable `ConcatFuse` because this rewriter combines `Concat -> Transpose -> Shape` into `ConcatShapeTranspose` operation (that isn't part of the standard but used to assist `onnx-mlir`). This rewriter prevents us from running `ConstProp` on `onnx.Shape` and optimize it away. Since we never even consumed it in the first place, it is okay to disable it when we can by providing a flag.

Ps.: also fixed a typo in `enableGAPToReduceMean` option.