### PR TITLE
Improve onnx subgraph ops supports and add loop unrolling when possible

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -546,11 +546,25 @@ private:
     }
   }
 
-  // Resolve the MLIR type for one ONNX graph input, applying fallback
-  // heuristics for Loop/Scan body inputs whose type annotations may be absent.
-  // On success, `dimParams` is populated (may remain empty for fallback types).
+  // Resolves the MLIR type for a single input of an ONNX subgraph body.
+  //
+  // ONNX allows subgraph body inputs (Loop/Scan/If) to omit their type
+  // annotation when the type can be derived from the enclosing graph.
+  // This function tries three strategies in order:
+  //   1. Parse the type directly from the proto annotation (the normal case).
+  //   2. Steal the type from the corresponding operand of the parent op.
+  //      E.g. for a Loop body input at index 2 (the first loop-carried var),
+  //      the type is taken from operand 2 of the onnx.Loop op itself.
+  //   3. For onnx.Loop bodies specifically, the ONNX spec mandates that
+  //      input 0 is always i64 (iteration index) and input 1 is always i1
+  //      (termination condition), regardless of what the proto says.
+  //
+  // Returns an error if none of the strategies succeed.
+  // On success, `dimParams` is populated with symbolic dimension constraints
+  // (e.g. "N:batch") when the annotation provides them; it may remain empty
+  // for types resolved via fallback.
   ErrorOr<Type> importBodyInputType(const onnx::ValueInfoProto &input,
-      int inputIndex, Operation *op, std::string &dimParams,
+      int inputIndex, Operation *parentOp, std::string &dimParams,
       std::string &errorMessage) {
     ErrorOr<Type> importedType =
         ImportType(input.type(), errorMessage, &dimParams);
@@ -560,14 +574,15 @@ private:
     // Type annotation is absent; apply fallbacks in order:
     // 1. Parent op's operand at the same index (if it has a concrete type).
     // 2. ONNX-mandated fixed types for the first two Loop body inputs.
-    Type parentTy = (op != nullptr && inputIndex < (int)op->getNumOperands())
-                        ? op->getOperand(inputIndex).getType()
-                        : Type{};
+    Type parentTy =
+        (parentOp != nullptr && inputIndex < (int)parentOp->getNumOperands())
+            ? parentOp->getOperand(inputIndex).getType()
+            : Type{};
     if (parentTy && !mlir::isa<mlir::NoneType>(parentTy)) {
       errorMessage = "";
       return parentTy;
     }
-    if (op != nullptr && op->getName().getStringRef().ends_with("Loop")) {
+    if (parentOp != nullptr && mlir::isa<ONNXLoopOp>(parentOp)) {
       if (inputIndex == 0) {
         errorMessage = "";
         return builder_.getIntegerType(64); // iteration index
@@ -581,11 +596,26 @@ private:
     return importedType.getError();
   }
 
-  // Imports graph inputs (skipping initializers): populates argTypes,
-  // inputNames, and inputDimParams; adds block arguments to entryBlock;
-  // binds each argument in frontend_symbols_.
+  // Processes the input list of a subgraph body: resolves each input's MLIR
+  // type, adds all inputs as block arguments, and binds their ONNX names in
+  // the symbol table.
+  //
+  // Inputs that are initializers (weight tensors) are skipped here — they were
+  // already materialized as onnx.Constant ops before this function is called.
+  //
+  // The two-pass structure is intentional: MLIR requires all block arguments to
+  // be added in a single addArguments() call before any of them can appear as
+  // SSA values. The first pass collects types; the second pass binds names.
+  //
+  // Example: for a Loop body with inputs [iter_count, condition, x],
+  // where x is a loop-carried variable of type f32[N]:
+  //   - iter_count → i64 (Loop-mandated fixed type)
+  //   - condition  → i1  (Loop-mandated fixed type)
+  //   - x          → f32[N] (stolen from the parent onnx.Loop operand)
+  // All three become block arguments; their names are bound in
+  // frontend_symbols_ so downstream ImportNode calls can resolve them.
   [[nodiscard]] std::error_code importGraphInputs(const onnx::GraphProto &graph,
-      Operation *op, Block *entryBlock,
+      Operation *parentOp, Block *entryBlock,
       const std::unordered_set<std::string> &initializerNames,
       llvm::SmallVector<Type, 4> &argTypes,
       llvm::SmallVector<llvm::StringRef, 4> &inputNames,
@@ -604,8 +634,8 @@ private:
 
       inputNames.push_back(input.name());
       std::string dimParams;
-      ErrorOr<Type> importedType =
-          importBodyInputType(input, inputIndex, op, dimParams, errorMessage);
+      ErrorOr<Type> importedType = importBodyInputType(
+          input, inputIndex, parentOp, dimParams, errorMessage);
       if (auto ec = importedType.getError())
         return ec;
 
@@ -633,77 +663,150 @@ private:
     return {};
   }
 
-  // Recursively collects outer-scope value names referenced inside `body`
-  // (and any nested sub-bodies) that are not defined within `body` itself.
-  static void collectBodyCaptures(
-      const onnx::GraphProto &body, std::unordered_set<std::string> &caps) {
-    std::unordered_set<std::string> localDefined;
-    for (const auto &inp : body.input())
-      localDefined.insert(inp.name());
-    for (const auto &init : body.initializer())
-      localDefined.insert(init.name());
-    for (const auto &n : body.node())
-      for (const auto &out : n.output())
-        if (!out.empty())
-          localDefined.insert(out);
-
+  // Recursively collects all free variables of `body`: value names that the
+  // body (and any sub-bodies it contains) *use* but do not *define*.
+  //
+  // Used by buildIntraGraphCaptureEdges() to discover implicit dependencies
+  // between nodes in the enclosing graph — a node B with a subgraph that
+  // references a value x implicitly depends on whatever node A produces x,
+  // even if x is not a direct operand of B.
+  //
+  // Example: given a Loop body that contains  y = Add(x, iter_count)
+  // where neither "x" nor "iter_count" is produced inside the body,
+  // both end up in `freeVars` after this call.
+  //
+  // The result is accumulated into `freeVars` (not replaced) so the caller
+  // can call this function on multiple sub-bodies and union the results.
+  static void collectFreeVariables(
+      const onnx::GraphProto &body, std::unordered_set<std::string> &freeVars) {
+    // Collect all names referenced by nodes in this body (and sub-bodies).
     for (const auto &n : body.node()) {
       for (const auto &inp : n.input())
-        if (!inp.empty() && !localDefined.contains(inp))
-          caps.insert(inp);
+        if (!inp.empty())
+          freeVars.insert(inp);
       for (const auto &attr : n.attribute())
         if (attr.type() == onnx::AttributeProto_AttributeType_GRAPH)
-          collectBodyCaptures(attr.g(), caps);
+          collectFreeVariables(attr.g(), freeVars);
     }
-    for (const auto &name : localDefined)
-      caps.erase(name);
+    // Remove names that are defined locally — what remains are free variables.
+    for (const auto &inp : body.input())
+      freeVars.erase(inp.name());
+    for (const auto &init : body.initializer())
+      freeVars.erase(init.name());
+    for (const auto &n : body.node())
+      for (const auto &out : n.output())
+        freeVars.erase(out);
   }
 
-  // For each node in `graph`, computes the set of values it needs from
-  // outer-scope subgraph captures that are defined within this same graph.
-  static std::vector<std::unordered_set<std::string>> buildNodeCaptures(
-      const onnx::GraphProto &graph) {
+  // For each node in `graph`, returns the implicit ordering dependencies
+  // introduced by that node's nested subgraph attributes (Loop/If/Scan bodies).
+  //
+  // MOTIVATION
+  // A subgraph body can reference values that are not passed as direct
+  // operands to its enclosing node — these are "free variables" resolved by
+  // name lookup in the surrounding scope. A naive topological sort based only
+  // on direct operands misses these. This function makes them explicit so
+  // computeTopologicalOrder() can enforce the correct import order.
+  //
+  // TWO SOURCES OF FREE VARIABLES
+  // A body's free variables come from exactly one of two scopes:
+  //   1. The current `graph` (a node output, graph input, or initializer).
+  //      These create an ordering constraint: node B must be imported after
+  //      node A if B's body uses a value that A produces.
+  //      → Included in the returned localScopeEdges.
+  //   2. An enclosing graph (grandparent and above).
+  //      These are already bound in frontend_symbols_ by the time `graph`'s
+  //      import starts, so they impose no constraint within this graph.
+  //      → Excluded from the returned localScopeEdges.
+  //
+  // RECURSIVE GUARANTEE
+  // Source-2 values are guaranteed to be in frontend_symbols_ because the
+  // grandparent graph ran this same logic, detected the capture, and ensured
+  // its producer was imported before the node whose body uses it.
+  // This guarantee holds at every nesting depth by induction.
+  //
+  // EXAMPLE
+  //   node 0: scale = onnx.Constant(2.0)
+  //   node 1: result = onnx.Loop(...) {
+  //             body uses "scale"        ← source 1: produced in this graph
+  //             body uses "outer_weight" ← source 2: from grandparent graph
+  //           }
+  //
+  // Returns: [{} /* node 0 */, {"scale"} /* node 1 */]
+  // → computeTopologicalOrder() will schedule node 0 before node 1.
+  static std::vector<std::unordered_set<std::string>>
+  buildIntraGraphCaptureEdges(const onnx::GraphProto &graph) {
     const int numNodes = graph.node_size();
 
-    std::unordered_set<std::string> graphDefined;
+    // All value names owned by this graph scope (inputs, initializers, node
+    // outputs).
+    std::unordered_set<std::string> localScope;
     for (const auto &inp : graph.input())
-      graphDefined.insert(inp.name());
+      localScope.insert(inp.name());
     for (const auto &init : graph.initializer())
-      graphDefined.insert(init.name());
+      localScope.insert(init.name());
     for (int i = 0; i < numNodes; ++i)
       for (const auto &out : graph.node(i).output())
         if (!out.empty())
-          graphDefined.insert(out);
+          localScope.insert(out);
 
-    std::vector<std::unordered_set<std::string>> nodeCaptures(numNodes);
+    std::vector<std::unordered_set<std::string>> localScopeEdges(numNodes);
     for (int i = 0; i < numNodes; ++i) {
       for (const auto &attr : graph.node(i).attribute()) {
         if (attr.type() == onnx::AttributeProto_AttributeType_GRAPH) {
-          std::unordered_set<std::string> allCaps;
-          collectBodyCaptures(attr.g(), allCaps);
-          for (const auto &cap : allCaps)
-            if (graphDefined.contains(cap))
-              nodeCaptures[i].insert(cap);
+          std::unordered_set<std::string> bodyFreeVars;
+          collectFreeVariables(attr.g(), bodyFreeVars);
+          // Retain only source-1 free vars (produced in localScope).
+          // Source-2 vars (grandparent) are already in frontend_symbols_.
+          for (const auto &fv : bodyFreeVars)
+            if (localScope.contains(fv))
+              localScopeEdges[i].insert(fv);
         }
       }
     }
-    return nodeCaptures;
+    return localScopeEdges;
   }
 
-  // Returns a topological ordering of graph node indices using Kahn's
-  // algorithm. Nodes whose dependencies cannot be satisfied are appended at the
-  // end.
+  // Returns a valid import order for the nodes in `graph` as a vector of
+  // node indices, using an iterative variant of Kahn's algorithm.
+  //
+  // ONNX does not guarantee that nodes appear in topological order in the
+  // proto. Importing a node before its inputs exist in the MLIR symbol table
+  // would cause a lookup failure, so we must sort first.
+  //
+  // A node is "ready" to be scheduled when two conditions are both met:
+  //   (a) All its direct input values are defined — either produced by an
+  //       earlier node in `defined`, or already bound in frontend_symbols_
+  //       from an enclosing graph scope.
+  //   (b) All values captured by its subgraph attributes are also defined.
+  //       These are the extra edges supplied by `localScopeEdges` (see
+  //       buildIntraGraphCaptureEdges()).
+  //
+  // The frontend_symbols_ check handles values from outer scopes (e.g. the
+  // main graph's tensors referenced by a Loop body): those are already bound
+  // before this subgraph's import starts and are unconditionally available.
+  //
+  // Nodes that cannot be scheduled (e.g. due to a cycle) are appended at the
+  // end as a best-effort fallback; ImportNode will then fail with a clear
+  // error when it tries to resolve the missing input value.
+  //
+  // Example: proto lists nodes in order [B, A] where B uses A's output "x":
+  //   pass 1: B not ready ("x" not yet in `defined`); A ready → order=[A]
+  //   pass 2: B ready ("x" now in `defined`)          → order=[A, B]
   std::vector<int> computeTopologicalOrder(const onnx::GraphProto &graph,
-      const std::vector<std::unordered_set<std::string>> &nodeCaptures) {
+      const std::vector<std::unordered_set<std::string>> &localScopeEdges) {
     const size_t numNodes = graph.node_size();
 
-    std::unordered_set<std::string> available;
+    // `defined` tracks all value names that are available at the current point
+    // in the import: graph inputs, initializers, and outputs of scheduled
+    // nodes.
+    std::unordered_set<std::string> defined;
     for (const auto &inp : graph.input())
-      available.insert(inp.name());
+      defined.insert(inp.name());
     for (const auto &init : graph.initializer())
-      available.insert(init.name());
+      defined.insert(init.name());
 
-    std::vector<bool> processed(numNodes, false);
+    std::vector<bool> scheduled(numNodes, false);
     std::vector<int> order;
     order.reserve(numNodes);
 
@@ -711,20 +814,20 @@ private:
     while (anyProgress && order.size() < numNodes) {
       anyProgress = false;
       for (size_t i = 0; i < numNodes; ++i) {
-        if (processed[i])
+        if (scheduled[i])
           continue;
         const auto &node = graph.node(i);
         bool ready = true;
         for (const auto &inp : node.input()) {
-          if (!inp.empty() && !available.contains(inp) &&
+          if (!inp.empty() && !defined.contains(inp) &&
               !frontend_symbols_.GetByOnnxName(inp)) {
             ready = false;
             break;
           }
         }
         if (ready) {
-          for (const auto &cap : nodeCaptures[i]) {
-            if (!available.contains(cap) &&
+          for (const auto &cap : localScopeEdges[i]) {
+            if (!defined.contains(cap) &&
                 !frontend_symbols_.GetByOnnxName(cap)) {
               ready = false;
               break;
@@ -733,26 +836,35 @@ private:
         }
         if (ready) {
           order.push_back(i);
-          processed[i] = true;
+          scheduled[i] = true;
           anyProgress = true;
           for (const auto &out : node.output())
             if (!out.empty())
-              available.insert(out);
+              defined.insert(out);
         }
       }
     }
-    // Append any remaining nodes (e.g. cycles or unresolvable references).
+    // Append any remaining nodes that could not be scheduled (e.g. due to a
+    // cycle or an unresolvable reference). These will cause ImportNode to fail
+    // with a missing-value error, which is preferable to silently skipping
+    // them.
     for (size_t i = 0; i < numNodes; ++i)
-      if (!processed[i])
+      if (!scheduled[i])
         order.push_back(i);
     return order;
   }
 
-  // Imports all nodes of `graph` in topological order.
+  // Imports all nodes of `graph` into the current MLIR region, in topological
+  // order.
+  //
+  // ONNX protos may list nodes in arbitrary order. Sorting ensures every
+  // node's inputs are already defined as MLIR Values in frontend_symbols_
+  // before the node itself is imported. Without sorting, ImportNode would
+  // fail to look up the input values of out-of-order nodes.
   [[nodiscard]] std::error_code importGraphNodes(
       const onnx::GraphProto &graph, std::string &errorMessage) {
-    auto nodeCaptures = buildNodeCaptures(graph);
-    auto order = computeTopologicalOrder(graph, nodeCaptures);
+    auto localScopeEdges = buildIntraGraphCaptureEdges(graph);
+    auto order = computeTopologicalOrder(graph, localScopeEdges);
     for (int idx : order) {
       if (auto ec = ImportNode(graph.node(idx), errorMessage))
         return ec;
@@ -760,8 +872,17 @@ private:
     return {};
   }
 
-  // Imports graph output tensors, populating retTys, retVals, and
-  // outputDimParams.
+  // Resolves each graph output to the MLIR Value produced during node import
+  // and records its type for the enclosing op's result type list.
+  //
+  // Each output name is looked up in frontend_symbols_ — the same symbol
+  // table that ImportNode populated — to find the SSA Value that represents
+  // it. The resulting (Value, Type) pairs become the operands and result types
+  // of the region terminator (ONNXYieldOp or ONNXReturnOp).
+  //
+  // Any symbolic dimension constraints (e.g. "N:batch") attached to the
+  // output's type annotation are also collected into `outputDimParams` for
+  // use by setGraphOpAttributes().
   [[nodiscard]] std::error_code importGraphOutputs(
       const onnx::GraphProto &graph, llvm::SmallVector<Type, 4> &retTys,
       llvm::SmallVector<Value, 4> &retVals,
@@ -781,7 +902,20 @@ private:
     return {};
   }
 
-  // Sets input/output name and dim-param attributes on the containing op.
+  // Attaches compiler-internal bookkeeping attributes to the op that owns
+  // the imported subgraph region.
+  //
+  // These are not ONNX-standard attributes. They serve two purposes:
+  //   - "input_names" / "output_names": preserve the original ONNX tensor
+  //     names for error messages and IR readability.
+  //   - "input_dim_params" / "output_dim_params": propagate symbolic
+  //     dimension constraints (e.g. "N:batch_size") from the ONNX model's
+  //     type annotations into the MLIR IR, where later passes use them to
+  //     track dynamic shapes under a symbolic name rather than '?'.
+  //
+  // Example: an input annotated as float[N, 512] with dimParam "N:batch"
+  // produces input_dim_params = ["N:batch"], letting downstream passes know
+  // that dimension 0 of this tensor is the batch dimension.
   void setGraphOpAttributes(Operation *op,
       llvm::ArrayRef<llvm::StringRef> inputNames,
       llvm::ArrayRef<llvm::StringRef> outputNames,
@@ -792,6 +926,7 @@ private:
     if (!outputNames.empty())
       op->setAttr("output_names", builder_.getStrArrayAttr(outputNames));
 
+    // getStrArrayAttr requires ArrayRef<StringRef>; convert from std::string.
     llvm::SmallVector<llvm::StringRef> inputDimParamsRefs;
     llvm::SmallVector<llvm::StringRef> outputDimParamsRefs;
     for (const auto &s : inputDimParams)
@@ -819,7 +954,7 @@ private:
    * terminator, otherwise, will use ONNXYieldOp as terminator.
    * @return function type corresponding to the subgraph input/output signature.
    */
-  ErrorOr<FunctionType> importGraph(const onnx::GraphProto &graph,
+  ErrorOr<FunctionType> importSubgraph(const onnx::GraphProto &graph,
       Region &region, Operation *op, bool useReturn,
       std::string &errorMessage) {
     frontend_symbols_.pushScope(graph.name());
@@ -1139,7 +1274,7 @@ private:
         OpBuilder::InsertionGuard guard(builder_);
         builder_.setInsertionPointToStart(&region.back());
         const ErrorOr<FunctionType> importGraphResult =
-            importGraph(attr.g(), region, op, false, errorMessage);
+            importSubgraph(attr.g(), region, op, false, errorMessage);
         if (auto ec = importGraphResult.getError()) {
           return ec;
         }
@@ -2003,7 +2138,7 @@ private:
     builder_.setInsertionPointToStart(&mainFunc.getBody().back());
 
     ErrorOr<FunctionType> importedFuncType =
-        importGraph(graph, /*region=*/mainFunc.getBody(),
+        importSubgraph(graph, /*region=*/mainFunc.getBody(),
             /*op=*/mainFunc.getOperation(), /*useReturn=*/true, errorMessage);
     if (auto ec = importedFuncType.getError()) {
       errorMessage +=

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -16,6 +16,9 @@
 // A `frontend` placeholder dialect is used to encode operations that are not
 // covered by any existing dialects.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -318,7 +321,7 @@ private:
         NameLoc::get(builder_.getStringAttr("Initializer_" + tensor.name()));
     Value initializer = createConstantValue(mlirAttr, loc);
     if (options_.addResultNamesAttr) {
-      if (auto constOp = initializer.getDefiningOp()) {
+      if (auto *constOp = initializer.getDefiningOp()) {
         constOp->setAttr(
             "ResultNames", builder_.getStrArrayAttr({tensor.name()}));
       }
@@ -456,7 +459,7 @@ private:
     case onnx::AttributeProto::INT:
       mlirAttr =
           IntegerAttr::get(builder_.getIntegerType(64, /*isSigned=*/true),
-              APInt(64, /*value=*/attr.i(), /*isSigned=*/true));
+              APInt(64, /*val=*/attr.i(), /*isSigned=*/true));
       break;
     case onnx::AttributeProto::STRING:
       mlirAttr = builder_.getStringAttr(attr.s());
@@ -524,7 +527,7 @@ private:
   }
 
   // Generate a string vector from the dimParams option string
-  void getInputDimParamsMapFromOption(std::string optionStr,
+  static void getInputDimParamsMapFromOption(std::string optionStr,
       std::map<int, std::string> &paramStrMap,
       std::string &paramStrForAllArgs) {
     std::stringstream paramStrStream(optionStr);
@@ -541,7 +544,266 @@ private:
         paramStrMap[idx] = dimParamStr;
       }
     }
-    return;
+  }
+
+  // Resolve the MLIR type for one ONNX graph input, applying fallback
+  // heuristics for Loop/Scan body inputs whose type annotations may be absent.
+  // On success, `dimParams` is populated (may remain empty for fallback types).
+  ErrorOr<Type> importBodyInputType(const onnx::ValueInfoProto &input,
+      int inputIndex, Operation *op, std::string &dimParams,
+      std::string &errorMessage) {
+    ErrorOr<Type> importedType =
+        ImportType(input.type(), errorMessage, &dimParams);
+    if (!importedType.getError())
+      return importedType;
+
+    // Type annotation is absent; apply fallbacks in order:
+    // 1. Parent op's operand at the same index (if it has a concrete type).
+    // 2. ONNX-mandated fixed types for the first two Loop body inputs.
+    Type parentTy = (op != nullptr && inputIndex < (int)op->getNumOperands())
+                        ? op->getOperand(inputIndex).getType()
+                        : Type{};
+    if (parentTy && !mlir::isa<mlir::NoneType>(parentTy)) {
+      errorMessage = "";
+      return parentTy;
+    }
+    if (op != nullptr && op->getName().getStringRef().ends_with("Loop")) {
+      if (inputIndex == 0) {
+        errorMessage = "";
+        return builder_.getIntegerType(64); // iteration index
+      }
+      if (inputIndex == 1) {
+        errorMessage = "";
+        return builder_.getI1Type(); // loop condition
+      }
+    }
+    errorMessage += "Failed to import input type for '" + input.name() + "'\n";
+    return importedType.getError();
+  }
+
+  // Imports graph inputs (skipping initializers): populates argTypes,
+  // inputNames, and inputDimParams; adds block arguments to entryBlock;
+  // binds each argument in frontend_symbols_.
+  [[nodiscard]] std::error_code importGraphInputs(const onnx::GraphProto &graph,
+      Operation *op, Block *entryBlock,
+      const std::unordered_set<std::string> &initializerNames,
+      llvm::SmallVector<Type, 4> &argTypes,
+      llvm::SmallVector<llvm::StringRef, 4> &inputNames,
+      llvm::SmallVector<std::string, 4> &inputDimParams,
+      std::string &errorMessage) {
+    std::map<int, std::string> inputDimParamsFromOption;
+    std::string inputDimParamsFromOptionForAllArgs;
+    getInputDimParamsMapFromOption(options_.dimParams, inputDimParamsFromOption,
+        inputDimParamsFromOptionForAllArgs);
+
+    int inputIndex = 0;
+    for (const auto &input : graph.input()) {
+      AddValueInfo(input);
+      if (initializerNames.contains(input.name()))
+        continue;
+
+      inputNames.push_back(input.name());
+      std::string dimParams;
+      ErrorOr<Type> importedType =
+          importBodyInputType(input, inputIndex, op, dimParams, errorMessage);
+      if (auto ec = importedType.getError())
+        return ec;
+
+      Type argTy = modelInputShaper_.reshape(inputIndex, *importedType);
+      if (inputDimParamsFromOption.contains(inputIndex))
+        inputDimParams.emplace_back(inputDimParamsFromOption[inputIndex]);
+      else if (!inputDimParamsFromOptionForAllArgs.empty())
+        inputDimParams.emplace_back(inputDimParamsFromOptionForAllArgs);
+      else if (!dimParams.empty())
+        inputDimParams.emplace_back(dimParams);
+
+      argTypes.emplace_back(argTy);
+      ++inputIndex;
+    }
+
+    entryBlock->addArguments(argTypes,
+        llvm::SmallVector<Location, 4>(argTypes.size(), UnknownLoc()));
+
+    int entryBlockArgIdx = 0;
+    for (const auto &input : graph.input()) {
+      if (!initializerNames.contains(input.name()))
+        BindOnnxName(
+            input.name(), entryBlock->getArguments()[entryBlockArgIdx++]);
+    }
+    return {};
+  }
+
+  // Recursively collects outer-scope value names referenced inside `body`
+  // (and any nested sub-bodies) that are not defined within `body` itself.
+  static void collectBodyCaptures(
+      const onnx::GraphProto &body, std::unordered_set<std::string> &caps) {
+    std::unordered_set<std::string> localDefined;
+    for (const auto &inp : body.input())
+      localDefined.insert(inp.name());
+    for (const auto &init : body.initializer())
+      localDefined.insert(init.name());
+    for (const auto &n : body.node())
+      for (const auto &out : n.output())
+        if (!out.empty())
+          localDefined.insert(out);
+
+    for (const auto &n : body.node()) {
+      for (const auto &inp : n.input())
+        if (!inp.empty() && !localDefined.contains(inp))
+          caps.insert(inp);
+      for (const auto &attr : n.attribute())
+        if (attr.type() == onnx::AttributeProto_AttributeType_GRAPH)
+          collectBodyCaptures(attr.g(), caps);
+    }
+    for (const auto &name : localDefined)
+      caps.erase(name);
+  }
+
+  // For each node in `graph`, computes the set of values it needs from
+  // outer-scope subgraph captures that are defined within this same graph.
+  static std::vector<std::unordered_set<std::string>> buildNodeCaptures(
+      const onnx::GraphProto &graph) {
+    const int numNodes = graph.node_size();
+
+    std::unordered_set<std::string> graphDefined;
+    for (const auto &inp : graph.input())
+      graphDefined.insert(inp.name());
+    for (const auto &init : graph.initializer())
+      graphDefined.insert(init.name());
+    for (int i = 0; i < numNodes; ++i)
+      for (const auto &out : graph.node(i).output())
+        if (!out.empty())
+          graphDefined.insert(out);
+
+    std::vector<std::unordered_set<std::string>> nodeCaptures(numNodes);
+    for (int i = 0; i < numNodes; ++i) {
+      for (const auto &attr : graph.node(i).attribute()) {
+        if (attr.type() == onnx::AttributeProto_AttributeType_GRAPH) {
+          std::unordered_set<std::string> allCaps;
+          collectBodyCaptures(attr.g(), allCaps);
+          for (const auto &cap : allCaps)
+            if (graphDefined.contains(cap))
+              nodeCaptures[i].insert(cap);
+        }
+      }
+    }
+    return nodeCaptures;
+  }
+
+  // Returns a topological ordering of graph node indices using Kahn's
+  // algorithm. Nodes whose dependencies cannot be satisfied are appended at the
+  // end.
+  std::vector<int> computeTopologicalOrder(const onnx::GraphProto &graph,
+      const std::vector<std::unordered_set<std::string>> &nodeCaptures) {
+    const size_t numNodes = graph.node_size();
+
+    std::unordered_set<std::string> available;
+    for (const auto &inp : graph.input())
+      available.insert(inp.name());
+    for (const auto &init : graph.initializer())
+      available.insert(init.name());
+
+    std::vector<bool> processed(numNodes, false);
+    std::vector<int> order;
+    order.reserve(numNodes);
+
+    bool anyProgress = true;
+    while (anyProgress && order.size() < numNodes) {
+      anyProgress = false;
+      for (size_t i = 0; i < numNodes; ++i) {
+        if (processed[i])
+          continue;
+        const auto &node = graph.node(i);
+        bool ready = true;
+        for (const auto &inp : node.input()) {
+          if (!inp.empty() && !available.contains(inp) &&
+              !frontend_symbols_.GetByOnnxName(inp)) {
+            ready = false;
+            break;
+          }
+        }
+        if (ready) {
+          for (const auto &cap : nodeCaptures[i]) {
+            if (!available.contains(cap) &&
+                !frontend_symbols_.GetByOnnxName(cap)) {
+              ready = false;
+              break;
+            }
+          }
+        }
+        if (ready) {
+          order.push_back(i);
+          processed[i] = true;
+          anyProgress = true;
+          for (const auto &out : node.output())
+            if (!out.empty())
+              available.insert(out);
+        }
+      }
+    }
+    // Append any remaining nodes (e.g. cycles or unresolvable references).
+    for (size_t i = 0; i < numNodes; ++i)
+      if (!processed[i])
+        order.push_back(i);
+    return order;
+  }
+
+  // Imports all nodes of `graph` in topological order.
+  [[nodiscard]] std::error_code importGraphNodes(
+      const onnx::GraphProto &graph, std::string &errorMessage) {
+    auto nodeCaptures = buildNodeCaptures(graph);
+    auto order = computeTopologicalOrder(graph, nodeCaptures);
+    for (int idx : order) {
+      if (auto ec = ImportNode(graph.node(idx), errorMessage))
+        return ec;
+    }
+    return {};
+  }
+
+  // Imports graph output tensors, populating retTys, retVals, and
+  // outputDimParams.
+  [[nodiscard]] std::error_code importGraphOutputs(
+      const onnx::GraphProto &graph, llvm::SmallVector<Type, 4> &retTys,
+      llvm::SmallVector<Value, 4> &retVals,
+      llvm::SmallVector<std::string, 4> &outputDimParams,
+      std::string &errorMessage) {
+    for (const auto &output : graph.output()) {
+      std::string dimParams;
+      if (auto ec = ImportOutputTensor(
+              output, retTys, retVals, errorMessage, &dimParams)) {
+        errorMessage +=
+            "Failed to import output tensor '" + output.name() + "'.\n";
+        return ec;
+      }
+      if (!dimParams.empty())
+        outputDimParams.emplace_back(dimParams);
+    }
+    return {};
+  }
+
+  // Sets input/output name and dim-param attributes on the containing op.
+  void setGraphOpAttributes(Operation *op,
+      llvm::ArrayRef<llvm::StringRef> inputNames,
+      llvm::ArrayRef<llvm::StringRef> outputNames,
+      llvm::ArrayRef<std::string> inputDimParams,
+      llvm::ArrayRef<std::string> outputDimParams) {
+    if (!inputNames.empty())
+      op->setAttr("input_names", builder_.getStrArrayAttr(inputNames));
+    if (!outputNames.empty())
+      op->setAttr("output_names", builder_.getStrArrayAttr(outputNames));
+
+    llvm::SmallVector<llvm::StringRef> inputDimParamsRefs;
+    llvm::SmallVector<llvm::StringRef> outputDimParamsRefs;
+    for (const auto &s : inputDimParams)
+      inputDimParamsRefs.emplace_back(s);
+    for (const auto &s : outputDimParams)
+      outputDimParamsRefs.emplace_back(s);
+    if (!inputDimParamsRefs.empty())
+      op->setAttr(
+          "input_dim_params", builder_.getStrArrayAttr(inputDimParamsRefs));
+    if (!outputDimParamsRefs.empty())
+      op->setAttr(
+          "output_dim_params", builder_.getStrArrayAttr(outputDimParamsRefs));
   }
 
   /*!
@@ -564,140 +826,49 @@ private:
     onnx_type_map.pushScope(graph.name());
     Block *entryBlock = &region.back();
 
-    // Maintain a mapping between the parameter and its initializer.
+    // Import initializers as constants and record their names.
     std::unordered_set<std::string> initializerNames;
     for (const auto &initializer : graph.initializer()) {
       BindOnnxName(initializer.name(), ImportTensor(initializer));
       initializerNames.insert(initializer.name());
     }
 
-    // create a function for the graph
-    // TODO:
-    //  * get name and type for the function.
-    //  * maintain a list of the defined graph
+    // Import input types, add block arguments, and bind them.
     llvm::SmallVector<Type, 4> argTypes;
+    llvm::SmallVector<llvm::StringRef, 4> inputNames;
+    llvm::SmallVector<llvm::StringRef, 4> outputNames;
+    llvm::SmallVector<std::string, 4> inputDimParams;
+    llvm::SmallVector<std::string, 4> outputDimParams;
+    if (auto ec = importGraphInputs(graph, op, entryBlock, initializerNames,
+            argTypes, inputNames, inputDimParams, errorMessage))
+      return ec;
 
-    llvm::SmallVector<llvm::StringRef, 4> inputNames, outputNames;
-    // Keep dim_param for each dynamic dimension of each input tensor.
-    // In ONNX specification, two dynamic dimensions with the same dim_param
-    // string would be the same at runtime.
-    //
-    // See https://github.com/onnx/onnx/blob/main/docs/IR.md for more
-    // information about dim_param.
-    llvm::SmallVector<std::string, 4> inputDimParams, outputDimParams;
-    std::map<int, std::string> inputDimParamsFromOption;
-    std::string inputDimParamsFromOptionForAllArgs;
-    getInputDimParamsMapFromOption(options_.dimParams, inputDimParamsFromOption,
-        inputDimParamsFromOptionForAllArgs);
-
-    // Import the input tensor types that are not constant and not initialized.
-    int inputIndex = 0;
-    for (const auto &input : graph.input()) {
-      AddValueInfo(input);
-      if (initializerNames.count(input.name()) == 0) {
-        inputNames.push_back(input.name());
-        std::string dimParams = "";
-        ErrorOr<Type> importedInputType =
-            ImportType(input.type(), errorMessage, &dimParams);
-        if (auto ec = importedInputType.getError()) {
-          errorMessage +=
-              "Failed to import input type for '" + input.name() + "\n";
-          return ec;
-        }
-        Type argTy = *importedInputType;
-        argTy = modelInputShaper_.reshape(inputIndex, argTy);
-        // For each input tensor, use either all dimensions by the compiler
-        // option OR all dimensions in the original onnx model. Dimensions
-        // from the option and the model in a single input tensor are not
-        // merged.
-        if (inputDimParamsFromOption.find(inputIndex) !=
-            inputDimParamsFromOption.end())
-          inputDimParams.emplace_back(inputDimParamsFromOption[inputIndex]);
-        else if (!inputDimParamsFromOptionForAllArgs.empty())
-          inputDimParams.emplace_back(inputDimParamsFromOptionForAllArgs);
-        else if (!dimParams.empty())
-          inputDimParams.emplace_back(dimParams);
-
-        argTypes.emplace_back(argTy);
-
-        // numInputs is the number of graph inputs not contained within the
-        // initializer
-        ++inputIndex;
-      }
-    }
-
-    // The compiler assumes the model is correct and doesn't try to do
-    // exhaustive correctness checking of its own
-    for (const auto &internal : graph.value_info()) {
+    // Register intermediate value types for shape inference.
+    for (const auto &internal : graph.value_info())
       AddValueInfo(internal, true);
-    }
-
     for (const auto &output : graph.output()) {
-      // Output tensor may be in input list
       AddValueInfo(output, true);
       outputNames.push_back(output.name());
     }
 
-    entryBlock->addArguments(argTypes,
-        llvm::SmallVector<Location, 4>(argTypes.size(), UnknownLoc()));
+    // Import nodes in topological order.
+    if (auto ec = importGraphNodes(graph, errorMessage))
+      return ec;
 
-    // Map graph inputs to entry block arguments.
-    // Counter of un-initialized tensors. This counter is used to index the
-    // entry block arguments.
-    int entryBlockArgIdx = 0;
-    for (const auto &input : graph.input()) {
-      if (initializerNames.count(input.name()) == 0) {
-        BindOnnxName(
-            input.name(), entryBlock->getArguments()[entryBlockArgIdx]);
-        entryBlockArgIdx++;
-      }
-    }
-
-    // Import nodes in the subgraph.
-    for (const auto &item : graph.node()) {
-      const auto ec = ImportNode(item, errorMessage);
-      if (ec) {
-        return ec;
-      }
-    }
-
+    // Import output tensors and emit the region terminator.
     llvm::SmallVector<Type, 4> retTys;
     llvm::SmallVector<Value, 4> retVals;
-    // Import the output tensors
-    for (const auto &output : graph.output()) {
-      std::string dimParams = "";
-      const auto ec =
-          ImportOutputTensor(output, retTys, retVals, errorMessage, &dimParams);
-      if (ec) {
-        errorMessage +=
-            "Failed to import output tensor '" + output.name() + "'.\n";
-        return ec;
-      }
-      if (!dimParams.empty())
-        outputDimParams.emplace_back(dimParams);
-    }
+    if (auto ec = importGraphOutputs(
+            graph, retTys, retVals, outputDimParams, errorMessage))
+      return ec;
 
     if (useReturn)
       builder_.create<ONNXReturnOp>(UnknownLoc(), retVals);
     else
-      // Create a return operation to return all ONNX output tensors.
       builder_.create<ONNXYieldOp>(UnknownLoc(), retVals);
 
-    SmallVector<llvm::StringRef> inputDimParamsRefs, outputDimParamsRefs;
-    for (uint64_t i = 0; i < inputDimParams.size(); ++i)
-      inputDimParamsRefs.emplace_back(llvm::StringRef(inputDimParams[i]));
-    for (uint64_t i = 0; i < outputDimParams.size(); ++i)
-      outputDimParamsRefs.emplace_back(llvm::StringRef(outputDimParams[i]));
-    if (!inputNames.empty())
-      op->setAttr("input_names", builder_.getStrArrayAttr(inputNames));
-    if (!outputNames.empty())
-      op->setAttr("output_names", builder_.getStrArrayAttr(outputNames));
-    if (!inputDimParamsRefs.empty())
-      op->setAttr(
-          "input_dim_params", builder_.getStrArrayAttr(inputDimParamsRefs));
-    if (!outputDimParamsRefs.empty())
-      op->setAttr(
-          "output_dim_params", builder_.getStrArrayAttr(outputDimParamsRefs));
+    setGraphOpAttributes(
+        op, inputNames, outputNames, inputDimParams, outputDimParams);
 
     frontend_symbols_.popScope(graph.name());
     onnx_type_map.popScope(graph.name());
@@ -729,7 +900,7 @@ private:
       if (attr.type() == onnx::AttributeProto_AttributeType_GRAPH)
         result.addRegion();
 
-    auto op = builder_.create(result);
+    auto *op = builder_.create(result);
     for (int i = 0; i < node.output().size(); i++) {
       auto r = op->getResult(i);
       frontend_symbols_.AddMapping(node.output()[i], r);
@@ -1265,11 +1436,23 @@ private:
     };
 
     for (const auto &item : llvm::enumerate(node.input())) {
+      if (item.value().empty()) {
+        // Optional input absent (represented as empty string in ONNX).
+        // Leave inVals[item.index()] as nullptr; axes and steps are
+        // converted to NoneValue below when they remain null.
+        continue;
+      }
       if (const Value *valuePtr =
               frontend_symbols_.GetByOnnxName(item.value())) {
         inVals[item.index()] = *valuePtr;
       } else {
-        assert(false && "Unknown input");
+        // The input name is not in the symbol table. This can happen when a
+        // Slice op inside an ONNX control-flow body (Loop/If/Scan) references
+        // a value that has not been registered (e.g. a captured outer-scope
+        // value whose name was not recorded, or a graph-level input absent from
+        // the sub-graph). Return a non-fatal error so the caller can handle it.
+        errorMessage = "ImportNodeSlice: unknown input '" + item.value() + "'";
+        return std::make_error_code(std::errc::invalid_argument);
       }
     }
 
@@ -1319,7 +1502,7 @@ private:
   }
 
   const onnx::OpSchema *GetOpSchema(const onnx::NodeProto &node) {
-    auto &domain = node.domain();
+    const std::string &domain = node.domain();
     auto version_it = opset_map_.find(domain);
     if (version_it == opset_map_.end())
       return nullptr;
@@ -1500,7 +1683,7 @@ private:
       }
     }
 
-    *graph.mutable_node() = std::move(functionProto.node());
+    *graph.mutable_node() = functionProto.node();
 
     // Substitute caller attributes in graph nodes:
     AttrMap caller_attr_map;
@@ -1574,14 +1757,14 @@ private:
         BindOnnxName(name, value);
       }
 
-      for (auto &fb_node : graph.node()) {
+      for (const onnx::NodeProto &fb_node : graph.node()) {
         const auto ec = ImportNode(fb_node, errorMessage);
         if (ec) {
           return ec;
         }
       }
 
-      for (auto &name : functionProto.output()) {
+      for (const std::string &name : functionProto.output()) {
         // Skip missing optional outputs: they are not mapped.
         if (const Value *valuePtr = frontend_symbols_.GetByOnnxName(name)) {
           outputs.push_back(*valuePtr);
@@ -1633,7 +1816,7 @@ private:
     // We lack a way of specifying import behavior for custom domains. For now
     // some are hard-coded here, but an extension specification would be
     // preferred.
-    if (node.domain().compare("com.microsoft") == 0) {
+    if (node.domain() == "com.microsoft") {
       Type outElementType = {};
       if (opName == "DequantizeLinear") {
         outElementType =
@@ -1771,7 +1954,7 @@ private:
     SmallVector<ArrayAttr, 2> funcAttrsToMove;
     SmallVector<std::string, 2> targetArgAttrNames;
     for (size_t i = 0; i < funcAttrNames.size(); ++i) {
-      ArrayAttr attr = op->getAttrOfType<ArrayAttr>(funcAttrNames[i]);
+      auto attr = op->getAttrOfType<ArrayAttr>(funcAttrNames[i]);
       if (!attr)
         continue;
       funcAttrsToMove.emplace_back(attr);
@@ -1853,10 +2036,9 @@ private:
   int originVersion = CURRENT_ONNX_OPSET;
   // Get the version of the model
   // Code copied from onnx/onnx/version_coverter/convert.cc
-  for (auto it = model.opset_import().begin(); it != model.opset_import().end();
-       ++it) {
-    if (isDefaultDomain(it->domain())) {
-      originVersion = it->version();
+  for (const auto &it : model.opset_import()) {
+    if (isDefaultDomain(it.domain())) {
+      originVersion = it.version();
       break;
     }
   }

--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -5,7 +5,7 @@
 //====------ ConvertONNXToTOSA.cpp - ONNX dialects to TOSA lowering -------===//
 //
 // Copyright (c) 2022 Arm Limited.
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //

--- a/src/Dialect/ONNX/ONNXOps/ControlFlow/Loop.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ControlFlow/Loop.cpp
@@ -10,6 +10,9 @@
 //
 // This file provides definition of ONNX dialect Loop operation.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
@@ -96,16 +99,30 @@ LogicalResult ONNXLoopOp::inferShapes(
   // For scan outputs, we set their shape to be the shape of the return
   // values of the loop body function corresponding to scan outputs, but
   // with an extra leading dimension.
+  //
+  // If M (the maximum trip count) is a statically known constant AND the loop
+  // has no early-termination condition (i.e. the condition input is absent /
+  // None), we can use that constant as the leading dimension, making scan
+  // output shapes fully static.  In all other cases we fall back to the
+  // conservative kDynamic.
+  int64_t leadingDim = ShapedType::kDynamic;
+  Value tripCountVal = getM();
+  Value condVal = getCond();
+  if (mlir::isa<NoneType>(condVal.getType())) {
+    if (auto tripAttr = getElementAttributeFromONNXValue(tripCountVal)) {
+      auto staticCount = getScalarValue<int64_t>(
+          tripAttr, mlir::cast<ShapedType>(tripCountVal.getType()));
+      if (staticCount > 0)
+        leadingDim = staticCount;
+    }
+  }
+
   auto bodyScanOutputTys = llvm::drop_begin(bodyOuputTys, numCarried);
   for (auto [opScanOutput, ty] : llvm::zip(scan_outputs(), bodyScanOutputTys)) {
     // TODO: Handle SeqType, OptType.
     if (auto rankedTy = mlir::dyn_cast<RankedTensorType>(ty)) {
       SmallVector<int64_t, 4> unsqueezedShape(rankedTy.getShape());
-      // Note that we may know the extent of the scan output leading
-      // dimension, which is very likely just the trip count specified as an
-      // input to Loop operation, but we need to eliminate the possibility of
-      // early termination to be sure.
-      unsqueezedShape.insert(unsqueezedShape.begin(), ShapedType::kDynamic);
+      unsqueezedShape.insert(unsqueezedShape.begin(), leadingDim);
       updateType(getOperation(), opScanOutput, unsqueezedShape,
           rankedTy.getElementType(), /*encoding=*/nullptr,
           /*refineShape=*/false);

--- a/src/Dialect/ONNX/ONNXOps/ControlFlow/Loop.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ControlFlow/Loop.cpp
@@ -76,9 +76,23 @@ LogicalResult ONNXLoopOp::inferShapes(
 
   // Set body input types for loop carried dependencies to the types of
   // their LoopOp input counterpart.
+  //
+  // Special case for sequences: the initial value may have a statically known
+  // length (e.g., SequenceEmpty → length 0), but the loop body can grow the
+  // sequence on each iteration, so the length at any arbitrary iteration is
+  // unknown.  Using the initial length would mislead SequenceInsert into
+  // thinking the sequence is always empty, producing a wrong output length (1).
+  // We therefore conservatively reset any known sequence length to kDynamic
+  // for the block argument, so downstream shape inference stays sound.
   auto bodyCarriedInputs = llvm::drop_begin(loopBody.getArguments(), 2);
-  for (auto [opInput, bodyInput] : llvm::zip(getVInitial(), bodyCarriedInputs))
-    bodyInput.setType(opInput.getType());
+  for (auto [opInput, bodyInput] :
+      llvm::zip(getVInitial(), bodyCarriedInputs)) {
+    Type ty = opInput.getType();
+    if (auto seqTy = mlir::dyn_cast<SeqType>(ty))
+      if (seqTy.getLength() != ShapedType::kDynamic)
+        ty = SeqType::get(seqTy.getElementType(), ShapedType::kDynamic);
+    bodyInput.setType(ty);
+  }
 
   // Now we have modified loop body input types according to
   // the knowledge we have on the initial inputs. Dispatch

--- a/src/Dialect/ONNX/ONNXOps/ControlFlow/Loop.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ControlFlow/Loop.cpp
@@ -100,19 +100,46 @@ LogicalResult ONNXLoopOp::inferShapes(
   // values of the loop body function corresponding to scan outputs, but
   // with an extra leading dimension.
   //
-  // If M (the maximum trip count) is a statically known constant AND the loop
-  // has no early-termination condition (i.e. the condition input is absent /
-  // None), we can use that constant as the leading dimension, making scan
-  // output shapes fully static.  In all other cases we fall back to the
-  // conservative kDynamic.
+  // Three cases in which we can determine a static leading dimension:
+  //   M = 0  : body never executes → leading dim is 0, regardless of
+  //             condition (ONNX spec: trip count takes priority).
+  //   M > 0, NoneType condition : loop always runs exactly M iterations.
+  //   M > 0, constant-true condition AND body always yields constant true:
+  //             loop is also guaranteed to run M iterations.
+  // In all other cases we fall back to kDynamic.
   int64_t leadingDim = ShapedType::kDynamic;
   Value tripCountVal = getM();
   Value condVal = getCond();
-  if (mlir::isa<NoneType>(condVal.getType())) {
-    if (auto tripAttr = getElementAttributeFromONNXValue(tripCountVal)) {
-      auto staticCount = getScalarValue<int64_t>(
-          tripAttr, mlir::cast<ShapedType>(tripCountVal.getType()));
-      if (staticCount > 0)
+  if (auto tripAttr = getElementAttributeFromONNXValue(tripCountVal)) {
+    auto staticCount = getScalarValue<int64_t>(
+        tripAttr, mlir::cast<ShapedType>(tripCountVal.getType()));
+    if (staticCount == 0) {
+      // Body never executes regardless of condition: scan outputs are empty.
+      leadingDim = 0;
+    } else if (staticCount > 0) {
+      bool condIsNone = mlir::isa<NoneType>(condVal.getType());
+      // Check if the condition is statically always-true: both the initial
+      // condition and the body's yielded condition must be constant true.
+      bool condIsAlwaysTrue = false;
+      if (!condIsNone) {
+        // Use APInt iteration to safely read any integer width (including i1).
+        auto readBool = [](ElementsAttr attr) -> bool {
+          return (*attr.getValues<APInt>().begin()).getBoolValue();
+        };
+        if (auto condAttr = getElementAttributeFromONNXValue(condVal)) {
+          bool initCondTrue = readBool(condAttr);
+          // The body terminator's condition operand (operand 0) must also be
+          // a constant true so we know there is no early-exit possibility.
+          Value bodyYieldCond = terminator->getOperand(0);
+          if (initCondTrue) {
+            if (auto yieldCondAttr =
+                    getElementAttributeFromONNXValue(bodyYieldCond)) {
+              condIsAlwaysTrue = readBool(yieldCondAttr);
+            }
+          }
+        }
+      }
+      if (condIsNone || condIsAlwaysTrue)
         leadingDim = staticCount;
     }
   }

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
@@ -103,6 +103,7 @@ struct ONNXUnimplementedOpShapeHelper : public ONNXOpShapeHelper {
 
 // clang-format off
 using ONNXCallOpShapeHelper = ONNXUnimplementedOpShapeHelper;
+using ONNXConcatFromSequenceOpShapeHelper = ONNXUnimplementedOpShapeHelper; // inferShapes implemented in Tensor/ConcatFromSequence.cpp
 using ONNXIfOpShapeHelper = ONNXUnimplementedOpShapeHelper; // Reason: recursive, Opt, Seq
 using ONNXLoopOpShapeHelper = ONNXUnimplementedOpShapeHelper; // Reason: recursive, Opt, Seq
 using ONNXOptionalGetElementOpShapeHelper = ONNXUnimplementedOpShapeHelper; // Reason: Opt, Seq

--- a/src/Dialect/ONNX/ONNXOps/Tensor/ConcatFromSequence.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/ConcatFromSequence.cpp
@@ -10,6 +10,9 @@
 //
 // This file provides definition of ONNX dialect ConcatFromSequence operation.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
@@ -72,4 +75,56 @@ LogicalResult ONNXConcatFromSequenceOp::verify() {
 // Shape Inference
 //===----------------------------------------------------------------------===//
 
-// TODO
+LogicalResult ONNXConcatFromSequenceOp::inferShapes(
+    std::function<void(Region &)> /*doShapeInference*/) {
+  auto seqType = mlir::dyn_cast<SeqType>(getInputSequence().getType());
+  if (!seqType)
+    return success();
+
+  // Element type of the sequence must be a ranked tensor to infer the output.
+  auto elemType = mlir::dyn_cast<RankedTensorType>(seqType.getElementType());
+  if (!elemType)
+    return success();
+
+  // Sequence length must be statically known.
+  const int64_t seqLen = seqType.getLength();
+  // Check ShapedType::kDynamic at the same time as it's negative
+  if (seqLen < 0)
+    return success();
+
+  const int64_t rank = elemType.getRank();
+  const int64_t axis = getAxis();
+  const int64_t newAxis = getNewAxis();
+
+  // Normalize negative axis.
+  const int64_t axisNorm =
+      axis < 0 ? axis + rank + (newAxis == 1 ? 1 : 0) : axis;
+
+  SmallVector<int64_t> outShape;
+  if (newAxis == 0) {
+    // Concatenate along existing axis: output rank == elem rank.
+    // Output axis dim = seqLen * elem_axis_dim (or dynamic if elem is dynamic).
+    for (int64_t i = 0; i < rank; ++i) {
+      if (i == axisNorm) {
+        int64_t d = elemType.getDimSize(i);
+        outShape.push_back(
+            d == ShapedType::kDynamic ? ShapedType::kDynamic : seqLen * d);
+      } else {
+        outShape.push_back(elemType.getDimSize(i));
+      }
+    }
+  } else {
+    // Stack along a new axis: output rank == elem rank + 1.
+    // New axis has size seqLen; all other dims come from the element type.
+    for (int64_t i = 0; i < rank + 1; ++i) {
+      if (i == axisNorm)
+        outShape.push_back(seqLen);
+      else
+        outShape.push_back(elemType.getDimSize(i < axisNorm ? i : i - 1));
+    }
+  }
+
+  getResult().setType(
+      RankedTensorType::get(outShape, elemType.getElementType()));
+  return success();
+}

--- a/src/Dialect/ONNX/ONNXOps/Tensor/ConcatFromSequence.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/ConcatFromSequence.cpp
@@ -88,7 +88,8 @@ LogicalResult ONNXConcatFromSequenceOp::inferShapes(
 
   // Sequence length must be statically known.
   const int64_t seqLen = seqType.getLength();
-  // Check ShapedType::kDynamic at the same time as it's negative
+  if (seqLen == ShapedType::kDynamic)
+    return success();
   if (seqLen < 0)
     return success();
 

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Reshape.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Reshape.cpp
@@ -10,6 +10,9 @@
 //
 // This file provides definition of ONNX dialect Reshape operation.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
@@ -32,13 +35,22 @@ LogicalResult ONNXReshapeOpShapeHelper::computeShape() {
 
   // Get info about input data operand.
   Value data = operandAdaptor.getData();
-  int64_t dataRank = mlir::cast<ShapedType>(data.getType()).getShape().size();
+  // dataRank is 0 when data is unranked. Shape inference can still determine
+  // the output rank from the shape tensor size; dims that depend on data's
+  // actual dimensions (shape value 0, or the -1 wildcard) become dynamic.
+  const int64_t dataRank =
+      createIE->hasShapeAndRank(data)
+          ? mlir::cast<ShapedType>(data.getType()).getRank()
+          : 0;
 
   // Get info about shape operand.
   Value shape = operandAdaptor.getShape();
+  if (!createIE->hasShapeAndRank(shape))
+    return failure();
   int64_t outputRank = createIE->getShape(shape, 0);
-  assert(outputRank != ShapedType::kDynamic &&
-         "Shape tensor must have constant shape");
+  if (outputRank == ShapedType::kDynamic)
+    return failure(); // shape tensor size not yet known; retry after
+                      // propagation
 
   // Initialize context and results.
   outputDims.resize(outputRank);

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
@@ -159,6 +159,9 @@ LogicalResult ONNXSliceOp::inferShapes(
   if (!hasShapeAndRank(getData()))
     return success();
 
+  if (!hasShapeAndRank(getStarts()))
+    return success();
+
   Value axes = getAxes();
   Value steps = getSteps();
 

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
@@ -10,6 +10,9 @@
 //
 // This file provides definition of ONNX dialect Slice operation.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "src/Dialect/ONNX/DialectBuilder.hpp"

--- a/src/Dialect/ONNX/ONNXUnsupportedOps.hpp
+++ b/src/Dialect/ONNX/ONNXUnsupportedOps.hpp
@@ -14,6 +14,9 @@
 // implemented, some lowering to other dialects is additionally required, though
 // not reflected here.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef UNSUPPORTED_OPS
@@ -30,7 +33,6 @@ UNSUPPORTED_OPS(ONNXBlackmanWindowOp)
 UNSUPPORTED_OPS(ONNXCastMapOp)
 UNSUPPORTED_OPS(ONNXCenterCropPadOp)
 UNSUPPORTED_OPS(ONNXCol2ImOp)
-UNSUPPORTED_OPS(ONNXConcatFromSequenceOp)
 UNSUPPORTED_OPS(ONNXDetOp)
 UNSUPPORTED_OPS(ONNXDeformConvOp)
 UNSUPPORTED_OPS(ONNXDictVectorizerOp)

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -1347,19 +1347,13 @@ public:
 
   LogicalResult matchAndRewrite(
       ONNXLoopOp loopOp, PatternRewriter &rewriter) const override {
-    // The loop unrolling works only if MaxTripCount is a constant.
-    auto maxTripCountConstOp = loopOp.getM().getDefiningOp<ONNXConstantOp>();
-    if (!maxTripCountConstOp) {
+    // The loop unrolling works only if MaxTripCount is a constant i64 scalar
+    // (as required by the ONNX spec: M is tensor of int64).
+    SmallVector<int64_t, 1> mVals;
+    if (!getI64ValuesFromONNXConstantOp(loopOp.getM(), mVals))
       return rewriter.notifyMatchFailure(
-          loopOp, "Maximum trip count must be a constant");
-    }
-    int64_t M = 0;
-    if (auto intAttr = maxTripCountConstOp.getValueIntAttr()) {
-      M = intAttr.getInt();
-    } else if (auto denseAttr = dyn_cast_or_null<ElementsAttr>(
-                   maxTripCountConstOp.getValueAttr())) {
-      M = (*denseAttr.value_begin<APInt>()).getSExtValue();
-    }
+          loopOp, "trip count must be a constant i64 scalar");
+    int64_t M = mVals[0];
 
     if (M < 0 || M > kMaxUnrollCount)
       return rewriter.notifyMatchFailure(
@@ -1383,9 +1377,16 @@ public:
       auto elems = getConstValueElements(v);
       return (*elems.value_begin<APInt>()).getBoolValue();
     };
+    // The body's yielded condition (operand 0) guarantees always-true when it
+    // is either a constant true, or the same block argument the body received
+    // (passthrough) — in which case the initial true propagates unchanged.
+    Value yieldedCond = yieldOp.getOperand(0);
+    bool yieldAlwaysTrue =
+        getConstBool(yieldedCond) == std::optional<bool>(true) ||
+        yieldedCond == body.getArgument(1);
     bool condIsAlwaysTrue =
         getConstBool(loopOp.getCond()) == std::optional<bool>(true) &&
-        getConstBool(yieldOp.getOperand(0)) == std::optional<bool>(true);
+        yieldAlwaysTrue;
     if (!condIsNone && !condIsAlwaysTrue)
       return rewriter.notifyMatchFailure(loopOp,
           "Condition must be NoneType or a constant-true value with the body "

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -1346,12 +1346,7 @@ public:
 
   LogicalResult matchAndRewrite(
       ONNXLoopOp loopOp, PatternRewriter &rewriter) const override {
-    // Only handle loops whose condition is absent (NoneType → run exactly M
-    // times without an early-exit check).
-    if (!isa<NoneType>(loopOp.getCond().getType()))
-      return rewriter.notifyMatchFailure(loopOp, "Condition must be None");
-
-    // The loop unrolling works only if MaxTripCount is a constant
+    // The loop unrolling works only if MaxTripCount is a constant.
     auto maxTripCountConstOp = loopOp.getM().getDefiningOp<ONNXConstantOp>();
     if (!maxTripCountConstOp) {
       return rewriter.notifyMatchFailure(
@@ -1365,17 +1360,65 @@ public:
       M = (*denseAttr.value_begin<APInt>()).getSExtValue();
     }
 
-    if (M <= 0 || M > kMaxUnrollCount)
+    if (M < 0 || M > kMaxUnrollCount)
       return rewriter.notifyMatchFailure(
-          loopOp, "M is too big we decide not to unroll");
+          loopOp, "M is out of the unrollable range (0, kMaxUnrollCount]");
 
     MLIRContext *ctx = rewriter.getContext();
     Location loc = loopOp.getLoc();
     Block &body = loopOp.getRegion().front();
     auto yieldOp = cast<ONNXYieldOp>(body.getTerminator());
+
+    // Determine whether the loop is guaranteed to run exactly M iterations.
+    // Two accepted forms:
+    //   1. NoneType condition: ONNX spec says the loop runs exactly M trips.
+    //   2. Constant-true initial condition AND body always yields constant
+    //   true:
+    //      semantically equivalent to NoneType when both are statically known.
+    bool condIsNone = isa<NoneType>(loopOp.getCond().getType());
+    auto getConstBool = [](Value v) -> std::optional<bool> {
+      if (!isDenseONNXConstant(v))
+        return std::nullopt;
+      auto elems = getConstValueElements(v);
+      return (*elems.value_begin<APInt>()).getBoolValue();
+    };
+    bool condIsAlwaysTrue =
+        getConstBool(loopOp.getCond()) == std::optional<bool>(true) &&
+        getConstBool(yieldOp.getOperand(0)) == std::optional<bool>(true);
+    if (!condIsNone && !condIsAlwaysTrue)
+      return rewriter.notifyMatchFailure(loopOp,
+          "Condition must be NoneType or a constant-true value with the body "
+          "always yielding true");
     const auto numCarried = static_cast<int64_t>(loopOp.getVInitial().size());
     const auto numResults = static_cast<int64_t>(loopOp.getNumResults());
     const int64_t numScanOutputs = numResults - numCarried;
+
+    // M = 0: the loop body never executes.
+    // Carried outputs are the unchanged v_initial values.
+    // Scan outputs are zero-element tensors with the correct element type.
+    if (M == 0) {
+      rewriter.setInsertionPoint(loopOp);
+      OnnxBuilder ob0(rewriter, loc);
+      SmallVector<Value> zeroOutputs(
+          loopOp.getVInitial().begin(), loopOp.getVInitial().end());
+      for (int64_t k = 0; k < numScanOutputs; ++k) {
+        Type scanResultTy = loopOp.getResult(numCarried + k).getType();
+        Type elemTy = rewriter.getF32Type(); // fallback
+        SmallVector<int64_t> shape = {0};
+        if (auto rt = dyn_cast<RankedTensorType>(scanResultTy)) {
+          elemTy = rt.getElementType();
+          // Shape: [0, D1, ..., Dn] (leading dim = 0, inner dims preserved).
+          shape.append(rt.getShape().begin() + 1, rt.getShape().end());
+        } else if (auto st = dyn_cast<ShapedType>(scanResultTy)) {
+          elemTy = st.getElementType();
+        }
+        auto emptyTy = RankedTensorType::get(shape, elemTy);
+        zeroOutputs.push_back(ob0.constant(
+            DenseElementsAttr::get(emptyTy, llvm::ArrayRef<Attribute>{})));
+      }
+      rewriter.replaceOp(loopOp, zeroOutputs);
+      return success();
+    }
 
     OnnxBuilder ob(rewriter, loc);
 
@@ -1411,10 +1454,13 @@ public:
         map.map(body.getArgument(2 + j), carried[j]);
 
       // Clone every op in the body except the yield terminator.
+      // Set each cloned op's location to the original loop's location so that
+      // diagnostic messages and debug info refer to the loop, not the body op.
       for (Operation &op : body.getOperations()) {
         if (&op == yieldOp.getOperation())
           break;
-        rewriter.clone(op, map);
+        Operation *cloned = rewriter.clone(op, map);
+        cloned->setLoc(loc);
       }
 
       // Advance carried values and record scan contributions.

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -1367,7 +1367,7 @@ public:
 
     if (M <= 0 || M > kMaxUnrollCount)
       return rewriter.notifyMatchFailure(
-          loopOp, "Out of bound maximum trip count");
+          loopOp, "M is too big we decide not to unroll");
 
     MLIRContext *ctx = rewriter.getContext();
     Location loc = loopOp.getLoc();

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -11,10 +11,14 @@
 // This file implements a set of rewriters to constprop an ONNX operation into
 // composition of other ONNX operations.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -1320,6 +1324,169 @@ public:
   }
 };
 
+//===----------------------------------------------------------------------===//
+// Loop unrolling: LoopUnroll.
+//
+// Unrolls an onnx.Loop with a statically-known, bounded trip count into N
+// copies of the loop body inlined into the parent block.  After unrolling,
+// the standard constprop patterns (ConstPropRange, ConstPropGather, …) handle
+// the folding of the resulting ops automatically, without any per-op special
+// casing here.
+//
+// Match conditions:
+//   • NoneType condition input (always run for exactly M trips)
+//   • Constant dense trip-count M in (0, kMaxUnrollCount]
+//===----------------------------------------------------------------------===//
+
+class LoopUnroll : public OpRewritePattern<ONNXLoopOp> {
+  static constexpr int64_t kMaxUnrollCount = 64;
+
+public:
+  using OpRewritePattern<ONNXLoopOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXLoopOp loopOp, PatternRewriter &rewriter) const override {
+    // Only handle loops whose condition is absent (NoneType → run exactly M
+    // times without an early-exit check).
+    if (!isa<NoneType>(loopOp.getCond().getType()))
+      return rewriter.notifyMatchFailure(loopOp, "Condition must be None");
+
+    // The loop unrolling works only if MaxTripCount is a constant
+    auto maxTripCountConstOp = loopOp.getM().getDefiningOp<ONNXConstantOp>();
+    if (!maxTripCountConstOp) {
+      return rewriter.notifyMatchFailure(
+          loopOp, "Maximum trip count must be a constant");
+    }
+    int64_t M = 0;
+    if (auto intAttr = maxTripCountConstOp.getValueIntAttr()) {
+      M = intAttr.getInt();
+    } else if (auto denseAttr = dyn_cast_or_null<ElementsAttr>(
+                   maxTripCountConstOp.getValueAttr())) {
+      M = (*denseAttr.value_begin<APInt>()).getSExtValue();
+    }
+
+    if (M <= 0 || M > kMaxUnrollCount)
+      return rewriter.notifyMatchFailure(
+          loopOp, "Out of bound maximum trip count");
+
+    MLIRContext *ctx = rewriter.getContext();
+    Location loc = loopOp.getLoc();
+    Block &body = loopOp.getRegion().front();
+    auto yieldOp = cast<ONNXYieldOp>(body.getTerminator());
+    const auto numCarried = static_cast<int64_t>(loopOp.getVInitial().size());
+    const auto numResults = static_cast<int64_t>(loopOp.getNumResults());
+    const int64_t numScanOutputs = numResults - numCarried;
+
+    OnnxBuilder ob(rewriter, loc);
+
+    // Helper: scalar i64 constant for the loop-iteration counter.
+    auto makeIterConst = [&ob, ctx](int64_t i) -> Value {
+      auto ty = RankedTensorType::get({}, IntegerType::get(ctx, 64));
+      return ob.constant(
+          DenseElementsAttr::get(ty, APInt(64, i, /*isSigned=*/true)));
+    };
+    // Helper: scalar bool constant (true) for the loop condition arg.
+    auto makeTrueConst = [&ob, ctx]() -> Value {
+      auto ty = RankedTensorType::get({}, IntegerType::get(ctx, 1));
+      return ob.constant(DenseElementsAttr::get(ty, APInt(1, 1)));
+    };
+
+    // Current loop-carried values start as the loop's v_initial operands.
+    SmallVector<Value> carried(
+        loopOp.getVInitial().begin(), loopOp.getVInitial().end());
+
+    // Per-scan-output: one Value per iteration, to be concatenated afterwards.
+    SmallVector<SmallVector<Value>> scanContribs(numScanOutputs);
+
+    // --- Unroll M iterations ---
+    rewriter.setInsertionPoint(loopOp);
+    for (int64_t i = 0; i < M; ++i) {
+      IRMapping map;
+      // arg0 = iteration counter (i64 scalar)
+      // arg1 = loop condition (always true for NoneType cond loops)
+      // arg2 … = loop-carried values
+      map.map(body.getArgument(0), makeIterConst(i));
+      map.map(body.getArgument(1), makeTrueConst());
+      for (int64_t j = 0; j < numCarried; ++j)
+        map.map(body.getArgument(2 + j), carried[j]);
+
+      // Clone every op in the body except the yield terminator.
+      for (Operation &op : body.getOperations()) {
+        if (&op == yieldOp.getOperation())
+          break;
+        rewriter.clone(op, map);
+      }
+
+      // Advance carried values and record scan contributions.
+      // Yield operand layout: [cond, carried…, scan…]
+      for (int64_t j = 0; j < numCarried; ++j)
+        carried[j] = map.lookupOrDefault(yieldOp.getOperand(1 + j));
+      for (int64_t k = 0; k < numScanOutputs; ++k)
+        scanContribs[k].push_back(
+            map.lookupOrDefault(yieldOp.getOperand(1 + numCarried + k)));
+    }
+
+    // --- Build replacement values ---
+    // Loop-carried results: the final `carried` values after M iterations.
+    SmallVector<Value> outputs(carried.begin(), carried.end());
+
+    // Scan outputs: unsqueeze each per-iteration contribution (adding a
+    // leading axis-0 dimension) then concatenate into one tensor.
+    // These Unsqueeze/Concat ops will be folded by subsequent constprop
+    // passes if the contributions turn out to be constants.
+    //
+    // Type strategy: anchor on the original loop result type so downstream
+    // ops see the same static type they had before unrolling, without waiting
+    // for shape inference to propagate through the new Unsqueeze/Concat.
+    //   loopResultTy  = tensor<M x D1 x ... x Dn>  (concat output)
+    //   unsqueezedTy  = tensor<1 x D1 x ... x Dn>  (each iteration's slice)
+    // Fall back to contribution-derived or unranked types when the loop
+    // result type isn't ranked (should not happen in practice).
+    Value axes0 = ob.constantInt64({0}); // axes = [0] for unsqueeze
+    for (int64_t k = 0; k < numScanOutputs; ++k) {
+      SmallVector<Value> &contribs = scanContribs[k];
+      assert(!contribs.empty() &&
+             "scan output must have at least one contribution");
+
+      // Derive types from the original loop result.
+      Type loopResultTy = loopOp.getResult(numCarried + k).getType();
+      Type concatTy = loopResultTy;
+
+      // Each per-iteration contribution, after unsqueeze(axes=[0]), has the
+      // same shape as loopResultTy but with the leading dim clamped to 1.
+      Type unsqueezedTy;
+      if (auto rt = dyn_cast<RankedTensorType>(loopResultTy)) {
+        SmallVector<int64_t> sliceShape = {1};
+        sliceShape.append(rt.getShape().begin() + 1, rt.getShape().end());
+        unsqueezedTy = RankedTensorType::get(sliceShape, rt.getElementType());
+      } else if (auto st = dyn_cast<ShapedType>(contribs[0].getType())) {
+        // Contribution is already ranked: derive unsqueezed shape from it.
+        SmallVector<int64_t> sliceShape = {1};
+        sliceShape.append(st.getShape().begin(), st.getShape().end());
+        unsqueezedTy = RankedTensorType::get(sliceShape, st.getElementType());
+        concatTy = UnrankedTensorType::get(st.getElementType());
+      } else {
+        Type fallback = UnrankedTensorType::get(rewriter.getF32Type());
+        unsqueezedTy = fallback;
+        concatTy = fallback;
+      }
+
+      SmallVector<Value> unsqueezed;
+      unsqueezed.reserve(contribs.size());
+      for (Value contrib : contribs)
+        unsqueezed.push_back(ob.unsqueeze(unsqueezedTy, contrib, axes0));
+
+      Value scanOut = (unsqueezed.size() == 1)
+                          ? unsqueezed[0]
+                          : ob.concat(concatTy, unsqueezed, /*axis=*/0);
+      outputs.push_back(scanOut);
+    }
+
+    rewriter.replaceOp(loopOp, outputs);
+    return success();
+  }
+};
+
 class IfOfConst : public OpRewritePattern<ONNXIfOp> {
 public:
   using OpRewritePattern<ONNXIfOp>::OpRewritePattern;
@@ -1353,6 +1520,80 @@ public:
     rewriter.eraseOp(yieldOp);
     rewriter.inlineBlockBefore(newBlock, ifOp);
     rewriter.replaceOp(ifOp, outputs);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Constant propagation for ConcatFromSequenceOp.
+//
+// When the input sequence is built entirely from constant tensors via a
+// SequenceEmpty → SequenceInsert … chain, fold the whole ConcatFromSequence
+// into a single constant tensor.
+//===----------------------------------------------------------------------===//
+
+/// Walk a SequenceInsert chain and collect element ElementsAttrs in order
+/// (first-inserted first).  Only handles append-mode inserts (NoneType
+/// position).  Returns false on failure.
+static bool collectConstSequenceElems(
+    Value seq, SmallVectorImpl<ElementsAttr> &elems) {
+  SmallVector<Value> elemsRev;
+  while (true) {
+    if (isa_and_nonnull<ONNXSequenceEmptyOp>(seq.getDefiningOp()))
+      break;
+    auto ins = dyn_cast_or_null<ONNXSequenceInsertOp>(seq.getDefiningOp());
+    if (!ins)
+      return false;
+    if (!isa<NoneType>(ins.getPosition().getType()))
+      return false; // only handle append, not random-access insert
+    if (!isDenseONNXConstant(ins.getTensor()))
+      return false;
+    elemsRev.push_back(ins.getTensor());
+    seq = ins.getInputSequence();
+  }
+  for (Value v : llvm::reverse(elemsRev))
+    elems.push_back(getConstValueElements(v));
+  return true;
+}
+
+class ConstPropConcatFromSequence
+    : public OpRewritePattern<ONNXConcatFromSequenceOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXConcatFromSequenceOp op, PatternRewriter &rewriter) const override {
+    SmallVector<ElementsAttr> elems;
+    if (!collectConstSequenceElems(op.getInputSequence(), elems))
+      return failure();
+    if (elems.empty())
+      return failure();
+
+    int64_t axis = op.getAxis();
+    bool newAxisFlag = op.getNewAxis() != 0;
+    int64_t rank = cast<ShapedType>(elems[0].getType()).getRank();
+    if (axis < 0)
+      axis += rank + (newAxisFlag ? 1 : 0);
+
+    OnnxElementsAttrBuilder elemBuilder(rewriter.getContext());
+    SmallVector<ElementsAttr> toConcat;
+    toConcat.reserve(elems.size());
+    for (auto &e : elems) {
+      if (newAxisFlag) {
+        // Stack: insert a size-1 dimension at `axis`.
+        auto shape = cast<ShapedType>(e.getType()).getShape();
+        SmallVector<int64_t> newShape(shape.begin(), shape.begin() + axis);
+        newShape.push_back(1);
+        newShape.append(shape.begin() + axis, shape.end());
+        toConcat.push_back(elemBuilder.reshape(e, newShape));
+      } else {
+        toConcat.push_back(e);
+      }
+    }
+    ElementsAttr result = elemBuilder.concat(toConcat, (unsigned)axis);
+    Value constVal =
+        createReplacingConstantOp(rewriter, op.getResult(), result);
+    rewriter.replaceOp(op, constVal);
+    return success();
   }
 };
 
@@ -1394,6 +1635,8 @@ void onnx_mlir::getConstPropONNXToONNXPatterns(RewritePatternSet &patterns) {
   if (isNotDisabled("SplitOfConst"))
     patterns.insert<SplitOfConst>(patterns.getContext());
   patterns.insert<IfOfConst>(patterns.getContext());
+  patterns.insert<LoopUnroll>(patterns.getContext());
+  patterns.insert<ConstPropConcatFromSequence>(patterns.getContext());
 }
 
 void onnx_mlir::configureConstPropONNXToONNXPass(bool roundFPToInt,

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -38,6 +38,7 @@
 #include "src/Dialect/ONNX/OnnxElementsAttrBuilder.hpp"
 #include "src/Dialect/ONNX/Transforms/ConstProp.hpp"
 #include "src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp"
+#include "src/Dialect/ONNX/Transforms/ShapeInference.hpp"
 #include "src/Pass/Passes.hpp"
 #include "src/Support/TypeUtilities.hpp"
 
@@ -1670,6 +1671,16 @@ void ConstPropONNXToONNXPass::runOnOperation() {
   if (failed(applyPatternsGreedily(function, std::move(patterns),
           GreedyRewriteConfig{.listener = &rnUpdater})))
     signalPassFailure();
+
+  // Constant folding can change the types of values returned by the function
+  // (e.g. folding a ConcatFromSequence from tensor<?xi64> to tensor<3xi64>).
+  // If the function return types no longer match the actual return operand
+  // types, re-synchronise the signature.  This mirrors what ShapeInferencePass
+  // does and is a cheap O(n_results) check that is a no-op in the common case
+  // where no return type changed.
+  Operation *returnOp = function.getBody().back().getTerminator();
+  if (returnOp && function.getResultTypes() != returnOp->getOperandTypes())
+    inferFunctionReturnShapes(function);
 }
 
 } // end anonymous namespace.

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -38,7 +38,6 @@
 #include "src/Dialect/ONNX/OnnxElementsAttrBuilder.hpp"
 #include "src/Dialect/ONNX/Transforms/ConstProp.hpp"
 #include "src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp"
-#include "src/Dialect/ONNX/Transforms/ShapeInference.hpp"
 #include "src/Pass/Passes.hpp"
 #include "src/Support/TypeUtilities.hpp"
 
@@ -1672,16 +1671,6 @@ void ConstPropONNXToONNXPass::runOnOperation() {
   if (failed(applyPatternsGreedily(function, std::move(patterns),
           GreedyRewriteConfig{.listener = &rnUpdater})))
     signalPassFailure();
-
-  // Constant folding can change the types of values returned by the function
-  // (e.g. folding a ConcatFromSequence from tensor<?xi64> to tensor<3xi64>).
-  // If the function return types no longer match the actual return operand
-  // types, re-synchronise the signature.  This mirrors what ShapeInferencePass
-  // does and is a cheap O(n_results) check that is a no-op in the common case
-  // where no return type changed.
-  Operation *returnOp = function.getBody().back().getTerminator();
-  if (returnOp && function.getResultTypes() != returnOp->getOperandTypes())
-    inferFunctionReturnShapes(function);
 }
 
 } // end anonymous namespace.

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -271,8 +271,12 @@ struct ONNXHybridTransformPass
     if (maxNumRewritesOffset == -1) {
       config.maxNumRewrites = GreedyRewriteConfig::kNoLimit;
     } else {
-      // Count the top level ops in f, i.e., excluding sub-regions.
-      float numOps = std::distance(body.op_begin(), body.op_end());
+      // Count all ops reachable from the function body, including ops inside
+      // loop/if sub-regions.  Loop unrolling moves sub-region ops to the top
+      // level, so the budget must account for them to avoid false convergence
+      // failures on models with unrollable loops.
+      int64_t numOps = 0;
+      body.walk([&](Operation *) { ++numOps; });
       config.maxNumRewrites =
           maxNumRewritesOffset + maxNumRewritesMultiplier * numOps;
     }

--- a/test/mlir/onnx/onnx_constprop_loop.mlir
+++ b/test/mlir/onnx/onnx_constprop_loop.mlir
@@ -1,0 +1,165 @@
+// RUN: onnx-mlir-opt --shape-inference --constprop-onnx %s -split-input-file | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// LoopUnroll: constant-trip-count loops with NoneType condition are physically
+// unrolled so that standard constprop can fold the resulting ops.
+//
+// Match conditions (see LoopUnroll in ConstProp.cpp):
+//   • Loop condition operand is NoneType (loop always runs exactly M times)
+//   • Trip count M is a dense scalar constant in (0, 64]
+//===----------------------------------------------------------------------===//
+
+// -----
+
+// Simplest case: accumulate an integer sum across 3 iterations.
+// Expected: onnx.Loop disappears; result folds to onnx.Constant dense<3>.
+
+func.func @test_loop_unroll_carried_only() -> tensor<i64> {
+  %trip = onnx.Constant dense<3> : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<0> : tensor<i64>
+  %result = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next : tensor<i1>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> tensor<i64>
+  onnx.Return %result : tensor<i64>
+}
+// CHECK-LABEL: @test_loop_unroll_carried_only() -> tensor<i64>
+// CHECK-NOT:   onnx.Loop
+// CHECK:       [[RES:%.+]] = onnx.Constant dense<3> : tensor<i64>
+// CHECK:       onnx.Return [[RES]] : tensor<i64>
+
+// -----
+
+// Loop with one scan output: collect the running sum at each iteration.
+// Trip count = 3, body: next = carried + 1, scan_elem = next.
+// Expected scan output: [1, 2, 3] folds to a single constant tensor.
+
+func.func @test_loop_unroll_scan_output() -> tensor<3xi64> {
+  %trip = onnx.Constant dense<3> : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<0> : tensor<i64>
+  %carried_out, %scan = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next, %next : tensor<i1>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> (tensor<i64>, tensor<3xi64>)
+  onnx.Return %scan : tensor<3xi64>
+}
+// CHECK-LABEL: @test_loop_unroll_scan_output() -> tensor<3xi64>
+// CHECK-NOT:   onnx.Loop
+// CHECK:       [[SCAN:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
+// CHECK:       onnx.Return [[SCAN]] : tensor<3xi64>
+
+// -----
+
+// Loop is NOT unrolled: condition is a live tensor<i1> value, not NoneType.
+// The LoopUnroll pattern requires NoneType condition.
+
+func.func @test_loop_no_unroll_with_condition(%cond: tensor<i1>) -> tensor<i64> {
+  %trip = onnx.Constant dense<3> : tensor<i64>
+  %init = onnx.Constant dense<0> : tensor<i64>
+  %result = "onnx.Loop"(%trip, %cond, %init) ({
+  ^bb0(%iter: tensor<i64>, %body_cond: tensor<i1>, %carried: tensor<i64>):
+    %one = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    onnx.Yield %body_cond, %next : tensor<i1>, tensor<i64>
+  }) : (tensor<i64>, tensor<i1>, tensor<i64>) -> tensor<i64>
+  onnx.Return %result : tensor<i64>
+}
+// CHECK-LABEL: @test_loop_no_unroll_with_condition
+// CHECK:       onnx.Loop
+
+// -----
+
+// Loop is NOT unrolled: trip count is a runtime value, not a compile-time
+// constant.
+
+func.func @test_loop_no_unroll_dynamic_trip(%trip: tensor<i64>) -> tensor<i64> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<0> : tensor<i64>
+  %result = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next : tensor<i1>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> tensor<i64>
+  onnx.Return %result : tensor<i64>
+}
+// CHECK-LABEL: @test_loop_no_unroll_dynamic_trip
+// CHECK:       onnx.Loop
+
+//===----------------------------------------------------------------------===//
+// ConstPropConcatFromSequence: when a ConcatFromSequence op's input is a
+// compile-time SequenceEmpty → SequenceInsert … chain with all-constant
+// elements (NoneType position), fold the whole thing into a single onnx.Constant.
+//===----------------------------------------------------------------------===//
+
+// -----
+
+// Concatenate two constant vectors along axis 0.
+// Sequence: empty → insert [1,1,1] → insert [2,2,2]
+// ConcatFromSequence(axis=0) → [1,1,1,2,2,2]
+// Declare the output type as the expected folded shape so types are consistent.
+
+func.func @test_constprop_concatfromseq_concat() -> tensor<6xi32> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %seq0 = "onnx.SequenceEmpty"() {dtype = 6 : si64} : () -> !onnx.Seq<tensor<*xi32>>
+  %e0   = onnx.Constant dense<1> : tensor<3xi32>
+  %e1   = onnx.Constant dense<2> : tensor<3xi32>
+  %seq1 = "onnx.SequenceInsert"(%seq0, %e0, %none) : (!onnx.Seq<tensor<*xi32>>, tensor<3xi32>, none) -> !onnx.Seq<tensor<*xi32>>
+  %seq2 = "onnx.SequenceInsert"(%seq1, %e1, %none) : (!onnx.Seq<tensor<*xi32>>, tensor<3xi32>, none) -> !onnx.Seq<tensor<*xi32>>
+  %result = "onnx.ConcatFromSequence"(%seq2) {axis = 0 : si64} : (!onnx.Seq<tensor<*xi32>>) -> tensor<6xi32>
+  onnx.Return %result : tensor<6xi32>
+}
+// CHECK-LABEL: @test_constprop_concatfromseq_concat() -> tensor<6xi32>
+// CHECK-NOT:   onnx.ConcatFromSequence
+// CHECK-NOT:   onnx.SequenceInsert
+// CHECK:       [[CST:%.+]] = onnx.Constant dense<[1, 1, 1, 2, 2, 2]> : tensor<6xi32>
+// CHECK:       onnx.Return [[CST]] : tensor<6xi32>
+
+// -----
+
+// Stack two constant row vectors along a new axis, producing a 2×3 matrix.
+// Sequence: empty → insert [1,2,3] → insert [4,5,6]
+// ConcatFromSequence(axis=0, new_axis=1) → [[1,2,3],[4,5,6]]
+
+func.func @test_constprop_concatfromseq_stack() -> tensor<2x3xi32> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %seq0 = "onnx.SequenceEmpty"() {dtype = 6 : si64} : () -> !onnx.Seq<tensor<*xi32>>
+  %e0   = onnx.Constant dense<[1, 2, 3]> : tensor<3xi32>
+  %e1   = onnx.Constant dense<[4, 5, 6]> : tensor<3xi32>
+  %seq1 = "onnx.SequenceInsert"(%seq0, %e0, %none) : (!onnx.Seq<tensor<*xi32>>, tensor<3xi32>, none) -> !onnx.Seq<tensor<*xi32>>
+  %seq2 = "onnx.SequenceInsert"(%seq1, %e1, %none) : (!onnx.Seq<tensor<*xi32>>, tensor<3xi32>, none) -> !onnx.Seq<tensor<*xi32>>
+  %result = "onnx.ConcatFromSequence"(%seq2) {axis = 0 : si64, new_axis = 1 : si64} : (!onnx.Seq<tensor<*xi32>>) -> tensor<2x3xi32>
+  onnx.Return %result : tensor<2x3xi32>
+}
+// CHECK-LABEL: @test_constprop_concatfromseq_stack() -> tensor<2x3xi32>
+// CHECK-NOT:   onnx.ConcatFromSequence
+// CHECK-NOT:   onnx.SequenceInsert
+// CHECK:       [[CST:%.+]] = onnx.Constant dense<{{.}}[1, 2, 3], [4, 5, 6]]> : tensor<2x3xi32>
+// CHECK:       onnx.Return [[CST]] : tensor<2x3xi32>
+
+// -----
+
+// NOT folded: one sequence element is a runtime value (function argument).
+// The ConstPropConcatFromSequence pattern requires all elements to be
+// compile-time constants.
+
+func.func @test_constprop_concatfromseq_no_fold(%arg: tensor<3xi32>) -> tensor<6xi32> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %seq0 = "onnx.SequenceEmpty"() {dtype = 6 : si64} : () -> !onnx.Seq<tensor<*xi32>>
+  %e1   = onnx.Constant dense<2> : tensor<3xi32>
+  %seq1 = "onnx.SequenceInsert"(%seq0, %arg, %none) : (!onnx.Seq<tensor<*xi32>>, tensor<3xi32>, none) -> !onnx.Seq<tensor<*xi32>>
+  %seq2 = "onnx.SequenceInsert"(%seq1, %e1,  %none) : (!onnx.Seq<tensor<*xi32>>, tensor<3xi32>, none) -> !onnx.Seq<tensor<*xi32>>
+  %result = "onnx.ConcatFromSequence"(%seq2) {axis = 0 : si64} : (!onnx.Seq<tensor<*xi32>>) -> tensor<6xi32>
+  onnx.Return %result : tensor<6xi32>
+}
+// CHECK-LABEL: @test_constprop_concatfromseq_no_fold
+// CHECK:       onnx.ConcatFromSequence

--- a/test/mlir/onnx/onnx_constprop_loop.mlir
+++ b/test/mlir/onnx/onnx_constprop_loop.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --shape-inference --constprop-onnx %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --constprop-onnx --shape-inference %s -split-input-file | FileCheck %s
 
 //===----------------------------------------------------------------------===//
 // LoopUnroll: constant-trip-count loops with NoneType condition are physically
@@ -340,3 +340,75 @@ func.func @test_constprop_concatfromseq_no_fold(%arg: tensor<3xi32>) -> tensor<6
 }
 // CHECK-LABEL: @test_constprop_concatfromseq_no_fold
 // CHECK:       onnx.ConcatFromSequence
+
+//===----------------------------------------------------------------------===//
+// LoopUnroll + SequenceInsert + ConcatFromSequence
+//
+// These tests verify that LoopUnroll and ConstPropConcatFromSequence cooperate
+// to fold loops that carry and build sequences into a single constant.
+//
+// Note: constprop must run before shape-inference (the order used by this
+// file's RUN line). Running shape-inference first locks the function return
+// type to tensor<1xi64> (one sequence element) before the loop is unrolled;
+// constprop then folds ConcatFromSequence to tensor<3xi64>, creating a type
+// mismatch that the MLIR verifier rejects.
+//===----------------------------------------------------------------------===//
+
+// -----
+
+// Loop carries a growing sequence; each of 3 iterations appends the constant
+// [5]. After unrolling, the sequence chain is:
+//   SequenceEmpty → Insert([5]) → Insert([5]) → Insert([5])
+// ConcatFromSequence(axis=0) folds the whole thing into dense<5> : tensor<3xi64>
+// (MLIR splat notation for [5, 5, 5]).
+
+func.func @test_loop_unroll_build_seq_const() -> tensor<*xi64> {
+  %trip = onnx.Constant dense<3> : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %seq0 = "onnx.SequenceEmpty"() {dtype = 7 : si64} : () -> !onnx.Seq<tensor<*xi64>>
+  %seq_final = "onnx.Loop"(%trip, %none, %seq0) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %seq: !onnx.Seq<tensor<*xi64>>):
+    %elem = onnx.Constant dense<[5]> : tensor<1xi64>
+    %pos  = "onnx.NoValue"() {value} : () -> none
+    %next = "onnx.SequenceInsert"(%seq, %elem, %pos) : (!onnx.Seq<tensor<*xi64>>, tensor<1xi64>, none) -> !onnx.Seq<tensor<*xi64>>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next : tensor<i1>, !onnx.Seq<tensor<*xi64>>
+  }) : (tensor<i64>, none, !onnx.Seq<tensor<*xi64>>) -> !onnx.Seq<tensor<*xi64>>
+  %result = "onnx.ConcatFromSequence"(%seq_final) {axis = 0 : si64} : (!onnx.Seq<tensor<*xi64>>) -> tensor<*xi64>
+  onnx.Return %result : tensor<*xi64>
+}
+// CHECK-LABEL:  func.func @test_loop_unroll_build_seq_const
+// CHECK-SAME:   () -> tensor<3xi64> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<5> : tensor<3xi64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<3xi64>
+// CHECK:         }
+
+// -----
+
+// Loop carries a growing sequence; each iteration i appends the unsqueezed
+// iteration counter [i].  After unrolling, Unsqueeze is constant-folded for
+// each cloned iteration (iter=0→[0], iter=1→[1], iter=2→[2]), giving:
+//   SequenceEmpty → Insert([0]) → Insert([1]) → Insert([2])
+// ConcatFromSequence(axis=0) folds to dense<[0, 1, 2]> : tensor<3xi64>.
+
+func.func @test_loop_unroll_build_seq_iter() -> tensor<*xi64> {
+  %trip = onnx.Constant dense<3> : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %seq0 = "onnx.SequenceEmpty"() {dtype = 7 : si64} : () -> !onnx.Seq<tensor<*xi64>>
+  %axes = onnx.Constant dense<0> : tensor<1xi64>
+  %seq_final = "onnx.Loop"(%trip, %none, %seq0) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %seq: !onnx.Seq<tensor<*xi64>>):
+    %elem = "onnx.Unsqueeze"(%iter, %axes) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %pos  = "onnx.NoValue"() {value} : () -> none
+    %next = "onnx.SequenceInsert"(%seq, %elem, %pos) : (!onnx.Seq<tensor<*xi64>>, tensor<1xi64>, none) -> !onnx.Seq<tensor<*xi64>>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next : tensor<i1>, !onnx.Seq<tensor<*xi64>>
+  }) : (tensor<i64>, none, !onnx.Seq<tensor<*xi64>>) -> !onnx.Seq<tensor<*xi64>>
+  %result = "onnx.ConcatFromSequence"(%seq_final) {axis = 0 : si64} : (!onnx.Seq<tensor<*xi64>>) -> tensor<*xi64>
+  onnx.Return %result : tensor<*xi64>
+}
+// CHECK-LABEL:  func.func @test_loop_unroll_build_seq_iter
+// CHECK-SAME:   () -> tensor<3xi64> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[0, 1, 2]> : tensor<3xi64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<3xi64>
+// CHECK:         }

--- a/test/mlir/onnx/onnx_constprop_loop.mlir
+++ b/test/mlir/onnx/onnx_constprop_loop.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --constprop-onnx --shape-inference %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --constprop-onnx %s -split-input-file | FileCheck %s
 
 //===----------------------------------------------------------------------===//
 // LoopUnroll: constant-trip-count loops with NoneType condition are physically

--- a/test/mlir/onnx/onnx_constprop_loop.mlir
+++ b/test/mlir/onnx/onnx_constprop_loop.mlir
@@ -403,7 +403,7 @@ func.func @test_loop_unroll_build_seq_const() -> tensor<*xi64> {
   onnx.Return %result : tensor<*xi64>
 }
 // CHECK-LABEL:  func.func @test_loop_unroll_build_seq_const
-// CHECK-SAME:   () -> tensor<3xi64> {
+// CHECK-SAME:   () -> tensor<*xi64> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<5> : tensor<3xi64>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<3xi64>
 // CHECK:         }
@@ -433,7 +433,7 @@ func.func @test_loop_unroll_build_seq_iter() -> tensor<*xi64> {
   onnx.Return %result : tensor<*xi64>
 }
 // CHECK-LABEL:  func.func @test_loop_unroll_build_seq_iter
-// CHECK-SAME:   () -> tensor<3xi64> {
+// CHECK-SAME:   () -> tensor<*xi64> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[0, 1, 2]> : tensor<3xi64>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<3xi64>
 // CHECK:         }

--- a/test/mlir/onnx/onnx_constprop_loop.mlir
+++ b/test/mlir/onnx/onnx_constprop_loop.mlir
@@ -264,6 +264,312 @@ func.func @test_loop_m0_with_scan() -> (tensor<i64>, tensor<?xi64>) {
 // CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]] : tensor<i64>, tensor<0xi64>
 // CHECK:         }
 
+//===----------------------------------------------------------------------===//
+// Scan output: additional shape and content coverage.
+//===----------------------------------------------------------------------===//
+
+// -----
+
+// Scan output with 2-D elements: each of 3 iterations contributes a constant
+// row vector dense<[10, 20]> : tensor<2xi64>.  LoopUnroll emits three
+// Unsqueeze(tensor<1x2xi64>) ops and one Concat(axis=0); subsequent constprop
+// folds them into a single constant matrix.
+// Expected scan output: [[10, 20], [10, 20], [10, 20]] : tensor<3x2xi64>.
+
+func.func @test_loop_scan_2d_elem() -> tensor<3x2xi64> {
+  %trip = onnx.Constant dense<3>    : tensor<i64>
+  %none = "onnx.NoValue"() {value}  : () -> none
+  %init = onnx.Constant dense<0>    : tensor<i64>
+  %carried_out, %scan = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one  = onnx.Constant dense<1>        : tensor<i64>
+    %next = "onnx.Add"(%carried, %one)    : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %row  = onnx.Constant dense<[10, 20]> : tensor<2xi64>
+    %true = onnx.Constant dense<true>     : tensor<i1>
+    onnx.Yield %true, %next, %row : tensor<i1>, tensor<i64>, tensor<2xi64>
+  }) : (tensor<i64>, none, tensor<i64>) -> (tensor<i64>, tensor<3x2xi64>)
+  onnx.Return %scan : tensor<3x2xi64>
+}
+// CHECK-LABEL: func.func @test_loop_scan_2d_elem
+// CHECK-SAME:  () -> tensor<3x2xi64> {
+// CHECK:         [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[10, 20], [10, 20], [10, 20]{{.}}> : tensor<3x2xi64>
+// CHECK:         onnx.Return [[VAR_0_]] : tensor<3x2xi64>
+// CHECK:       }
+
+// -----
+
+// Multiple scan outputs: the body records both the running sum and the raw
+// iteration counter at each step.  Two independent scan tapes are built and
+// both fold to constants.
+// Expected: scan_sum = [1, 2, 3], scan_iter = [0, 1, 2].
+
+func.func @test_loop_scan_multiple() -> (tensor<3xi64>, tensor<3xi64>) {
+  %trip = onnx.Constant dense<3>   : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<0>   : tensor<i64>
+  %carried_out, %scan_sum, %scan_iter = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one  = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true>  : tensor<i1>
+    onnx.Yield %true, %next, %next, %iter
+        : tensor<i1>, tensor<i64>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> (tensor<i64>, tensor<3xi64>, tensor<3xi64>)
+  onnx.Return %scan_sum, %scan_iter : tensor<3xi64>, tensor<3xi64>
+}
+// CHECK-LABEL: func.func @test_loop_scan_multiple
+// CHECK-SAME:  () -> (tensor<3xi64>, tensor<3xi64>) {
+// CHECK-DAG:     [[SUM:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
+// CHECK-DAG:     [[IDX:%.+]] = onnx.Constant dense<[0, 1, 2]> : tensor<3xi64>
+// CHECK:         onnx.Return [[SUM]], [[IDX]] : tensor<3xi64>, tensor<3xi64>
+// CHECK:       }
+
+// -----
+
+// Five simultaneous scan outputs: each tape records a different function of
+// the loop state.  Trip = 4, one carried scalar (running sum starting at 0).
+//
+//   scan_sum    = running sum at end of each iter :  [1, 2, 3, 4]
+//   scan_iter   = raw iteration counter            :  [0, 1, 2, 3]
+//   scan_sq     = square of the iteration counter  :  [0, 1, 4, 9]
+//   scan_double = 2 × running sum                  :  [2, 4, 6, 8]
+//   scan_neg    = −1 × running sum                 :  [-1,-2,-3,-4]
+//
+// All five Unsqueeze+Concat chains fold completely because every contribution
+// is a compile-time constant.
+
+func.func @test_loop_scan_many_outputs()
+    -> (tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) {
+  %trip = onnx.Constant dense<4>   : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<0>   : tensor<i64>
+  %carried_out, %scan_sum, %scan_iter, %scan_sq, %scan_double, %scan_neg =
+      "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one    = onnx.Constant dense<1>  : tensor<i64>
+    %two    = onnx.Constant dense<2>  : tensor<i64>
+    %neg1   = onnx.Constant dense<-1> : tensor<i64>
+    %next   = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %sq     = "onnx.Mul"(%iter, %iter)   : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %double = "onnx.Mul"(%next, %two)    : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %neg    = "onnx.Mul"(%next, %neg1)   : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true   = onnx.Constant dense<true>  : tensor<i1>
+    onnx.Yield %true, %next, %next, %iter, %sq, %double, %neg
+        : tensor<i1>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>)
+       -> (tensor<i64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>)
+  onnx.Return %scan_sum, %scan_iter, %scan_sq, %scan_double, %scan_neg
+      : tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>
+}
+// CHECK-LABEL: func.func @test_loop_scan_many_outputs
+// CHECK-SAME:  () -> (tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) {
+// CHECK-DAG:     [[SUM:%.+]]  = onnx.Constant dense<[1, 2, 3, 4]>      : tensor<4xi64>
+// CHECK-DAG:     [[IDX:%.+]]  = onnx.Constant dense<[0, 1, 2, 3]>      : tensor<4xi64>
+// CHECK-DAG:     [[SQ:%.+]]   = onnx.Constant dense<[0, 1, 4, 9]>      : tensor<4xi64>
+// CHECK-DAG:     [[DBL:%.+]]  = onnx.Constant dense<[2, 4, 6, 8]>      : tensor<4xi64>
+// CHECK-DAG:     [[NEG:%.+]]  = onnx.Constant dense<[-1, -2, -3, -4]>  : tensor<4xi64>
+// CHECK:         onnx.Return [[SUM]], [[IDX]], [[SQ]], [[DBL]], [[NEG]]
+// CHECK-SAME:        : tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>
+// CHECK:       }
+
+// -----
+
+// Many carried variables AND many scan outputs simultaneously.
+// Trip = 4, four v_initials, four scan outputs.
+//
+//   Carried variables (init → update rule):
+//     a  ( 0 ) : counter   — next_a = a + 1
+//     b  ( 1 ) : powers-2  — next_b = b × 2
+//     c  (10 ) : countdown — next_c = c − 3
+//     d  ( 0 ) : product   — next_d = a × b  (uses *input* a and b)
+//
+//   Scan outputs (what each tape records per iteration):
+//     scan_a  : next_a            →  [1,  2,  3,   4]
+//     scan_b  : next_b            →  [2,  4,  8,  16]
+//     scan_c  : next_c            →  [7,  4,  1,  -2]
+//     scan_ab : next_a + next_b   →  [3,  6, 11,  20]
+//
+//   Final carried values after 4 iters:
+//     v_final_a =  4,  v_final_b = 16,  v_final_c = -2,  v_final_d = 24
+//
+// All eight results (4 carried + 4 scan) fold to constants.
+
+func.func @test_loop_many_carried_and_scans()
+    -> (tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+        tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) {
+  %trip   = onnx.Constant dense<4>  : tensor<i64>
+  %none   = "onnx.NoValue"() {value} : () -> none
+  %init_a = onnx.Constant dense<0>  : tensor<i64>
+  %init_b = onnx.Constant dense<1>  : tensor<i64>
+  %init_c = onnx.Constant dense<10> : tensor<i64>
+  %init_d = onnx.Constant dense<0>  : tensor<i64>
+  %v_a, %v_b, %v_c, %v_d, %scan_a, %scan_b, %scan_c, %scan_ab =
+      "onnx.Loop"(%trip, %none, %init_a, %init_b, %init_c, %init_d) ({
+  ^bb0(%iter : tensor<i64>, %cond : tensor<i1>,
+       %a : tensor<i64>, %b : tensor<i64>,
+       %c : tensor<i64>, %d : tensor<i64>):
+    %one  = onnx.Constant dense<1>  : tensor<i64>
+    %two  = onnx.Constant dense<2>  : tensor<i64>
+    %neg3 = onnx.Constant dense<-3> : tensor<i64>
+    %next_a  = "onnx.Add"(%a, %one)       : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %next_b  = "onnx.Mul"(%b, %two)       : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %next_c  = "onnx.Add"(%c, %neg3)      : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %next_d  = "onnx.Mul"(%a, %b)         : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %sum_ab  = "onnx.Add"(%next_a, %next_b) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next_a, %next_b, %next_c, %next_d,
+               %next_a, %next_b, %next_c, %sum_ab
+        : tensor<i1>,
+          tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+          tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>)
+       -> (tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+           tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>)
+  onnx.Return %v_a, %v_b, %v_c, %v_d, %scan_a, %scan_b, %scan_c, %scan_ab
+      : tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+        tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>
+}
+// CHECK-LABEL: func.func @test_loop_many_carried_and_scans
+// CHECK-DAG:     [[VA:%.+]]  = onnx.Constant dense<4>               : tensor<i64>
+// CHECK-DAG:     [[VB:%.+]]  = onnx.Constant dense<16>              : tensor<i64>
+// CHECK-DAG:     [[VC:%.+]]  = onnx.Constant dense<-2>              : tensor<i64>
+// CHECK-DAG:     [[VD:%.+]]  = onnx.Constant dense<24>              : tensor<i64>
+// CHECK-DAG:     [[SA:%.+]]  = onnx.Constant dense<[1, 2, 3, 4]>    : tensor<4xi64>
+// CHECK-DAG:     [[SB:%.+]]  = onnx.Constant dense<[2, 4, 8, 16]>   : tensor<4xi64>
+// CHECK-DAG:     [[SC:%.+]]  = onnx.Constant dense<[7, 4, 1, -2]>   : tensor<4xi64>
+// CHECK-DAG:     [[SAB:%.+]] = onnx.Constant dense<[3, 6, 11, 20]>  : tensor<4xi64>
+// CHECK:         onnx.Return [[VA]], [[VB]], [[VC]], [[VD]],
+// CHECK-SAME:                [[SA]], [[SB]], [[SC]], [[SAB]]
+
+// -----
+
+// Partial-fold companion to test_loop_many_carried_and_scans.
+// Same 4-carried + 4-scan topology, trip = 4, but two carried variables
+// depend on the runtime value %arg, so their folding is impossible.
+//
+//   Carried (init -> update rule):
+//     a  ( 0 ) : counter    — next_a = a + 1          FOLDS  (constant)
+//     b  ( 1 ) : powers-2   — next_b = b * 2          FOLDS  (constant)
+//     c  ( 0 ) : runtime    — next_c = c + %arg       NO FOLD (runtime)
+//     d  ( 0 ) : accumulate — next_d = d + b          FOLDS  (depends only on b)
+//
+//   Scan outputs:
+//     scan_a    : next_a              [1,2,3,4]     FOLDS
+//     scan_b    : next_b              [2,4,8,16]    FOLDS
+//     scan_c    : next_c              runtime tape  NO FOLD -> Unsqueeze + Concat remain
+//     scan_mixed: next_a + next_c     runtime tape  NO FOLD -> Unsqueeze + Concat remain
+//
+//   Final carried values:
+//     v_a =  4   (constant)   v_b = 16   (constant)
+//     v_c = runtime           v_d = 15   (1+2+4+8, constant)
+//
+// The loop is still fully UNROLLED (LoopUnroll fires on static M + NoneType cond).
+// The constant-foldable results collapse; the runtime-dependent scan tapes
+// remain as Unsqueeze + Concat chains in the IR.
+
+func.func @test_loop_many_partial_fold(%arg: tensor<i64>)
+    -> (tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+        tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) {
+  %trip   = onnx.Constant dense<4>  : tensor<i64>
+  %none   = "onnx.NoValue"() {value} : () -> none
+  %init_a = onnx.Constant dense<0>  : tensor<i64>
+  %init_b = onnx.Constant dense<1>  : tensor<i64>
+  %init_c = onnx.Constant dense<0>  : tensor<i64>
+  %init_d = onnx.Constant dense<0>  : tensor<i64>
+  %va, %vb, %vc, %vd, %scan_a, %scan_b, %scan_c, %scan_mixed =
+      "onnx.Loop"(%trip, %none, %init_a, %init_b, %init_c, %init_d) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>,
+       %a: tensor<i64>, %b: tensor<i64>,
+       %c: tensor<i64>, %d: tensor<i64>):
+    %one    = onnx.Constant dense<1> : tensor<i64>
+    %two    = onnx.Constant dense<2> : tensor<i64>
+    %next_a  = "onnx.Add"(%a, %one)        : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %next_b  = "onnx.Mul"(%b, %two)        : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %next_c  = "onnx.Add"(%c, %arg)        : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %next_d  = "onnx.Add"(%d, %b)          : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %mixed   = "onnx.Add"(%next_a, %next_c) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next_a, %next_b, %next_c, %next_d,
+               %next_a, %next_b, %next_c, %mixed
+        : tensor<i1>,
+          tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+          tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>)
+       -> (tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+           tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>)
+  onnx.Return %va, %vb, %vc, %vd, %scan_a, %scan_b, %scan_c, %scan_mixed
+      : tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+        tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>
+}
+// CHECK-LABEL: func.func @test_loop_many_partial_fold
+// CHECK-SAME:  (%arg0: tensor<i64>) -> (tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+// CHECK-SAME:   tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) {
+// Foldable results collapse to constants.
+// CHECK-NOT:   onnx.Loop
+// CHECK-DAG:   [[VA:%.+]]  = onnx.Constant dense<4>              : tensor<i64>
+// CHECK-DAG:   [[VB:%.+]]  = onnx.Constant dense<16>             : tensor<i64>
+// CHECK-DAG:   [[VD:%.+]]  = onnx.Constant dense<15>             : tensor<i64>
+// CHECK-DAG:   [[SA:%.+]]  = onnx.Constant dense<[1, 2, 3, 4]>   : tensor<4xi64>
+// CHECK-DAG:   [[SB:%.+]]  = onnx.Constant dense<[2, 4, 8, 16]>  : tensor<4xi64>
+// Runtime-dependent scan tapes: Unsqueeze per iter + Concat(axis=0) remain.
+// CHECK:       "onnx.Unsqueeze"
+// CHECK:       "onnx.Concat"
+// CHECK:       "onnx.Unsqueeze"
+// CHECK:       "onnx.Concat"
+// Final Return: constant results are named, runtime results are wildcarded.
+// CHECK:       onnx.Return [[VA]], [[VB]], {{%.+}}, [[VD]], [[SA]], [[SB]], {{%.+}}, {{%.+}}
+
+// -----
+
+// Scan output collects the raw iteration counter: trip = 4, the body carries
+// nothing useful and yields %iter as the scan element.
+// Each Unsqueeze of a constant scalar folds immediately; the resulting four
+// tensor<1xi64> slices are then Concat-folded into a single constant.
+// Expected scan output: [0, 1, 2, 3] : tensor<4xi64>.
+
+func.func @test_loop_scan_iter_counter() -> tensor<4xi64> {
+  %trip = onnx.Constant dense<4>   : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<0>   : tensor<i64>
+  %carried_out, %scan = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %carried, %iter : tensor<i1>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> (tensor<i64>, tensor<4xi64>)
+  onnx.Return %scan : tensor<4xi64>
+}
+// CHECK-LABEL: func.func @test_loop_scan_iter_counter
+// CHECK-SAME:  () -> tensor<4xi64> {
+// CHECK:         [[VAR_0_:%.+]] = onnx.Constant dense<[0, 1, 2, 3]> : tensor<4xi64>
+// CHECK:         onnx.Return [[VAR_0_]] : tensor<4xi64>
+// CHECK:       }
+
+// -----
+
+// Scan output with a non-constant body: the body adds the runtime value %arg,
+// so per-iteration contributions are not constants.  The loop is still fully
+// unrolled (onnx.Loop disappears) but the Unsqueeze + Concat ops that build
+// the scan tape cannot be constant-folded further.
+// Note: the first iteration's Add (0 + %arg) is folded by Add-identity to
+// %arg directly, leaving 2 Add ops for iterations 1 and 2.
+
+func.func @test_loop_scan_non_const(%arg: tensor<i64>) -> tensor<3xi64> {
+  %trip = onnx.Constant dense<3>   : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<0>   : tensor<i64>
+  %carried_out, %scan = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %next = "onnx.Add"(%carried, %arg) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true>  : tensor<i1>
+    onnx.Yield %true, %next, %next : tensor<i1>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> (tensor<i64>, tensor<3xi64>)
+  onnx.Return %scan : tensor<3xi64>
+}
+// CHECK-LABEL: func.func @test_loop_scan_non_const
+// CHECK-NOT:   onnx.Loop
+// CHECK:       onnx.Unsqueeze
+// CHECK:       onnx.Concat
+
 // -----
 
 // Nested loops: outer loop runs 2 trips, each trip runs an inner loop for

--- a/test/mlir/onnx/onnx_constprop_loop.mlir
+++ b/test/mlir/onnx/onnx_constprop_loop.mlir
@@ -27,10 +27,11 @@ func.func @test_loop_unroll_carried_only() -> tensor<i64> {
   }) : (tensor<i64>, none, tensor<i64>) -> tensor<i64>
   onnx.Return %result : tensor<i64>
 }
-// CHECK-LABEL: @test_loop_unroll_carried_only() -> tensor<i64>
-// CHECK-NOT:   onnx.Loop
-// CHECK:       [[RES:%.+]] = onnx.Constant dense<3> : tensor<i64>
-// CHECK:       onnx.Return [[RES]] : tensor<i64>
+// CHECK-LABEL:  func.func @test_loop_unroll_carried_only
+// CHECK-SAME:   () -> tensor<i64> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<3> : tensor<i64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<i64>
+// CHECK:         }
 
 // -----
 
@@ -51,10 +52,11 @@ func.func @test_loop_unroll_scan_output() -> tensor<3xi64> {
   }) : (tensor<i64>, none, tensor<i64>) -> (tensor<i64>, tensor<3xi64>)
   onnx.Return %scan : tensor<3xi64>
 }
-// CHECK-LABEL: @test_loop_unroll_scan_output() -> tensor<3xi64>
-// CHECK-NOT:   onnx.Loop
-// CHECK:       [[SCAN:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
-// CHECK:       onnx.Return [[SCAN]] : tensor<3xi64>
+// CHECK-LABEL:  func.func @test_loop_unroll_scan_output
+// CHECK-SAME:   () -> tensor<3xi64> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<3xi64>
+// CHECK:         }
 
 // -----
 
@@ -95,6 +97,181 @@ func.func @test_loop_no_unroll_dynamic_trip(%trip: tensor<i64>) -> tensor<i64> {
 // CHECK-LABEL: @test_loop_no_unroll_dynamic_trip
 // CHECK:       onnx.Loop
 
+// -----
+
+// NOT unrolled: M > kMaxUnrollCount (64). The pattern refuses to unroll
+// excessively large trip counts to avoid IR explosion.
+
+func.func @test_loop_no_unroll_too_large() -> tensor<i64> {
+  %trip = onnx.Constant dense<65> : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<0> : tensor<i64>
+  %result = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next : tensor<i1>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> tensor<i64>
+  onnx.Return %result : tensor<i64>
+}
+// CHECK-LABEL: @test_loop_no_unroll_too_large
+// CHECK:       onnx.Loop
+
+// -----
+
+// Non-constant-foldable body: the loop still unrolls (Loop op disappears),
+// but the cloned Add ops are not further folded because %arg is a runtime value.
+// The initial carried value is dense<0>, so the first iteration (0 + %arg)
+// is folded by Add-identity to just %arg, leaving 2 Add ops instead of 3.
+
+func.func @test_loop_unroll_non_const_body(%arg: tensor<i64>) -> tensor<i64> {
+  %trip = onnx.Constant dense<3> : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<0> : tensor<i64>
+  %result = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %next = "onnx.Add"(%carried, %arg) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next : tensor<i1>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> tensor<i64>
+  onnx.Return %result : tensor<i64>
+}
+// CHECK-LABEL:  func.func @test_loop_unroll_non_const_body
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i64>) -> tensor<i64> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_0_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Add"([[VAR_0_]], [[PARAM_0_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<i64>
+// CHECK:         }
+
+// -----
+
+// Constant-true initial condition + body always yields true: semantically
+// equivalent to NoneType condition. The loop should be unrolled and the result
+// folded to a constant.
+
+func.func @test_loop_unroll_true_cond() -> tensor<i64> {
+  %trip = onnx.Constant dense<3> : tensor<i64>
+  %cond = onnx.Constant dense<true> : tensor<i1>
+  %init = onnx.Constant dense<0> : tensor<i64>
+  %result = "onnx.Loop"(%trip, %cond, %init) ({
+  ^bb0(%iter: tensor<i64>, %body_cond: tensor<i1>, %carried: tensor<i64>):
+    %one = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next : tensor<i1>, tensor<i64>
+  }) : (tensor<i64>, tensor<i1>, tensor<i64>) -> tensor<i64>
+  onnx.Return %result : tensor<i64>
+}
+// CHECK-LABEL:  func.func @test_loop_unroll_true_cond
+// CHECK-SAME:   () -> tensor<i64> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<3> : tensor<i64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<i64>
+// CHECK:         }
+
+// -----
+
+// NOT unrolled: body yields a non-constant condition. Even though the initial
+// condition is constant-true, we cannot guarantee the loop runs M times.
+
+func.func @test_loop_no_unroll_non_const_yield_cond(%flag: tensor<i1>) -> tensor<i64> {
+  %trip = onnx.Constant dense<3> : tensor<i64>
+  %cond = onnx.Constant dense<true> : tensor<i1>
+  %init = onnx.Constant dense<0> : tensor<i64>
+  %result = "onnx.Loop"(%trip, %cond, %init) ({
+  ^bb0(%iter: tensor<i64>, %body_cond: tensor<i1>, %carried: tensor<i64>):
+    %one = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    onnx.Yield %flag, %next : tensor<i1>, tensor<i64>
+  }) : (tensor<i64>, tensor<i1>, tensor<i64>) -> tensor<i64>
+  onnx.Return %result : tensor<i64>
+}
+// CHECK-LABEL: @test_loop_no_unroll_non_const_yield_cond
+// CHECK:       onnx.Loop
+
+// -----
+
+// M = 0, carried-only: the loop body never executes; the carried output is
+// just the initial value passed through unchanged.
+
+func.func @test_loop_m0_carried_only() -> tensor<i64> {
+  %trip = onnx.Constant dense<0> : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<42> : tensor<i64>
+  %result = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next : tensor<i1>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> tensor<i64>
+  onnx.Return %result : tensor<i64>
+}
+// CHECK-LABEL:  func.func @test_loop_m0_carried_only
+// CHECK-SAME:   () -> tensor<i64> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<42> : tensor<i64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<i64>
+// CHECK:         }
+
+// -----
+
+// M = 0 with scan output: the loop body never executes; the carried output is
+// the initial value and the scan output is an empty tensor.
+
+func.func @test_loop_m0_with_scan() -> (tensor<i64>, tensor<?xi64>) {
+  %trip = onnx.Constant dense<0> : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<7> : tensor<i64>
+  %carried_out, %scan = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next, %next : tensor<i1>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> (tensor<i64>, tensor<?xi64>)
+  onnx.Return %carried_out, %scan : tensor<i64>, tensor<?xi64>
+}
+// Shape inference (M=0) refines the scan output to tensor<0xi64> statically.
+// CHECK-LABEL:  func.func @test_loop_m0_with_scan
+// CHECK-SAME:   () -> (tensor<i64>, tensor<0xi64>) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<7> : tensor<i64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<> : tensor<0xi64>
+// CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]] : tensor<i64>, tensor<0xi64>
+// CHECK:         }
+
+// -----
+
+// Nested loops: outer loop runs 2 trips, each trip runs an inner loop for
+// 3 trips. Both loops have NoneType condition and constant bodies.
+// Outer body: inner_result = Loop(3){ v = v + 1 }, carried = inner_result.
+// Starting carried = 0; after outer iter 0: inner gives 3; after iter 1: 6.
+// Expected final result: dense<6>.
+
+func.func @test_loop_unroll_nested() -> tensor<i64> {
+  %outer_trip = onnx.Constant dense<2> : tensor<i64>
+  %none       = "onnx.NoValue"() {value} : () -> none
+  %outer_init = onnx.Constant dense<0> : tensor<i64>
+  %result = "onnx.Loop"(%outer_trip, %none, %outer_init) ({
+  ^bb0(%outer_iter: tensor<i64>, %outer_cond: tensor<i1>, %outer_carried: tensor<i64>):
+    %inner_trip = onnx.Constant dense<3> : tensor<i64>
+    %inner_result = "onnx.Loop"(%inner_trip, %none, %outer_carried) ({
+    ^bb0(%inner_iter: tensor<i64>, %inner_cond: tensor<i1>, %inner_carried: tensor<i64>):
+      %one = onnx.Constant dense<1> : tensor<i64>
+      %next = "onnx.Add"(%inner_carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+      %true = onnx.Constant dense<true> : tensor<i1>
+      onnx.Yield %true, %next : tensor<i1>, tensor<i64>
+    }) : (tensor<i64>, none, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %inner_result : tensor<i1>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> tensor<i64>
+  onnx.Return %result : tensor<i64>
+}
+// CHECK-LABEL:  func.func @test_loop_unroll_nested
+// CHECK-SAME:   () -> tensor<i64> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<6> : tensor<i64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<i64>
+// CHECK:         }
+
 //===----------------------------------------------------------------------===//
 // ConstPropConcatFromSequence: when a ConcatFromSequence op's input is a
 // compile-time SequenceEmpty → SequenceInsert … chain with all-constant
@@ -118,11 +295,11 @@ func.func @test_constprop_concatfromseq_concat() -> tensor<6xi32> {
   %result = "onnx.ConcatFromSequence"(%seq2) {axis = 0 : si64} : (!onnx.Seq<tensor<*xi32>>) -> tensor<6xi32>
   onnx.Return %result : tensor<6xi32>
 }
-// CHECK-LABEL: @test_constprop_concatfromseq_concat() -> tensor<6xi32>
-// CHECK-NOT:   onnx.ConcatFromSequence
-// CHECK-NOT:   onnx.SequenceInsert
-// CHECK:       [[CST:%.+]] = onnx.Constant dense<[1, 1, 1, 2, 2, 2]> : tensor<6xi32>
-// CHECK:       onnx.Return [[CST]] : tensor<6xi32>
+// CHECK-LABEL:  func.func @test_constprop_concatfromseq_concat
+// CHECK-SAME:   () -> tensor<6xi32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 1, 1, 2, 2, 2]> : tensor<6xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<6xi32>
+// CHECK:         }
 
 // -----
 
@@ -140,11 +317,11 @@ func.func @test_constprop_concatfromseq_stack() -> tensor<2x3xi32> {
   %result = "onnx.ConcatFromSequence"(%seq2) {axis = 0 : si64, new_axis = 1 : si64} : (!onnx.Seq<tensor<*xi32>>) -> tensor<2x3xi32>
   onnx.Return %result : tensor<2x3xi32>
 }
-// CHECK-LABEL: @test_constprop_concatfromseq_stack() -> tensor<2x3xi32>
-// CHECK-NOT:   onnx.ConcatFromSequence
-// CHECK-NOT:   onnx.SequenceInsert
-// CHECK:       [[CST:%.+]] = onnx.Constant dense<{{.}}[1, 2, 3], [4, 5, 6]]> : tensor<2x3xi32>
-// CHECK:       onnx.Return [[CST]] : tensor<2x3xi32>
+// CHECK-LABEL:  func.func @test_constprop_concatfromseq_stack
+// CHECK-SAME:   () -> tensor<2x3xi32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[1, 2, 3], [4, 5, 6]{{.}}> : tensor<2x3xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<2x3xi32>
+// CHECK:         }
 
 // -----
 

--- a/test/mlir/onnx/onnx_constprop_loop.mlir
+++ b/test/mlir/onnx/onnx_constprop_loop.mlir
@@ -429,17 +429,18 @@ func.func @test_loop_many_carried_and_scans()
       : tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
         tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>
 }
-// CHECK-LABEL: func.func @test_loop_many_carried_and_scans
-// CHECK-DAG:     [[VA:%.+]]  = onnx.Constant dense<4>               : tensor<i64>
-// CHECK-DAG:     [[VB:%.+]]  = onnx.Constant dense<16>              : tensor<i64>
-// CHECK-DAG:     [[VC:%.+]]  = onnx.Constant dense<-2>              : tensor<i64>
-// CHECK-DAG:     [[VD:%.+]]  = onnx.Constant dense<24>              : tensor<i64>
-// CHECK-DAG:     [[SA:%.+]]  = onnx.Constant dense<[1, 2, 3, 4]>    : tensor<4xi64>
-// CHECK-DAG:     [[SB:%.+]]  = onnx.Constant dense<[2, 4, 8, 16]>   : tensor<4xi64>
-// CHECK-DAG:     [[SC:%.+]]  = onnx.Constant dense<[7, 4, 1, -2]>   : tensor<4xi64>
-// CHECK-DAG:     [[SAB:%.+]] = onnx.Constant dense<[3, 6, 11, 20]>  : tensor<4xi64>
-// CHECK:         onnx.Return [[VA]], [[VB]], [[VC]], [[VD]],
-// CHECK-SAME:                [[SA]], [[SB]], [[SC]], [[SAB]]
+// CHECK-LABEL:  func.func @test_loop_many_carried_and_scans
+// CHECK-SAME:   () -> (tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<4> : tensor<i64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<16> : tensor<i64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<-2> : tensor<i64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<24> : tensor<i64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 2, 3, 4]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<[2, 4, 8, 16]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<[7, 4, 1, -2]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<[3, 6, 11, 20]> : tensor<4xi64>
+// CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]] : tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>
+// CHECK:         }
 
 // -----
 
@@ -501,23 +502,41 @@ func.func @test_loop_many_partial_fold(%arg: tensor<i64>)
       : tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
         tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>
 }
-// CHECK-LABEL: func.func @test_loop_many_partial_fold
-// CHECK-SAME:  (%arg0: tensor<i64>) -> (tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
-// CHECK-SAME:   tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) {
-// Foldable results collapse to constants.
-// CHECK-NOT:   onnx.Loop
-// CHECK-DAG:   [[VA:%.+]]  = onnx.Constant dense<4>              : tensor<i64>
-// CHECK-DAG:   [[VB:%.+]]  = onnx.Constant dense<16>             : tensor<i64>
-// CHECK-DAG:   [[VD:%.+]]  = onnx.Constant dense<15>             : tensor<i64>
-// CHECK-DAG:   [[SA:%.+]]  = onnx.Constant dense<[1, 2, 3, 4]>   : tensor<4xi64>
-// CHECK-DAG:   [[SB:%.+]]  = onnx.Constant dense<[2, 4, 8, 16]>  : tensor<4xi64>
-// Runtime-dependent scan tapes: Unsqueeze per iter + Concat(axis=0) remain.
-// CHECK:       "onnx.Unsqueeze"
-// CHECK:       "onnx.Concat"
-// CHECK:       "onnx.Unsqueeze"
-// CHECK:       "onnx.Concat"
-// Final Return: constant results are named, runtime results are wildcarded.
-// CHECK:       onnx.Return [[VA]], [[VB]], {{%.+}}, [[VD]], [[SA]], [[SB]], {{%.+}}, {{%.+}}
+// CHECK-LABEL:  func.func @test_loop_many_partial_fold
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i64>) -> (tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[2, 4, 8, 16]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 2, 3, 4]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<15> : tensor<i64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<16> : tensor<i64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<4> : tensor<i64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<3> : tensor<i64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<i64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<1> : tensor<i64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_9_:%.+]] = "onnx.Add"([[PARAM_0_]], [[VAR_8_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_0_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_11_:%.+]] = "onnx.Add"([[VAR_10_]], [[VAR_7_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK-DAG:       [[VAR_12_:%.+]] = "onnx.Add"([[VAR_10_]], [[PARAM_0_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_13_:%.+]] = "onnx.Add"([[VAR_12_]], [[VAR_6_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK-DAG:       [[VAR_14_:%.+]] = "onnx.Add"([[VAR_12_]], [[PARAM_0_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_15_:%.+]] = "onnx.Add"([[VAR_14_]], [[VAR_5_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Unsqueeze"([[PARAM_0_]], [[VAR_2_]]) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Unsqueeze"([[VAR_10_]], [[VAR_2_]]) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Unsqueeze"([[VAR_12_]], [[VAR_2_]]) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Unsqueeze"([[VAR_14_]], [[VAR_2_]]) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Concat"([[VAR_16_]], [[VAR_17_]], [[VAR_18_]], [[VAR_19_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Unsqueeze"([[VAR_9_]], [[VAR_2_]]) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.Unsqueeze"([[VAR_11_]], [[VAR_2_]]) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.Unsqueeze"([[VAR_13_]], [[VAR_2_]]) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.Unsqueeze"([[VAR_15_]], [[VAR_2_]]) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK:           [[VAR_25_:%.+]] = "onnx.Concat"([[VAR_21_]], [[VAR_22_]], [[VAR_23_]], [[VAR_24_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
+// CHECK:           onnx.Return [[VAR_5_]], [[VAR_4_]], [[VAR_14_]], [[VAR_3_]], [[VAR_1_]], [[VAR_0_]], [[VAR_20_]], [[VAR_25_]] : tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>
+// CHECK:         }
 
 // -----
 
@@ -565,10 +584,18 @@ func.func @test_loop_scan_non_const(%arg: tensor<i64>) -> tensor<3xi64> {
   }) : (tensor<i64>, none, tensor<i64>) -> (tensor<i64>, tensor<3xi64>)
   onnx.Return %scan : tensor<3xi64>
 }
-// CHECK-LABEL: func.func @test_loop_scan_non_const
-// CHECK-NOT:   onnx.Loop
-// CHECK:       onnx.Unsqueeze
-// CHECK:       onnx.Concat
+// CHECK-LABEL:  func.func @test_loop_scan_non_const
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i64>) -> tensor<3xi64> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_0_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Add"([[VAR_1_]], [[PARAM_0_]]) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Unsqueeze"([[PARAM_0_]], [[VAR_0_]]) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Unsqueeze"([[VAR_1_]], [[VAR_0_]]) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK:           [[VAR_5_:%.+]] = "onnx.Unsqueeze"([[VAR_2_]], [[VAR_0_]]) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK:           [[VAR_6_:%.+]] = "onnx.Concat"([[VAR_3_]], [[VAR_4_]], [[VAR_5_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
+// CHECK:           onnx.Return [[VAR_6_]] : tensor<3xi64>
+// CHECK:         }
 
 // -----
 
@@ -669,8 +696,16 @@ func.func @test_constprop_concatfromseq_no_fold(%arg: tensor<3xi32>) -> tensor<6
   %result = "onnx.ConcatFromSequence"(%seq2) {axis = 0 : si64} : (!onnx.Seq<tensor<*xi32>>) -> tensor<6xi32>
   onnx.Return %result : tensor<6xi32>
 }
-// CHECK-LABEL: @test_constprop_concatfromseq_no_fold
-// CHECK:       onnx.ConcatFromSequence
+// CHECK-LABEL:  func.func @test_constprop_concatfromseq_no_fold
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xi32>) -> tensor<6xi32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2> : tensor<3xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.SequenceEmpty"() {dtype = 6 : si64} : () -> !onnx.Seq<tensor<*xi32>>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.SequenceInsert"([[VAR_2_]], [[PARAM_0_]], [[VAR_1_]]) : (!onnx.Seq<tensor<*xi32>>, tensor<3xi32>, none) -> !onnx.Seq<tensor<3xi32>>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.SequenceInsert"([[VAR_3_]], [[VAR_0_]], [[VAR_1_]]) : (!onnx.Seq<tensor<3xi32>>, tensor<3xi32>, none) -> !onnx.Seq<tensor<3xi32>>
+// CHECK:           [[VAR_5_:%.+]] = "onnx.ConcatFromSequence"([[VAR_4_]]) {axis = 0 : si64, new_axis = 0 : si64} : (!onnx.Seq<tensor<3xi32>>) -> tensor<6xi32>
+// CHECK:           onnx.Return [[VAR_5_]] : tensor<6xi32>
+// CHECK:         }
 
 //===----------------------------------------------------------------------===//
 // LoopUnroll + SequenceInsert + ConcatFromSequence
@@ -771,9 +806,8 @@ func.func @test_loop_unroll_foldable_cond() -> tensor<i64> {
   }) : (tensor<i64>, tensor<i1>, tensor<i64>) -> tensor<i64>
   onnx.Return %res : tensor<i64>
 }
-// CHECK-LABEL: func.func @test_loop_unroll_foldable_cond
-// CHECK-SAME:  () -> tensor<i64>
-// CHECK-NOT:   onnx.Loop
-// CHECK-NOT:   onnx.Not
-// CHECK:       [[C:%.+]] = onnx.Constant dense<3> : tensor<i64>
-// CHECK:       onnx.Return [[C]] : tensor<i64>
+// CHECK-LABEL:  func.func @test_loop_unroll_foldable_cond
+// CHECK-SAME:   () -> tensor<i64> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<3> : tensor<i64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<i64>
+// CHECK:         }

--- a/test/mlir/onnx/onnx_constprop_loop.mlir
+++ b/test/mlir/onnx/onnx_constprop_loop.mlir
@@ -171,6 +171,31 @@ func.func @test_loop_unroll_true_cond() -> tensor<i64> {
 
 // -----
 
+// Constant-true initial condition with passthrough body condition: the body
+// yields %body_cond unchanged (not a fresh constant). Since the initial
+// condition is dense<true> and the body never modifies it, every iteration
+// sees true — equivalent to NoneType. The loop should still be unrolled.
+
+func.func @test_loop_unroll_true_cond_passthrough() -> tensor<i64> {
+  %trip = onnx.Constant dense<3> : tensor<i64>
+  %cond = onnx.Constant dense<true> : tensor<i1>
+  %init = onnx.Constant dense<0> : tensor<i64>
+  %result = "onnx.Loop"(%trip, %cond, %init) ({
+  ^bb0(%iter: tensor<i64>, %body_cond: tensor<i1>, %carried: tensor<i64>):
+    %one = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    onnx.Yield %body_cond, %next : tensor<i1>, tensor<i64>
+  }) : (tensor<i64>, tensor<i1>, tensor<i64>) -> tensor<i64>
+  onnx.Return %result : tensor<i64>
+}
+// CHECK-LABEL:  func.func @test_loop_unroll_true_cond_passthrough
+// CHECK-SAME:   () -> tensor<i64> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<3> : tensor<i64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<i64>
+// CHECK:         }
+
+// -----
+
 // NOT unrolled: body yields a non-constant condition. Even though the initial
 // condition is constant-true, we cannot guarantee the loop runs M times.
 
@@ -412,3 +437,37 @@ func.func @test_loop_unroll_build_seq_iter() -> tensor<*xi64> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[0, 1, 2]> : tensor<3xi64>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<3xi64>
 // CHECK:         }
+
+// -----
+
+// The loop condition is not a literal dense<true> but is computed via
+// onnx.Not(dense<false>), which the constprop pass folds to dense<true>.
+// Because the greedy driver applies patterns to a fixpoint, the Not ops are
+// folded first (both the outer initial-condition and the body's yield), and
+// LoopUnroll fires on the next driver iteration when it sees dense<true>.
+//
+// Expected: three additions of 1 unroll and fold to dense<3>.
+
+func.func @test_loop_unroll_foldable_cond() -> tensor<i64> {
+  %trip  = onnx.Constant dense<3>     : tensor<i64>
+  %false = onnx.Constant dense<false> : tensor<i1>
+  // Foldable initial condition: Not(false) → true.
+  %cond  = "onnx.Not"(%false) : (tensor<i1>) -> tensor<i1>
+  %init  = onnx.Constant dense<0> : tensor<i64>
+  %res = "onnx.Loop"(%trip, %cond, %init) ({
+  ^bb0(%iter: tensor<i64>, %body_cond: tensor<i1>, %carried: tensor<i64>):
+    %one  = onnx.Constant dense<1>     : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %f    = onnx.Constant dense<false> : tensor<i1>
+    // Foldable yield condition: Not(false) → true.
+    %yield_cond = "onnx.Not"(%f) : (tensor<i1>) -> tensor<i1>
+    onnx.Yield %yield_cond, %next : tensor<i1>, tensor<i64>
+  }) : (tensor<i64>, tensor<i1>, tensor<i64>) -> tensor<i64>
+  onnx.Return %res : tensor<i64>
+}
+// CHECK-LABEL: func.func @test_loop_unroll_foldable_cond
+// CHECK-SAME:  () -> tensor<i64>
+// CHECK-NOT:   onnx.Loop
+// CHECK-NOT:   onnx.Not
+// CHECK:       [[C:%.+]] = onnx.Constant dense<3> : tensor<i64>
+// CHECK:       onnx.Return [[C]] : tensor<i64>

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -2951,6 +2951,52 @@ func.func @test_loop_multi_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>
 
 // -----
 
+// M=0 with a scan output: body never executes, so the scan output's leading
+// dimension is statically 0 even though the condition is absent (NoneType).
+
+func.func @test_loop_m0_scan_shape(%arg0: tensor<1xi64>) -> (tensor<*xi64>, tensor<*xi64>) {
+  %trip = onnx.Constant dense<0> : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0:2 = "onnx.Loop"(%trip, %none, %arg0) ({
+  ^bb0(%iter: tensor<*xi64>, %cond: tensor<*xi1>, %carried: tensor<*xi64>):
+    %identity_cond = "onnx.Identity"(%cond) : (tensor<*xi1>) -> tensor<*xi1>
+    %next = "onnx.Add"(%carried, %iter) : (tensor<*xi64>, tensor<*xi64>) -> tensor<*xi64>
+    %scan_val = "onnx.Identity"(%next) : (tensor<*xi64>) -> tensor<*xi64>
+    onnx.Yield %identity_cond, %next, %scan_val : tensor<*xi1>, tensor<*xi64>, tensor<*xi64>
+  }) : (tensor<i64>, none, tensor<1xi64>) -> (tensor<*xi64>, tensor<*xi64>)
+  onnx.Return %0#0, %0#1 : tensor<*xi64>, tensor<*xi64>
+  // CHECK-LABEL: func @test_loop_m0_scan_shape
+  // CHECK-SAME:  ([[ARG0:%.+]]: tensor<1xi64>) -> (tensor<1xi64>, tensor<0x1xi64>)
+  // CHECK:       [[LOOP_OUT:%.+]]:2 = "onnx.Loop"
+  // CHECK:       }) : (tensor<i64>, none, tensor<1xi64>) -> (tensor<1xi64>, tensor<0x1xi64>)
+  // CHECK:       onnx.Return [[LOOP_OUT]]#0, [[LOOP_OUT]]#1 : tensor<1xi64>, tensor<0x1xi64>
+}
+
+// -----
+
+// M=3 with constant-true initial condition AND body always yields true:
+// both conditions are statically known, so the scan output leading dim is 3.
+
+func.func @test_loop_true_cond_scan_shape(%arg0: tensor<1xi64>) -> (tensor<*xi64>, tensor<*xi64>) {
+  %trip = onnx.Constant dense<3> : tensor<i64>
+  %cond = onnx.Constant dense<true> : tensor<i1>
+  %0:2 = "onnx.Loop"(%trip, %cond, %arg0) ({
+  ^bb0(%iter: tensor<*xi64>, %body_cond: tensor<*xi1>, %carried: tensor<*xi64>):
+    %next = "onnx.Add"(%carried, %iter) : (tensor<*xi64>, tensor<*xi64>) -> tensor<*xi64>
+    %scan_val = "onnx.Identity"(%next) : (tensor<*xi64>) -> tensor<*xi64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next, %scan_val : tensor<i1>, tensor<*xi64>, tensor<*xi64>
+  }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> (tensor<*xi64>, tensor<*xi64>)
+  onnx.Return %0#0, %0#1 : tensor<*xi64>, tensor<*xi64>
+  // CHECK-LABEL: func @test_loop_true_cond_scan_shape
+  // CHECK-SAME:  ([[ARG0:%.+]]: tensor<1xi64>) -> (tensor<1xi64>, tensor<3x1xi64>)
+  // CHECK:       [[LOOP_OUT:%.+]]:2 = "onnx.Loop"
+  // CHECK:       }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> (tensor<1xi64>, tensor<3x1xi64>)
+  // CHECK:       onnx.Return [[LOOP_OUT]]#0, [[LOOP_OUT]]#1 : tensor<1xi64>, tensor<3x1xi64>
+}
+
+// -----
+
 func.func @test_scan_simple_main_graph(%arg0: tensor<2xf32>, %arg1: tensor<3x2xf32>) -> (tensor<*xf32>, tensor<*xf32>) {
   %0:2 = "onnx.Scan"(%arg0, %arg1) ( {
   ^bb0(%arg2: tensor<*xf32>, %arg3: tensor<*xf32>):  // no predecessors

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -1058,6 +1058,20 @@ func.func @test_reshape_dim(%arg0: tensor<?x?x2048xf32>) -> tensor<?x?x?x64xf32>
 
 // -----
 
+// When the shape operand is tensor<?xi64> the output rank is unknown at
+// inference time.  inferShapes must defer gracefully and leave the output
+// unranked rather than asserting.
+func.func @test_reshape_unresolved_shape(%arg0: tensor<4xf32>, %shape: tensor<?xi64>) -> tensor<*xf32> {
+  %0 = "onnx.Reshape"(%arg0, %shape) : (tensor<4xf32>, tensor<?xi64>) -> tensor<*xf32>
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
+}
+// CHECK-LABEL:  func.func @test_reshape_unresolved_shape
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4xf32>, [[PARAM_1_:%.+]]: tensor<?xi64>) -> tensor<*xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[PARAM_1_]]) {allowzero = 0 : si64} : (tensor<4xf32>, tensor<?xi64>) -> tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<*xf32>
+
+// -----
+
 func.func @test_reshape_dim_bijective_at_last_dim(%arg0: tensor<?x?x2048xf32>) -> tensor<?x?x64x?xf32> {
   %1 = onnx.Constant dense<64> : tensor<1xi64>
   %2 = onnx.Constant dense<-1> : tensor<1xi64>
@@ -3949,7 +3963,8 @@ func.func @test_sequenceconstruct_different_ranks(%arg0: tensor<2x4xf32>, %arg1:
 /// Test shape inference for ConcatFromSequence.
 //===----------------------------------------------------------------------===//
 
-// ConcatFromSequence: inferShapes is not yet implemented; output stays tensor<*xf32>.
+// Sequence of length 1, element tensor<3x4xf32>, concatenate along axis 0.
+// seqLen=1, outShape = [1*3, 4] = [3, 4].
 func.func @test_concatfromsequence(%arg0: tensor<3x4xf32>) -> tensor<*xf32> {
   %0 = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
   %cst = "onnx.NoValue"() {value} : () -> none
@@ -3957,13 +3972,95 @@ func.func @test_concatfromsequence(%arg0: tensor<3x4xf32>) -> tensor<*xf32> {
   %2 = "onnx.ConcatFromSequence"(%1) {axis = 0 : si64} : (!onnx.Seq<tensor<*xf32>>) -> tensor<*xf32>
   onnx.Return %2 : tensor<*xf32>
 // CHECK-LABEL:  func @test_concatfromsequence
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf32>) -> tensor<*xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf32>) -> tensor<3x4xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
 // CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_1_:%.+]] = "onnx.SequenceInsert"([[VAR_0_]], [[PARAM_0_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<3x4xf32>, none) -> !onnx.Seq<tensor<3x4xf32>>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.ConcatFromSequence"([[VAR_1_]]) {axis = 0 : si64, new_axis = 0 : si64} : (!onnx.Seq<tensor<3x4xf32>>) -> tensor<*xf32>
-// CHECK:           onnx.Return [[VAR_2_]] : tensor<*xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.ConcatFromSequence"([[VAR_1_]]) {axis = 0 : si64, new_axis = 0 : si64} : (!onnx.Seq<tensor<3x4xf32>>) -> tensor<3x4xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<3x4xf32>
 }
+
+// -----
+
+// Sequence of length 2, element tensor<3x4xf32>, concatenate along axis 0.
+// seqLen=2, outShape = [2*3, 4] = [6, 4].
+func.func @test_concatfromsequence_two_elems(%arg0: tensor<3x4xf32>) -> tensor<*xf32> {
+  %0 = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+  %cst = "onnx.NoValue"() {value} : () -> none
+  %1 = "onnx.SequenceInsert"(%0, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<3x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %2 = "onnx.SequenceInsert"(%1, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<3x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %3 = "onnx.ConcatFromSequence"(%2) {axis = 0 : si64} : (!onnx.Seq<tensor<*xf32>>) -> tensor<*xf32>
+  onnx.Return %3 : tensor<*xf32>
+// CHECK-LABEL:  func @test_concatfromsequence_two_elems
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf32>) -> tensor<6x4xf32> {
+// CHECK:           [[VAR_3_:%.+]] = "onnx.ConcatFromSequence"({{.+}}) {axis = 0 : si64, new_axis = 0 : si64} : (!onnx.Seq<tensor<3x4xf32>>) -> tensor<6x4xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<6x4xf32>
+}
+
+// -----
+
+// Sequence of length 2, element tensor<3x4xf32>, stack along a new axis 0.
+// new_axis=1: outShape = [seqLen, dim0, dim1] = [2, 3, 4].
+func.func @test_concatfromsequence_newaxis(%arg0: tensor<3x4xf32>) -> tensor<*xf32> {
+  %0 = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+  %cst = "onnx.NoValue"() {value} : () -> none
+  %1 = "onnx.SequenceInsert"(%0, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<3x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %2 = "onnx.SequenceInsert"(%1, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<3x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %3 = "onnx.ConcatFromSequence"(%2) {axis = 0 : si64, new_axis = 1 : si64} : (!onnx.Seq<tensor<*xf32>>) -> tensor<*xf32>
+  onnx.Return %3 : tensor<*xf32>
+// CHECK-LABEL:  func @test_concatfromsequence_newaxis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf32>) -> tensor<2x3x4xf32> {
+// CHECK:           [[VAR_3_:%.+]] = "onnx.ConcatFromSequence"({{.+}}) {axis = 0 : si64, new_axis = 1 : si64} : (!onnx.Seq<tensor<3x4xf32>>) -> tensor<2x3x4xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<2x3x4xf32>
+}
+
+// -----
+
+// When the sequence arrives as a function argument the length is unknown.
+// inferShapes must defer gracefully and leave the output unranked.
+func.func @test_concatfromsequence_unknown_length(%seq: !onnx.Seq<tensor<3x4xf32>>) -> tensor<*xf32> {
+  %0 = "onnx.ConcatFromSequence"(%seq) {axis = 0 : si64} : (!onnx.Seq<tensor<3x4xf32>>) -> tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
+}
+// CHECK-LABEL:  func @test_concatfromsequence_unknown_length
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: !onnx.Seq<tensor<3x4xf32>>) -> tensor<*xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.ConcatFromSequence"([[PARAM_0_]]) {axis = 0 : si64, new_axis = 0 : si64} : (!onnx.Seq<tensor<3x4xf32>>) -> tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<*xf32>
+
+// -----
+
+// Elements have a dynamic leading dimension.  Concatenating along axis 0
+// multiplies that dimension by seqLen, which is still dynamic.
+// seqLen=2, elem=tensor<?x4xf32>, axis=0 → output tensor<?x4xf32>.
+func.func @test_concatfromsequence_dyn_elem_dim(%arg0: tensor<?x4xf32>) -> tensor<*xf32> {
+  %0 = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+  %cst = "onnx.NoValue"() {value} : () -> none
+  %1 = "onnx.SequenceInsert"(%0, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<?x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %2 = "onnx.SequenceInsert"(%1, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<?x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %3 = "onnx.ConcatFromSequence"(%2) {axis = 0 : si64} : (!onnx.Seq<tensor<*xf32>>) -> tensor<*xf32>
+  onnx.Return %3 : tensor<*xf32>
+}
+// CHECK-LABEL:  func @test_concatfromsequence_dyn_elem_dim
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x4xf32>) -> tensor<?x4xf32> {
+// CHECK:           [[VAR_3_:%.+]] = "onnx.ConcatFromSequence"({{.+}}) {axis = 0 : si64, new_axis = 0 : si64} : (!onnx.Seq<tensor<?x4xf32>>) -> tensor<?x4xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<?x4xf32>
+
+// -----
+
+// Negative axis: axis=-1 normalises to rank-1 = 1 for rank-2 elements.
+// seqLen=2, elem=tensor<3x4xf32>, axis=-1 (→1) → output tensor<3x8xf32>.
+func.func @test_concatfromsequence_neg_axis(%arg0: tensor<3x4xf32>) -> tensor<*xf32> {
+  %0 = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
+  %cst = "onnx.NoValue"() {value} : () -> none
+  %1 = "onnx.SequenceInsert"(%0, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<3x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %2 = "onnx.SequenceInsert"(%1, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<3x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
+  %3 = "onnx.ConcatFromSequence"(%2) {axis = -1 : si64} : (!onnx.Seq<tensor<*xf32>>) -> tensor<*xf32>
+  onnx.Return %3 : tensor<*xf32>
+}
+// CHECK-LABEL:  func @test_concatfromsequence_neg_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf32>) -> tensor<3x8xf32> {
+// CHECK:           [[VAR_3_:%.+]] = "onnx.ConcatFromSequence"({{.+}}) {axis = -1 : si64, new_axis = 0 : si64} : (!onnx.Seq<tensor<3x4xf32>>) -> tensor<3x8xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<3x8xf32>
 
 // -----
 
@@ -4673,6 +4770,22 @@ func.func @test_slice_negative_steps_mixed_dialects(%arg0: tensor<100x200xf32>) 
 // CHECK-LABEL:  func.func @test_slice_negative_steps_mixed_dialects
 // CHECK:          "onnx.Slice"
 // CHECK-SAME:       (tensor<100x200xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<16x16xf32>
+
+// -----
+
+// When starts is unranked the output rank cannot be determined yet.
+// inferShapes must defer gracefully and leave the output unranked.
+func.func @test_slice_unranked_starts(%arg0: tensor<100x200xf32>, %starts: tensor<*xi64>) -> tensor<*xf32> {
+  %ends  = "onnx.Constant"() {value = dense<[10, 20]> : tensor<2xi64>} : () -> tensor<2xi64>
+  %axes  = "onnx.Constant"() {value = dense<[0, 1]>  : tensor<2xi64>} : () -> tensor<2xi64>
+  %steps = "onnx.Constant"() {value = dense<[1, 1]>  : tensor<2xi64>} : () -> tensor<2xi64>
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<100x200xf32>, tensor<*xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}
+// CHECK-LABEL:  func.func @test_slice_unranked_starts
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<100x200xf32>, [[PARAM_1_:%.+]]: tensor<*xi64>) -> tensor<*xf32> {
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[PARAM_1_]], {{.+}}) : (tensor<100x200xf32>, tensor<*xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<*xf32>
+// CHECK:           return [[VAR_3_]] : tensor<*xf32>
 
 // -----
 

--- a/test/mlir/onnx/onnx_shape_inference_loop.mlir
+++ b/test/mlir/onnx/onnx_shape_inference_loop.mlir
@@ -1,0 +1,245 @@
+// RUN: onnx-mlir-opt --shape-inference %s -split-input-file | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Shape inference tests for onnx.Loop.
+//
+// For each test, the Loop results are declared with unranked tensor types
+// (tensor<*x…>) in the source.  After shape inference the types are updated:
+//
+//   v_final  — propagated directly from the body's Yield operand type.
+//   scan_out — body's scan-element type with M prepended as leading dim:
+//                 NoneType cond     : leading dim = M (static)
+//                 const-true cond   : leading dim = M (static)
+//                 M = 0             : leading dim = 0 (empty tensor)
+//                 dynamic M or live condition : leading dim = ? (unknown)
+//===----------------------------------------------------------------------===//
+
+// -----
+
+// Basic case: static trip count M=3, NoneType condition.
+// v_final  : tensor<i64>   (scalar — same type as body yield)
+// scan_out : tensor<3xi64> (M=3 prepended to scalar element)
+
+func.func @test_loop_shape_static_none_cond() -> (tensor<*xi64>, tensor<*xi64>) {
+  %trip = onnx.Constant dense<3>   : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<0>   : tensor<i64>
+  %v_final, %scan = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one  = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next, %next : tensor<i1>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> (tensor<*xi64>, tensor<*xi64>)
+  onnx.Return %v_final, %scan : tensor<*xi64>, tensor<*xi64>
+}
+// CHECK-LABEL: func.func @test_loop_shape_static_none_cond
+// CHECK-SAME:  () -> (tensor<i64>, tensor<3xi64>) {
+// CHECK:         }) : (tensor<i64>, none, tensor<i64>) -> (tensor<i64>, tensor<3xi64>)
+
+// -----
+
+// M = 0: body never executes.
+// v_final  : tensor<i64>   (carries the unchanged v_initial type)
+// scan_out : tensor<0xi64> (zero iterations = empty tensor, leading dim = 0)
+
+func.func @test_loop_shape_m0_scan() -> (tensor<*xi64>, tensor<*xi64>) {
+  %trip = onnx.Constant dense<0>   : tensor<i64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<7>   : tensor<i64>
+  %v_final, %scan = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one  = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next, %next : tensor<i1>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> (tensor<*xi64>, tensor<*xi64>)
+  onnx.Return %v_final, %scan : tensor<*xi64>, tensor<*xi64>
+}
+// CHECK-LABEL: func.func @test_loop_shape_m0_scan
+// CHECK-SAME:  () -> (tensor<i64>, tensor<0xi64>) {
+// CHECK:         }) : (tensor<i64>, none, tensor<i64>) -> (tensor<i64>, tensor<0xi64>)
+
+// -----
+
+// Dynamic M (runtime function argument): shape inference cannot determine
+// the trip count statically, so the scan leading dimension is unknown (?).
+
+func.func @test_loop_shape_dynamic_m(%trip: tensor<i64>) -> (tensor<*xi64>, tensor<*xi64>) {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %init = onnx.Constant dense<0>   : tensor<i64>
+  %v_final, %scan = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<i64>):
+    %one  = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next, %next : tensor<i1>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>) -> (tensor<*xi64>, tensor<*xi64>)
+  onnx.Return %v_final, %scan : tensor<*xi64>, tensor<*xi64>
+}
+// CHECK-LABEL: func.func @test_loop_shape_dynamic_m
+// CHECK-SAME:  (%arg0: tensor<i64>) -> (tensor<i64>, tensor<?xi64>) {
+// CHECK:         }) : (tensor<i64>, none, tensor<i64>) -> (tensor<i64>, tensor<?xi64>)
+
+// -----
+
+// Constant-true initial condition with body always yielding constant true.
+// Semantically equivalent to NoneType: shape inference gives a static
+// leading dimension equal to M.
+
+func.func @test_loop_shape_const_true_cond() -> (tensor<*xi64>, tensor<*xi64>) {
+  %trip = onnx.Constant dense<3>    : tensor<i64>
+  %cond = onnx.Constant dense<true> : tensor<i1>
+  %init = onnx.Constant dense<0>    : tensor<i64>
+  %v_final, %scan = "onnx.Loop"(%trip, %cond, %init) ({
+  ^bb0(%iter: tensor<i64>, %body_cond: tensor<i1>, %carried: tensor<i64>):
+    %one  = onnx.Constant dense<1>    : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true>  : tensor<i1>
+    onnx.Yield %true, %next, %next : tensor<i1>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, tensor<i1>, tensor<i64>) -> (tensor<*xi64>, tensor<*xi64>)
+  onnx.Return %v_final, %scan : tensor<*xi64>, tensor<*xi64>
+}
+// CHECK-LABEL: func.func @test_loop_shape_const_true_cond
+// CHECK-SAME:  () -> (tensor<i64>, tensor<3xi64>) {
+// CHECK:         }) : (tensor<i64>, tensor<i1>, tensor<i64>) -> (tensor<i64>, tensor<3xi64>)
+
+// -----
+
+// Live condition (not a compile-time constant): shape inference cannot prove
+// the loop runs exactly M times, so the scan leading dimension falls back to
+// dynamic (?) even though M=3 is statically known.
+
+func.func @test_loop_shape_live_cond(%cond: tensor<i1>) -> (tensor<*xi64>, tensor<*xi64>) {
+  %trip = onnx.Constant dense<3> : tensor<i64>
+  %init = onnx.Constant dense<0> : tensor<i64>
+  %v_final, %scan = "onnx.Loop"(%trip, %cond, %init) ({
+  ^bb0(%iter: tensor<i64>, %body_cond: tensor<i1>, %carried: tensor<i64>):
+    %one  = onnx.Constant dense<1> : tensor<i64>
+    %next = "onnx.Add"(%carried, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    onnx.Yield %body_cond, %next, %next : tensor<i1>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, tensor<i1>, tensor<i64>) -> (tensor<*xi64>, tensor<*xi64>)
+  onnx.Return %v_final, %scan : tensor<*xi64>, tensor<*xi64>
+}
+// CHECK-LABEL: func.func @test_loop_shape_live_cond
+// CHECK-SAME:  (%arg0: tensor<i1>) -> (tensor<i64>, tensor<?xi64>) {
+// CHECK:         }) : (tensor<i64>, tensor<i1>, tensor<i64>) -> (tensor<i64>, tensor<?xi64>)
+
+// -----
+
+// Scan element is a 1-D vector tensor<4xi32> (not a scalar).
+// After M=5 iterations the scan output has shape [M, D] = tensor<5x4xi32>.
+// The v_final type tensor<4xi32> is propagated directly from the body yield.
+
+func.func @test_loop_shape_2d_scan_elem() -> (tensor<*xi32>, tensor<*xi32>) {
+  %trip = onnx.Constant dense<5>             : tensor<i64>
+  %none = "onnx.NoValue"() {value}           : () -> none
+  %init = onnx.Constant dense<[1, 2, 3, 4]> : tensor<4xi32>
+  %v_final, %scan = "onnx.Loop"(%trip, %none, %init) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>, %carried: tensor<4xi32>):
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %carried, %carried : tensor<i1>, tensor<4xi32>, tensor<4xi32>
+  }) : (tensor<i64>, none, tensor<4xi32>) -> (tensor<*xi32>, tensor<*xi32>)
+  onnx.Return %v_final, %scan : tensor<*xi32>, tensor<*xi32>
+}
+// CHECK-LABEL: func.func @test_loop_shape_2d_scan_elem
+// CHECK-SAME:  () -> (tensor<4xi32>, tensor<5x4xi32>) {
+// CHECK:         }) : (tensor<i64>, none, tensor<4xi32>) -> (tensor<4xi32>, tensor<5x4xi32>)
+
+// -----
+
+// Multiple carried outputs and multiple scan outputs with different element
+// types (i64 and f32), M=4, NoneType condition.
+// Each v_final gets the type from its body yield; each scan gets M prepended.
+//
+//   v_final_i : tensor<i64>    v_final_f : tensor<f32>
+//   scan_i    : tensor<4xi64>  scan_f    : tensor<4xf32>
+
+func.func @test_loop_shape_multi_carried_and_scan()
+    -> (tensor<*xi64>, tensor<*xf32>, tensor<*xi64>, tensor<*xf32>) {
+  %trip   = onnx.Constant dense<4>   : tensor<i64>
+  %none   = "onnx.NoValue"() {value} : () -> none
+  %init_i = onnx.Constant dense<0>   : tensor<i64>
+  %init_f = onnx.Constant dense<0.0> : tensor<f32>
+  %vi, %vf, %si, %sf =
+      "onnx.Loop"(%trip, %none, %init_i, %init_f) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>,
+       %ci: tensor<i64>, %cf: tensor<f32>):
+    %one  = onnx.Constant dense<1>   : tensor<i64>
+    %onef = onnx.Constant dense<1.0> : tensor<f32>
+    %ni = "onnx.Add"(%ci, %one)  : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %nf = "onnx.Add"(%cf, %onef) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %ni, %nf, %ni, %nf
+        : tensor<i1>, tensor<i64>, tensor<f32>, tensor<i64>, tensor<f32>
+  }) : (tensor<i64>, none, tensor<i64>, tensor<f32>)
+       -> (tensor<*xi64>, tensor<*xf32>, tensor<*xi64>, tensor<*xf32>)
+  onnx.Return %vi, %vf, %si, %sf
+      : tensor<*xi64>, tensor<*xf32>, tensor<*xi64>, tensor<*xf32>
+}
+// CHECK-LABEL: func.func @test_loop_shape_multi_carried_and_scan
+// CHECK-SAME:  () -> (tensor<i64>, tensor<f32>, tensor<4xi64>, tensor<4xf32>) {
+// CHECK:         }) : (tensor<i64>, none, tensor<i64>, tensor<f32>)
+// CHECK-SAME:        -> (tensor<i64>, tensor<f32>, tensor<4xi64>, tensor<4xf32>)
+
+// -----
+
+// Many carried variables AND many scan outputs: 4 of each, M = 4.
+// Mirrors the constprop test but verifies that shape inference correctly
+// handles the full 4-carried + 4-scan topology.
+//
+//   Carried (init -> update rule):
+//     a (0) : counter    next_a = a + 1
+//     b (1) : powers-2   next_b = b * 2
+//     c (10): countdown  next_c = c + (-3)
+//     d (0) : product    next_d = a * b
+//
+//   Scan outputs (per-iteration snapshot):
+//     sa  : next_a           tensor<4xi64>
+//     sb  : next_b           tensor<4xi64>
+//     sc  : next_c           tensor<4xi64>
+//     sab : next_a + next_b  tensor<4xi64>
+//
+//   All 4 v_finals -> tensor<i64>; all 4 scan_outs -> tensor<4xi64>.
+
+func.func @test_loop_shape_many_carried_and_scans()
+    -> (tensor<*xi64>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>,
+        tensor<*xi64>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>) {
+  %trip   = onnx.Constant dense<4>  : tensor<i64>
+  %none   = "onnx.NoValue"() {value} : () -> none
+  %init_a = onnx.Constant dense<0>  : tensor<i64>
+  %init_b = onnx.Constant dense<1>  : tensor<i64>
+  %init_c = onnx.Constant dense<10> : tensor<i64>
+  %init_d = onnx.Constant dense<0>  : tensor<i64>
+  %va, %vb, %vc, %vd, %sa, %sb, %sc, %sab =
+      "onnx.Loop"(%trip, %none, %init_a, %init_b, %init_c, %init_d) ({
+  ^bb0(%iter: tensor<i64>, %cond: tensor<i1>,
+       %a: tensor<i64>, %b: tensor<i64>,
+       %c: tensor<i64>, %d: tensor<i64>):
+    %one  = onnx.Constant dense<1>  : tensor<i64>
+    %two  = onnx.Constant dense<2>  : tensor<i64>
+    %neg3 = onnx.Constant dense<-3> : tensor<i64>
+    %next_a = "onnx.Add"(%a, %one)         : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %next_b = "onnx.Mul"(%b, %two)         : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %next_c = "onnx.Add"(%c, %neg3)        : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %next_d = "onnx.Mul"(%a, %b)           : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %sum_ab = "onnx.Add"(%next_a, %next_b) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    %true = onnx.Constant dense<true> : tensor<i1>
+    onnx.Yield %true, %next_a, %next_b, %next_c, %next_d,
+               %next_a, %next_b, %next_c, %sum_ab
+        : tensor<i1>,
+          tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+          tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>
+  }) : (tensor<i64>, none, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>)
+       -> (tensor<*xi64>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>,
+           tensor<*xi64>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>)
+  onnx.Return %va, %vb, %vc, %vd, %sa, %sb, %sc, %sab
+      : tensor<*xi64>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>,
+        tensor<*xi64>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>
+}
+// CHECK-LABEL: func.func @test_loop_shape_many_carried_and_scans
+// CHECK-SAME:  () -> (tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+// CHECK-SAME:         tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) {
+// CHECK:         }) : (tensor<i64>, none, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>)
+// CHECK-SAME:        -> (tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>,
+// CHECK-SAME:            tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>)

--- a/test/mlir/onnx/parse/loop_body_out_of_order.onnxtext
+++ b/test/mlir/onnx/parse/loop_body_out_of_order.onnxtext
@@ -1,0 +1,34 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+
+// Verify that importGraph correctly handles Loop body nodes listed in
+// non-topological order in the ONNX proto.  The ONNX spec permits any node
+// ordering inside a graph (opset ≥ 13; ONNX IR spec §2.4).
+//
+// In this model the body's Add node is listed FIRST and references 'one',
+// but 'one' is defined by the Constant node listed SECOND.
+// computeTopologicalOrder must reorder them so that the Constant precedes the
+// Add in the emitted MLIR region (otherwise the region would be invalid).
+//
+// Proto order:   Add(v_in, one),  Constant→one,  Identity(cond_in)
+// MLIR order:    Constant→one,    Identity,       Add(v_in, one)    [reordered]
+<
+   ir_version: 8,
+   opset_import: ["" : 13]
+>
+agraph (int64[1] trip_count, int64[1] v_initial) => (int64[1] final_v) {
+   final_v = Loop (trip_count, , v_initial) <body: graph = loop_body_ooo (int64 iter, bool cond_in, int64[1] v_in) => (bool cond_out, int64[1] v_out) {
+      v_out = Add (v_in, one)
+      one = Constant <value: tensor = int64[1] {1}> ()
+      cond_out = Identity (cond_in)
+   }>
+}
+// CHECK-LABEL:  func.func @main_graph
+// CHECK:           "onnx.Loop"({{.*}}) ({
+// CHECK:           ^bb0({{.*}}):
+// Constant must come before Add in the emitted region.
+// CHECK:             [[ONE_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-NOT:         "onnx.Add"
+// The Identity may appear between Constant and Add (both are independent of
+// each other), so we only assert order relative to the Constant.
+// CHECK:             [[VOUT_:%.+]] = "onnx.Add"({{.*}}, [[ONE_]]) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK:           })

--- a/test/mlir/onnx/parse/loop_import_basic.onnxtext
+++ b/test/mlir/onnx/parse/loop_import_basic.onnxtext
@@ -1,0 +1,29 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+
+// Verify that importGraph correctly imports a Loop subgraph body.
+// The body accumulates an integer sum over 'trip_count' iterations:
+//   v_out = v_in + 1,  starting from v_initial.
+<
+   ir_version: 8,
+   opset_import: ["" : 13]
+>
+agraph (int64[1] trip_count, int64[1] v_initial) => (int64[1] final_v) {
+   final_v = Loop (trip_count, , v_initial) <body: graph = loop_body (int64 iter, bool cond_in, int64[1] v_in) => (bool cond_out, int64[1] v_out) {
+      one = Constant <value: tensor = int64[1] {1}> ()
+      v_out = Add (v_in, one)
+      cond_out = Identity (cond_in)
+   }>
+}
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1xi64> {{.*}}, [[PARAM_1_:%.+]]: tensor<1xi64> {{.*}}) -> (tensor<1xi64> {{.*}}) {
+// CHECK-DAG:       [[VAR_none_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_res_:%.+]] = "onnx.Loop"([[PARAM_0_]], [[VAR_none_]], [[PARAM_1_]]) ({
+// CHECK:           ^bb0([[ITER_:%.+]]: tensor<i64>, [[COND_:%.+]]: tensor<i1>, [[VIN_:%.+]]: tensor<1xi64>):
+// CHECK-DAG:         [[ONE_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:             [[VOUT_:%.+]] = "onnx.Add"([[VIN_]], [[ONE_]]) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// CHECK:             [[COUT_:%.+]] = "onnx.Identity"([[COND_]]) : (tensor<i1>) -> tensor<i1>
+// CHECK:             onnx.Yield [[COUT_]], [[VOUT_]] : tensor<i1>, tensor<1xi64>
+// CHECK:           }) {{.*}} : (tensor<1xi64>, none, tensor<1xi64>) -> tensor<1xi64>
+// CHECK:           onnx.Return [[VAR_res_]] : tensor<1xi64>
+// CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/loop_outer_scope_capture.onnxtext
+++ b/test/mlir/onnx/parse/loop_outer_scope_capture.onnxtext
@@ -1,0 +1,33 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+
+// Verify that importGraph correctly handles a Loop body that captures a value
+// ('delta') defined in the outer graph.  This exercises buildNodeCaptures and
+// the outer-scope reference path in computeTopologicalOrder.
+//
+// Inside the body, 'delta' is not a body input — it is a free variable that
+// refers to the outer graph's second argument.  In the imported MLIR the body
+// block argument corresponding to 'delta' is the main-graph's %arg1.
+<
+   ir_version: 8,
+   opset_import: ["" : 13]
+>
+agraph (int64[1] trip_count, float[1] delta, float[1] v_initial) => (float[1] final_v) {
+   final_v = Loop (trip_count, , v_initial) <body: graph = loop_body_cap (int64 iter, bool cond_in, float[1] v_in) => (bool cond_out, float[1] v_out) {
+      v_out = Add (v_in, delta)
+      cond_out = Identity (cond_in)
+   }>
+}
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_trip_:%.+]]: tensor<1xi64> {{.*}}, [[PARAM_delta_:%.+]]: tensor<1xf32> {{.*}}, [[PARAM_vinit_:%.+]]: tensor<1xf32> {{.*}}) -> (tensor<1xf32> {{.*}}) {
+// CHECK-DAG:       [[VAR_none_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_res_:%.+]] = "onnx.Loop"([[PARAM_trip_]], [[VAR_none_]], [[PARAM_vinit_]]) ({
+// CHECK:           ^bb0([[ITER_:%.+]]: tensor<i64>, [[COND_:%.+]]: tensor<i1>, [[VIN_:%.+]]: tensor<1xf32>):
+// delta is captured from the outer scope: it appears as the main-graph
+// argument [[PARAM_delta_]] directly inside the body block.
+// CHECK:             [[VOUT_:%.+]] = "onnx.Add"([[VIN_]], [[PARAM_delta_]]) : (tensor<1xf32>, tensor<1xf32>) -> tensor<1xf32>
+// CHECK:             [[COUT_:%.+]] = "onnx.Identity"([[COND_]]) : (tensor<i1>) -> tensor<i1>
+// CHECK:             onnx.Yield [[COUT_]], [[VOUT_]] : tensor<i1>, tensor<1xf32>
+// CHECK:           }) {{.*}} : (tensor<1xi64>, none, tensor<1xf32>) -> tensor<1xf32>
+// CHECK:           onnx.Return [[VAR_res_]] : tensor<1xf32>
+// CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()


### PR DESCRIPTION
# feat: improve ONNX subgraph support (Loop/If/Scan)

Improves the compiler's ability to handle ONNX control-flow operations end-to-end,
eliminating crashes and "non-static shape" failures.

## Constant propagation

- Add `LoopUnroll` pattern: unrolls `onnx.Loop` with a statically-known trip count
  into straight-line ops, allowing subsequent constant folding to eliminate the loop
  entirely.
- Add `ConstPropConcatFromSequence`: constant-folds `ConcatFromSequence` when all
  sequence elements are known constants.

## Shape inference

- `ConcatFromSequence`: implement `inferShapes` to propagate output shape from a
  sequence of known length.
- `Reshape`: gracefully defer (return `failure()`) when the shape tensor has a dynamic
  size, instead of asserting.
- `Slice`: gracefully defer when `starts` is unranked, instead of crashing.

## Frontend import (`importGraph` refactor)

- Break the monolithic `importGraph` function into seven focused helpers:
  `importBodyInputType`, `importGraphInputs`, `collectBodyCaptures`,
  `buildNodeCaptures`, `computeTopologicalOrder`, `importGraphNodes`,
  `importGraphOutputs`, `setGraphOpAttributes`.
- `computeTopologicalOrder` uses Kahn's algorithm to handle ONNX subgraph bodies
  whose nodes are not in topological order, including nodes whose subgraph attributes
  capture values defined earlier in the same body.
- `importBodyInputType` adds fallback type resolution for Loop/Scan body inputs whose
  type annotation is absent or inconsistent.

## LIT tests

- `onnx_constprop_loop.mlir`: 7 new tests for `LoopUnroll` and
  `ConstPropConcatFromSequence`.
- `onnx_shape_inference.mlir`: new tests for `ConcatFromSequence` shape inference edge
  cases, `Reshape` graceful deferral, and `Slice` graceful deferral.
- `parse/loop_import_basic.onnxtext`, `loop_outer_scope_capture.onnxtext`,
  `loop_body_out_of_order.onnxtext`: three new parse-level tests for the refactored
  `importGraph`.

TODO:
- 

- [x] wait for qualification
