### PR TITLE
[AIESW-30368] Fix condition to check single op replacement

### DIFF
--- a/.github/workflows/ubuntu-build-intree.yml
+++ b/.github/workflows/ubuntu-build-intree.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build-intree:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
+++ b/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
@@ -78,10 +78,7 @@ void ResultNamesUpdater::notifyOperationReplaced(
 
   // If the op is replaced by a single op, use the simpler method
   if (Operation *replSingleOp = replacement.front().getDefiningOp();
-      replSingleOp &&
-      llvm::all_of(replacement, [replSingleOp](Value value) -> bool {
-        return value.getDefiningOp() == replSingleOp;
-      }))
+      replSingleOp && replSingleOp->getResults() == replacement)
     return notifyOperationReplaced(op, replSingleOp);
 
   // First, copy the ResultNames attribute for the last value

--- a/test/mlir/onnx/onnx_quanttypes.mlir
+++ b/test/mlir/onnx/onnx_quanttypes.mlir
@@ -287,3 +287,30 @@ func.func @rmslayernorm_quant_types(%arg0: tensor<1x128x2880xi16>) -> tensor<1x1
 // CHECK: "onnx.RMSLayerNormalization"
 // CHECK-SAME: (tensor<1x128x2880x!quant.uniform<i16:f32, 9.5933937700465322E-4:8361>>, tensor<2880xf32>, none)
 // CHECK-SAME: -> (tensor<1x128x2880x!quant.uniform<i16:f32, 9.5933937700465322E-4:8361>>, none)
+
+// Test that removing Q after multi-result op doesn't cause issues
+func.func @layernorm_quant_types_resultnames(%arg0: tensor<1x128x768xui16>) -> tensor<1x128x768xui16> {
+  %0 = onnx.Constant dense<5.12130391E-5> : tensor<f32>
+  %1 = onnx.Constant dense<38292> : tensor<ui16>
+  %2 = onnx.Constant dense_resource<__elided__> : tensor<768xui8>
+  %3 = onnx.Constant dense<0.00385600515> : tensor<f32>
+  %4 = onnx.Constant dense<0> : tensor<ui8>
+  %5 = onnx.Constant dense_resource<__elided__> : tensor<768xi32>
+  %6 = onnx.Constant dense<1.97477746E-7> : tensor<f32>
+  %7 = onnx.Constant dense<0> : tensor<i32>
+  %8 = onnx.Constant dense<47366> : tensor<ui16>
+  %9 = onnx.Constant dense<2.34206527E-4> : tensor<f32>
+
+  %10 = "onnx.DequantizeLinear"(%arg0, %0, %1) {ResultNames = ["dq_data"], axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
+  %11 = "onnx.DequantizeLinear"(%2, %3, %4) {ResultNames = ["dq_scale"], axis = 1 : si64, block_size = 0 : si64} : (tensor<768xui8>, tensor<f32>, tensor<ui8>) -> tensor<768xf32>
+  %12 = "onnx.DequantizeLinear"(%5, %6, %7) {ResultNames = ["dq_bias"], axis = 1 : si64, block_size = 0 : si64} : (tensor<768xi32>, tensor<f32>, tensor<i32>) -> tensor<768xf32>
+  %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%10, %11, %12) {ResultNames = ["ln0", "ln1", "ln2"], axis = -1 : si64, epsilon = 9.99999996E-13 : f32, stash_type = 1 : si64} : (tensor<1x128x768xf32>, tensor<768xf32>, tensor<768xf32>) -> (tensor<1x128x768xf32>, none, none)
+  %13 = "onnx.QuantizeLinear"(%Y, %9, %8) {ResultNames = ["q_ln_out"], axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
+  return %13 : tensor<1x128x768xui16>
+}
+
+// CHECK-LABEL: @layernorm_quant_types_resultnames
+// CHECK: onnx.LayerNormalization
+// CHECK-SAME: ResultNames = ["q_ln_out", "ln1", "ln2"]
+// CHECK-SAME: (tensor<1x128x768x!quant.uniform<u16:f32, 5.1213039114372805E-5:38292>>, tensor<768x!quant.uniform<u8:f32, 0.0038560051470994949>>, tensor<768x!quant.uniform<i32:f32, 1.9747774615552771E-7>>)
+// CHECK-SAME: -> (tensor<1x128x768x!quant.uniform<u16:f32, 2.3420652723871171E-4:47366>>, none, none)


### PR DESCRIPTION
When op -> replOp replacement occurs, we were only checking if all the replacement values come from a single op. This can fail in following cases:
1. replOp has more outputs than the original op it is replacing.
2. all outputs of replOp are present, but in different order.

Simple solution is to check if the op's results are the same as replacement values, which handles both of these cases.