### PR TITLE
MicrosoftGroupQueryAttention: check for dynamic shape before modification

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -3342,6 +3342,21 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
       return rewriter.notifyMatchFailure(
           customOp, "expected 'query' input to have static type");
     assert(queryType.getRank() == 3 && "Query input must have rank 3");
+    // Check pastKey shape requirements early, before any IR modifications.
+    auto doRotary = customOp->getAttrOfType<IntegerAttr>("do_rotary");
+    if (doRotary && doRotary.getSInt() > 0 &&
+        (numIn < 10 || isNoneValue(positionIds))) {
+      // We need to know the past sequence length to find the total sequence
+      // length (or vice versa). We could get the total sequence length from
+      // seqlens_k, but only if this input is a constant that we can read.
+      if (isNoneValue(pastKey))
+        return rewriter.notifyMatchFailure(
+            customOp, "expected 'past_ks' input to be provided");
+      auto pastKeyType = cast<ShapedType>(pastKey.getType());
+      if (!pastKeyType.hasStaticShape())
+        return rewriter.notifyMatchFailure(
+            customOp, "expected 'past_ks' input to have static type");
+    }
 
     auto none = rewriter.create<ONNXNoneOp>(loc);
     auto si64Type = rewriter.getIntegerType(64, true);
@@ -3389,7 +3404,6 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
 
     // If do_rotary = 1, query and key need to be passed through a rotary
     // embedding op
-    auto doRotary = customOp->getAttrOfType<IntegerAttr>("do_rotary");
     ONNXRotaryEmbeddingOp ropeQuery;
     ONNXRotaryEmbeddingOp ropeKey;
     if (doRotary && doRotary.getSInt() > 0) {
@@ -3400,16 +3414,7 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
       if (numIn < 10 || isNoneValue(positionIds)) {
         positionIds = none;
 
-        // We need to know the past sequence length to find the total sequence
-        // length (or vice versa). We could get the total sequence length from
-        // seqlens_k, but only if this input is a constant that we can read.
-        if (isNoneValue(pastKey))
-          return rewriter.notifyMatchFailure(
-              customOp, "expected 'past_ks' input to be provided");
         auto pastKeyType = cast<ShapedType>(pastKey.getType());
-        if (!pastKeyType.hasStaticShape())
-          return rewriter.notifyMatchFailure(
-              customOp, "expected 'past_ks' input to have static type");
 
         // Assuming the sequence length is the same kv_sequence_length
         const int64_t seqLen = queryType.getShape()[1];

--- a/test/mlir/onnx/onnx_decompose_customop.mlir
+++ b/test/mlir/onnx/onnx_decompose_customop.mlir
@@ -947,6 +947,62 @@ func.func @gqa_batch4_do_rotary_no_position_ids(
 
 // -----
 
+// Test: do_rotary=1 with no position_ids and no past_key; GQA should not be decomposed.
+func.func @gqa_rotary_no_position_ids_no_past_key(
+  %q: tensor<1x128x3072xf32>,
+  %k: tensor<1x128x1536xf32>,
+  %v: tensor<1x128x1536xf32>,
+  %cos_cache: tensor<4096x48xf32>,
+  %sin_cache: tensor<4096x48xf32>
+) -> (tensor<1x128x3072xf32>, tensor<?x16x?x96xf32>, tensor<?x16x?x48xf32>) {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %total_seqlen = "onnx.Constant"() {value = dense<128> : tensor<i32>} : () -> tensor<i32>
+  %seqlens = "onnx.Constant"() {value = dense<127> : tensor<1x1xi32>} : () -> tensor<1x1xi32>
+  %out, %present_k, %present_v = "onnx.Custom"(%q, %k, %v, %none, %none, %seqlens, %total_seqlen, %cos_cache, %sin_cache) {
+    domain_name = "com.microsoft",
+    function_name = "GroupQueryAttention",
+    do_rotary = 1 : si64,
+    kv_num_heads = 16 : si64,
+    num_heads = 32 : si64
+  } : (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>, none, none, tensor<1x1xi32>, tensor<i32>, tensor<4096x48xf32>, tensor<4096x48xf32>) -> (tensor<1x128x3072xf32>, tensor<?x16x?x96xf32>, tensor<?x16x?x48xf32>)
+  return %out, %present_k, %present_v : tensor<1x128x3072xf32>, tensor<?x16x?x96xf32>, tensor<?x16x?x48xf32>
+}
+// CHECK-LABEL: func.func @gqa_rotary_no_position_ids_no_past_key
+// CHECK-NOT: "onnx.Attention"
+// CHECK: "onnx.Custom"
+// CHECK-SAME: function_name = "GroupQueryAttention"
+
+// -----
+
+// Test: do_rotary=1 with no position_ids and a dynamic past_key;  GQA should not be decomposed
+func.func @gqa_rotary_no_position_ids_dynamic_past_key(
+  %q: tensor<1x128x3072xf32>,
+  %k: tensor<1x128x1536xf32>,
+  %v: tensor<1x128x1536xf32>,
+  %past_k: tensor<?x16x?x96xf32>,
+  %past_v: tensor<?x16x?x48xf32>,
+  %cos_cache: tensor<4096x48xf32>,
+  %sin_cache: tensor<4096x48xf32>
+) -> (tensor<1x128x3072xf32>, tensor<?x16x?x96xf32>, tensor<?x16x?x48xf32>) {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %total_seqlen = "onnx.Constant"() {value = dense<128> : tensor<i32>} : () -> tensor<i32>
+  %seqlens = "onnx.Constant"() {value = dense<127> : tensor<1x1xi32>} : () -> tensor<1x1xi32>
+  %out, %present_k, %present_v = "onnx.Custom"(%q, %k, %v, %past_k, %past_v, %seqlens, %total_seqlen, %cos_cache, %sin_cache) {
+    domain_name = "com.microsoft",
+    function_name = "GroupQueryAttention",
+    do_rotary = 1 : si64,
+    kv_num_heads = 16 : si64,
+    num_heads = 32 : si64
+  } : (tensor<1x128x3072xf32>, tensor<1x128x1536xf32>, tensor<1x128x1536xf32>, tensor<?x16x?x96xf32>, tensor<?x16x?x48xf32>, tensor<1x1xi32>, tensor<i32>, tensor<4096x48xf32>, tensor<4096x48xf32>) -> (tensor<1x128x3072xf32>, tensor<?x16x?x96xf32>, tensor<?x16x?x48xf32>)
+  return %out, %present_k, %present_v : tensor<1x128x3072xf32>, tensor<?x16x?x96xf32>, tensor<?x16x?x48xf32>
+}
+// CHECK-LABEL: func.func @gqa_rotary_no_position_ids_dynamic_past_key
+// CHECK-NOT: "onnx.Attention"
+// CHECK: "onnx.Custom"
+// CHECK-SAME: function_name = "GroupQueryAttention"
+
+// -----
+
 func.func @rotary_embedding_4d_interleaved_rotdim_16(%data: tensor<1x32x128x96xf32>, %pos_ids: tensor<1x128xi64>, %cos_cache: tensor<4096x8xf32>, %sin_cache: tensor<4096x8xf32>) -> tensor<1x32x128x96xf32> {
   %0 = "onnx.Custom"(%data, %pos_ids, %cos_cache, %sin_cache) {
     domain_name = "com.microsoft",


### PR DESCRIPTION
This PR moves the check of dynamic shapes during the decomposition of GroupQueryAttention with included rotary before the first modification of the IR.