### PR TITLE
Add Softmax simplification if axis size=1

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2436,33 +2436,36 @@ struct SoftmaxNegativeAxisPattern : public OpRewritePattern<ONNXSoftmaxOp> {
 };
 
 // Softmax along an axis whose dimension has size 1 is the constant tensor 1.0
-// because exp(x)/exp(x) == 1.0 for all x.
+// because exp(x)/exp(x) == 1.0 for all finite x.
 // E.g. Softmax(x: tensor<8x1xf32>) {axis=1} ==> Constant 1.0 : tensor<8x1xf32>
 struct SoftmaxSizeOneAxisPattern : public OpRewritePattern<ONNXSoftmaxOp> {
   using OpRewritePattern<ONNXSoftmaxOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(
       ONNXSoftmaxOp softmaxOp, PatternRewriter &rewriter) const final {
-    auto inputType = dyn_cast<RankedTensorType>(softmaxOp.getInput().getType());
+    const auto inputType =
+        dyn_cast<RankedTensorType>(softmaxOp.getInput().getType());
     if (!inputType || !inputType.hasStaticShape())
       return rewriter.notifyMatchFailure(
           softmaxOp, "requires ranked, static-shape input");
-    auto elementType = dyn_cast<FloatType>(inputType.getElementType());
+    const auto elementType = dyn_cast<FloatType>(inputType.getElementType());
     if (!elementType)
       return rewriter.notifyMatchFailure(
           softmaxOp, "only float element types are folded");
 
-    int64_t rank = inputType.getRank();
+    const int64_t rank = inputType.getRank();
     int64_t axis = softmaxOp.getAxis();
     if (axis < 0)
       axis += rank;
 
+    assert(axis >= 0 && axis < rank && "axis is out of range");
     if (inputType.getShape()[axis] != 1)
       return failure();
 
-    auto resultType = RankedTensorType::get(inputType.getShape(), elementType);
-    auto valueAttr = DenseElementsAttr::get(
+    const auto resultType =
+        RankedTensorType::get(inputType.getShape(), elementType);
+    const auto valueAttr = DenseElementsAttr::get(
         resultType, rewriter.getFloatAttr(elementType, 1.0));
-    Value constantOp = rewriter.create<ONNXConstantOp>(
+    const Value constantOp = rewriter.create<ONNXConstantOp>(
         softmaxOp.getLoc(), Attribute(), valueAttr);
     rewriter.replaceOp(softmaxOp, constantOp);
     return success();

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2435,6 +2435,40 @@ struct SoftmaxNegativeAxisPattern : public OpRewritePattern<ONNXSoftmaxOp> {
   }
 };
 
+// Softmax along an axis whose dimension has size 1 is the constant tensor 1.0
+// because exp(x)/exp(x) == 1.0 for all x.
+// E.g. Softmax(x: tensor<8x1xf32>) {axis=1} ==> Constant 1.0 : tensor<8x1xf32>
+struct SoftmaxSizeOneAxisPattern : public OpRewritePattern<ONNXSoftmaxOp> {
+  using OpRewritePattern<ONNXSoftmaxOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(
+      ONNXSoftmaxOp softmaxOp, PatternRewriter &rewriter) const final {
+    auto inputType = dyn_cast<RankedTensorType>(softmaxOp.getInput().getType());
+    if (!inputType || !inputType.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          softmaxOp, "requires ranked, static-shape input");
+    auto elementType = dyn_cast<FloatType>(inputType.getElementType());
+    if (!elementType)
+      return rewriter.notifyMatchFailure(
+          softmaxOp, "only float element types are folded");
+
+    int64_t rank = inputType.getRank();
+    int64_t axis = softmaxOp.getAxis();
+    if (axis < 0)
+      axis += rank;
+
+    if (inputType.getShape()[axis] != 1)
+      return failure();
+
+    auto resultType = RankedTensorType::get(inputType.getShape(), elementType);
+    auto valueAttr = DenseElementsAttr::get(
+        resultType, rewriter.getFloatAttr(elementType, 1.0));
+    Value constantOp = rewriter.create<ONNXConstantOp>(
+        softmaxOp.getLoc(), Attribute(), valueAttr);
+    rewriter.replaceOp(softmaxOp, constantOp);
+    return success();
+  }
+};
+
 // Rewrite ONNXSoftmaxV11Op to ONNXSoftmaxOp (V13).
 //
 // V11 computes softmax over the flattened suffix [axis..rank-1].
@@ -3334,6 +3368,7 @@ void ONNXSizeOp::getCanonicalizationPatterns(
 void ONNXSoftmaxOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<SoftmaxNegativeAxisPattern>(context);
+  results.insert<SoftmaxSizeOneAxisPattern>(context);
 }
 
 /// on the ONNXSoftmaxV11Op.

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -1677,11 +1677,13 @@ func.func @test_softmax_size_one_negative_axis(%arg0 : tensor<4x8x1x1xf32>) -> t
 
 // -----
 
-func.func @test_softmax_size_one_axis_non_unit(%arg0 : tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32> {
+// Negative test for Softmax size-1 canonicalization pattern.
+// Verifies that the op is not folded when the axis is not size 1.
+func.func @test_softmax_size_not_one_axis(%arg0 : tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32> {
   %0 = "onnx.Softmax"(%arg0) {axis = 1 : si64} : (tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32>
   onnx.Return %0 : tensor<4x8x1x1xf32>
 
-// CHECK-LABEL:  func.func @test_softmax_size_one_axis_non_unit
+// CHECK-LABEL:  func.func @test_softmax_size_not_one_axis
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32> {
 // CHECK:            [[VAR_0_:%.+]] = "onnx.Softmax"([[PARAM_0_]]) {axis = 1 : si64} : (tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32>
 // CHECK:            onnx.Return [[VAR_0_]] : tensor<4x8x1x1xf32>

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -1649,6 +1649,47 @@ func.func @test_softmax_negative_axis(%arg0 : tensor<10x20x30xf32>) -> tensor<10
 
 // -----
 
+func.func @test_softmax_size_one_axis(%arg0 : tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32> {
+  %0 = "onnx.Softmax"(%arg0) {axis = 2 : si64} : (tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32>
+  onnx.Return %0 : tensor<4x8x1x1xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_size_one_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32> {
+// CHECK-NOT:        "onnx.Softmax"
+// CHECK:            [[CST_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x8x1x1xf32>
+// CHECK:            onnx.Return [[CST_]] : tensor<4x8x1x1xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_softmax_size_one_negative_axis(%arg0 : tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32> {
+  %0 = "onnx.Softmax"(%arg0) {axis = -2 : si64} : (tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32>
+  onnx.Return %0 : tensor<4x8x1x1xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_size_one_negative_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32> {
+// CHECK-NOT:        "onnx.Softmax"
+// CHECK:            [[CST_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x8x1x1xf32>
+// CHECK:            onnx.Return [[CST_]] : tensor<4x8x1x1xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_softmax_size_one_axis_non_unit(%arg0 : tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32> {
+  %0 = "onnx.Softmax"(%arg0) {axis = 1 : si64} : (tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32>
+  onnx.Return %0 : tensor<4x8x1x1xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_size_one_axis_non_unit
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32> {
+// CHECK:            [[VAR_0_:%.+]] = "onnx.Softmax"([[PARAM_0_]]) {axis = 1 : si64} : (tensor<4x8x1x1xf32>) -> tensor<4x8x1x1xf32>
+// CHECK:            onnx.Return [[VAR_0_]] : tensor<4x8x1x1xf32>
+// CHECK:         }
+}
+
+// -----
+
 #transpose = affine_map<(d0, d1, d2, d3) -> (d2, d0, d1, d3)>
 #reshape =  affine_map<(d0, d1) -> (d0 floordiv 32, d0 mod 32, d1 floordiv 64, d1 mod 64)>
 func.func @shape_transform_compose(%arg0: tensor<128x128xf32>) -> tensor<2x4x32x64xf32> {


### PR DESCRIPTION
This pattern rewrites Softmax to the constant 1.0 tensor if the axis has size 1. It's mathematically sound because we are effectively computing exp(x)/ sum_j [exp(x_j)] where the sum degenerates to exp(x). This pattern shouldn't occur in any reasonable model but it is causing downstream issues which, I believe, are best addressed here.

I've conditioned the pattern to only work on static shapes and float data.