### PR TITLE
Add recomposition pattern for HardSigmoid

### DIFF
--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -9,6 +9,9 @@
 // Defines language-specific pattern match rewritings for ONNX using
 // Declarative Rewrite Rules (DRR) specified using TableGen records.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef ONNX_CONSTPROP
@@ -751,7 +754,8 @@ def MulAddConstDistributive : NamedPat<"MulAddConstDistributive",
   (ONNXAddOp
     (ONNXMulOp $x, $a),
     (ONNXMulOp $a, $b)),
-  [(IsNotAConstant:$x), (HasOneUse:$addOp)]>;
+  [(IsNotAConstant:$x), (HasOneUse:$addOp), (IsIntOrFloatType:$a),
+  (IsIntOrFloatType:$b), (IsIntOrFloatType:$x)]>;
 
 // Distribute multiplication into clip: mul(clip(x, l, u), a) -> clip(mul(x, a), mul(a, l), mul(a, u)).
 // mul(a, l) and mul(a, u) are folded to single constants by MulConstProp in a later iteration.
@@ -767,7 +771,8 @@ def MulClipConstDistributive : NamedPat<"MulClipConstDistributive",
     (ONNXMulOp $x, $a),
     (ONNXMulOp $a, $l),
     (ONNXMulOp $a, $u)),
-  [(IsNotAConstant:$x), (HasOneUse:$clipOp)]>;
+  [(IsNotAConstant:$x), (HasOneUse:$clipOp),  (IsIntOrFloatType:$x), 
+  (IsIntOrFloatType:$a), (IsIntOrFloatType:$l), (IsIntOrFloatType:$u)]>;
 
 // Constant Propagation for Mul
 def MulConstProp : NamedPat<"MulConstProp",

--- a/src/Dialect/ONNX/Transforms/ConstProp.td
+++ b/src/Dialect/ONNX/Transforms/ConstProp.td
@@ -740,6 +740,35 @@ def MulConstAssociative4 : NamedPat<"MulConstAssociative4",
     (ONNXMulOp $c1, $c2)),
   [(IsNotAConstant:$x), (IsNotAConstant:$y), (HasOneUse:$lhs), (HasOneUse:$rhs)]>;
 
+// mul(add(x, b), a) -> add(mul(x, a), mul(a, b)).
+// mul(a, b) is folded to a single constant by MulConstProp.
+def MulAddConstDistributive : NamedPat<"MulAddConstDistributive",
+  // From mul(add(x, b), a) where a, b are constants.
+  (ONNXMulOp
+    (ONNXAddOp:$addOp $x, (ONNXConstantOp:$b $_, $_, $_, $_, $_, $_, $_, $_)),
+    (ONNXConstantOp:$a $_, $_, $_, $_, $_, $_, $_, $_)),
+  // To add(mul(x, a), mul(a, b)).
+  (ONNXAddOp
+    (ONNXMulOp $x, $a),
+    (ONNXMulOp $a, $b)),
+  [(IsNotAConstant:$x), (HasOneUse:$addOp)]>;
+
+// Distribute multiplication into clip: mul(clip(x, l, u), a) -> clip(mul(x, a), mul(a, l), mul(a, u)).
+// mul(a, l) and mul(a, u) are folded to single constants by MulConstProp in a later iteration.
+def MulClipConstDistributive : NamedPat<"MulClipConstDistributive",
+  // From mul(clip(x, l, u), a) where a, l, u are constants.
+  (ONNXMulOp
+    (ONNXClipOp:$clipOp $x,
+      (ONNXConstantOp:$l $_, $_, $_, $_, $_, $_, $_, $_),
+      (ONNXConstantOp:$u $_, $_, $_, $_, $_, $_, $_, $_)),
+    (ONNXConstantOp:$a $_, $_, $_, $_, $_, $_, $_, $_)),
+  // To clip(mul(x, a), mul(a, l), mul(a, u)).
+  (ONNXClipOp
+    (ONNXMulOp $x, $a),
+    (ONNXMulOp $a, $l),
+    (ONNXMulOp $a, $u)),
+  [(IsNotAConstant:$x), (HasOneUse:$clipOp)]>;
+
 // Constant Propagation for Mul
 def MulConstProp : NamedPat<"MulConstProp",
     // From mul(c1, c2).

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -5,7 +5,7 @@
 //===----------- ONNXRecompose.cpp - ONNX High Level Rewriting ------------===//
 //
 // Copyright 2023 The IBM Research Authors.
-// Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+// Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 // =============================================================================
 //
@@ -744,6 +744,67 @@ private:
     // Can disable line below if not needed.
     LLVM_DEBUG(llvm::dbgs() << "LayerNorm failure:" << msg << "\n");
     return false;
+  }
+};
+
+// Recompose HardSigmoid from `clip(x * a + b, 0, 1)`.
+struct RecomposeHardSigmoidFromMulClipPattern
+    : public OpRewritePattern<ONNXClipOp> {
+  using OpRewritePattern<ONNXClipOp>::OpRewritePattern;
+
+  static bool matchScalarConstant(Value v, double &out) {
+    using namespace onnx_mlir;
+    if (!isDenseONNXConstant(v))
+      return false;
+    ElementsAttr attr = getElementAttributeFromONNXValue(v);
+    if (!attr || attr.getNumElements() != 1)
+      return false;
+    out = getScalarValue<double>(attr, attr.getElementType());
+    return true;
+  }
+
+  LogicalResult matchAndRewrite(
+      ONNXClipOp clipOp, PatternRewriter &rewriter) const final {
+    using namespace onnx_mlir;
+
+    auto elementType = getElementTypeOrSelf(clipOp.getType());
+    if (!isa<Float32Type, BFloat16Type, Float16Type>(elementType))
+      return failure();
+
+    // clip(input, 0, 1)
+    Value clipMin = clipOp.getMin();
+    Value clipMax = clipOp.getMax();
+    if (isNoneValue(clipMin) || isNoneValue(clipMax) ||
+        !isConstOf(clipMin, 0.0) || !isConstOf(clipMax, 1.0))
+      return failure();
+
+    // add(mul(x, a), b)
+    auto addOp = clipOp.getInput().getDefiningOp<ONNXAddOp>();
+    if (!addOp)
+      return failure();
+
+    auto mulOp = addOp.getOperand(0).getDefiningOp<ONNXMulOp>();
+    if (!mulOp)
+      return failure();
+
+    Value x = mulOp.getOperand(0);
+    double alpha;
+    if (!matchScalarConstant(mulOp.getOperand(1), alpha) || alpha <= 0.0)
+      return failure();
+
+    double beta;
+    if (!matchScalarConstant(addOp.getOperand(1), beta))
+      return failure();
+
+    auto alphaAttr = rewriter.getF32FloatAttr(alpha);
+    auto betaAttr = rewriter.getF32FloatAttr(beta);
+
+    auto loc = mlir::FusedLoc::get(rewriter.getContext(),
+        {clipOp.getLoc(), addOp.getLoc(), mulOp.getLoc()});
+    Value hardSigmoidOp = rewriter.create<ONNXHardSigmoidOp>(
+        loc, clipOp.getType(), x, alphaAttr, betaAttr);
+    rewriter.replaceOp(clipOp, hardSigmoidOp);
+    return success();
   }
 };
 
@@ -1517,6 +1578,7 @@ void RecomposeONNXToONNXPass::runOnOperation() {
 void onnx_mlir::getRecomposeONNXToONNXPatterns(
     mlir::RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
+  patterns.insert<RecomposeHardSigmoidFromMulClipPattern>(context);
   patterns.insert<RecomposeGeluFromMulPattern>(context);
   patterns.insert<RecomposeLayerNormFromDivPattern<ONNXDivOp, false>>(context);
   patterns.insert<RecomposeLayerNormFromDivPattern<ONNXMulOp, false>>(context);

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -1,3 +1,5 @@
+// Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+
 // RUN: onnx-mlir-opt --shape-inference --constprop-onnx %s -split-input-file | FileCheck %s
 
 //===----------------------------------------------------------------------===//
@@ -322,6 +324,58 @@ func.func @test_mul_const_associative_scalar_not_apply_2(%x: tensor<5xi32>, %y: 
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<5xi32>, tensor<1xi32>) -> tensor<5xi32>
 // CHECK:           onnx.Return [[VAR_2_]] : tensor<5xi32>
 // CHECK:         }
+}
+
+// -----
+
+// CHECK-LABEL: @test_mul_add_const_distributive
+func.func @test_mul_add_const_distributive(%x: tensor<3xf32>) -> tensor<3xf32> {
+  %a = onnx.Constant dense<2.0> : tensor<3xf32>
+  %b = onnx.Constant dense<3.0> : tensor<3xf32>
+  %1 = "onnx.Add"(%x, %b) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  %2 = "onnx.Mul"(%1, %a) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  onnx.Return %2 : tensor<3xf32>
+  // CHECK-DAG: [[AB:%.+]] = onnx.Constant dense<6.000000e+00> : tensor<3xf32>
+  // CHECK-DAG: [[A:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<3xf32>
+  // CHECK: [[MUL:%.+]] = "onnx.Mul"(%arg0, [[A]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  // CHECK: [[ADD:%.+]] = "onnx.Add"([[MUL]], [[AB]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  // CHECK: onnx.Return [[ADD]] : tensor<3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_mul_add_const_distributive_multiuse
+// CHECK-SAME:  (%[[X:.*]]: tensor<3xf32>) -> (tensor<3xf32>, tensor<3xf32>)
+// CHECK-DAG:   %[[A:.*]] = onnx.Constant dense<2.000000e+00> : tensor<3xf32>
+// CHECK-DAG:   %[[B:.*]] = onnx.Constant dense<3.000000e+00> : tensor<3xf32>
+// CHECK:       %[[ADD:.*]] = "onnx.Add"(%[[X]], %[[B]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+// CHECK:       %[[MUL:.*]] = "onnx.Mul"(%[[ADD]], %[[A]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+// CHECK:       onnx.Return %[[MUL]], %[[ADD]] : tensor<3xf32>, tensor<3xf32>
+func.func @test_mul_add_const_distributive_multiuse(%x: tensor<3xf32>) -> (tensor<3xf32>, tensor<3xf32>) {
+  %a = onnx.Constant dense<2.0> : tensor<3xf32>
+  %b = onnx.Constant dense<3.0> : tensor<3xf32>
+  %add = "onnx.Add"(%x, %b) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  %mul = "onnx.Mul"(%add, %a) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  onnx.Return %mul, %add : tensor<3xf32>, tensor<3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_mul_clip_const_distributive
+func.func @test_mul_clip_const_distributive(%x: tensor<3xf32>) -> tensor<3xf32> {
+  %a = onnx.Constant dense<2.0> : tensor<3xf32>
+  %lo = onnx.Constant dense<0.0> : tensor<3xf32>
+  %hi = onnx.Constant dense<5.0> : tensor<3xf32>
+  %1 = "onnx.Clip"(%x, %lo, %hi) : (tensor<3xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  %2 = "onnx.Mul"(%1, %a) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  onnx.Return %2 : tensor<3xf32>
+  // After distribution: clip(mul(x, 2), mul(2, 0), mul(2, 5)) => clip(mul(x, 2), 0, 10)
+  // CHECK-DAG: [[AL:%.+]] = onnx.Constant dense<0.000000e+00> : tensor<3xf32>
+  // CHECK-DAG: [[AU:%.+]] = onnx.Constant dense<1.000000e+01> : tensor<3xf32>
+  // CHECK-DAG: [[A:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<3xf32>
+  // CHECK: [[MUL:%.+]] = "onnx.Mul"(%arg0, [[A]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  // CHECK: [[CLIP:%.+]] = "onnx.Clip"([[MUL]], [[AL]], [[AU]]) : (tensor<3xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  // CHECK: onnx.Return [[CLIP]] : tensor<3xf32>
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/mlir/onnx/onnx_recompose.mlir
+++ b/test/mlir/onnx/onnx_recompose.mlir
@@ -1,4 +1,4 @@
-// Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+// Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 // RUN: onnx-mlir-opt --recompose-onnx --canonicalize %s -split-input-file | FileCheck %s
 
 // -----
@@ -872,3 +872,83 @@ func.func @test_depth_to_space_DCR_not_static_shapes(%arg0: tensor<*xf32>) -> te
   return %4 : tensor<*xf32>
 }
 // CHECK-NOT: onnx.DepthToSpace
+
+// -----
+
+// HardSigmoid(x) = clip(x * a + b, 0, 1) with alpha=1/6, beta=0.5 in f32
+func.func @test_hardsigmoid_clip_mul_add_f32(%arg0 : tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+  %a = onnx.Constant dense<0.166666672> : tensor<f32>
+  %b = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %zero = onnx.Constant dense<0.000000e+00> : tensor<f32>
+  %one = onnx.Constant dense<1.000000e+00> : tensor<f32>
+  %0 = "onnx.Mul"(%arg0, %a) : (tensor<?x?x3072xf32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  %1 = "onnx.Add"(%0, %b) : (tensor<?x?x3072xf32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  %2 = "onnx.Clip"(%1, %zero, %one) : (tensor<?x?x3072xf32>, tensor<f32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  return %2 : tensor<?x?x3072xf32>
+
+// CHECK-LABEL:  func.func @test_hardsigmoid_clip_mul_add_f32
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]]) {alpha = 0.166666672 : f32, beta = 5.000000e-01 : f32} : (tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+// CHECK:           return [[VAR_0_]] : tensor<?x?x3072xf32>
+// CHECK:         }
+}
+
+// -----
+
+// HardSigmoid(x) = clip(x * a + b, 0, 1) with alpha=1/6, beta=0.5 in bf16
+func.func @test_hardsigmoid_clip_mul_add_bf16(%arg0 : tensor<?x?x3072xbf16>) -> tensor<?x?x3072xbf16> {
+  %a = onnx.Constant dense<0.166015625> : tensor<bf16>
+  %b = onnx.Constant dense<5.000000e-01> : tensor<bf16>
+  %zero = onnx.Constant dense<0.000000e+00> : tensor<bf16>
+  %one = onnx.Constant dense<1.000000e+00> : tensor<bf16>
+  %0 = "onnx.Mul"(%arg0, %a) : (tensor<?x?x3072xbf16>, tensor<bf16>) -> tensor<?x?x3072xbf16>
+  %1 = "onnx.Add"(%0, %b) : (tensor<?x?x3072xbf16>, tensor<bf16>) -> tensor<?x?x3072xbf16>
+  %2 = "onnx.Clip"(%1, %zero, %one) : (tensor<?x?x3072xbf16>, tensor<bf16>, tensor<bf16>) -> tensor<?x?x3072xbf16>
+  return %2 : tensor<?x?x3072xbf16>
+
+// CHECK-LABEL:  func.func @test_hardsigmoid_clip_mul_add_bf16
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xbf16>) -> tensor<?x?x3072xbf16> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]]) {alpha = 0.166015625 : f32, beta = 5.000000e-01 : f32} : (tensor<?x?x3072xbf16>) -> tensor<?x?x3072xbf16>
+// CHECK:           return [[VAR_0_]] : tensor<?x?x3072xbf16>
+// CHECK:         }
+}
+
+// -----
+
+// HardSigmoid(x) = clip(x * a + b, 0, 1) with alpha=1/6, beta=0.5 in f16
+func.func @test_hardsigmoid_clip_mul_add_f16(%arg0 : tensor<?x?x3072xf16>) -> tensor<?x?x3072xf16> {
+  %a = onnx.Constant dense<0.166625977> : tensor<f16>
+  %b = onnx.Constant dense<5.000000e-01> : tensor<f16>
+  %zero = onnx.Constant dense<0.000000e+00> : tensor<f16>
+  %one = onnx.Constant dense<1.000000e+00> : tensor<f16>
+  %0 = "onnx.Mul"(%arg0, %a) : (tensor<?x?x3072xf16>, tensor<f16>) -> tensor<?x?x3072xf16>
+  %1 = "onnx.Add"(%0, %b) : (tensor<?x?x3072xf16>, tensor<f16>) -> tensor<?x?x3072xf16>
+  %2 = "onnx.Clip"(%1, %zero, %one) : (tensor<?x?x3072xf16>, tensor<f16>, tensor<f16>) -> tensor<?x?x3072xf16>
+  return %2 : tensor<?x?x3072xf16>
+
+// CHECK-LABEL:  func.func @test_hardsigmoid_clip_mul_add_f16
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xf16>) -> tensor<?x?x3072xf16> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]]) {alpha = 0.166625977 : f32, beta = 5.000000e-01 : f32} : (tensor<?x?x3072xf16>) -> tensor<?x?x3072xf16>
+// CHECK:           return [[VAR_0_]] : tensor<?x?x3072xf16>
+// CHECK:         }
+}
+
+// -----
+
+// HardSigmoid(x) = clip(x * a + b, 0, 1) with alpha=0.2, beta=0.5 in f32
+func.func @test_hardsigmoid_clip_mul_add_default_alpha_beta(%arg0 : tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+  %a = onnx.Constant dense<2.000000e-01> : tensor<f32>
+  %b = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %zero = onnx.Constant dense<0.000000e+00> : tensor<f32>
+  %one = onnx.Constant dense<1.000000e+00> : tensor<f32>
+  %0 = "onnx.Mul"(%arg0, %a) : (tensor<?x?x3072xf32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  %1 = "onnx.Add"(%0, %b) : (tensor<?x?x3072xf32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  %2 = "onnx.Clip"(%1, %zero, %one) : (tensor<?x?x3072xf32>, tensor<f32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  return %2 : tensor<?x?x3072xf32>
+
+// CHECK-LABEL:  func.func @test_hardsigmoid_clip_mul_add_default_alpha_beta
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]]) {alpha = 2.000000e-01 : f32, beta = 5.000000e-01 : f32} : (tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+// CHECK:           return [[VAR_0_]] : tensor<?x?x3072xf32>
+// CHECK:         }
+}

--- a/test/mlir/onnx/onnx_recompose_constprop.mlir
+++ b/test/mlir/onnx/onnx_recompose_constprop.mlir
@@ -1,0 +1,125 @@
+// Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+
+// RUN: onnx-mlir-opt --shape-inference --constprop-onnx --recompose-onnx --canonicalize %s -split-input-file | FileCheck %s
+
+// Tests that the factored HardSigmoid decomposition clip(x + b/a, 0, 1/a) * a
+// is first distributed by const-prop into clip(x * a + b, 0, 1) and then
+// recomposed into onnx.HardSigmoid.
+
+// clip(x + b/a, 0, 1/a) * a with a=1/6, b=0.5 in f32
+func.func @test_hardsigmoid_factored_f32(%arg0 : tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+  %a = onnx.Constant dense<0.166666672> : tensor<f32>
+  %b_over_a = onnx.Constant dense<3.000000e+00> : tensor<f32>
+  %zero = onnx.Constant dense<0.000000e+00> : tensor<f32>
+  %inv_a = onnx.Constant dense<6.000000e+00> : tensor<f32>
+  %0 = "onnx.Add"(%arg0, %b_over_a) : (tensor<?x?x3072xf32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  %1 = "onnx.Clip"(%0, %zero, %inv_a) : (tensor<?x?x3072xf32>, tensor<f32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  %2 = "onnx.Mul"(%1, %a) : (tensor<?x?x3072xf32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  return %2 : tensor<?x?x3072xf32>
+
+// CHECK-LABEL:  func.func @test_hardsigmoid_factored_f32
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]])
+// CHECK:           return [[VAR_0_]] : tensor<?x?x3072xf32>
+// CHECK:         }
+}
+
+// -----
+
+// clip(x + b/a, 0, 1/a) * a with a=1/6, b=0.5 in bf16
+func.func @test_hardsigmoid_factored_bf16(%arg0 : tensor<?x?x3072xbf16>) -> tensor<?x?x3072xbf16> {
+  %a = onnx.Constant dense<0.166992188> : tensor<bf16>
+  %b_over_a = onnx.Constant dense<3.000000e+00> : tensor<bf16>
+  %zero = onnx.Constant dense<0.000000e+00> : tensor<bf16>
+  %inv_a = onnx.Constant dense<6.000000e+00> : tensor<bf16>
+  %0 = "onnx.Add"(%arg0, %b_over_a) : (tensor<?x?x3072xbf16>, tensor<bf16>) -> tensor<?x?x3072xbf16>
+  %1 = "onnx.Clip"(%0, %zero, %inv_a) : (tensor<?x?x3072xbf16>, tensor<bf16>, tensor<bf16>) -> tensor<?x?x3072xbf16>
+  %2 = "onnx.Mul"(%1, %a) : (tensor<?x?x3072xbf16>, tensor<bf16>) -> tensor<?x?x3072xbf16>
+  return %2 : tensor<?x?x3072xbf16>
+
+// CHECK-LABEL:  func.func @test_hardsigmoid_factored_bf16
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xbf16>) -> tensor<?x?x3072xbf16> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]])
+// CHECK:           return [[VAR_0_]] : tensor<?x?x3072xbf16>
+// CHECK:         }
+}
+
+// -----
+
+// clip(x + b/a, 0, 1/a) * a with a=1/6, b=0.5 in f16
+func.func @test_hardsigmoid_factored_f16(%arg0 : tensor<?x?x3072xf16>) -> tensor<?x?x3072xf16> {
+  %a = onnx.Constant dense<0.166625977> : tensor<f16>
+  %b_over_a = onnx.Constant dense<3.000000e+00> : tensor<f16>
+  %zero = onnx.Constant dense<0.000000e+00> : tensor<f16>
+  %inv_a = onnx.Constant dense<6.000000e+00> : tensor<f16>
+  %0 = "onnx.Add"(%arg0, %b_over_a) : (tensor<?x?x3072xf16>, tensor<f16>) -> tensor<?x?x3072xf16>
+  %1 = "onnx.Clip"(%0, %zero, %inv_a) : (tensor<?x?x3072xf16>, tensor<f16>, tensor<f16>) -> tensor<?x?x3072xf16>
+  %2 = "onnx.Mul"(%1, %a) : (tensor<?x?x3072xf16>, tensor<f16>) -> tensor<?x?x3072xf16>
+  return %2 : tensor<?x?x3072xf16>
+
+// CHECK-LABEL:  func.func @test_hardsigmoid_factored_f16
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xf16>) -> tensor<?x?x3072xf16> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]])
+// CHECK:           return [[VAR_0_]] : tensor<?x?x3072xf16>
+// CHECK:         }
+}
+
+// -----
+
+// clip(x + b/a, 0, 1/a) * a with a=0.2, b=0.5 in f32
+func.func @test_hardsigmoid_factored_default_alpha_beta(%arg0 : tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+  %a = onnx.Constant dense<2.000000e-01> : tensor<f32>
+  %b_over_a = onnx.Constant dense<2.500000e+00> : tensor<f32>
+  %zero = onnx.Constant dense<0.000000e+00> : tensor<f32>
+  %inv_a = onnx.Constant dense<5.000000e+00> : tensor<f32>
+  %0 = "onnx.Add"(%arg0, %b_over_a) : (tensor<?x?x3072xf32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  %1 = "onnx.Clip"(%0, %zero, %inv_a) : (tensor<?x?x3072xf32>, tensor<f32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  %2 = "onnx.Mul"(%1, %a) : (tensor<?x?x3072xf32>, tensor<f32>) -> tensor<?x?x3072xf32>
+  return %2 : tensor<?x?x3072xf32>
+
+// CHECK-LABEL:  func.func @test_hardsigmoid_factored_default_alpha_beta
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]])
+// CHECK:           return [[VAR_0_]] : tensor<?x?x3072xf32>
+// CHECK:         }
+}
+
+// -----
+
+// clip(x + b/a, 0, 1/a) * a with a=0.2, b=0.5 in f16
+func.func @test_hardsigmoid_factored_default_alpha_beta_f16(%arg0 : tensor<?x?x3072xf16>) -> tensor<?x?x3072xf16> {
+  %a = onnx.Constant dense<2.000000e-01> : tensor<f16>
+  %b_over_a = onnx.Constant dense<2.500000e+00> : tensor<f16>
+  %zero = onnx.Constant dense<0.000000e+00> : tensor<f16>
+  %inv_a = onnx.Constant dense<5.000000e+00> : tensor<f16>
+  %0 = "onnx.Add"(%arg0, %b_over_a) : (tensor<?x?x3072xf16>, tensor<f16>) -> tensor<?x?x3072xf16>
+  %1 = "onnx.Clip"(%0, %zero, %inv_a) : (tensor<?x?x3072xf16>, tensor<f16>, tensor<f16>) -> tensor<?x?x3072xf16>
+  %2 = "onnx.Mul"(%1, %a) : (tensor<?x?x3072xf16>, tensor<f16>) -> tensor<?x?x3072xf16>
+  return %2 : tensor<?x?x3072xf16>
+
+// CHECK-LABEL:  func.func @test_hardsigmoid_factored_default_alpha_beta_f16
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xf16>) -> tensor<?x?x3072xf16> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]])
+// CHECK:           return [[VAR_0_]] : tensor<?x?x3072xf16>
+// CHECK:         }
+}
+
+// -----
+
+// clip(x + b/a, 0, 1/a) * a with a=0.2, b=0.5 in bf16
+func.func @test_hardsigmoid_factored_default_alpha_beta_bf16(%arg0 : tensor<?x?x3072xbf16>) -> tensor<?x?x3072xbf16> {
+  %a = onnx.Constant dense<2.000000e-01> : tensor<bf16>
+  %b_over_a = onnx.Constant dense<2.500000e+00> : tensor<bf16>
+  %zero = onnx.Constant dense<0.000000e+00> : tensor<bf16>
+  %inv_a = onnx.Constant dense<5.000000e+00> : tensor<bf16>
+  %0 = "onnx.Add"(%arg0, %b_over_a) : (tensor<?x?x3072xbf16>, tensor<bf16>) -> tensor<?x?x3072xbf16>
+  %1 = "onnx.Clip"(%0, %zero, %inv_a) : (tensor<?x?x3072xbf16>, tensor<bf16>, tensor<bf16>) -> tensor<?x?x3072xbf16>
+  %2 = "onnx.Mul"(%1, %a) : (tensor<?x?x3072xbf16>, tensor<bf16>) -> tensor<?x?x3072xbf16>
+  return %2 : tensor<?x?x3072xbf16>
+
+// CHECK-LABEL:  func.func @test_hardsigmoid_factored_default_alpha_beta_bf16
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xbf16>) -> tensor<?x?x3072xbf16> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]])
+// CHECK:           return [[VAR_0_]] : tensor<?x?x3072xbf16>
+// CHECK:         }
+}


### PR DESCRIPTION
Hi, this PR adds a recomposition pattern for HardSigmoid. Mathematically HardSigmoid is clip(ax + b, 0, 1), where a, b are scalar constants and x is a tensor. Sometimes (e.g. lowering from torch) we see the equivalent decomposition a * clip(x + b/a, 0, 1/a).
This pattern rewrites this back to onnx.HardSigmoid(x) { a, b }. 

PS: It handles commutativity since both a and b/a are constants and will be moved to the rhs of the mul or add.