### PR TITLE
Add ExtendedDQ/ExtendedQ ops for per-layer quantization

### DIFF
--- a/docs/Dialects/onnx.md
+++ b/docs/Dialects/onnx.md
@@ -42,6 +42,84 @@ Effects: `MemoryEffects::Effect{}`
 | :----: | ----------- |
 | `Y` | tensor of 32-bit float values or tensor of bfloat16 type values
 
+### `onnx.AMDQuarkExtendedQuantizeLinearOp` (AMDQuarkExtendedQuantizeLinearOp)
+
+_ExtendedQuantizeLinear_
+
+Extended quantization operator from AMD's Quark quantizer. Consumes a high-precision tensor, a scale, and a zero point to compute the low-precision/quantized tensor. The quantization formula is `y = saturate((x / scale) + zero_point)`.
+
+This operator extends the official ONNX QuantizeLinear operator by adding early support for uint16 and int16 quantization, along with additional support for bfloat16, float16, int32 and uint32. It enables floating-point quantization to deploy models on edge devices and wide-bit quantization to facilitate detailed analysis of accuracy bottlenecks.
+
+The scale factor and zero point must have the same shape, determining the quantization granularity: a scalar for per-tensor/per-layer quantization, or a 1-D tensor for per-axis/per-channel quantization. Saturation is applied according to the target data type's representable range.
+
+This is part of the `com.amd.quark` ONNX custom domain. See https://quark.docs.amd.com/latest/onnx/custom_operators/ExtendedQuantizeLinear.html.
+
+Traits: `AlwaysSpeculatableImplTrait`, `OpVersionTrait<1>`
+
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
+
+Effects: `MemoryEffects::Effect{}`
+
+#### Attributes:
+
+<table>
+<tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
+<tr><td><code>axis</code></td><td>::mlir::IntegerAttr</td><td>64-bit signed integer attribute</td></tr>
+</table>
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+| `x` | tensor of 32-bit float values or tensor of 16-bit float values or tensor of bfloat16 type values
+| `y_scale` | tensor of 32-bit float values or tensor of 16-bit float values or tensor of bfloat16 type values
+| `y_zero_point` | tensor of 8-bit signless integer values or tensor of 8-bit unsigned integer values or tensor of 16-bit signless integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit signless integer values or tensor of 32-bit unsigned integer values or tensor of 16-bit float values or tensor of bfloat16 type values or none type
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+| `y` | tensor of 8-bit signless integer values or tensor of 8-bit unsigned integer values or tensor of 16-bit signless integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit signless integer values or tensor of 32-bit unsigned integer values or tensor of 16-bit float values or tensor of bfloat16 type values
+
+### `onnx.AMDQuarkExtendedDequantizeLinearOp` (AMDQuarkExtendedDequantizeLinearOp)
+
+_ExtendedDequantizeLinear_
+
+Extended dequantization operator from AMD's Quark quantizer. Consumes a quantized tensor, a scale, and a zero point to compute the full-precision tensor. The dequantization formula is `y = (x - zero_point) * scale`.
+
+This operator extends the official ONNX DequantizeLinear operator by adding early support for uint16 and int16 quantization, along with additional support for bfloat16, float16, and uint32. It enables floating-point quantization to deploy models on edge devices and wide-bit quantization to facilitate detailed analysis of accuracy bottlenecks.
+
+`x_scale` and `x_zero_point` must have the same shape, determining the quantization granularity: a scalar for per-tensor/per-layer dequantization, or a 1-D tensor for per-axis/per-channel dequantization. `x_zero_point` and `x` must have the same type. The output type is the same as `x_scale`.
+
+This is part of the `com.amd.quark` ONNX custom domain. See https://quark.docs.amd.com/latest/onnx/custom_operators/ExtendedDequantizeLinear.html.
+
+Traits: `AlwaysSpeculatableImplTrait`, `OpVersionTrait<1>`
+
+Interfaces: `ConditionallySpeculatable`, `NoMemoryEffect (MemoryEffectOpInterface)`, `ShapeHelperOpInterface`, `ShapeInferenceOpInterface`
+
+Effects: `MemoryEffects::Effect{}`
+
+#### Attributes:
+
+<table>
+<tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
+<tr><td><code>axis</code></td><td>::mlir::IntegerAttr</td><td>64-bit signed integer attribute</td></tr>
+</table>
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+| `x` | tensor of 8-bit signless integer values or tensor of 8-bit unsigned integer values or tensor of 16-bit signless integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit signless integer values or tensor of 32-bit unsigned integer values or tensor of 16-bit float values or tensor of bfloat16 type values
+| `x_scale` | tensor of 32-bit float values or tensor of 16-bit float values or tensor of bfloat16 type values
+| `x_zero_point` | tensor of 8-bit signless integer values or tensor of 8-bit unsigned integer values or tensor of 16-bit signless integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit signless integer values or tensor of 32-bit unsigned integer values or tensor of 16-bit float values or tensor of bfloat16 type values or none type
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+| `y` | tensor of 32-bit float values or tensor of 16-bit float values or tensor of bfloat16 type values
+
 ### `onnx.Abs` (ONNXAbsOp)
 
 _ONNX Abs operation_

--- a/src/Builder/OpBuildTable.inc
+++ b/src/Builder/OpBuildTable.inc
@@ -795,12 +795,10 @@ import_handler_map_["com.amd.xfe"]["SpaceToDepth"] =
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFESpaceToDepthOp>;
 import_handler_map_["com.amd.quark"]["BFPQuantizeDequantize"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::AMDQuarkBFPQuantizeDequantizeOp>;
-import_handler_map_["com.amd.quark"]["ExtendedQuantizeLinear"] =
-    &onnx_mlir::detail::FrontendGenImpl::buildOperation<
-        mlir::AMDQuarkExtendedQuantizeLinearOp>;
-import_handler_map_["com.amd.quark"]["ExtendedDequantizeLinear"] =
-    &onnx_mlir::detail::FrontendGenImpl::buildOperation<
-        mlir::AMDQuarkExtendedDequantizeLinearOp>;
+import_handler_map_["com.amd.quark"]["ExtendedQuantizeLinear"] = 
+   &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::AMDQuarkExtendedQuantizeLinearOp>;
+import_handler_map_["com.amd.quark"]["ExtendedDequantizeLinear"] = 
+   &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::AMDQuarkExtendedDequantizeLinearOp>;
 import_handler_map_["com.amd.xcompiler"]["FusedEltwise"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XCOMPILERFusedEltwiseOp>;
 import_handler_map_["com.amd.xcompiler"]["DepthwiseConv"] = 

--- a/src/Builder/OpBuildTable.inc
+++ b/src/Builder/OpBuildTable.inc
@@ -239,6 +239,8 @@ dialect_op_version_map_["com.amd.xfe"]["SpaceToDepth"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["GroupNormalization"] = {1};
 dialect_op_version_map_["com.amd.xfe"]["Resize"] = {1};
 dialect_op_version_map_["com.amd.quark"]["BFPQuantizeDequantize"] = {1};
+dialect_op_version_map_["com.amd.quark"]["ExtendedQuantizeLinear"] = {1};
+dialect_op_version_map_["com.amd.quark"]["ExtendedDequantizeLinear"] = {1};
 dialect_op_version_map_["com.amd.xcompiler"]["FusedEltwise"] = {1};
 dialect_op_version_map_["com.amd.xcompiler"]["DepthwiseConv"] = {1};
 dialect_op_version_map_["com.amd.xcompiler"]["Requantize"] = {1};
@@ -793,6 +795,12 @@ import_handler_map_["com.amd.xfe"]["SpaceToDepth"] =
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XFESpaceToDepthOp>;
 import_handler_map_["com.amd.quark"]["BFPQuantizeDequantize"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::AMDQuarkBFPQuantizeDequantizeOp>;
+import_handler_map_["com.amd.quark"]["ExtendedQuantizeLinear"] =
+    &onnx_mlir::detail::FrontendGenImpl::buildOperation<
+        mlir::AMDQuarkExtendedQuantizeLinearOp>;
+import_handler_map_["com.amd.quark"]["ExtendedDequantizeLinear"] =
+    &onnx_mlir::detail::FrontendGenImpl::buildOperation<
+        mlir::AMDQuarkExtendedDequantizeLinearOp>;
 import_handler_map_["com.amd.xcompiler"]["FusedEltwise"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::XCOMPILERFusedEltwiseOp>;
 import_handler_map_["com.amd.xcompiler"]["DepthwiseConv"] = 
@@ -1063,6 +1071,8 @@ dialect_op_opsets_map_["com.amd.xfe"]["MaxPool"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["Resize"] = {1};
 dialect_op_opsets_map_["com.amd.xfe"]["SpaceToDepth"] = {1};
 dialect_op_opsets_map_["com.amd.quark"]["BFPQuantizeDequantize"] = {1};
+dialect_op_opsets_map_["com.amd.quark"]["ExtendedQuantizeLinear"] = {1};
+dialect_op_opsets_map_["com.amd.quark"]["ExtendedDequantizeLinear"] = {1};
 dialect_op_opsets_map_["com.amd.xcompiler"]["FusedEltwise"] = {1};
 dialect_op_opsets_map_["com.amd.xcompiler"]["DepthwiseConv"] = {1};
 dialect_op_opsets_map_["com.amd.xcompiler"]["Requantize"] = {1};

--- a/src/Dialect/ONNX/AMDQuarkOps.td
+++ b/src/Dialect/ONNX/AMDQuarkOps.td
@@ -2,7 +2,7 @@
 
 //===-- AMDQuarkOps.td -- AMD Quark Ops  -*- tablegen -===//
 //
-// Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+// Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 // =============================================================================
 //
@@ -65,3 +65,100 @@ def AMDQuarkBFPQuantizeDequantizeOp: ONNX_Op<"AMDQuarkBFPQuantizeDequantizeOp",
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// AMDQuarkExtendedQuantizeLinearOp
+def AMDQuarkExtendedQuantizeLinearOp
+    : ONNX_Op<"AMDQuarkExtendedQuantizeLinearOp",
+          [Pure, OpVersionTrait<1>,
+              DeclareOpInterfaceMethods<ShapeInferenceOpInterface>,
+              DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let summary = "ExtendedQuantizeLinear";
+  let description = [{
+    Extended quantization operator from AMD's Quark quantizer. Consumes a
+    high-precision tensor, a scale, and a zero point to compute the
+    low-precision/quantized tensor. The quantization formula is
+    `y = saturate((x / scale) + zero_point)`.
+
+    This is part of the `com.amd.quark` ONNX custom domain.
+  }];
+
+  let arguments = (ins AnyTypeOf<[TensorOf<[F32]>, TensorOf<[F16]>,
+                       TensorOf<[BF16]>]>:$x,
+      AnyTypeOf<[TensorOf<[F32]>, TensorOf<[F16]>, TensorOf<[BF16]>]>:$y_scale,
+      AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[I16]>,
+          TensorOf<[UI16]>, TensorOf<[F8E4M3FN]>, TensorOf<[F8E4M3FNUZ]>,
+          TensorOf<[F8E5M2]>, TensorOf<[F8E5M2FNUZ]>, TensorOf<[F16]>,
+          TensorOf<[BF16]>, NoneType]>:$y_zero_point);
+  let results = (outs AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>,
+      TensorOf<[I16]>, TensorOf<[UI16]>, TensorOf<[F8E4M3FN]>,
+      TensorOf<[F8E4M3FNUZ]>, TensorOf<[F8E5M2]>, TensorOf<[F8E5M2FNUZ]>,
+      TensorOf<[F32]>, TensorOf<[F16]>, TensorOf<[BF16]>]>:$y);
+
+  let extraClassDeclaration = [{
+    static int getNumberOfOperands() { return 3; }
+    static int getNumberOfResults() { return 1; }
+    static std::vector<int> getTypeMap() { return {32}; }
+    static int getAxis() { return 1; } // stub
+    static void setAxis(int /*axis*/) { return; } // stub
+  }];
+
+  let extraClassDefinition = [{
+    onnx_mlir::ONNXOpShapeHelper * AMDQuarkExtendedQuantizeLinearOp::getShapeHelper(
+        mlir::Operation *op, mlir::ArrayRef<mlir::Value> oper,
+        onnx_mlir::IndexExprBuilder *ieb, onnx_mlir::IndexExprScope *scope) {
+      onnx_mlir::ONNXOpShapeHelper *sh =
+          new onnx_mlir::AMDQuarkExtendedQuantizeLinearOpShapeHelper(op, oper, ieb, scope);
+      assert(sh && "failed to allocate shape helper");
+      return sh;
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// AMDQuarkExtendedDequantizeLinearOp
+def AMDQuarkExtendedDequantizeLinearOp
+    : ONNX_Op<"AMDQuarkExtendedDequantizeLinearOp",
+          [Pure, OpVersionTrait<1>,
+              DeclareOpInterfaceMethods<ShapeInferenceOpInterface>,
+              DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let summary = "ExtendedDequantizeLinear";
+  let description = [{
+    Extended dequantization operator from AMD's Quark quantizer. Consumes a
+    quantized tensor, a scale, and a zero point to compute the full-precision
+    tensor. The dequantization formula is `y = (x - zero_point) * scale`.
+
+    This is part of the `com.amd.quark` ONNX custom domain.
+  }];
+
+  let arguments = (ins AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>,
+                       TensorOf<[I16]>, TensorOf<[UI16]>, TensorOf<[F8E4M3FN]>,
+                       TensorOf<[F8E4M3FNUZ]>, TensorOf<[F8E5M2]>,
+                       TensorOf<[F8E5M2FNUZ]>, TensorOf<[F32]>, TensorOf<[F16]>,
+                       TensorOf<[BF16]>]>:$x,
+      AnyTypeOf<[TensorOf<[F32]>, TensorOf<[F16]>, TensorOf<[BF16]>]>:$x_scale,
+      AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[I16]>,
+          TensorOf<[UI16]>, TensorOf<[F8E4M3FN]>, TensorOf<[F8E4M3FNUZ]>,
+          TensorOf<[F8E5M2]>, TensorOf<[F8E5M2FNUZ]>, TensorOf<[F16]>,
+          TensorOf<[BF16]>, NoneType]>:$x_zero_point);
+  let results =
+      (outs AnyTypeOf<[TensorOf<[F32]>, TensorOf<[F16]>, TensorOf<[BF16]>]>:$y);
+
+  let extraClassDeclaration = [{
+    static int getNumberOfOperands() { return 3; }
+    static int getNumberOfResults() { return 1; }
+    static std::vector<int> getTypeMap() { return {31}; }
+    static int getAxis() { return 1; } // stub
+    static void setAxis(int /*axis*/) { return; } // stub
+  }];
+
+  let extraClassDefinition = [{
+    onnx_mlir::ONNXOpShapeHelper * AMDQuarkExtendedDequantizeLinearOp::getShapeHelper(
+        mlir::Operation *op, mlir::ArrayRef<mlir::Value> oper,
+        onnx_mlir::IndexExprBuilder *ieb, onnx_mlir::IndexExprScope *scope) {
+      onnx_mlir::ONNXOpShapeHelper *sh =
+          new onnx_mlir::AMDQuarkExtendedDequantizeLinearOpShapeHelper(op, oper, ieb, scope);
+      assert(sh && "failed to allocate shape helper");
+      return sh;
+    }
+  }];
+}

--- a/src/Dialect/ONNX/AMDQuarkOps.td
+++ b/src/Dialect/ONNX/AMDQuarkOps.td
@@ -80,26 +80,29 @@ def AMDQuarkExtendedQuantizeLinearOp
     `y = saturate((x / scale) + zero_point)`.
 
     This is part of the `com.amd.quark` ONNX custom domain.
+
+    Support for F16 and BF16 is an AMD extension in ONNX-MLIR to
+    https://quark.docs.amd.com/latest/onnx/custom_operators/ExtendedQuantizeLinear.html.
   }];
 
   let arguments = (ins AnyTypeOf<[TensorOf<[F32]>, TensorOf<[F16]>,
                        TensorOf<[BF16]>]>:$x,
       AnyTypeOf<[TensorOf<[F32]>, TensorOf<[F16]>, TensorOf<[BF16]>]>:$y_scale,
-      AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[I16]>,
-          TensorOf<[UI16]>, TensorOf<[F8E4M3FN]>, TensorOf<[F8E4M3FNUZ]>,
-          TensorOf<[F8E5M2]>, TensorOf<[F8E5M2FNUZ]>, TensorOf<[F16]>,
-          TensorOf<[BF16]>, NoneType]>:$y_zero_point);
-  let results = (outs AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>,
-      TensorOf<[I16]>, TensorOf<[UI16]>, TensorOf<[F8E4M3FN]>,
-      TensorOf<[F8E4M3FNUZ]>, TensorOf<[F8E5M2]>, TensorOf<[F8E5M2FNUZ]>,
-      TensorOf<[F32]>, TensorOf<[F16]>, TensorOf<[BF16]>]>:$y);
+      AnyTypeOf<[TensorOf<[I32]>, TensorOf<[I16]>, TensorOf<[I8]>,
+          TensorOf<[UI32]>, TensorOf<[UI16]>, TensorOf<[UI8]>, TensorOf<[F16]>,
+          TensorOf<[BF16]>, NoneType]>:$y_zero_point,
+      DefaultValuedAttr<SI64Attr, "1">:$axis);
+  let results = (outs AnyTypeOf<[TensorOf<[I32]>, TensorOf<[I16]>,
+      TensorOf<[I8]>, TensorOf<[UI32]>, TensorOf<[UI16]>, TensorOf<[UI8]>,
+      TensorOf<[F16]>, TensorOf<[BF16]>]>:$y);
+
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     static int getNumberOfOperands() { return 3; }
     static int getNumberOfResults() { return 1; }
     static std::vector<int> getTypeMap() { return {32}; }
-    static int getAxis() { return 1; } // stub
-    static void setAxis(int /*axis*/) { return; } // stub
+    [[nodiscard]] std::optional<int64_t> getNormalizedAxis();
   }];
 
   let extraClassDefinition = [{
@@ -128,27 +131,29 @@ def AMDQuarkExtendedDequantizeLinearOp
     tensor. The dequantization formula is `y = (x - zero_point) * scale`.
 
     This is part of the `com.amd.quark` ONNX custom domain.
+
+    Support for F16 and BF16 is an AMD extension in ONNX-MLIR to
+    https://quark.docs.amd.com/latest/onnx/custom_operators/ExtendedDequantizeLinear.html.
   }];
 
-  let arguments = (ins AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>,
-                       TensorOf<[I16]>, TensorOf<[UI16]>, TensorOf<[F8E4M3FN]>,
-                       TensorOf<[F8E4M3FNUZ]>, TensorOf<[F8E5M2]>,
-                       TensorOf<[F8E5M2FNUZ]>, TensorOf<[F32]>, TensorOf<[F16]>,
-                       TensorOf<[BF16]>]>:$x,
+  let arguments = (ins AnyTypeOf<[TensorOf<[I32]>, TensorOf<[I16]>,
+                       TensorOf<[I8]>, TensorOf<[UI32]>, TensorOf<[UI16]>,
+                       TensorOf<[UI8]>, TensorOf<[F16]>, TensorOf<[BF16]>]>:$x,
       AnyTypeOf<[TensorOf<[F32]>, TensorOf<[F16]>, TensorOf<[BF16]>]>:$x_scale,
-      AnyTypeOf<[TensorOf<[I8]>, TensorOf<[UI8]>, TensorOf<[I16]>,
-          TensorOf<[UI16]>, TensorOf<[F8E4M3FN]>, TensorOf<[F8E4M3FNUZ]>,
-          TensorOf<[F8E5M2]>, TensorOf<[F8E5M2FNUZ]>, TensorOf<[F16]>,
-          TensorOf<[BF16]>, NoneType]>:$x_zero_point);
+      AnyTypeOf<[TensorOf<[I32]>, TensorOf<[I16]>, TensorOf<[I8]>,
+          TensorOf<[UI32]>, TensorOf<[UI16]>, TensorOf<[UI8]>, TensorOf<[F16]>,
+          TensorOf<[BF16]>, NoneType]>:$x_zero_point,
+      DefaultValuedAttr<SI64Attr, "1">:$axis);
   let results =
       (outs AnyTypeOf<[TensorOf<[F32]>, TensorOf<[F16]>, TensorOf<[BF16]>]>:$y);
+
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     static int getNumberOfOperands() { return 3; }
     static int getNumberOfResults() { return 1; }
     static std::vector<int> getTypeMap() { return {31}; }
-    static int getAxis() { return 1; } // stub
-    static void setAxis(int /*axis*/) { return; } // stub
+    [[nodiscard]] std::optional<int64_t> getNormalizedAxis();
   }];
 
   let extraClassDefinition = [{

--- a/src/Dialect/ONNX/ONNXOps/Additional/AMDQuark.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/AMDQuark.cpp
@@ -14,6 +14,17 @@
 using namespace mlir;
 using namespace onnx_mlir;
 
+template <typename AMDQuarkOpTy>
+std::optional<int64_t> getNormalizedAxis(AMDQuarkOpTy *op) {
+  const int64_t axis = op->getAxis();
+  if (axis >= 0)
+    return axis;
+  const auto rankedType = dyn_cast<RankedTensorType>(op->getX().getType());
+  if (!rankedType)
+    return std::nullopt;
+  return axis + rankedType.getRank();
+}
+
 LogicalResult AMDQuarkBFPQuantizeDequantizeOp::verify() {
   // Verify that the quantization mode is valid.
   const auto method = getBfpMethod();
@@ -91,13 +102,7 @@ bool AMDQuarkBFPQuantizeDequantizeOp::isMX9(bool ignoreAxis) {
 }
 
 std::optional<int64_t> AMDQuarkBFPQuantizeDequantizeOp::getNormalizedAxis() {
-  const int64_t axis = getAxis();
-  if (axis >= 0)
-    return axis;
-  const auto rankedType = dyn_cast<RankedTensorType>(getX().getType());
-  if (!rankedType)
-    return std::nullopt;
-  return axis + rankedType.getRank();
+  return ::getNormalizedAxis<AMDQuarkBFPQuantizeDequantizeOp>(this);
 }
 
 LogicalResult AMDQuarkBFPQuantizeDequantizeOp::inferShapes(
@@ -105,66 +110,84 @@ LogicalResult AMDQuarkBFPQuantizeDequantizeOp::inferShapes(
   return inferShapeForUnaryOps(this->getOperation());
 }
 
+// Common methods for
+// - AMDQuarkExtendedQuantizeLinearOp
+// - AMDQuarkExtendedDequantizeLinearOp
+
+template <typename AMDExtendedQDQOpTy>
+LogicalResult inferShapes(AMDExtendedQDQOpTy *op,
+    std::function<void(Region &)> /*doShapeInference*/) {
+  if (!mlir::dyn_cast<RankedTensorType>(op->getX().getType()))
+    return success();
+  Type elementType =
+      mlir::cast<ShapedType>(op->getY().getType()).getElementType();
+  ONNXUnaryOpShapeHelper shapeHelper(op->getOperation(), {});
+  return shapeHelper.computeShapeAndUpdateType(elementType);
+}
+
+template <typename AMDExtendedQDQOpTy>
+LogicalResult verify(AMDExtendedQDQOpTy *op) {
+  if (auto rankedType = dyn_cast<RankedTensorType>(op->getX().getType())) {
+    const int64_t rank = rankedType.getRank();
+    const int64_t axis = op->getAxis();
+    if ((rank != 1) && (axis < -rank || axis >= rank))
+      return op->emitOpError("axis attribute value ")
+             << axis << " is out of range [-" << rank << ", " << rank << ")";
+  }
+  return success();
+}
+
 // ===----------- AMDQuarkExtendedQuantizeLinearOp ----------===//
 
 LogicalResult AMDQuarkExtendedQuantizeLinearOp::verify() {
-  if (auto rankedType = dyn_cast<RankedTensorType>(getX().getType())) {
-    const int64_t rank = rankedType.getRank();
-    const int64_t axis = getAxis();
-    if ((rank != 1) && (axis < -rank || axis >= rank))
-      return emitOpError("axis attribute value ")
-             << axis << " is out of range [-" << rank << ", " << rank << ")";
+  if (failed(::verify<AMDQuarkExtendedQuantizeLinearOp>(this)))
+    return failure();
+  // Verify that zero_point element type matches the output element type.
+  auto zpType = dyn_cast<ShapedType>(getYZeroPoint().getType());
+  if (zpType) {
+    Type zpElemType = zpType.getElementType();
+    Type resultElemType = cast<ShapedType>(getY().getType()).getElementType();
+    if (zpElemType != resultElemType)
+      return emitOpError("y_zero_point element type ")
+             << zpElemType << " must match result element type "
+             << resultElemType;
   }
   return success();
 }
 
 std::optional<int64_t> AMDQuarkExtendedQuantizeLinearOp::getNormalizedAxis() {
-  const int64_t axis = getAxis();
-  if (axis >= 0)
-    return axis;
-  const auto rankedType = dyn_cast<RankedTensorType>(getX().getType());
-  if (!rankedType)
-    return std::nullopt;
-  return axis + rankedType.getRank();
+  return ::getNormalizedAxis<AMDQuarkExtendedQuantizeLinearOp>(this);
 }
 
 LogicalResult AMDQuarkExtendedQuantizeLinearOp::inferShapes(
     std::function<void(Region &)> /*doShapeInference*/) {
-  if (!mlir::dyn_cast<RankedTensorType>(getX().getType()))
-    return success();
-  Type elementType = mlir::cast<ShapedType>(getY().getType()).getElementType();
-  ONNXUnaryOpShapeHelper shapeHelper(getOperation(), {});
-  return shapeHelper.computeShapeAndUpdateType(elementType);
+  return ::inferShapes<AMDQuarkExtendedQuantizeLinearOp>(this, [](Region &) {});
 }
 
 // ===----------- AMDQuarkExtendedDequantizeLinearOp ----------===//
 
 LogicalResult AMDQuarkExtendedDequantizeLinearOp::verify() {
-  if (auto rankedType = dyn_cast<RankedTensorType>(getX().getType())) {
-    const int64_t rank = rankedType.getRank();
-    const int64_t axis = getAxis();
-    if ((rank != 1) && (axis < -rank || axis >= rank))
-      return emitOpError("axis attribute value ")
-             << axis << " is out of range [-" << rank << ", " << rank << ")";
+  if (failed(::verify<AMDQuarkExtendedDequantizeLinearOp>(this)))
+    return failure();
+  // Verify that zero_point element type matches the input element type.
+  auto zpType = dyn_cast<ShapedType>(getXZeroPoint().getType());
+  if (zpType) {
+    Type zpElemType = zpType.getElementType();
+    Type inputElemType = cast<ShapedType>(getX().getType()).getElementType();
+    if (zpElemType != inputElemType)
+      return emitOpError("x_zero_point element type ")
+             << zpElemType << " must match input element type "
+             << inputElemType;
   }
   return success();
 }
 
 std::optional<int64_t> AMDQuarkExtendedDequantizeLinearOp::getNormalizedAxis() {
-  const int64_t axis = getAxis();
-  if (axis >= 0)
-    return axis;
-  const auto rankedType = dyn_cast<RankedTensorType>(getX().getType());
-  if (!rankedType)
-    return std::nullopt;
-  return axis + rankedType.getRank();
+  return ::getNormalizedAxis<AMDQuarkExtendedDequantizeLinearOp>(this);
 }
 
 LogicalResult AMDQuarkExtendedDequantizeLinearOp::inferShapes(
     std::function<void(Region &)> /*doShapeInference*/) {
-  if (!mlir::dyn_cast<RankedTensorType>(getX().getType()))
-    return success();
-  Type elementType = mlir::cast<ShapedType>(getY().getType()).getElementType();
-  ONNXUnaryOpShapeHelper shapeHelper(getOperation(), {});
-  return shapeHelper.computeShapeAndUpdateType(elementType);
+  return ::inferShapes<AMDQuarkExtendedDequantizeLinearOp>(
+      this, [](Region &) {});
 }

--- a/src/Dialect/ONNX/ONNXOps/Additional/AMDQuark.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/AMDQuark.cpp
@@ -104,7 +104,29 @@ LogicalResult AMDQuarkBFPQuantizeDequantizeOp::inferShapes(
     std::function<void(Region &)> /*doShapeInference*/) {
   return inferShapeForUnaryOps(this->getOperation());
 }
+
 // ===----------- AMDQuarkExtendedQuantizeLinearOp ----------===//
+
+LogicalResult AMDQuarkExtendedQuantizeLinearOp::verify() {
+  if (auto rankedType = dyn_cast<RankedTensorType>(getX().getType())) {
+    const int64_t rank = rankedType.getRank();
+    const int64_t axis = getAxis();
+    if ((rank != 1) && (axis < -rank || axis >= rank))
+      return emitOpError("axis attribute value ")
+             << axis << " is out of range [-" << rank << ", " << rank << ")";
+  }
+  return success();
+}
+
+std::optional<int64_t> AMDQuarkExtendedQuantizeLinearOp::getNormalizedAxis() {
+  const int64_t axis = getAxis();
+  if (axis >= 0)
+    return axis;
+  const auto rankedType = dyn_cast<RankedTensorType>(getX().getType());
+  if (!rankedType)
+    return std::nullopt;
+  return axis + rankedType.getRank();
+}
 
 LogicalResult AMDQuarkExtendedQuantizeLinearOp::inferShapes(
     std::function<void(Region &)> /*doShapeInference*/) {
@@ -116,6 +138,27 @@ LogicalResult AMDQuarkExtendedQuantizeLinearOp::inferShapes(
 }
 
 // ===----------- AMDQuarkExtendedDequantizeLinearOp ----------===//
+
+LogicalResult AMDQuarkExtendedDequantizeLinearOp::verify() {
+  if (auto rankedType = dyn_cast<RankedTensorType>(getX().getType())) {
+    const int64_t rank = rankedType.getRank();
+    const int64_t axis = getAxis();
+    if ((rank != 1) && (axis < -rank || axis >= rank))
+      return emitOpError("axis attribute value ")
+             << axis << " is out of range [-" << rank << ", " << rank << ")";
+  }
+  return success();
+}
+
+std::optional<int64_t> AMDQuarkExtendedDequantizeLinearOp::getNormalizedAxis() {
+  const int64_t axis = getAxis();
+  if (axis >= 0)
+    return axis;
+  const auto rankedType = dyn_cast<RankedTensorType>(getX().getType());
+  if (!rankedType)
+    return std::nullopt;
+  return axis + rankedType.getRank();
+}
 
 LogicalResult AMDQuarkExtendedDequantizeLinearOp::inferShapes(
     std::function<void(Region &)> /*doShapeInference*/) {

--- a/src/Dialect/ONNX/ONNXOps/Additional/AMDQuark.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/AMDQuark.cpp
@@ -4,7 +4,7 @@
 
 //===------------------ AMDQuark.cpp - AMD Quark custom ops ---------------===//
 //
-// Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+// Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
@@ -103,4 +103,25 @@ std::optional<int64_t> AMDQuarkBFPQuantizeDequantizeOp::getNormalizedAxis() {
 LogicalResult AMDQuarkBFPQuantizeDequantizeOp::inferShapes(
     std::function<void(Region &)> /*doShapeInference*/) {
   return inferShapeForUnaryOps(this->getOperation());
+}
+// ===----------- AMDQuarkExtendedQuantizeLinearOp ----------===//
+
+LogicalResult AMDQuarkExtendedQuantizeLinearOp::inferShapes(
+    std::function<void(Region &)> /*doShapeInference*/) {
+  if (!mlir::dyn_cast<RankedTensorType>(getX().getType()))
+    return success();
+  Type elementType = mlir::cast<ShapedType>(getY().getType()).getElementType();
+  ONNXUnaryOpShapeHelper shapeHelper(getOperation(), {});
+  return shapeHelper.computeShapeAndUpdateType(elementType);
+}
+
+// ===----------- AMDQuarkExtendedDequantizeLinearOp ----------===//
+
+LogicalResult AMDQuarkExtendedDequantizeLinearOp::inferShapes(
+    std::function<void(Region &)> /*doShapeInference*/) {
+  if (!mlir::dyn_cast<RankedTensorType>(getX().getType()))
+    return success();
+  Type elementType = mlir::cast<ShapedType>(getY().getType()).getElementType();
+  ONNXUnaryOpShapeHelper shapeHelper(getOperation(), {});
+  return shapeHelper.computeShapeAndUpdateType(elementType);
 }

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
@@ -414,6 +414,8 @@ using ONNXTanhOpShapeHelper = ONNXUnaryOpShapeHelper;
 using ONNXThresholdedReluOpShapeHelper = ONNXUnaryOpShapeHelper;
 using ONNXTriluOpShapeHelper = ONNXUnaryOpShapeHelper;
 using AMDQuarkBFPQuantizeDequantizeOpShapeHelper = ONNXUnaryOpShapeHelper;
+using AMDQuarkExtendedQuantizeLinearOpShapeHelper = ONNXUnaryOpShapeHelper;
+using AMDQuarkExtendedDequantizeLinearOpShapeHelper = ONNXUnaryOpShapeHelper;
 // clang-format on
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
@@ -414,6 +414,8 @@ using ONNXTanhOpShapeHelper = ONNXUnaryOpShapeHelper;
 using ONNXThresholdedReluOpShapeHelper = ONNXUnaryOpShapeHelper;
 using ONNXTriluOpShapeHelper = ONNXUnaryOpShapeHelper;
 using AMDQuarkBFPQuantizeDequantizeOpShapeHelper = ONNXUnaryOpShapeHelper;
+using AMDQuarkExtendedQuantizeLinearOpShapeHelper = ONNXUnaryOpShapeHelper;
+using AMDQuarkExtendedDequantizeLinearOpShapeHelper = ONNXUnaryOpShapeHelper;
 // clang-format on
 
 //===----------------------------------------------------------------------===//
@@ -969,9 +971,6 @@ protected:
   // Shape inference pattern
   int pattern;
 };
-
-using AMDQuarkExtendedQuantizeLinearOpShapeHelper = ONNXCustomOpShapeHelper;
-using AMDQuarkExtendedDequantizeLinearOpShapeHelper = ONNXCustomOpShapeHelper;
 
 //===----------------------------------------------------------------------===//
 // Setting a new constant or attribute value.

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
@@ -414,8 +414,6 @@ using ONNXTanhOpShapeHelper = ONNXUnaryOpShapeHelper;
 using ONNXThresholdedReluOpShapeHelper = ONNXUnaryOpShapeHelper;
 using ONNXTriluOpShapeHelper = ONNXUnaryOpShapeHelper;
 using AMDQuarkBFPQuantizeDequantizeOpShapeHelper = ONNXUnaryOpShapeHelper;
-using AMDQuarkExtendedQuantizeLinearOpShapeHelper = ONNXUnaryOpShapeHelper;
-using AMDQuarkExtendedDequantizeLinearOpShapeHelper = ONNXUnaryOpShapeHelper;
 // clang-format on
 
 //===----------------------------------------------------------------------===//
@@ -971,6 +969,9 @@ protected:
   // Shape inference pattern
   int pattern;
 };
+
+using AMDQuarkExtendedQuantizeLinearOpShapeHelper = ONNXCustomOpShapeHelper;
+using AMDQuarkExtendedDequantizeLinearOpShapeHelper = ONNXCustomOpShapeHelper;
 
 //===----------------------------------------------------------------------===//
 // Setting a new constant or attribute value.

--- a/test/mlir/onnx/onnx_amd_quark_verify.mlir
+++ b/test/mlir/onnx/onnx_amd_quark_verify.mlir
@@ -1,0 +1,82 @@
+// RUN: onnx-mlir-opt %s -split-input-file -verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+/// Verification tests for AMD Quark Extended Quantize/Dequantize Operations
+/// Domain: com.amd.quark
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+/// AMDQuarkExtendedQuantizeLinearOp: zero_point type must match result type
+//===----------------------------------------------------------------------===//
+
+// Test: y_zero_point element type (i16) does not match result element type (i8)
+func.func @test_eq_zp_type_mismatch(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<i16>) -> tensor<5x2x3x4xi8> {
+  // expected-error @+1 {{'onnx.AMDQuarkExtendedQuantizeLinearOp' op y_zero_point element type 'i16' must match result element type 'i8'}}
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<i16>) -> tensor<5x2x3x4xi8>
+  return %0 : tensor<5x2x3x4xi8>
+}
+
+// -----
+
+// Test: y_zero_point element type (f16) does not match result element type (i8)
+func.func @test_eq_zp_float_vs_int(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<f16>) -> tensor<5x2x3x4xi8> {
+  // expected-error @+1 {{'onnx.AMDQuarkExtendedQuantizeLinearOp' op y_zero_point element type 'f16' must match result element type 'i8'}}
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<f16>) -> tensor<5x2x3x4xi8>
+  return %0 : tensor<5x2x3x4xi8>
+}
+
+// -----
+
+// Test: none zero_point is allowed (no type check)
+func.func @test_eq_none_zp_ok(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>) -> tensor<5x2x3x4xi8> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %none) {axis = 1 : si64} : (tensor<5x2x3x4xf32>, tensor<f32>, none) -> tensor<5x2x3x4xi8>
+  return %0 : tensor<5x2x3x4xi8>
+}
+
+// -----
+
+// Test: matching types should pass
+func.func @test_eq_zp_type_match(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<5x2x3x4xi8> {
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xi8>
+  return %0 : tensor<5x2x3x4xi8>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// AMDQuarkExtendedDequantizeLinearOp: zero_point type must match input type
+//===----------------------------------------------------------------------===//
+
+// Test: x_zero_point element type (i16) does not match input element type (i8)
+func.func @test_edq_zp_type_mismatch(%arg0: tensor<5x2x3x4xi8>, %arg1: tensor<f32>, %arg2: tensor<i16>) -> tensor<5x2x3x4xf32> {
+  // expected-error @+1 {{'onnx.AMDQuarkExtendedDequantizeLinearOp' op x_zero_point element type 'i16' must match input element type 'i8'}}
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x2x3x4xi8>, tensor<f32>, tensor<i16>) -> tensor<5x2x3x4xf32>
+  return %0 : tensor<5x2x3x4xf32>
+}
+
+// -----
+
+// Test: x_zero_point element type (bf16) does not match input element type (f16)
+func.func @test_edq_zp_bf16_vs_f16(%arg0: tensor<5x2x3x4xf16>, %arg1: tensor<f32>, %arg2: tensor<bf16>) -> tensor<5x2x3x4xf32> {
+  // expected-error @+1 {{'onnx.AMDQuarkExtendedDequantizeLinearOp' op x_zero_point element type 'bf16' must match input element type 'f16'}}
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x2x3x4xf16>, tensor<f32>, tensor<bf16>) -> tensor<5x2x3x4xf32>
+  return %0 : tensor<5x2x3x4xf32>
+}
+
+// -----
+
+// Test: none zero_point is allowed (no type check)
+func.func @test_edq_none_zp_ok(%arg0: tensor<5x2x3x4xi8>, %arg1: tensor<f32>) -> tensor<5x2x3x4xf32> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %none) {axis = 1 : si64} : (tensor<5x2x3x4xi8>, tensor<f32>, none) -> tensor<5x2x3x4xf32>
+  return %0 : tensor<5x2x3x4xf32>
+}
+
+// -----
+
+// Test: matching types should pass
+func.func @test_edq_zp_type_match(%arg0: tensor<5x2x3x4xi8>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<5x2x3x4xf32> {
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x2x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xf32>
+  return %0 : tensor<5x2x3x4xf32>
+}

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -4794,6 +4794,103 @@ func.func @test_bfp_quant_dequant_negative_axis(%arg0: tensor<16x32xf32>) -> ten
 // CHECK-SAME:       (tensor<16x32xf32>) -> tensor<16x32xf32>
 
 // -----
+//===----------------------------------------------------------------------===//
+/// Test shape inference for amd.quark.ExtendedQuantizeLinear
+//===----------------------------------------------------------------------===//
+
+func.func @test_extended_quantize(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<*xi8> {
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<*xi8>
+  return %0 : tensor<*xi8>
+}
+// CHECK-LABEL:  func.func @test_extended_quantize
+// CHECK:          "onnx.AMDQuarkExtendedQuantizeLinearOp"
+// CHECK-SAME:       (tensor<5x2x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xi8>
+
+func.func @test_extended_quantize_f16_zp(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<f16>) -> tensor<*xf16> {
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<f16>) -> tensor<*xf16>
+  return %0 : tensor<*xf16>
+}
+// CHECK-LABEL:  func.func @test_extended_quantize_f16_zp
+// CHECK:          "onnx.AMDQuarkExtendedQuantizeLinearOp"
+// CHECK-SAME:       (tensor<5x2x3x4xf32>, tensor<f32>, tensor<f16>) -> tensor<5x2x3x4xf16>
+
+func.func @test_extended_quantize_bf16_zp(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<bf16>, %arg2: tensor<bf16>) -> tensor<*xbf16> {
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xf32>, tensor<bf16>, tensor<bf16>) -> tensor<*xbf16>
+  return %0 : tensor<*xbf16>
+}
+// CHECK-LABEL:  func.func @test_extended_quantize_bf16_zp
+// CHECK:          "onnx.AMDQuarkExtendedQuantizeLinearOp"
+// CHECK-SAME:       (tensor<5x2x3x4xf32>, tensor<bf16>, tensor<bf16>) -> tensor<5x2x3x4xbf16>
+
+func.func @test_extended_quantize_none_zp(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>) -> tensor<*xi8> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %none) : (tensor<5x2x3x4xf32>, tensor<f32>, none) -> tensor<*xi8>
+  return %0 : tensor<*xi8>
+}
+// CHECK-LABEL:  func.func @test_extended_quantize_none_zp
+// CHECK:          "onnx.AMDQuarkExtendedQuantizeLinearOp"
+// CHECK-SAME:       (tensor<5x2x3x4xf32>, tensor<f32>, none) -> tensor<5x2x3x4xi8>
+
+// -----
+
+func.func @test_extended_quantize_dynamic(%arg0: tensor<5x?x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<*xi8> {
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x?x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<*xi8>
+  return %0 : tensor<*xi8>
+}
+// CHECK-LABEL:  func.func @test_extended_quantize_dynamic
+// CHECK:          "onnx.AMDQuarkExtendedQuantizeLinearOp"
+// CHECK-SAME:       (tensor<5x?x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<5x?x3x4xi8>
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Test shape inference for amd.quark.ExtendedDequantizeLinear
+//===----------------------------------------------------------------------===//
+
+func.func @test_extended_dequantize(%arg0: tensor<5x2x3x4xi8>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<*xf32> {
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}
+// CHECK-LABEL:  func.func @test_extended_dequantize
+// CHECK:          "onnx.AMDQuarkExtendedDequantizeLinearOp"
+// CHECK-SAME:       (tensor<5x2x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xf32>
+
+func.func @test_extended_dequantize_f16(%arg0: tensor<5x2x3x4xf16>, %arg1: tensor<f16>, %arg2: tensor<f16>) -> tensor<*xf16> {
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xf16>, tensor<f16>, tensor<f16>) -> tensor<*xf16>
+  return %0 : tensor<*xf16>
+}
+// CHECK-LABEL:  func.func @test_extended_dequantize_f16
+// CHECK:          "onnx.AMDQuarkExtendedDequantizeLinearOp"
+// CHECK-SAME:       (tensor<5x2x3x4xf16>, tensor<f16>, tensor<f16>) -> tensor<5x2x3x4xf16>
+
+func.func @test_extended_dequantize_bf16_zp(%arg0: tensor<5x2x3x4xbf16>, %arg1: tensor<bf16>, %arg2: tensor<bf16>) -> tensor<*xbf16> {
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xbf16>, tensor<bf16>, tensor<bf16>) -> tensor<*xbf16>
+  return %0 : tensor<*xbf16>
+}
+// CHECK-LABEL:  func.func @test_extended_dequantize_bf16_zp
+// CHECK:          "onnx.AMDQuarkExtendedDequantizeLinearOp"
+// CHECK-SAME:       (tensor<5x2x3x4xbf16>, tensor<bf16>, tensor<bf16>) -> tensor<5x2x3x4xbf16>
+
+func.func @test_extended_dequantize_none_zp(%arg0: tensor<5x2x3x4xi8>, %arg1: tensor<f32>) -> tensor<*xf32> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %none) : (tensor<5x2x3x4xi8>, tensor<f32>, none) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}
+// CHECK-LABEL:  func.func @test_extended_dequantize_none_zp
+// CHECK:          "onnx.AMDQuarkExtendedDequantizeLinearOp"
+// CHECK-SAME:       (tensor<5x2x3x4xi8>, tensor<f32>, none) -> tensor<5x2x3x4xf32>
+
+// -----
+
+func.func @test_extended_dequantize_dynamic(%arg0: tensor<5x?x3x4xi8>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<*xf32> {
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x?x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}
+// CHECK-LABEL:  func.func @test_extended_dequantize_dynamic
+// CHECK:          "onnx.AMDQuarkExtendedDequantizeLinearOp"
+// CHECK-SAME:       (tensor<5x?x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<5x?x3x4xf32>
+
+// -----
 
 //===----------------------------------------------------------------------===//
 // RegexFullMatch

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -4799,12 +4799,12 @@ func.func @test_bfp_quant_dequant_negative_axis(%arg0: tensor<16x32xf32>) -> ten
 //===----------------------------------------------------------------------===//
 
 func.func @test_extended_quantize(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<*xi8> {
-  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<*xi8>
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<*xi8>
   return %0 : tensor<*xi8>
 }
 // CHECK-LABEL:  func.func @test_extended_quantize
 // CHECK:          "onnx.AMDQuarkExtendedQuantizeLinearOp"
-// CHECK-SAME:       (tensor<5x2x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xi8>
+// CHECK-SAME:       {axis = 1 : si64} : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xi8>
 
 func.func @test_extended_quantize_f16_zp(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<f16>) -> tensor<*xf16> {
   %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<f16>) -> tensor<*xf16>
@@ -4814,13 +4814,13 @@ func.func @test_extended_quantize_f16_zp(%arg0: tensor<5x2x3x4xf32>, %arg1: tens
 // CHECK:          "onnx.AMDQuarkExtendedQuantizeLinearOp"
 // CHECK-SAME:       (tensor<5x2x3x4xf32>, tensor<f32>, tensor<f16>) -> tensor<5x2x3x4xf16>
 
-func.func @test_extended_quantize_bf16_zp(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<bf16>, %arg2: tensor<bf16>) -> tensor<*xbf16> {
-  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xf32>, tensor<bf16>, tensor<bf16>) -> tensor<*xbf16>
+func.func @test_extended_quantize_bf16_zp(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<bf16>) -> tensor<*xbf16> {
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<bf16>) -> tensor<*xbf16>
   return %0 : tensor<*xbf16>
 }
 // CHECK-LABEL:  func.func @test_extended_quantize_bf16_zp
 // CHECK:          "onnx.AMDQuarkExtendedQuantizeLinearOp"
-// CHECK-SAME:       (tensor<5x2x3x4xf32>, tensor<bf16>, tensor<bf16>) -> tensor<5x2x3x4xbf16>
+// CHECK-SAME:       (tensor<5x2x3x4xf32>, tensor<f32>, tensor<bf16>) -> tensor<5x2x3x4xbf16>
 
 func.func @test_extended_quantize_none_zp(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>) -> tensor<*xi8> {
   %none = "onnx.NoValue"() {value} : () -> none
@@ -4848,28 +4848,28 @@ func.func @test_extended_quantize_dynamic(%arg0: tensor<5x?x3x4xf32>, %arg1: ten
 //===----------------------------------------------------------------------===//
 
 func.func @test_extended_dequantize(%arg0: tensor<5x2x3x4xi8>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<*xf32> {
-  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<*xf32>
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x2x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<*xf32>
   return %0 : tensor<*xf32>
 }
 // CHECK-LABEL:  func.func @test_extended_dequantize
 // CHECK:          "onnx.AMDQuarkExtendedDequantizeLinearOp"
-// CHECK-SAME:       (tensor<5x2x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xf32>
+// CHECK-SAME:       {axis = 1 : si64} : (tensor<5x2x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xf32>
 
-func.func @test_extended_dequantize_f16(%arg0: tensor<5x2x3x4xf16>, %arg1: tensor<f16>, %arg2: tensor<f16>) -> tensor<*xf16> {
-  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xf16>, tensor<f16>, tensor<f16>) -> tensor<*xf16>
-  return %0 : tensor<*xf16>
+func.func @test_extended_dequantize_f16(%arg0: tensor<5x2x3x4xf16>, %arg1: tensor<f32>, %arg2: tensor<f16>) -> tensor<*xf32> {
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xf16>, tensor<f32>, tensor<f16>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
 }
 // CHECK-LABEL:  func.func @test_extended_dequantize_f16
 // CHECK:          "onnx.AMDQuarkExtendedDequantizeLinearOp"
-// CHECK-SAME:       (tensor<5x2x3x4xf16>, tensor<f16>, tensor<f16>) -> tensor<5x2x3x4xf16>
+// CHECK-SAME:       (tensor<5x2x3x4xf16>, tensor<f32>, tensor<f16>) -> tensor<5x2x3x4xf32>
 
-func.func @test_extended_dequantize_bf16_zp(%arg0: tensor<5x2x3x4xbf16>, %arg1: tensor<bf16>, %arg2: tensor<bf16>) -> tensor<*xbf16> {
-  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xbf16>, tensor<bf16>, tensor<bf16>) -> tensor<*xbf16>
-  return %0 : tensor<*xbf16>
+func.func @test_extended_dequantize_bf16_zp(%arg0: tensor<5x2x3x4xbf16>, %arg1: tensor<f32>, %arg2: tensor<bf16>) -> tensor<*xf32> {
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) : (tensor<5x2x3x4xbf16>, tensor<f32>, tensor<bf16>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
 }
 // CHECK-LABEL:  func.func @test_extended_dequantize_bf16_zp
 // CHECK:          "onnx.AMDQuarkExtendedDequantizeLinearOp"
-// CHECK-SAME:       (tensor<5x2x3x4xbf16>, tensor<bf16>, tensor<bf16>) -> tensor<5x2x3x4xbf16>
+// CHECK-SAME:       (tensor<5x2x3x4xbf16>, tensor<f32>, tensor<bf16>) -> tensor<5x2x3x4xf32>
 
 func.func @test_extended_dequantize_none_zp(%arg0: tensor<5x2x3x4xi8>, %arg1: tensor<f32>) -> tensor<*xf32> {
   %none = "onnx.NoValue"() {value} : () -> none

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -335,6 +335,8 @@ version_dict = {
 additional_op_version_dict = {
     "com.amd.quark": {
         "BFPQuantizeDequantize": [1],
+        "ExtendedQuantizeLinear": [1],
+        "ExtendedDequantizeLinear": [1],
     }
 }
 


### PR DESCRIPTION
Adds

- com.amd.quark.ExtendedQuantizeLinear
- com.amd.quark.ExtendedDequantizeLinear

support in ONNX MLIR for per-layer quantization (bf16 or fp16).