### PR TITLE
Add canonicalization for abs

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -6,6 +6,7 @@
 
 def ONNXAbsOp:ONNX_Op<"Abs",
   [Pure, OpVersionTrait<13>, SameOperandsAndResultShape, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Abs operation";
   let description = [{
   Absolute takes one input data (Tensor<T>) and produces one output data

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -20,6 +20,7 @@
 #include <math.h>
 #include <numeric>
 
+#include "mlir/Dialect/Quant/IR/QuantTypes.h"
 #include "mlir/Dialect/Traits.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
@@ -2966,11 +2967,35 @@ public:
   }
 };
 
+// onnx.Abs(onnx.Abs(x)) -> onnx.Abs(x) by reusing the inner Abs result.
+class AbsAbsPattern : public OpRewritePattern<ONNXAbsOp> {
+public:
+  using OpRewritePattern<ONNXAbsOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXAbsOp op, PatternRewriter &rewriter) const override {
+    Value x = op.getX();
+    if (mlir::isa<quant::QuantizedType>(getElementTypeOrSelf(x)))
+      return failure();
+    auto innerAbs = x.getDefiningOp<ONNXAbsOp>();
+    if (!innerAbs)
+      return failure();
+    rewriter.replaceOp(op, innerAbs.getResult());
+    return success();
+  }
+};
+
 // =============================================================================
 /// Register optimization patterns as "canonicalization" patterns.
 /// Add op to OpsWithCanonicalizer in gen_onnx_mlir.py to activate.
 /// Please keep in alphabetical order.
 // =============================================================================
+
+/// on the ONNXAbsOp.
+void ONNXAbsOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<AbsAbsPattern>(context);
+}
 
 /// on the ONNXBatchNormalizationInferenceModeOp.
 void ONNXBatchNormalizationInferenceModeOp::getCanonicalizationPatterns(

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -59,6 +59,17 @@ func.func @test_dropout(%arg: tensor<10x10xf32>) -> (tensor<10x10xf32>, none) {
 
 // -----
 
+// CHECK-LABEL: @abs_abs(%arg0: tensor<3xf32>) -> tensor<3xf32>
+func.func @abs_abs(%arg0: tensor<3xf32>) -> tensor<3xf32> {
+  %0 = "onnx.Abs"(%arg0) : (tensor<3xf32>) -> tensor<3xf32>
+  %1 = "onnx.Abs"(%0) : (tensor<3xf32>) -> tensor<3xf32>
+  onnx.Return %1 : tensor<3xf32>
+  // CHECK-NEXT: [[R:%.+]] = "onnx.Abs"(%arg0) : (tensor<3xf32>) -> tensor<3xf32>
+  // CHECK-NEXT: onnx.Return [[R]] : tensor<3xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @cast_elimination(%{{.*}}: tensor<2xf32>) -> tensor<2xf32> {
 func.func @cast_elimination(%arg0: tensor<2xf32>) -> tensor<2xf32> {
   %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<2xf32>) -> tensor<2xf32>

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -512,6 +512,7 @@ OpsWithCustomAssemblyFormat = [
 
 # Operations supporting canonicalization (alphabetical order).
 OpsWithCanonicalizer = [
+    "Abs",
     "Add",
     "And",
     "AveragePool",


### PR DESCRIPTION
Simple canonicalization pattern which replaces abs(abs(x)) with abs(x).