### PR TITLE
Add softmaxV11ToLatest for non-innermost axis

### DIFF
--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -10,6 +10,9 @@
 //
 // This file contains builder functions for ONNX Dialect.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "mlir/IR/TypeUtilities.h"
@@ -484,6 +487,11 @@ Value OnnxBuilder::slice(Type outputType, Value input, int64_t start,
   Value endVal = constant(b().getI64TensorAttr(ArrayRef<int64_t>({end})));
   Value stepVal = constant(b().getI64TensorAttr(ArrayRef<int64_t>({step})));
   return slice(outputType, input, startVal, endVal, /*axis*/ zeroVal, stepVal);
+}
+
+Value OnnxBuilder::softmax(Type outputType, Value input, int64_t axis) const {
+  return createTypedOpAndInferShapes<ONNXSoftmaxOp>(
+      toTensor(outputType), toTensor(input), axis);
 }
 
 Value OnnxBuilder::sqrt(Value input) const {

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -10,6 +10,9 @@
 //
 // This file contains helper functions for lowering ONNX ops to Krnl Dialect.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef ONNX_MLIR_ONNX_DIALECT_BUILDER_H
@@ -208,6 +211,10 @@ struct OnnxBuilder : DialectBuilder {
       mlir::Value steps) const;
   mlir::Value slice(mlir::Type outputType, mlir::Value input, int64_t start,
       int64_t end, int64_t step = 1) const; // 1D slice
+
+  // ONNXSoftmaxOp
+  mlir::Value softmax(
+      mlir::Type outputType, mlir::Value input, int64_t axis) const;
 
   // ONNXSqrtOp
   mlir::Value sqrt(mlir::Value input) const;

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2433,6 +2433,76 @@ struct SoftmaxNegativeAxisPattern : public OpRewritePattern<ONNXSoftmaxOp> {
   }
 };
 
+// Rewrite ONNXSoftmaxV11Op to ONNXSoftmaxOp (V13).
+//
+// V11 computes softmax over the flattened suffix [axis..rank-1].
+// V13 computes softmax along a single axis.
+//
+// When axis is already the last dim the ops are equivalent.
+// Otherwise we flatten the trailing dims, apply V13 softmax on that single
+// flattened dim, then reshape back.
+struct SoftmaxV11ToLatestPattern : public OpRewritePattern<ONNXSoftmaxV11Op> {
+  using OpRewritePattern<ONNXSoftmaxV11Op>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXSoftmaxV11Op op, PatternRewriter &rewriter) const final {
+    Value input = op.getInput();
+    int64_t axis = op.getAxis();
+    Type resultType = op.getResult().getType();
+
+    // axis == -1 always refers to the last dim, even for unranked tensors.
+    if (axis == -1) {
+      rewriter.replaceOpWithNewOp<ONNXSoftmaxOp>(op, resultType, input, axis);
+      return success();
+    }
+
+    auto inputType = dyn_cast<RankedTensorType>(input.getType());
+    if (!inputType)
+      return rewriter.notifyMatchFailure(op, "requires ranked input");
+
+    int64_t rank = inputType.getRank();
+    if (axis < 0)
+      axis += rank;
+
+    // If axis is innermost V11 and V13 semantics are identical.
+    if (axis == rank - 1) {
+      rewriter.replaceOpWithNewOp<ONNXSoftmaxOp>(op, resultType, input, axis);
+      return success();
+    }
+
+    if (!inputType.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          op, "non-last-axis requires static shape");
+
+    // Flatten [axis..rank-1] into a single trailing dimension, e.g.
+    //   [2, 3, 4, 5] with axis=1  ->  [2, 60]
+    ArrayRef<int64_t> inputShape = inputType.getShape();
+    int64_t trailingDim = 1;
+    for (int64_t i = axis; i < rank; ++i)
+      trailingDim *= inputShape[i];
+
+    SmallVector<int64_t> flatShape(
+        inputShape.begin(), inputShape.begin() + axis);
+    flatShape.push_back(trailingDim);
+    auto flatType =
+        RankedTensorType::get(flatShape, inputType.getElementType());
+
+    Location loc = op.getLoc();
+    auto shapeAttr = [&](ArrayRef<int64_t> shape) {
+      return rewriter.create<ONNXConstantOp>(
+          loc, nullptr, rewriter.getI64TensorAttr(shape));
+    };
+
+    Value flat = rewriter.create<ONNXReshapeOp>(
+        loc, flatType, input, shapeAttr(flatShape));
+    Value softmax = rewriter.create<ONNXSoftmaxOp>(loc, flatType, flat, axis);
+    rewriter.replaceOpWithNewOp<ONNXReshapeOp>(
+        op, resultType, softmax, shapeAttr(inputShape));
+
+    return success();
+  }
+};
+
 /*
  * Push down the transpose after scale (mul op), so the scale can be fused to
  * Layernorm.

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -17,6 +17,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <functional>
 #include <math.h>
 #include <numeric>
 
@@ -2475,30 +2476,22 @@ struct SoftmaxV11ToLatestPattern : public OpRewritePattern<ONNXSoftmaxV11Op> {
           op, "non-last-axis requires static shape");
 
     // Flatten [axis..rank-1] into a single trailing dimension, e.g.
-    //   [2, 3, 4, 5] with axis=1  ->  [2, 60]
+    //   [1, 2, 3, 4, 5] with axis=2  ->  [1, 2, 60]
     ArrayRef<int64_t> inputShape = inputType.getShape();
-    int64_t trailingDim = 1;
-    for (int64_t i = axis; i < rank; ++i)
-      trailingDim *= inputShape[i];
-
-    SmallVector<int64_t> flatShape(
-        inputShape.begin(), inputShape.begin() + axis);
+    int64_t trailingDim = std::accumulate(inputShape.begin() + axis,
+        inputShape.end(), int64_t(1), std::multiplies<int64_t>{});
+    SmallVector<int64_t> flatShape(inputShape.take_front(axis));
     flatShape.push_back(trailingDim);
     auto flatType =
         RankedTensorType::get(flatShape, inputType.getElementType());
 
-    Location loc = op.getLoc();
-    auto shapeAttr = [&](ArrayRef<int64_t> shape) {
-      return rewriter.create<ONNXConstantOp>(
-          loc, nullptr, rewriter.getI64TensorAttr(shape));
-    };
-
-    Value flat = rewriter.create<ONNXReshapeOp>(
-        loc, flatType, input, shapeAttr(flatShape));
-    Value softmax = rewriter.create<ONNXSoftmaxOp>(loc, flatType, flat, axis);
-    rewriter.replaceOpWithNewOp<ONNXReshapeOp>(
-        op, resultType, softmax, shapeAttr(inputShape));
-
+    OnnxBuilder onnx(rewriter, op.getLoc());
+    auto inputReshapeOp =
+        onnx.reshape(flatType, input, onnx.constantInt64(flatShape));
+    auto softmaxOp = onnx.softmax(flatType, inputReshapeOp, axis);
+    auto outputReshapeOp =
+        onnx.reshape(resultType, softmaxOp, onnx.constantInt64(inputShape));
+    rewriter.replaceOp(op, outputReshapeOp);
     return success();
   }
 };

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -1108,18 +1108,6 @@ def DimOpToConstantPattern: Pat<
 >;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXSoftmaxV11 to the latest version
-//===----------------------------------------------------------------------===//
-
-// When axis is the last dimension of the input tensor, the semantics of V11 is
-// the same as that of V13 (the latest version).
-def SoftmaxV11ToLatestPattern: Pat<
-   (ONNXSoftmaxV11Op $input, $axisAttr),
-   (ONNXSoftmaxOp $input, $axisAttr),
-   [(AxisIsTheLastDim $input, $axisAttr)]
->;
-
-//===----------------------------------------------------------------------===//
 // Canonicalization for ONNXShapeTransform
 //===----------------------------------------------------------------------===//
 

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -1536,6 +1536,48 @@ func.func @test_softmax_v11_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
 
 // -----
 
+func.func @test_softmax_v11_axis_minus_one_ranked(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+  %0 = "onnx.SoftmaxV11"(%arg0) {axis = -1 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
+  onnx.Return %0 : tensor<10x20x30xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_v11_axis_minus_one_ranked
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Softmax"([[PARAM_0_]]) {axis = 2 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<10x20x30xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_softmax_v11_negative_axis(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+  %0 = "onnx.SoftmaxV11"(%arg0) {axis = -2 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
+  onnx.Return %0 : tensor<10x20x30xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_v11_negative_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+// CHECK-DAG:       [[SHAPE_ORIG_:%.+]] = onnx.Constant dense<[10, 20, 30]> : tensor<3xi64>
+// CHECK-DAG:       [[SHAPE_FLAT_:%.+]] = onnx.Constant dense<[10, 600]> : tensor<2xi64>
+// CHECK:           [[FLAT_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[SHAPE_FLAT_]]) {{.*}} : (tensor<10x20x30xf32>, tensor<2xi64>) -> tensor<10x600xf32>
+// CHECK:           [[SOFTMAX_:%.+]] = "onnx.Softmax"([[FLAT_]]) {axis = 1 : si64} : (tensor<10x600xf32>) -> tensor<10x600xf32>
+// CHECK:           [[RESULT_:%.+]] = "onnx.Reshape"([[SOFTMAX_]], [[SHAPE_ORIG_]]) {{.*}} : (tensor<10x600xf32>, tensor<3xi64>) -> tensor<10x20x30xf32>
+// CHECK:           onnx.Return [[RESULT_]] : tensor<10x20x30xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_softmax_v11_dynamic_shape_unchanged(%arg0 : tensor<12x4x56x?xf32>) -> tensor<12x4x56x?xf32> {
+  %0 = "onnx.SoftmaxV11"(%arg0) {axis = -2 : si64} : (tensor<12x4x56x?xf32>) -> tensor<12x4x56x?xf32>
+  onnx.Return %0 : tensor<12x4x56x?xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_v11_dynamic_shape_unchanged
+// CHECK: "onnx.SoftmaxV11"
+// CHECK-NOT: "onnx.Reshape"
+// CHECK-NOT: "onnx.Softmax"
+}
+
+// -----
+
 func.func @test_softmax_v11_non_last_axis(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
   %0 = "onnx.SoftmaxV11"(%arg0) {axis = 1 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
   onnx.Return %0 : tensor<10x20x30xf32>

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -1536,6 +1536,40 @@ func.func @test_softmax_v11_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
 
 // -----
 
+func.func @test_softmax_v11_non_last_axis(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+  %0 = "onnx.SoftmaxV11"(%arg0) {axis = 1 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
+  onnx.Return %0 : tensor<10x20x30xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_v11_non_last_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+// CHECK-DAG:       [[SHAPE_ORIG_:%.+]] = onnx.Constant dense<[10, 20, 30]> : tensor<3xi64>
+// CHECK-DAG:       [[SHAPE_FLAT_:%.+]] = onnx.Constant dense<[10, 600]> : tensor<2xi64>
+// CHECK:           [[FLAT_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[SHAPE_FLAT_]]) {{.*}} : (tensor<10x20x30xf32>, tensor<2xi64>) -> tensor<10x600xf32>
+// CHECK:           [[SOFTMAX_:%.+]] = "onnx.Softmax"([[FLAT_]]) {axis = 1 : si64} : (tensor<10x600xf32>) -> tensor<10x600xf32>
+// CHECK:           [[RESULT_:%.+]] = "onnx.Reshape"([[SOFTMAX_]], [[SHAPE_ORIG_]]) {{.*}} : (tensor<10x600xf32>, tensor<3xi64>) -> tensor<10x20x30xf32>
+// CHECK:           onnx.Return [[RESULT_]] : tensor<10x20x30xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_softmax_v11_axis_zero(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+  %0 = "onnx.SoftmaxV11"(%arg0) {axis = 0 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
+  onnx.Return %0 : tensor<10x20x30xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_v11_axis_zero
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+// CHECK-DAG:       [[SHAPE_ORIG_:%.+]] = onnx.Constant dense<[10, 20, 30]> : tensor<3xi64>
+// CHECK-DAG:       [[SHAPE_FLAT_:%.+]] = onnx.Constant dense<6000> : tensor<1xi64>
+// CHECK:           [[FLAT_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[SHAPE_FLAT_]]) {{.*}} : (tensor<10x20x30xf32>, tensor<1xi64>) -> tensor<6000xf32>
+// CHECK:           [[SOFTMAX_:%.+]] = "onnx.Softmax"([[FLAT_]]) {axis = 0 : si64} : (tensor<6000xf32>) -> tensor<6000xf32>
+// CHECK:           [[RESULT_:%.+]] = "onnx.Reshape"([[SOFTMAX_]], [[SHAPE_ORIG_]]) {{.*}} : (tensor<6000xf32>, tensor<3xi64>) -> tensor<10x20x30xf32>
+// CHECK:           onnx.Return [[RESULT_]] : tensor<10x20x30xf32>
+// CHECK:         }
+}
+
+// -----
+
 func.func @test_softmax_negative_axis(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
   %0 = "onnx.Softmax"(%arg0) {axis = -1 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
   onnx.Return %0 : tensor<10x20x30xf32>

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -1549,6 +1549,19 @@ func.func @test_softmax_v11_axis_minus_one_ranked(%arg0 : tensor<10x20x30xf32>) 
 
 // -----
 
+func.func @test_softmax_v11_axis_minus_one_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
+  %0 = "onnx.SoftmaxV11"(%arg0) {axis = -1 : si64} : (tensor<*xf32>) -> tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_v11_axis_minus_one_unranked
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>) -> tensor<*xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Softmax"([[PARAM_0_]]) {axis = -1 : si64} : (tensor<*xf32>) -> tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<*xf32>
+// CHECK:         }
+}
+
+// -----
+
 func.func @test_softmax_v11_negative_axis(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
   %0 = "onnx.SoftmaxV11"(%arg0) {axis = -2 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
   onnx.Return %0 : tensor<10x20x30xf32>


### PR DESCRIPTION
This PR improves the pre-existing canonicalization pattern which rewrites SoftmaxV11 to Softmax. They have different semantics and the old pattern only converted in case the dimension was last/innermost. 
The new pattern reshapes the input tensor before and after such that the new version emulates the old one.

Example:
`onnx.SoftmaxV11(%x : tensor<1x2x3x4x5xf32>) { axis = 2} `
becomes
```
onnx.Reshape(...) : tensor<1x2x3x4x5xf32> -> tensor<1x2x60xf32>
onnx.Softmax(...) { axis = 2 } : tensor<1x2x60xf32> -> tensor<1x2x60xf32>
onnx.Reshape(...) : tensor<1x2x60xf32> -> tensor<1x2x3x4x5xf32>
```

See [link](https://onnx.ai/onnx/operators/onnx__Softmax.html#softmax-11) for the docs of SoftmaxV11