### PR TITLE
Move Gather-to-Slice+Reshape decomposition from canonicalization to decompose pass

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -143,7 +143,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
       opts.enableInstanceNormDecompose, opts.enableGroupNormDecompose,
       opts.enableMatmulNBitsDecompose, opts.enableGroupQueryAttentionDecompose,
       opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
-      opts.enableLstmSeqDecompose, opts.enableReduceL2Decompose));
+      opts.enableLstmSeqDecompose, opts.enableReduceL2Decompose,
+      opts.enableGatherToSlice));
   if (!opts.disableRecomposeOption)
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::createRecomposeONNXToONNXPass(/*target=*/""));

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -40,6 +40,7 @@ struct OnnxToMlirOptions {
   bool enableXMCPasses = false;
   bool enableSplitToSliceDecompose = false;
   bool enableLstmSeqDecompose = false;
+  bool enableGatherToSlice = true;
 
   bool disableBatchNormDecompose = false;
   bool disableRecomposeOption = false;

--- a/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
@@ -61,6 +61,24 @@ public:
 
     auto indicesType = cast<ShapedType>(indices.getType());
 
+    APInt indicesVal;
+    if (indicesType.getRank() == 0 &&
+        matchPattern(indices, m_ConstantInt(&indicesVal))) {
+      llvm::SmallVector<int64_t, 4> starts(inputType.getRank(), 0);
+      llvm::SmallVector<int64_t, 4> size{inputType.getShape()};
+
+      // onnx allows indices to be negative integer
+      int64_t indicesValInteger = indicesVal.getSExtValue();
+      starts[axis] = indicesValInteger >= 0 ? indicesValInteger
+                                            : indicesValInteger + size[axis];
+
+      size[axis] = 1;
+      Value sliceOp = tosaBuilder.slice(input, size, starts);
+      auto reshape = tosaBuilder.reshape(sliceOp, resultTy.getShape());
+      rewriter.replaceOp(op, reshape);
+      return success();
+    }
+
     SmallVector<int32_t, 4> newIndicesValues;
     newIndicesValues.resize(indicesType.getNumElements());
 

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -2713,7 +2713,6 @@ def ONNXGRUOp:ONNX_Op<"GRU",
 
 def ONNXGatherOp:ONNX_Op<"Gather",
   [Pure, OpVersionTrait<13>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
-  let hasCanonicalizer = 1;
   let summary = "ONNX Gather operation";
   let description = [{
   Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2981,74 +2981,6 @@ struct FusePadIntoAveragePoolPattern
   }
 };
 
-// Replace onnx.Gather with a scalar constant index by onnx.Slice +
-// onnx.Reshape. Gather(data, scalar_constant_index, axis) is equivalent to
-// slicing a single element along the axis and then squeezing that axis away.
-class ReplaceGatherWithSlicePattern : public OpRewritePattern<ONNXGatherOp> {
-public:
-  using OpRewritePattern<ONNXGatherOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(
-      ONNXGatherOp gatherOp, PatternRewriter &rewriter) const override {
-    Location loc = gatherOp.getLoc();
-    Value data = gatherOp.getData();
-    Value indices = gatherOp.getIndices();
-    int64_t axis = gatherOp.getAxis();
-
-    auto inputType = dyn_cast<RankedTensorType>(data.getType());
-    if (!inputType || !inputType.hasStaticShape())
-      return failure();
-
-    // Check that indices is a scalar
-    auto indicesType = dyn_cast<RankedTensorType>(indices.getType());
-    if (!indicesType || indicesType.getRank() != 0)
-      return failure();
-
-    auto gatherOutputType = dyn_cast<RankedTensorType>(gatherOp.getType());
-    if (!gatherOutputType)
-      return failure();
-
-    // Check that indices is a constant integer value
-    auto indicesConstOp = indices.getDefiningOp<ONNXConstantOp>();
-    if (!indicesConstOp)
-      return failure();
-    auto idx = getScalarValue<int64_t>(indicesConstOp);
-
-    const int64_t inputRank = inputType.getRank();
-    if (axis < 0)
-      axis += inputRank;
-
-    ArrayRef<int64_t> inputShape = inputType.getShape();
-
-    if (idx < 0)
-      idx += inputShape[axis];
-
-    OnnxBuilder createONNX(rewriter, loc);
-
-    Value starts = createONNX.constantInt64({idx});
-    Value ends = createONNX.constantInt64({idx + 1});
-    Value axes = createONNX.constantInt64({axis});
-    Value steps = createONNX.constantInt64({1});
-
-    SmallVector<int64_t, 4> sliceShape(inputShape.begin(), inputShape.end());
-    sliceShape[axis] = 1;
-    auto sliceType =
-        RankedTensorType::get(sliceShape, inputType.getElementType());
-
-    Value sliceOp =
-        createONNX.slice(sliceType, data, starts, ends, axes, steps);
-
-    // Gather with a scalar index removes the gathered axis from the result,
-    // but Slice preserves rank. Reshape to drop the size-1 axis.
-    Value shapeConst = createONNX.constantInt64(
-        SmallVector<int64_t>(gatherOutputType.getShape()));
-    Value reshapeOp = createONNX.reshape(gatherOutputType, sliceOp, shapeConst);
-    rewriter.replaceOp(gatherOp, reshapeOp);
-
-    return success();
-  }
-};
-
 // LeakyRelu with alpha == 0.0 is equivalent to Relu.
 class LeakyReluAlphaZeroToReluPattern
     : public OpRewritePattern<ONNXLeakyReluOp> {
@@ -3217,12 +3149,6 @@ void ONNXDimOp::getCanonicalizationPatterns(
 void ONNXEqualOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
   result.insert<BinaryOpBroadcastAxisPattern<ONNXEqualOp>>(context);
-}
-
-/// on the ONNXGatherOp.
-void ONNXGatherOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<ReplaceGatherWithSlicePattern>(context);
 }
 
 /// on the ONNXGlobalAveragePoolOp.

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -4621,6 +4621,68 @@ struct DecomposeLSTMSeqUnrollPattern : public OpRewritePattern<ONNXLSTMOp> {
   }
 };
 
+// Decompose Gather(data, scalar_constant_index, axis) into Slice + Reshape.
+class DecomposeGatherToSlicePattern : public OpRewritePattern<ONNXGatherOp> {
+public:
+  using OpRewritePattern<ONNXGatherOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXGatherOp gatherOp, PatternRewriter &rewriter) const override {
+    Location loc = gatherOp.getLoc();
+    Value data = gatherOp.getData();
+    Value indices = gatherOp.getIndices();
+    int64_t axis = gatherOp.getAxis();
+
+    auto inputType = dyn_cast<RankedTensorType>(data.getType());
+    if (!inputType || !inputType.hasStaticShape())
+      return failure();
+
+    auto indicesType = dyn_cast<RankedTensorType>(indices.getType());
+    if (!indicesType || indicesType.getRank() != 0)
+      return failure();
+
+    auto gatherOutputType = dyn_cast<RankedTensorType>(gatherOp.getType());
+    if (!gatherOutputType)
+      return failure();
+
+    auto indicesConstOp = indices.getDefiningOp<ONNXConstantOp>();
+    if (!indicesConstOp)
+      return failure();
+    auto idx = onnx_mlir::getScalarValue<int64_t>(indicesConstOp);
+
+    const int64_t inputRank = inputType.getRank();
+    if (axis < 0)
+      axis += inputRank;
+
+    ArrayRef<int64_t> inputShape = inputType.getShape();
+
+    if (idx < 0)
+      idx += inputShape[axis];
+
+    onnx_mlir::OnnxBuilder createONNX(rewriter, loc);
+
+    Value starts = createONNX.constantInt64({idx});
+    Value ends = createONNX.constantInt64({idx + 1});
+    Value axes = createONNX.constantInt64({axis});
+    Value steps = createONNX.constantInt64({1});
+
+    SmallVector<int64_t, 4> sliceShape(inputShape.begin(), inputShape.end());
+    sliceShape[axis] = 1;
+    auto sliceType =
+        RankedTensorType::get(sliceShape, inputType.getElementType());
+
+    Value sliceOp =
+        createONNX.slice(sliceType, data, starts, ends, axes, steps);
+
+    Value shapeConst = createONNX.constantInt64(
+        SmallVector<int64_t>(gatherOutputType.getShape()));
+    Value reshapeOp = createONNX.reshape(gatherOutputType, sliceOp, shapeConst);
+    rewriter.replaceOp(gatherOp, reshapeOp);
+
+    return success();
+  }
+};
+
 struct DecomposeONNXToONNXPass
     : public PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DecomposeONNXToONNXPass)
@@ -4634,8 +4696,8 @@ struct DecomposeONNXToONNXPass
       bool enableMatmulNBitsDecompose = false,
       bool enableGroupQueryAttentionDecompose = true,
       bool enableSplitToSliceDecompose = false, bool enableConcatFuse = true,
-      bool enableLstmSeqDecompose = false,
-      bool enableReduceL2Decompose = true) {
+      bool enableLstmSeqDecompose = false, bool enableReduceL2Decompose = true,
+      bool enableGatherToSlice = true) {
     this->target = target;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
     this->enableConvTransposeDecomposeToPhasedConv =
@@ -4651,6 +4713,7 @@ struct DecomposeONNXToONNXPass
     this->enableConcatFuse = enableConcatFuse;
     this->enableLstmSeqDecompose = enableLstmSeqDecompose;
     this->enableReduceL2Decompose = enableReduceL2Decompose;
+    this->enableGatherToSlice = enableGatherToSlice;
   }
 
   DecomposeONNXToONNXPass(const DecomposeONNXToONNXPass &pass)
@@ -4673,6 +4736,7 @@ struct DecomposeONNXToONNXPass
     this->enableConcatFuse = pass.enableConcatFuse.getValue();
     this->enableLstmSeqDecompose = pass.enableLstmSeqDecompose.getValue();
     this->enableReduceL2Decompose = pass.enableReduceL2Decompose.getValue();
+    this->enableGatherToSlice = pass.enableGatherToSlice.getValue();
   }
 
   StringRef getArgument() const override { return "decompose-onnx"; }
@@ -4742,6 +4806,11 @@ struct DecomposeONNXToONNXPass
                      "Sqrt(ReduceSumSquare(x))"),
       ::llvm::cl::init(true)};
 
+  Option<bool> enableGatherToSlice{*this, "enable-gather-to-slice",
+      llvm::cl::desc(
+          "Enable decomposition of Gather with scalar index to Slice+Reshape"),
+      ::llvm::cl::init(true)};
+
   void runOnOperation() final;
 
   typedef PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>>
@@ -4758,7 +4827,7 @@ void DecomposeONNXToONNXPass::runOnOperation() {
       enableGroupNormDecompose, enableMatmulNBitsDecompose,
       enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
       enableConcatFuse, enableLstmSeqDecompose, enableReduceL2Decompose,
-      /*disableGenericDecompositions=*/false);
+      /*disableGenericDecompositions=*/false, enableGatherToSlice);
   patterns.insert<ReplaceCastLikeByCastPattern>(context);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
@@ -4783,7 +4852,7 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
     bool enableSplitToSliceDecompose, bool enableConcatFuse,
     bool enableLstmSeqDecompose, bool enableReduceL2Decompose,
-    bool disableGenericDecompositions) {
+    bool disableGenericDecompositions, bool enableGatherToSlice) {
   MLIRContext *context = patterns.getContext();
   if (!disableGenericDecompositions)
     populateWithGenerated(patterns);
@@ -4848,6 +4917,9 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
   //   }
   // }
 
+  if (enableGatherToSlice)
+    patterns.insert<DecomposeGatherToSlicePattern>(context);
+
   // TODO: consider whether to include SoftmaxPattern here
 }
 
@@ -4861,11 +4933,13 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createDecomposeONNXToONNXPass(
     bool enableInstanceNormDecompose, bool enableGroupNormDecompose,
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
     bool enableSplitToSliceDecompose, bool enableConcatFuse,
-    bool enableLstmSeqDecompose, bool enableReduceL2Decompose) {
+    bool enableLstmSeqDecompose, bool enableReduceL2Decompose,
+    bool enableGatherToSlice) {
   return std::make_unique<DecomposeONNXToONNXPass>(target,
       enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableGroupNormDecompose, enableMatmulNBitsDecompose,
       enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
-      enableConcatFuse, enableLstmSeqDecompose, enableReduceL2Decompose);
+      enableConcatFuse, enableLstmSeqDecompose, enableReduceL2Decompose,
+      enableGatherToSlice);
 }

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -37,7 +37,7 @@ void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
     bool enableSplitToSliceDecompose, bool enableConcatFuse,
     bool enableLstmSeqDecompose = false, bool enableReduceL2Decompose = true,
-    bool disableGenericDecompositions = false);
+    bool disableGenericDecompositions = false, bool enableGatherToSlice = true);
 
 } // namespace onnx_mlir
 #endif

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -49,7 +49,8 @@ std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
     bool enableMatmulNBitsDecompose = false,
     bool enableGroupQueryAttentionDecompose = true,
     bool enableSplitToSliceDecompose = false, bool enableConcatFuse = false,
-    bool enableLstmSeqDecompose = false, bool enableReduceL2Decompose = true);
+    bool enableLstmSeqDecompose = false, bool enableReduceL2Decompose = true,
+    bool enableGatherToSlice = true);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "");
 

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
@@ -151,6 +151,57 @@ func.func @test_gather_dynamic_indices_i32(%arg0 : tensor<3x3xf32>, %indices: te
 
 // -----
 
+func.func @test_gather_like_slice(%arg0 : tensor<3x3xf32>) -> tensor<3xf32> {
+  %indices = onnx.Constant dense<0> : tensor<i64>
+  %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
+  "func.return"(%0) : (tensor<3xf32>) -> ()
+// CHECK-LABEL:   test_gather_like_slice
+// CHECK-SAME:    (%[[ARG:.*]]: tensor<3x3xf32>)
+// CHECK:         %[[VAL_1:.*]] = tosa.slice %[[ARG]] {size = array<i64: 3, 1>, start = array<i64: 0, 0>} : (tensor<3x3xf32>) -> tensor<3x1xf32>
+// CHECK:         %[[VAL_2:.*]] = tosa.reshape %[[VAL_1]] {{.*}} -> tensor<3xf32>
+// CHECK:         return %[[VAL_2]]
+
+// EXCLUDE-LABEL:   func.func @test_gather_like_slice(
+// EXCLUDE:           onnx.Gather
+// EXCLUDE-NOT:       tosa.slice
+}
+
+// -----
+
+func.func @test_gather_like_slice_positive_integer(%arg0 : tensor<3x3xf32>) -> tensor<3xf32> {
+  %indices = onnx.Constant dense<2> : tensor<i64>
+  %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
+  "func.return"(%0) : (tensor<3xf32>) -> ()
+// CHECK-LABEL:   test_gather_like_slice
+// CHECK-SAME:    (%[[ARG:.*]]: tensor<3x3xf32>)
+// CHECK:         %[[VAL_1:.*]] = tosa.slice %[[ARG]] {size = array<i64: 1, 3>, start = array<i64: 2, 0>} : (tensor<3x3xf32>) -> tensor<1x3xf32>
+// CHECK:         %[[VAL_2:.*]] = tosa.reshape %[[VAL_1]] {{.*}} -> tensor<3xf32>
+// CHECK:         return %[[VAL_2]]
+
+// EXCLUDE-LABEL:   func.func @test_gather_like_slice_positive_integer(
+// EXCLUDE:           onnx.Gather
+// EXCLUDE-NOT:       tosa.slice
+}
+
+// -----
+
+func.func @test_gather_like_slice_negative_integer(%arg0 : tensor<3x3xf32>) -> tensor<3xf32> {
+  %indices = onnx.Constant dense<-1> : tensor<i64>
+  %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
+  "func.return"(%0) : (tensor<3xf32>) -> ()
+// CHECK-LABEL:   test_gather_like_slice
+// CHECK-SAME:    (%[[ARG:.*]]: tensor<3x3xf32>)
+// CHECK:         %[[VAL_1:.*]] = tosa.slice %[[ARG]] {size = array<i64: 1, 3>, start = array<i64: 2, 0>} : (tensor<3x3xf32>) -> tensor<1x3xf32>
+// CHECK:         %[[VAL_2:.*]] = tosa.reshape %[[VAL_1]] {{.*}} -> tensor<3xf32>
+// CHECK:         return %[[VAL_2]]
+
+// EXCLUDE-LABEL:   func.func @test_gather_like_slice_negative_integer(
+// EXCLUDE:           onnx.Gather
+// EXCLUDE-NOT:       tosa.slice
+}
+
+// -----
+
 func.func @test_gather_dynamic_shape_indices_i32(%arg0 : tensor<?x4xf32>, %indices: tensor<?xi64>) -> tensor<?x4xf32> {
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<?x4xf32>, tensor<?xi64>) -> tensor<?x4xf32>
   "func.return"(%0) : (tensor<?x4xf32>) -> ()

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -3300,56 +3300,6 @@ func.func @back_to_back_i8_maxpools(%arg0: tensor<1x192x23x40xf32>) -> tensor<1x
 
 // -----
 
-func.func @test_gather_like_slice(%arg0 : tensor<3x3xf32>) -> tensor<3xf32> {
-  %indices = onnx.Constant dense<0> : tensor<i64>
-  %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
-  "func.return"(%0) : (tensor<3xf32>) -> ()
-// CHECK-LABEL:   test_gather_like_slice
-// CHECK-SAME:    (%[[ARG:.*]]: tensor<3x3xf32>)
-// CHECK-DAG:     %[[C3:.*]] = onnx.Constant dense<3> : tensor<1xi64>
-// CHECK-DAG:     %[[C0:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK-DAG:     %[[C1:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:         %[[SLICE:.*]] = "onnx.Slice"(%[[ARG]], %[[C0]], %[[C1]], %[[C1]], %[[C1]]) : (tensor<3x3xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3x1xf32>
-// CHECK:         %[[RESHAPE:.*]] = "onnx.Reshape"(%[[SLICE]], %[[C3]]) {allowzero = 0 : si64} : (tensor<3x1xf32>, tensor<1xi64>) -> tensor<3xf32>
-// CHECK:         return %[[RESHAPE]]
-}
-
-// -----
-
-func.func @test_gather_like_slice_positive_integer(%arg0 : tensor<3x3xf32>) -> tensor<3xf32> {
-  %indices = onnx.Constant dense<2> : tensor<i64>
-  %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
-  "func.return"(%0) : (tensor<3xf32>) -> ()
-// CHECK-LABEL:   test_gather_like_slice_positive_integer
-// CHECK-SAME:    (%[[ARG:.*]]: tensor<3x3xf32>)
-// CHECK-DAG:     %[[C2:.*]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK-DAG:     %[[C3:.*]] = onnx.Constant dense<3> : tensor<1xi64>
-// CHECK-DAG:     %[[C0:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK-DAG:     %[[C1:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:         %[[SLICE:.*]] = "onnx.Slice"(%[[ARG]], %[[C2]], %[[C3]], %[[C0]], %[[C1]]) : (tensor<3x3xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x3xf32>
-// CHECK:         %[[RESHAPE:.*]] = "onnx.Reshape"(%[[SLICE]], %[[C3]]) {allowzero = 0 : si64} : (tensor<1x3xf32>, tensor<1xi64>) -> tensor<3xf32>
-// CHECK:         return %[[RESHAPE]]
-}
-
-// -----
-
-func.func @test_gather_like_slice_negative_integer(%arg0 : tensor<3x3xf32>) -> tensor<3xf32> {
-  %indices = onnx.Constant dense<-1> : tensor<i64>
-  %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x3xf32>, tensor<i64>) -> tensor<3xf32>
-  "func.return"(%0) : (tensor<3xf32>) -> ()
-// CHECK-LABEL:   test_gather_like_slice_negative_integer
-// CHECK-SAME:    (%[[ARG:.*]]: tensor<3x3xf32>)
-// CHECK-DAG:     %[[C2:.*]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK-DAG:     %[[C3:.*]] = onnx.Constant dense<3> : tensor<1xi64>
-// CHECK-DAG:     %[[C0:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK-DAG:     %[[C1:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:         %[[SLICE:.*]] = "onnx.Slice"(%[[ARG]], %[[C2]], %[[C3]], %[[C0]], %[[C1]]) : (tensor<3x3xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x3xf32>
-// CHECK:         %[[RESHAPE:.*]] = "onnx.Reshape"(%[[SLICE]], %[[C3]]) {allowzero = 0 : si64} : (tensor<1x3xf32>, tensor<1xi64>) -> tensor<3xf32>
-// CHECK:         return %[[RESHAPE]]
-}
-
-// -----
-
 // LeakyRelu with alpha = 0 is canonicalized to Relu.
 // CHECK-LABEL:   func.func @leaky_relu_alpha_zero_to_relu(%arg0: tensor<2x3xf32>) -> tensor<2x3xf32> {
 func.func @leaky_relu_alpha_zero_to_relu(%arg0: tensor<2x3xf32>) -> tensor<2x3xf32> {

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -529,7 +529,6 @@ OpsWithCanonicalizer = [
     "Div",
     "Dropout",
     "Equal",
-    "Gather",
     "GlobalAveragePool",
     "GlobalMaxPool",
     "Greater",


### PR DESCRIPTION
This PR reverts the ReplaceGatherWithSlicePattern from ONNXGatherOp::getCanonicalizationPatterns (introduced in b2fe504) and re-introduces it as a gated pattern in DecomposeONNXToONNXPass under a new enable-gather-to-slice flag (default: true).