### PR TITLE
Add canonicalizations for onnx.Slice

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
@@ -164,37 +164,116 @@ LogicalResult ONNXSliceOp::inferShapes(
   if (!isNoneValue(axes) && !isConstLikeValue(axes))
     return success();
 
-  const auto startsType =
-      mlir::dyn_cast<RankedTensorType>(getStarts().getType());
-  assert(startsType != nullptr && "starts type is not a RankedTensorType");
-  auto startsDim = startsType.getShape()[0];
   {
     OpBuilder builder(this->getContext());
     OnnxBuilder createONNX(builder, this->getLoc());
-    const Type elementType = builder.getIntegerType(64);
-    const auto tensorType = RankedTensorType::get({startsDim}, elementType);
+    builder.setInsertionPoint(*this);
 
-    // If axes is not specified, default to [0, ..., ndim-1]
+    auto buildI64Const = [&](ArrayRef<int64_t> vals) -> Value {
+      auto ty = RankedTensorType::get(
+          {static_cast<int64_t>(vals.size())}, builder.getI64Type());
+      return createONNX.constant(DenseElementsAttr::get(ty, vals));
+    };
+
+    // Helper: return the static length of the starts tensor, or -1 if not
+    // yet known (unranked type or dynamic first dim).  Callers skip
+    // materialisation and let a later inferShapes round handle it.
+    auto getStartsLen = [&]() -> std::optional<int64_t> {
+      auto ty = mlir::dyn_cast<RankedTensorType>(getStarts().getType());
+      if (!ty)
+        return std::nullopt;
+      int64_t n = ty.getShape()[0];
+      return (n == ShapedType::kDynamic) ? std::nullopt
+                                         : std::optional<int64_t>(n);
+    };
+
+    // If axes is not specified, default to [0, ..., len(starts)-1].
     if (isNoneValue(axes)) {
-      SmallVector<int64_t, 1> vals = {};
-      for (size_t s = 0; s < static_cast<size_t>(startsDim); ++s)
-        vals.emplace_back(s);
-      auto constantDenseAttribute =
-          DenseElementsAttr::get(tensorType, llvm::ArrayRef(vals));
-      builder.setInsertionPoint(*this);
-      Value constantResult = createONNX.constant(constantDenseAttribute);
-      this->setOperand(3, constantResult);
+      auto maybeN = getStartsLen();
+      if (!maybeN)
+        return success(); // starts shape not yet known; retry later
+      int64_t n = *maybeN;
+      SmallVector<int64_t> vals;
+      for (int64_t s = 0; s < n; ++s)
+        vals.push_back(s);
+      this->setOperand(3, buildI64Const(vals));
     }
 
-    // If steps is not specified, default to [1, ..., 1]
+    // If steps is not specified, default to [1, ..., 1] (same length as
+    // starts).
     if (isNoneValue(steps)) {
-      SmallVector<int64_t, 1> vals(startsDim, 1);
-      auto constantDenseAttribute =
-          DenseElementsAttr::get(tensorType, llvm::ArrayRef(vals));
-      builder.setInsertionPoint(*this);
-      Value constantResult = createONNX.constant(constantDenseAttribute);
-      this->setOperand(4, constantResult);
+      auto maybeN = getStartsLen();
+      if (!maybeN)
+        return success(); // starts shape not yet known; retry later
+      int64_t n = *maybeN;
+      SmallVector<int64_t> vals(n, 1);
+      this->setOperand(4, buildI64Const(vals));
     }
+
+    // Normalize axes to non-negative, and starts/ends steps. Ends are only
+    // normalized for positive steps. This runs after None axes/steps have been
+    // materialized above, so all four operands are now explicit constants.
+
+    auto canonicalize = [&]() {
+      const auto dataTy = mlir::dyn_cast<RankedTensorType>(getData().getType());
+      if (!dataTy || !dataTy.hasStaticShape()) {
+        return;
+      }
+      SmallVector<int64_t> axesVals, stepsVals, startsVals, endsVals;
+      if (!onnx_mlir::getI64ValuesFromONNXConstantOp(getAxes(), axesVals) ||
+          !onnx_mlir::getI64ValuesFromONNXConstantOp(getSteps(), stepsVals) ||
+          !onnx_mlir::getI64ValuesFromONNXConstantOp(getStarts(), startsVals) ||
+          !onnx_mlir::getI64ValuesFromONNXConstantOp(getEnds(), endsVals)) {
+        return;
+      }
+      const int64_t rank = dataTy.getRank();
+      const auto dataShape = dataTy.getShape();
+      const auto numAxes = static_cast<int64_t>(axesVals.size());
+      SmallVector<int64_t> newAxes(axesVals);
+      SmallVector<int64_t> newStarts(startsVals);
+      SmallVector<int64_t> newEnds(endsVals);
+
+      // A step of 0 is invalid
+      if (llvm::any_of(stepsVals, [](int64_t s) { return s == 0; })) {
+        return;
+      }
+
+      for (int64_t i = 0; i < numAxes; ++i) {
+        int64_t axis = newAxes[i];
+        if (axis < 0)
+          axis += rank;
+        if (axis < 0 || axis >= rank) {
+          return;
+        }
+        newAxes[i] = axis;
+
+        const int64_t step = stepsVals[i];
+        const int64_t dim = dataShape[axis];
+
+        auto wrapAndClamp = [dim](int64_t v) -> int64_t {
+          if (v < 0)
+            v = (v < -dim) ? 0 : v + dim;
+          return std::clamp<int64_t>(v, 0LL, dim);
+        };
+        const int64_t startHi =
+            (step > 0) ? dim : std::max<int64_t>(0, dim - 1);
+        newStarts[i] =
+            std::clamp<int64_t>(wrapAndClamp(newStarts[i]), 0, startHi);
+        if (step < 0)
+          continue; // skip end: negative-step -1 sentinel not
+                    // idempotent
+        newEnds[i] = wrapAndClamp(newEnds[i]);
+      }
+
+      if (newAxes != axesVals)
+        this->setOperand(3, buildI64Const(newAxes));
+      if (newStarts != startsVals)
+        this->setOperand(1, buildI64Const(newStarts));
+      if (newEnds != endsVals)
+        this->setOperand(2, buildI64Const(newEnds));
+    };
+
+    canonicalize();
   }
 
   Type elementType =

--- a/test/mlir/onnx/onnx_canonicalization_slice.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_slice.mlir
@@ -1,0 +1,177 @@
+// Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+// RUN: onnx-mlir-opt --shape-inference %s -split-input-file | FileCheck %s
+//
+// Tests for ONNXSliceOp::inferShapes normalization of starts/ends/axes.
+//
+// Shape inference materializes None axes -> [0,...,n-1] and None steps -> [1,...,1]
+// and then normalizes:
+//   - axes to non-negative (wrap by rank)
+//   - starts and ends (positive step only): wrap negatives by dim, clamp to [0, dim]
+//
+// Negative-step start/end normalization is intentionally skipped because the
+// -1 "before-index-0" end sentinel is not idempotent under repeated inferShapes.
+
+// -----
+// INT64_MAX end clamped to dim (64); explicit step=1 and axis=3 preserved.
+func.func @slice_clamps_int64_max_end(%arg0: tensor<1x1600x3x64xf32>) -> tensor<1x1600x3x32xf32> {
+  %starts = onnx.Constant dense<32> : tensor<1xi64>
+  %ends   = onnx.Constant dense<9223372036854775807> : tensor<1xi64>
+  %axes   = onnx.Constant dense<3> : tensor<1xi64>
+  %steps  = onnx.Constant dense<1> : tensor<1xi64>
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<1x1600x3x64xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x1600x3x32xf32>
+  return %0 : tensor<1x1600x3x32xf32>
+// CHECK-LABEL:  func.func @slice_clamps_int64_max_end
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1600x3x64xf32>) -> tensor<1x1600x3x32xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<32> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<64> : tensor<1xi64>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_0_]], [[VAR_3_]], [[VAR_1_]], [[VAR_2_]]) : (tensor<1x1600x3x64xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x1600x3x32xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1600x3x32xf32>
+}
+
+// -----
+// Negative axis (-1 -> 2) and negative start (-2 -> 2) normalized.
+func.func @slice_normalizes_negative_axis_and_start(%arg0: tensor<2x3x4xf32>) -> tensor<2x3x2xf32> {
+  %starts = onnx.Constant dense<-2> : tensor<1xi64>
+  %ends   = onnx.Constant dense<4> : tensor<1xi64>
+  %axes   = onnx.Constant dense<-1> : tensor<1xi64>
+  %steps  = onnx.Constant dense<1> : tensor<1xi64>
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<2x3x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2x3x2xf32>
+  return %0 : tensor<2x3x2xf32>
+// CHECK-LABEL:  func.func @slice_normalizes_negative_axis_and_start
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>) -> tensor<2x3x2xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_2_]], [[VAR_0_]], [[VAR_2_]], [[VAR_1_]]) : (tensor<2x3x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2x3x2xf32>
+// CHECK:           return [[VAR_3_]] : tensor<2x3x2xf32>
+}
+
+// -----
+// None axes materialized to [0]; None steps materialized to [1]; then
+// starts/ends already canonical -> no further change.
+func.func @slice_materializes_none_axes_and_steps(%arg0: tensor<8xf32>) -> tensor<3xf32> {
+  %starts = onnx.Constant dense<2> : tensor<1xi64>
+  %ends   = onnx.Constant dense<5> : tensor<1xi64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %none, %none) : (tensor<8xf32>, tensor<1xi64>, tensor<1xi64>, none, none) -> tensor<3xf32>
+  return %0 : tensor<3xf32>
+// CHECK-LABEL:  func.func @slice_materializes_none_axes_and_steps
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<8xf32>) -> tensor<3xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<5> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]]) : (tensor<8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xf32>
+// CHECK:           return [[VAR_4_]] : tensor<3xf32>
+}
+
+// -----
+// Already canonical: no rewrites expected.
+func.func @slice_already_canonical(%arg0: tensor<2x3x4xf32>) -> tensor<2x3x2xf32> {
+  %starts = onnx.Constant dense<2> : tensor<1xi64>
+  %ends   = onnx.Constant dense<4> : tensor<1xi64>
+  %axes   = onnx.Constant dense<2> : tensor<1xi64>
+  %steps  = onnx.Constant dense<1> : tensor<1xi64>
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<2x3x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2x3x2xf32>
+  return %0 : tensor<2x3x2xf32>
+// CHECK-LABEL: func.func @slice_already_canonical
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>) -> tensor<2x3x2xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]], [[VAR_0_]], [[VAR_2_]]) : (tensor<2x3x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2x3x2xf32>
+// CHECK:           return [[VAR_3_]] : tensor<2x3x2xf32>
+}
+
+// -----
+// Overshoot end (100 > dim=6) clamped to 6.
+func.func @slice_clamps_overshoot_end(%arg0: tensor<5x6xf32>) -> tensor<5x4xf32> {
+  %starts = onnx.Constant dense<2> : tensor<1xi64>
+  %ends   = onnx.Constant dense<100> : tensor<1xi64>
+  %axes   = onnx.Constant dense<1> : tensor<1xi64>
+  %steps  = onnx.Constant dense<1> : tensor<1xi64>
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<5x6xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<5x4xf32>
+  return %0 : tensor<5x4xf32>
+// CHECK-LABEL:  func.func @slice_clamps_overshoot_end
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x6xf32>) -> tensor<5x4xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<6> : tensor<1xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_0_]], [[VAR_2_]], [[VAR_1_]], [[VAR_1_]]) : (tensor<5x6xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<5x4xf32>
+// CHECK:           return [[VAR_3_]] : tensor<5x4xf32>
+}
+
+// -----
+// Dynamic input: shape inference cannot normalize without static dims; bails.
+func.func @slice_dynamic_data_unchanged(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %starts = onnx.Constant dense<-1> : tensor<1xi64>
+  %ends   = onnx.Constant dense<9223372036854775807> : tensor<1xi64>
+  %axes   = onnx.Constant dense<1> : tensor<1xi64>
+  %steps  = onnx.Constant dense<1> : tensor<1xi64>
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<?x?xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+// CHECK-LABEL:  func.func @slice_dynamic_data_unchanged
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<-1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<9223372036854775807> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_2_]]) : (tensor<?x?xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?x?xf32>
+// CHECK:           return [[VAR_3_]] : tensor<?x?xf32>
+}
+
+// -----
+// Negative step: axis normalized (-1->0) and starts, but ends are left untouched.
+func.func @slice_negative_step_axis_normalized_only(%arg0: tensor<3x2xi64>) -> tensor<3x2xi64> {
+  %starts = onnx.Constant dense<-1> : tensor<1xi64>
+  %ends   = onnx.Constant dense<-9223372036854775807> : tensor<1xi64>
+  %axes   = onnx.Constant dense<0> : tensor<1xi64>
+  %steps  = onnx.Constant dense<-1> : tensor<1xi64>
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) {onnx_node_name = "/Slice"} : (tensor<3x2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3x2xi64>
+  return %0 : tensor<3x2xi64>
+// CHECK-LABEL:  func.func @slice_negative_step_axis_normalized_only
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2xi64>) -> tensor<3x2xi64> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<-1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<-9223372036854775807> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_3_]], [[VAR_1_]], [[VAR_2_]], [[VAR_0_]]) {onnx_node_name = "/Slice"} : (tensor<3x2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3x2xi64>
+// CHECK:           return [[VAR_4_]] : tensor<3x2xi64>
+}
+
+// -----
+func.func @slice_neg_step_start_at_dim_clamps_to_dim_minus_one(%arg0: tensor<4xf32>) -> tensor<3xf32> {
+  %starts = onnx.Constant dense<4> : tensor<1xi64>
+  %ends   = onnx.Constant dense<0> : tensor<1xi64>
+  %axes   = onnx.Constant dense<0> : tensor<1xi64>
+  %steps  = onnx.Constant dense<-1> : tensor<1xi64>
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) : (tensor<4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xf32>
+  return %0 : tensor<3xf32>
+// CHECK-LABEL:  func.func @slice_neg_step_start_at_dim_clamps_to_dim_minus_one
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4xf32>) -> tensor<3xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<-1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_2_]], [[VAR_0_]], [[VAR_0_]], [[VAR_1_]]) : (tensor<4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xf32>
+// CHECK:           return [[VAR_3_]] : tensor<3xf32>
+}
+
+// -----
+// axes must materialise to [0, 1] (len=2, not len=4=rank).
+// steps must materialise to [1, 1] (len=2, not len=4=rank).
+// -----
+func.func @slice_none_axes_steps_n_less_than_rank(%arg0: tensor<2x4x6x8xf32>) -> tensor<1x3x6x8xf32> {
+  %starts = onnx.Constant dense<[1, 1]> : tensor<2xi64>
+  %ends   = onnx.Constant dense<[2, 4]> : tensor<2xi64>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %none, %none) : (tensor<2x4x6x8xf32>, tensor<2xi64>, tensor<2xi64>, none, none) -> tensor<1x3x6x8xf32>
+  return %0 : tensor<1x3x6x8xf32>
+// CHECK-LABEL:  func.func @slice_none_axes_steps_n_less_than_rank
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4x6x8xf32>) -> tensor<1x3x6x8xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 4]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_0_]]) : (tensor<2x4x6x8xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x3x6x8xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x3x6x8xf32>
+}

--- a/test/mlir/onnx/onnx_decompose_convtranspose1d_phased_conv.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose1d_phased_conv.mlir
@@ -6,35 +6,33 @@ func.func @test_convtrans_stride_2_kernel_shape_4(%arg0: tensor<1x64x200xf32>, %
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {dilations = [1], group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x200xf32>, tensor<64x24x4xf32>, tensor<24xf32>) -> tensor<1x24x400xf32>
   onnx.Return %1 : tensor<1x24x400xf32>
 }
-// CHECK-LABEL:   func.func @test_convtrans_stride_2_kernel_shape_4(
-// CHECK-SAME:                                                      %[[VAL_0:.*]]: tensor<1x64x200xf32>,
-// CHECK-SAME:                                                      %[[VAL_1:.*]]: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 400]> : tensor<3xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<200> : tensor<1xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<201> : tensor<1xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<5> : tensor<1xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<4> : tensor<1xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<4> : tensor<64xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
-// CHECK:           %[[VAL_13:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
-// CHECK:           %[[VAL_14:.*]] = "onnx.ReverseSequence"(%[[VAL_13]], %[[VAL_11]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
-// CHECK:           %[[VAL_15:.*]] = "onnx.Transpose"(%[[VAL_14]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
-// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_15]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_9]], %[[VAL_8]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_7]], %[[VAL_6]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_18]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_17]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_19]], %[[VAL_7]], %[[VAL_5]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_4]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Reshape"(%[[VAL_21]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Reshape"(%[[VAL_22]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_23]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x2xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x2xf32>, tensor<3xi64>) -> tensor<1x24x400xf32>
-// CHECK:           onnx.Return %[[VAL_26]] : tensor<1x24x400xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride_2_kernel_shape_4
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x200xf32>, [[PARAM_1_:%.+]]: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 24, 400]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<4> : tensor<64xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
+// CHECK:           [[VAR_11_:%.+]] = "onnx.ReverseSequence"([[VAR_10_]], [[VAR_8_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.Transpose"([[VAR_11_]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.Transpose"([[VAR_12_]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_6_]], [[VAR_5_]], [[VAR_7_]], [[VAR_7_]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_4_]], [[VAR_5_]], [[VAR_7_]], [[VAR_7_]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_15_]], [[VAR_9_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_14_]], [[VAR_9_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_16_]], [[VAR_4_]], [[VAR_3_]], [[VAR_7_]], [[VAR_4_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_17_]], [[VAR_6_]], [[VAR_2_]], [[VAR_7_]], [[VAR_4_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Reshape"([[VAR_18_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Reshape"([[VAR_19_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Concat"([[VAR_21_]], [[VAR_20_]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x2xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Reshape"([[VAR_22_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x24x200x2xf32>, tensor<3xi64>) -> tensor<1x24x400xf32>
+// CHECK:           onnx.Return [[VAR_23_]] : tensor<1x24x400xf32>
 // CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_2_kernel_shape_4
 // DISABLED: onnx.ConvTranspose
@@ -46,35 +44,33 @@ func.func @test_convtrans_stride_2_kernel_shape_4_b(%arg0: tensor<1x64x400xf32>,
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {dilations = [1], group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x400xf32>, tensor<64x24x4xf32>, tensor<24xf32>) -> tensor<1x24x800xf32>
   onnx.Return %1 : tensor<1x24x800xf32>
 }
-// CHECK-LABEL:   func.func @test_convtrans_stride_2_kernel_shape_4_b(
-// CHECK-SAME:                                                        %[[VAL_0:.*]]: tensor<1x64x400xf32>,
-// CHECK-SAME:                                                        %[[VAL_1:.*]]: tensor<64x24x4xf32>) -> tensor<1x24x800xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 400, 1]> : tensor<4xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<400> : tensor<1xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<401> : tensor<1xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<5> : tensor<1xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<4> : tensor<1xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<4> : tensor<64xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
-// CHECK:           %[[VAL_13:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
-// CHECK:           %[[VAL_14:.*]] = "onnx.ReverseSequence"(%[[VAL_13]], %[[VAL_11]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
-// CHECK:           %[[VAL_15:.*]] = "onnx.Transpose"(%[[VAL_14]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
-// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_15]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_9]], %[[VAL_8]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_7]], %[[VAL_6]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_18]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x400xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x401xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_17]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x400xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x401xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_19]], %[[VAL_7]], %[[VAL_5]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x401xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x400xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_4]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x401xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x400xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Reshape"(%[[VAL_21]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x400xf32>, tensor<4xi64>) -> tensor<1x24x400x1xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Reshape"(%[[VAL_22]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x400xf32>, tensor<4xi64>) -> tensor<1x24x400x1xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_23]]) {axis = -1 : si64} : (tensor<1x24x400x1xf32>, tensor<1x24x400x1xf32>) -> tensor<1x24x400x2xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x400x2xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
-// CHECK:           onnx.Return %[[VAL_26]] : tensor<1x24x800xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride_2_kernel_shape_4_b
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x400xf32>, [[PARAM_1_:%.+]]: tensor<64x24x4xf32>) -> tensor<1x24x800xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 24, 400, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<400> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<401> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<4> : tensor<64xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
+// CHECK:           [[VAR_11_:%.+]] = "onnx.ReverseSequence"([[VAR_10_]], [[VAR_8_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.Transpose"([[VAR_11_]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.Transpose"([[VAR_12_]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_6_]], [[VAR_5_]], [[VAR_7_]], [[VAR_7_]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_4_]], [[VAR_5_]], [[VAR_7_]], [[VAR_7_]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_15_]], [[VAR_9_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x400xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x401xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_14_]], [[VAR_9_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x400xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x401xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_16_]], [[VAR_4_]], [[VAR_3_]], [[VAR_7_]], [[VAR_4_]]) : (tensor<1x24x401xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x400xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_17_]], [[VAR_6_]], [[VAR_2_]], [[VAR_7_]], [[VAR_4_]]) : (tensor<1x24x401xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x400xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Reshape"([[VAR_18_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x400xf32>, tensor<4xi64>) -> tensor<1x24x400x1xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Reshape"([[VAR_19_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x400xf32>, tensor<4xi64>) -> tensor<1x24x400x1xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Concat"([[VAR_21_]], [[VAR_20_]]) {axis = -1 : si64} : (tensor<1x24x400x1xf32>, tensor<1x24x400x1xf32>) -> tensor<1x24x400x2xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Reshape"([[VAR_22_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x24x400x2xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
+// CHECK:           onnx.Return [[VAR_23_]] : tensor<1x24x800xf32>
 // CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_2_kernel_shape_4_b
 // DISABLED: onnx.ConvTranspose
@@ -98,35 +94,33 @@ func.func @test_convtrans_stride_2_kernel_shape_4_nobias(%arg0: tensor<1x64x200x
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x200xf32>, tensor<64x24x4xf32>, none) -> tensor<1x24x400xf32>
   onnx.Return %1 : tensor<1x24x400xf32>
 }
-// CHECK-LABEL:   func.func @test_convtrans_stride_2_kernel_shape_4_nobias(
-// CHECK-SAME:                                                             %[[VAL_0:.*]]: tensor<1x64x200xf32>,
-// CHECK-SAME:                                                             %[[VAL_1:.*]]: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 400]> : tensor<3xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<200> : tensor<1xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<201> : tensor<1xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<5> : tensor<1xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<4> : tensor<1xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<4> : tensor<64xi64>
-// CHECK:           %[[VAL_12:.*]] = "onnx.NoValue"() {value} : () -> none
-// CHECK:           %[[VAL_13:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
-// CHECK:           %[[VAL_14:.*]] = "onnx.ReverseSequence"(%[[VAL_13]], %[[VAL_11]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
-// CHECK:           %[[VAL_15:.*]] = "onnx.Transpose"(%[[VAL_14]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
-// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_15]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_9]], %[[VAL_8]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_7]], %[[VAL_6]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_18]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, none) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_17]], %[[VAL_12]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, none) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_19]], %[[VAL_7]], %[[VAL_5]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_4]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Reshape"(%[[VAL_21]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Reshape"(%[[VAL_22]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_23]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x2xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x2xf32>, tensor<3xi64>) -> tensor<1x24x400xf32>
-// CHECK:           onnx.Return %[[VAL_26]] : tensor<1x24x400xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride_2_kernel_shape_4_nobias
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x200xf32>, [[PARAM_1_:%.+]]: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 24, 400]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<4> : tensor<64xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_10_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
+// CHECK:           [[VAR_11_:%.+]] = "onnx.ReverseSequence"([[VAR_10_]], [[VAR_8_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.Transpose"([[VAR_11_]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.Transpose"([[VAR_12_]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_6_]], [[VAR_5_]], [[VAR_7_]], [[VAR_7_]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_4_]], [[VAR_5_]], [[VAR_7_]], [[VAR_7_]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_15_]], [[VAR_9_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, none) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_14_]], [[VAR_9_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, none) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_16_]], [[VAR_4_]], [[VAR_3_]], [[VAR_7_]], [[VAR_4_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_17_]], [[VAR_6_]], [[VAR_2_]], [[VAR_7_]], [[VAR_4_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Reshape"([[VAR_18_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Reshape"([[VAR_19_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Concat"([[VAR_21_]], [[VAR_20_]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x2xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Reshape"([[VAR_22_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x24x200x2xf32>, tensor<3xi64>) -> tensor<1x24x400xf32>
+// CHECK:           onnx.Return [[VAR_23_]] : tensor<1x24x400xf32>
 // CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_2_kernel_shape_4_nobias
 // DISABLED: onnx.ConvTranspose
@@ -137,47 +131,43 @@ func.func @test_convtrans_stride_4(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [8],  pads = [2,2], strides = [4]} : (tensor<1x64x200xf32>, tensor<64x24x8xf32>, tensor<24xf32>) -> tensor<1x24x800xf32>
   onnx.Return %1 : tensor<1x24x800xf32>
 }
-// CHECK-LABEL:   func.func @test_convtrans_stride_4(
-// CHECK-SAME:                                       %[[VAL_0:.*]]: tensor<1x64x200xf32>,
-// CHECK-SAME:                                       %[[VAL_1:.*]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<201> : tensor<1xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<200> : tensor<1xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<11> : tensor<1xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<3> : tensor<1xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<10> : tensor<1xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<9> : tensor<1xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<8> : tensor<1xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<1xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<8> : tensor<64xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_14]], %[[VAL_8]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_26]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_27]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Reshape"(%[[VAL_29]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Reshape"(%[[VAL_30]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Reshape"(%[[VAL_32]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Concat"(%[[VAL_33]], %[[VAL_34]], %[[VAL_35]], %[[VAL_36]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_37]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
-// CHECK:           onnx.Return %[[VAL_38]] : tensor<1x24x800xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride_4
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x200xf32>, [[PARAM_1_:%.+]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<8> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<8> : tensor<64xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.ReverseSequence"([[VAR_12_]], [[VAR_10_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
+// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
+// CHECK:           [[VAR_15_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_7_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_5_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_9_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_4_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_17_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_16_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_19_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_18_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_7_]], [[VAR_3_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Slice"([[VAR_21_]], [[VAR_7_]], [[VAR_3_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Slice"([[VAR_22_]], [[VAR_5_]], [[VAR_2_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_5_]], [[VAR_2_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Reshape"([[VAR_24_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Reshape"([[VAR_25_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Reshape"([[VAR_26_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.Reshape"([[VAR_27_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           [[VAR_32_:%.+]] = "onnx.Concat"([[VAR_28_]], [[VAR_29_]], [[VAR_30_]], [[VAR_31_]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
+// CHECK:           [[VAR_33_:%.+]] = "onnx.Reshape"([[VAR_32_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
+// CHECK:           onnx.Return [[VAR_33_]] : tensor<1x24x800xf32>
 // CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_4
 // DISABLED: onnx.ConvTranspose
@@ -189,56 +179,51 @@ func.func @test_convtrans_stride_5(%arg0: tensor<1x64x200xf32>, %arg1: tensor<64
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { dilations = [1], group = 1 : si64, kernel_shape = [10],  pads = [2,2], strides = [5]} : (tensor<1x64x200xf32>, tensor<64x24x10xf32>, tensor<24xf32>) -> tensor<1x24x1001xf32>
   onnx.Return %1 : tensor<1x24x1001xf32>
 }
-// CHECK-LABEL:   func.func @test_convtrans_stride_5(
-// CHECK-SAME:                                       %[[VAL_0:.*]]: tensor<1x64x200xf32>,
-// CHECK-SAME:                                       %[[VAL_1:.*]]: tensor<64x24x10xf32>) -> tensor<1x24x1001xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<1001> : tensor<1xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 1005]> : tensor<3xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 24, 201, 1]> : tensor<4xi64>
-// CHECK:           %[[VAL_5:.*]] = "onnx.NoValue"() {value} : () -> none
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<0.000000e+00> : tensor<f32>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[0, 0, 0, 0, 0, 1]> : tensor<6xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<201> : tensor<1xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<14> : tensor<1xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<4> : tensor<1xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<13> : tensor<1xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<3> : tensor<1xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<12> : tensor<1xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<11> : tensor<1xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<10> : tensor<1xi64>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<5> : tensor<1xi64>
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<10> : tensor<64xi64>
-// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x10xf32>) -> tensor<10x64x24xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.ReverseSequence"(%[[VAL_22]], %[[VAL_20]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<10x64x24xf32>, tensor<64xi64>) -> tensor<10x64x24xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Transpose"(%[[VAL_23]]) {perm = [1, 2, 0]} : (tensor<10x64x24xf32>) -> tensor<64x24x10xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Transpose"(%[[VAL_24]]) {perm = [1, 0, 2]} : (tensor<64x24x10xf32>) -> tensor<24x64x10xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_17]], %[[VAL_16]], %[[VAL_19]], %[[VAL_18]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_15]], %[[VAL_14]], %[[VAL_19]], %[[VAL_18]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_19]], %[[VAL_13]], %[[VAL_19]], %[[VAL_18]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_12]], %[[VAL_11]], %[[VAL_19]], %[[VAL_18]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_25]], %[[VAL_10]], %[[VAL_9]], %[[VAL_19]], %[[VAL_18]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_28]], %[[VAL_21]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_27]], %[[VAL_21]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_26]], %[[VAL_21]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_30]], %[[VAL_21]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_29]], %[[VAL_21]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_34]], %[[VAL_15]], %[[VAL_8]], %[[VAL_19]], %[[VAL_15]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Slice"(%[[VAL_35]], %[[VAL_15]], %[[VAL_8]], %[[VAL_19]], %[[VAL_15]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Pad"(%[[VAL_36]], %[[VAL_7]], %[[VAL_6]], %[[VAL_5]]) {mode = "constant"} : (tensor<1x24x200xf32>, tensor<6xi64>, tensor<f32>, none) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Pad"(%[[VAL_37]], %[[VAL_7]], %[[VAL_6]], %[[VAL_5]]) {mode = "constant"} : (tensor<1x24x200xf32>, tensor<6xi64>, tensor<f32>, none) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.Reshape"(%[[VAL_32]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
-// CHECK:           %[[VAL_43:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
-// CHECK:           %[[VAL_44:.*]] = "onnx.Reshape"(%[[VAL_39]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
-// CHECK:           %[[VAL_45:.*]] = "onnx.Concat"(%[[VAL_40]], %[[VAL_41]], %[[VAL_42]], %[[VAL_43]], %[[VAL_44]]) {axis = -1 : si64} : (tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>) -> tensor<1x24x201x5xf32>
-// CHECK:           %[[VAL_46:.*]] = "onnx.Reshape"(%[[VAL_45]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x201x5xf32>, tensor<3xi64>) -> tensor<1x24x1005xf32>
-// CHECK:           %[[VAL_47:.*]] = "onnx.Slice"(%[[VAL_46]], %[[VAL_17]], %[[VAL_2]], %[[VAL_19]], %[[VAL_15]]) : (tensor<1x24x1005xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x1001xf32>
-// CHECK:           onnx.Return %[[VAL_47]] : tensor<1x24x1001xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride_5
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x200xf32>, [[PARAM_1_:%.+]]: tensor<64x24x10xf32>) -> tensor<1x24x1001xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1001> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 24, 1005]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 24, 201, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<0.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<[0, 0, 0, 0, 0, 1]> : tensor<6xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<10> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<5> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<10> : tensor<64xi64>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 0, 1]} : (tensor<64x24x10xf32>) -> tensor<10x64x24xf32>
+// CHECK:           [[VAR_17_:%.+]] = "onnx.ReverseSequence"([[VAR_16_]], [[VAR_14_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<10x64x24xf32>, tensor<64xi64>) -> tensor<10x64x24xf32>
+// CHECK:           [[VAR_18_:%.+]] = "onnx.Transpose"([[VAR_17_]]) {perm = [1, 2, 0]} : (tensor<10x64x24xf32>) -> tensor<64x24x10xf32>
+// CHECK:           [[VAR_19_:%.+]] = "onnx.Transpose"([[VAR_18_]]) {perm = [1, 0, 2]} : (tensor<64x24x10xf32>) -> tensor<24x64x10xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Slice"([[VAR_19_]], [[VAR_11_]], [[VAR_10_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Slice"([[VAR_19_]], [[VAR_9_]], [[VAR_10_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.Slice"([[VAR_19_]], [[VAR_13_]], [[VAR_10_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.Slice"([[VAR_19_]], [[VAR_8_]], [[VAR_10_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.Slice"([[VAR_19_]], [[VAR_7_]], [[VAR_10_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<24x64x10xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_22_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_21_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_20_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_24_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_23_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Slice"([[VAR_28_]], [[VAR_9_]], [[VAR_6_]], [[VAR_13_]], [[VAR_9_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_9_]], [[VAR_6_]], [[VAR_13_]], [[VAR_9_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_32_:%.+]] = "onnx.Pad"([[VAR_30_]], [[VAR_5_]], [[VAR_4_]], [[VAR_3_]]) {mode = "constant"} : (tensor<1x24x200xf32>, tensor<6xi64>, tensor<f32>, none) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.Pad"([[VAR_31_]], [[VAR_5_]], [[VAR_4_]], [[VAR_3_]]) {mode = "constant"} : (tensor<1x24x200xf32>, tensor<6xi64>, tensor<f32>, none) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Reshape"([[VAR_25_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
+// CHECK-DAG:       [[VAR_35_:%.+]] = "onnx.Reshape"([[VAR_26_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
+// CHECK-DAG:       [[VAR_36_:%.+]] = "onnx.Reshape"([[VAR_27_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
+// CHECK-DAG:       [[VAR_37_:%.+]] = "onnx.Reshape"([[VAR_32_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
+// CHECK-DAG:       [[VAR_38_:%.+]] = "onnx.Reshape"([[VAR_33_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x24x201xf32>, tensor<4xi64>) -> tensor<1x24x201x1xf32>
+// CHECK:           [[VAR_39_:%.+]] = "onnx.Concat"([[VAR_34_]], [[VAR_35_]], [[VAR_36_]], [[VAR_37_]], [[VAR_38_]]) {axis = -1 : si64} : (tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>, tensor<1x24x201x1xf32>) -> tensor<1x24x201x5xf32>
+// CHECK:           [[VAR_40_:%.+]] = "onnx.Reshape"([[VAR_39_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x201x5xf32>, tensor<3xi64>) -> tensor<1x24x1005xf32>
+// CHECK:           [[VAR_41_:%.+]] = "onnx.Slice"([[VAR_40_]], [[VAR_11_]], [[VAR_0_]], [[VAR_13_]], [[VAR_9_]]) : (tensor<1x24x1005xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x1001xf32>
+// CHECK:           onnx.Return [[VAR_41_]] : tensor<1x24x1001xf32>
 // CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_5
 // DISABLED: onnx.ConvTranspose
@@ -262,35 +247,33 @@ func.func @test_convtrans_stride_2_nodilation(%arg0: tensor<1x64x200xf32>, %arg1
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) { group = 1 : si64, kernel_shape = [4],  pads = [1,1], strides = [2]} : (tensor<1x64x200xf32>, tensor<64x24x4xf32>, tensor<24xf32>) -> tensor<1x24x400xf32>
   onnx.Return %1 : tensor<1x24x400xf32>
 }
-// CHECK-LABEL:   func.func @test_convtrans_stride_2_nodilation(
-// CHECK-SAME:                                                  %[[VAL_0:.*]]: tensor<1x64x200xf32>,
-// CHECK-SAME:                                                  %[[VAL_1:.*]]: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 400]> : tensor<3xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<200> : tensor<1xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<201> : tensor<1xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<5> : tensor<1xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<4> : tensor<1xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<4> : tensor<64xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
-// CHECK:           %[[VAL_13:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
-// CHECK:           %[[VAL_14:.*]] = "onnx.ReverseSequence"(%[[VAL_13]], %[[VAL_11]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
-// CHECK:           %[[VAL_15:.*]] = "onnx.Transpose"(%[[VAL_14]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
-// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_15]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_9]], %[[VAL_8]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.Slice"(%[[VAL_16]], %[[VAL_7]], %[[VAL_6]], %[[VAL_10]], %[[VAL_10]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_18]], %[[VAL_12]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_17]], %[[VAL_12]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_19]], %[[VAL_7]], %[[VAL_5]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_4]], %[[VAL_10]], %[[VAL_7]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Reshape"(%[[VAL_21]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Reshape"(%[[VAL_22]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_23]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x2xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Reshape"(%[[VAL_25]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x2xf32>, tensor<3xi64>) -> tensor<1x24x400xf32>
-// CHECK:           onnx.Return %[[VAL_26]] : tensor<1x24x400xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride_2_nodilation
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x200xf32>, [[PARAM_1_:%.+]]: tensor<64x24x4xf32>) -> tensor<1x24x400xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 24, 400]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<4> : tensor<64xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 0, 1]} : (tensor<64x24x4xf32>) -> tensor<4x64x24xf32>
+// CHECK:           [[VAR_11_:%.+]] = "onnx.ReverseSequence"([[VAR_10_]], [[VAR_8_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x64x24xf32>, tensor<64xi64>) -> tensor<4x64x24xf32>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.Transpose"([[VAR_11_]]) {perm = [1, 2, 0]} : (tensor<4x64x24xf32>) -> tensor<64x24x4xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.Transpose"([[VAR_12_]]) {perm = [1, 0, 2]} : (tensor<64x24x4xf32>) -> tensor<24x64x4xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_6_]], [[VAR_5_]], [[VAR_7_]], [[VAR_7_]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_4_]], [[VAR_5_]], [[VAR_7_]], [[VAR_7_]]) : (tensor<24x64x4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_15_]], [[VAR_9_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_14_]], [[VAR_9_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_16_]], [[VAR_4_]], [[VAR_3_]], [[VAR_7_]], [[VAR_4_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_17_]], [[VAR_6_]], [[VAR_2_]], [[VAR_7_]], [[VAR_4_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Reshape"([[VAR_18_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Reshape"([[VAR_19_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Concat"([[VAR_21_]], [[VAR_20_]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x2xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Reshape"([[VAR_22_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x24x200x2xf32>, tensor<3xi64>) -> tensor<1x24x400xf32>
+// CHECK:           onnx.Return [[VAR_23_]] : tensor<1x24x400xf32>
 // CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_2_nodilation
 // DISABLED: onnx.ConvTranspose
@@ -303,51 +286,47 @@ func.func @test_convtrans_stride_4_lrelu(%arg0: tensor<1x64x200xf32>, %arg1: ten
   %2 = "onnx.LeakyRelu"(%1) {alpha = 1.000000e-01 : f32} : (tensor<1x24x800xf32>) -> tensor<1x24x800xf32> 
   onnx.Return %2 : tensor<1x24x800xf32>
 }
-// CHECK-LABEL:   func.func @test_convtrans_stride_4_lrelu(
-// CHECK-SAME:                                             %[[VAL_0:.*]]: tensor<1x64x200xf32>,
-// CHECK-SAME:                                             %[[VAL_1:.*]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<201> : tensor<1xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<200> : tensor<1xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<11> : tensor<1xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<3> : tensor<1xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<10> : tensor<1xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<9> : tensor<1xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<8> : tensor<1xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<1xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<8> : tensor<64xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_14]], %[[VAL_8]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.LeakyRelu"(%[[VAL_25]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.LeakyRelu"(%[[VAL_27]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.LeakyRelu"(%[[VAL_29]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.LeakyRelu"(%[[VAL_31]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_26]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_32]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_34]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Reshape"(%[[VAL_35]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_36]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.Concat"(%[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
-// CHECK:           onnx.Return %[[VAL_42]] : tensor<1x24x800xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride_4_lrelu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x200xf32>, [[PARAM_1_:%.+]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<8> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<8> : tensor<64xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.ReverseSequence"([[VAR_12_]], [[VAR_10_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
+// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
+// CHECK:           [[VAR_15_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_7_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_5_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_9_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_4_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           [[VAR_20_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_17_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.LeakyRelu"([[VAR_20_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_16_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.LeakyRelu"([[VAR_22_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_19_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.LeakyRelu"([[VAR_24_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_18_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.LeakyRelu"([[VAR_26_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Slice"([[VAR_21_]], [[VAR_7_]], [[VAR_3_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_7_]], [[VAR_3_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Slice"([[VAR_25_]], [[VAR_5_]], [[VAR_2_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.Slice"([[VAR_27_]], [[VAR_5_]], [[VAR_2_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_32_:%.+]] = "onnx.Reshape"([[VAR_28_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.Reshape"([[VAR_29_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Reshape"([[VAR_30_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           [[VAR_35_:%.+]] = "onnx.Reshape"([[VAR_31_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           [[VAR_36_:%.+]] = "onnx.Concat"([[VAR_32_]], [[VAR_33_]], [[VAR_34_]], [[VAR_35_]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
+// CHECK:           [[VAR_37_:%.+]] = "onnx.Reshape"([[VAR_36_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
+// CHECK:           onnx.Return [[VAR_37_]] : tensor<1x24x800xf32>
 // CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_4_lrelu
 // DISABLED: onnx.ConvTranspose
@@ -360,51 +339,47 @@ func.func @test_convtrans_stride_4_relu(%arg0: tensor<1x64x200xf32>, %arg1: tens
   %2 = "onnx.Relu"(%1) : (tensor<1x24x800xf32>) -> tensor<1x24x800xf32> 
   onnx.Return %2 : tensor<1x24x800xf32>
 }
-// CHECK-LABEL:   func.func @test_convtrans_stride_4_relu(
-// CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<1x64x200xf32>,
-// CHECK-SAME:                                            %[[VAL_1:.*]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<201> : tensor<1xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<200> : tensor<1xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<11> : tensor<1xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<3> : tensor<1xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<10> : tensor<1xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<9> : tensor<1xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<8> : tensor<1xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<1xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<8> : tensor<64xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_14]], %[[VAL_8]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Relu"(%[[VAL_25]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Relu"(%[[VAL_27]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Relu"(%[[VAL_29]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Relu"(%[[VAL_31]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_26]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_32]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_34]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Reshape"(%[[VAL_35]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_36]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.Concat"(%[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
-// CHECK:           onnx.Return %[[VAL_42]] : tensor<1x24x800xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride_4_relu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x200xf32>, [[PARAM_1_:%.+]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<8> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<8> : tensor<64xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.ReverseSequence"([[VAR_12_]], [[VAR_10_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
+// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
+// CHECK:           [[VAR_15_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_7_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_5_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_9_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_4_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           [[VAR_20_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_17_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Relu"([[VAR_20_]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_16_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.Relu"([[VAR_22_]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_19_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Relu"([[VAR_24_]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_18_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Relu"([[VAR_26_]]) : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Slice"([[VAR_21_]], [[VAR_7_]], [[VAR_3_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_7_]], [[VAR_3_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Slice"([[VAR_25_]], [[VAR_5_]], [[VAR_2_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.Slice"([[VAR_27_]], [[VAR_5_]], [[VAR_2_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_32_:%.+]] = "onnx.Reshape"([[VAR_28_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.Reshape"([[VAR_29_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Reshape"([[VAR_30_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           [[VAR_35_:%.+]] = "onnx.Reshape"([[VAR_31_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           [[VAR_36_:%.+]] = "onnx.Concat"([[VAR_32_]], [[VAR_33_]], [[VAR_34_]], [[VAR_35_]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
+// CHECK:           [[VAR_37_:%.+]] = "onnx.Reshape"([[VAR_36_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
+// CHECK:           onnx.Return [[VAR_37_]] : tensor<1x24x800xf32>
 // CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_4_relu
 // DISABLED: onnx.ConvTranspose
@@ -417,51 +392,47 @@ func.func @test_convtrans_stride_4_lrelu_default_value(%arg0: tensor<1x64x200xf3
   %2 = "onnx.LeakyRelu"(%1) : (tensor<1x24x800xf32>) -> tensor<1x24x800xf32> 
   onnx.Return %2 : tensor<1x24x800xf32>
 }
-// CHECK-LABEL:   func.func @test_convtrans_stride_4_lrelu_default_value(
-// CHECK-SAME:                                                           %[[VAL_0:.*]]: tensor<1x64x200xf32>,
-// CHECK-SAME:                                                           %[[VAL_1:.*]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<201> : tensor<1xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<200> : tensor<1xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<11> : tensor<1xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<3> : tensor<1xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<10> : tensor<1xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<9> : tensor<1xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<1> : tensor<1xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<8> : tensor<1xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<1xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<8> : tensor<64xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_15]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_12]], %[[VAL_11]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_10]], %[[VAL_9]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_14]], %[[VAL_8]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_14]], %[[VAL_13]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.LeakyRelu"(%[[VAL_25]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.LeakyRelu"(%[[VAL_27]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.LeakyRelu"(%[[VAL_29]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_16]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.LeakyRelu"(%[[VAL_31]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_26]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_12]], %[[VAL_5]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_32]], %[[VAL_10]], %[[VAL_4]], %[[VAL_14]], %[[VAL_10]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_33]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_34]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Reshape"(%[[VAL_35]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_36]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.Concat"(%[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
-// CHECK:           onnx.Return %[[VAL_42]] : tensor<1x24x800xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride_4_lrelu_default_value
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x200xf32>, [[PARAM_1_:%.+]]: tensor<64x24x8xf32>) -> tensor<1x24x800xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 24, 800]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 24, 200, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<201> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<200> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<8> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<8> : tensor<64xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<24xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 0, 1]} : (tensor<64x24x8xf32>) -> tensor<8x64x24xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.ReverseSequence"([[VAR_12_]], [[VAR_10_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<8x64x24xf32>, tensor<64xi64>) -> tensor<8x64x24xf32>
+// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [1, 2, 0]} : (tensor<8x64x24xf32>) -> tensor<64x24x8xf32>
+// CHECK:           [[VAR_15_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [1, 0, 2]} : (tensor<64x24x8xf32>) -> tensor<24x64x8xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_7_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_5_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_9_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_4_]], [[VAR_6_]], [[VAR_9_]], [[VAR_8_]]) : (tensor<24x64x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<24x64x2xf32>
+// CHECK:           [[VAR_20_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_17_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.LeakyRelu"([[VAR_20_]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_16_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.LeakyRelu"([[VAR_22_]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_19_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.LeakyRelu"([[VAR_24_]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_18_]], [[VAR_11_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [2], pads = [1, 1], strides = [1]} : (tensor<1x64x200xf32>, tensor<24x64x2xf32>, tensor<24xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.LeakyRelu"([[VAR_26_]]) {alpha = 0.00999999977 : f32} : (tensor<1x24x201xf32>) -> tensor<1x24x201xf32>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Slice"([[VAR_21_]], [[VAR_7_]], [[VAR_3_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_7_]], [[VAR_3_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Slice"([[VAR_25_]], [[VAR_5_]], [[VAR_2_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.Slice"([[VAR_27_]], [[VAR_5_]], [[VAR_2_]], [[VAR_9_]], [[VAR_5_]]) : (tensor<1x24x201xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1x24x200xf32>
+// CHECK-DAG:       [[VAR_32_:%.+]] = "onnx.Reshape"([[VAR_28_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.Reshape"([[VAR_29_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Reshape"([[VAR_30_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           [[VAR_35_:%.+]] = "onnx.Reshape"([[VAR_31_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x24x200xf32>, tensor<4xi64>) -> tensor<1x24x200x1xf32>
+// CHECK:           [[VAR_36_:%.+]] = "onnx.Concat"([[VAR_32_]], [[VAR_33_]], [[VAR_34_]], [[VAR_35_]]) {axis = -1 : si64} : (tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>, tensor<1x24x200x1xf32>) -> tensor<1x24x200x4xf32>
+// CHECK:           [[VAR_37_:%.+]] = "onnx.Reshape"([[VAR_36_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x24x200x4xf32>, tensor<3xi64>) -> tensor<1x24x800xf32>
+// CHECK:           onnx.Return [[VAR_37_]] : tensor<1x24x800xf32>
 // CHECK:         }
 // DISABLED-LABEL: test_convtrans_stride_4_lrelu
 // DISABLED: onnx.ConvTranspose

--- a/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv.mlir
@@ -5,39 +5,35 @@ func.func @test_convtrans_4phase_kernel_shape_66(%arg0: tensor<1x512x10x16xf32>,
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [6, 6], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [2, 2, 2, 2], strides = [2, 2]} : (tensor<1x512x10x16xf32>, tensor<512x256x6x6xf32>, tensor<256xf32>) -> tensor<1x256x20x32xf32>
   onnx.Return %1 : tensor<1x256x20x32xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_66(
-// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
-// CHECK-SAME:                                                     %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[2, 2, 256, 10, 16]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<7> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<6> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<6> : tensor<6xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
-// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.ReverseSequence"(%[[VAL_16]], %[[VAL_14]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_14]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_11]], %[[VAL_10]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_8]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_5]], %[[VAL_4]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_22]], %[[VAL_23]], %[[VAL_21]]) {axis = 0 : si64} : (tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>) -> tensor<1024x512x3x3xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Concat"(%[[VAL_15]], %[[VAL_15]], %[[VAL_15]], %[[VAL_15]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_25]], %[[VAL_26]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x10x16xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Reshape"(%[[VAL_27]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1024x10x16xf32>, tensor<5xi64>) -> tensor<2x2x256x10x16xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Transpose"(%[[VAL_28]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x10x16xf32>) -> tensor<256x10x2x16x2xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Reshape"(%[[VAL_29]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<256x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
-// CHECK:           onnx.Return %[[VAL_30]] : tensor<1x256x20x32xf32>
+// CHECK-LABEL:  func.func @test_convtrans_4phase_kernel_shape_66
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x10x16xf32>, [[PARAM_1_:%.+]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 256, 10, 16]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.ReverseSequence"([[VAR_11_]], [[VAR_9_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.ReverseSequence"([[VAR_12_]], [[VAR_9_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
+// CHECK:           [[VAR_15_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_6_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_4_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_3_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_2_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Concat"([[VAR_19_]], [[VAR_17_]], [[VAR_18_]], [[VAR_16_]]) {axis = 0 : si64} : (tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>) -> tensor<1024x512x3x3xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Concat"([[VAR_10_]], [[VAR_10_]], [[VAR_10_]], [[VAR_10_]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_20_]], [[VAR_21_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x10x16xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Reshape"([[VAR_22_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1024x10x16xf32>, tensor<5xi64>) -> tensor<2x2x256x10x16xf32>
+// CHECK:           [[VAR_24_:%.+]] = "onnx.Transpose"([[VAR_23_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x10x16xf32>) -> tensor<256x10x2x16x2xf32>
+// CHECK:           [[VAR_25_:%.+]] = "onnx.Reshape"([[VAR_24_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<256x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
+// CHECK:           onnx.Return [[VAR_25_]] : tensor<1x256x20x32xf32>
 // CHECK:         }
 }
 
@@ -48,38 +44,34 @@ func.func @test_convtrans_4phase_kernel_shape_66_nobias(%arg0: tensor<1x512x10x1
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [6, 6], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [2, 2, 2, 2], strides = [2, 2]} : (tensor<1x512x10x16xf32>, tensor<512x256x6x6xf32>, none) -> tensor<1x256x20x32xf32>
   onnx.Return %1 : tensor<1x256x20x32xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_66_nobias(
-// CHECK-SAME:                                                            %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
-// CHECK-SAME:                                                            %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[2, 2, 256, 10, 16]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<7> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<6> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<6> : tensor<6xi64>
-// CHECK:           %[[VAL_15:.*]] = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none
-// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.ReverseSequence"(%[[VAL_16]], %[[VAL_14]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_14]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_11]], %[[VAL_10]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_8]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_5]], %[[VAL_4]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_22]], %[[VAL_23]], %[[VAL_21]]) {axis = 0 : si64} : (tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>) -> tensor<1024x512x3x3xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_25]], %[[VAL_15]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<1024x512x3x3xf32>, none) -> tensor<1x1024x10x16xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Reshape"(%[[VAL_26]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1024x10x16xf32>, tensor<5xi64>) -> tensor<2x2x256x10x16xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Transpose"(%[[VAL_27]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x10x16xf32>) -> tensor<256x10x2x16x2xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Reshape"(%[[VAL_28]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<256x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
-// CHECK:           onnx.Return %[[VAL_29]] : tensor<1x256x20x32xf32>
+// CHECK-LABEL:  func.func @test_convtrans_4phase_kernel_shape_66_nobias
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x10x16xf32>, [[PARAM_1_:%.+]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 256, 10, 16]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = "onnx.NoValue"() {onnx_node_name = "onnx.NoValue_0", value} : () -> none
+// CHECK-DAG:       [[VAR_11_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.ReverseSequence"([[VAR_11_]], [[VAR_9_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.ReverseSequence"([[VAR_12_]], [[VAR_9_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
+// CHECK:           [[VAR_15_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_6_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_4_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_3_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_2_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK:           [[VAR_20_:%.+]] = "onnx.Concat"([[VAR_19_]], [[VAR_17_]], [[VAR_18_]], [[VAR_16_]]) {axis = 0 : si64} : (tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>) -> tensor<1024x512x3x3xf32>
+// CHECK:           [[VAR_21_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_20_]], [[VAR_10_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<1024x512x3x3xf32>, none) -> tensor<1x1024x10x16xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Reshape"([[VAR_21_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1024x10x16xf32>, tensor<5xi64>) -> tensor<2x2x256x10x16xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Transpose"([[VAR_22_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x10x16xf32>) -> tensor<256x10x2x16x2xf32>
+// CHECK:           [[VAR_24_:%.+]] = "onnx.Reshape"([[VAR_23_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<256x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
+// CHECK:           onnx.Return [[VAR_24_]] : tensor<1x256x20x32xf32>
 // CHECK:         }
 }
 
@@ -205,74 +197,65 @@ func.func @test_convtrans_9phase(%arg0: tensor<1x1x18x74xf32>, %arg1: tensor<1x1
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [0, 0, 0, 0], strides = [3, 3]} : (tensor<1x1x18x74xf32>, tensor<1x1x3x3xf32>, tensor<1xf32>) -> tensor<1x1x54x222xf32>
   onnx.Return %1 : tensor<1x1x54x222xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_9phase(
-// CHECK-SAME:                                     %[[VAL_0:.*]]: tensor<1x1x18x74xf32>,
-// CHECK-SAME:                                     %[[VAL_1:.*]]: tensor<1x1x3x3xf32>) -> tensor<1x1x54x222xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<5> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[3, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<[3, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<[5, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<[4, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<3> : tensor<2xi64>
-// CHECK:           %[[VAL_23:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_24:.*]] = onnx.Constant dense<3> : tensor<3xi64>
-// CHECK:           %[[VAL_25:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xf32>) -> tensor<3x3x1x1xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.ReverseSequence"(%[[VAL_26]], %[[VAL_24]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.ReverseSequence"(%[[VAL_27]], %[[VAL_24]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Transpose"(%[[VAL_28]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xf32>) -> tensor<1x1x3x3xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Transpose"(%[[VAL_29]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_21]], %[[VAL_22]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_20]], %[[VAL_19]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_18]], %[[VAL_17]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_16]], %[[VAL_15]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_14]], %[[VAL_13]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_12]], %[[VAL_11]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_10]], %[[VAL_9]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_8]], %[[VAL_7]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_6]], %[[VAL_5]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_39]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_36]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_37]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_43:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_38]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_44:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_35]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_45:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_32]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_46:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_33]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_47:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_34]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_48:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_31]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_49:.*]] = "onnx.Reshape"(%[[VAL_40]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_50:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_51:.*]] = "onnx.Reshape"(%[[VAL_42]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_52:.*]] = "onnx.Reshape"(%[[VAL_43]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_53:.*]] = "onnx.Reshape"(%[[VAL_44]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_54:.*]] = "onnx.Reshape"(%[[VAL_45]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_55:.*]] = "onnx.Reshape"(%[[VAL_46]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_56:.*]] = "onnx.Reshape"(%[[VAL_47]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_57:.*]] = "onnx.Reshape"(%[[VAL_48]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_58:.*]] = "onnx.Concat"(%[[VAL_49]], %[[VAL_50]], %[[VAL_55]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_59:.*]] = "onnx.Concat"(%[[VAL_52]], %[[VAL_53]], %[[VAL_54]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_60:.*]] = "onnx.Concat"(%[[VAL_51]], %[[VAL_56]], %[[VAL_57]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_61:.*]] = "onnx.Reshape"(%[[VAL_58]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_62:.*]] = "onnx.Reshape"(%[[VAL_59]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_63:.*]] = "onnx.Reshape"(%[[VAL_60]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_64:.*]] = "onnx.Concat"(%[[VAL_61]], %[[VAL_62]], %[[VAL_63]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
-// CHECK:           %[[VAL_65:.*]] = "onnx.Reshape"(%[[VAL_64]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
-// CHECK:           onnx.Return %[[VAL_65]] : tensor<1x1x54x222xf32>
+// CHECK-LABEL:  func.func @test_convtrans_9phase
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x18x74xf32>, [[PARAM_1_:%.+]]: tensor<1x1x3x3xf32>) -> tensor<1x1x54x222xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<3> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xf32>) -> tensor<3x3x1x1xf32>
+// CHECK:           [[VAR_17_:%.+]] = "onnx.ReverseSequence"([[VAR_16_]], [[VAR_14_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
+// CHECK:           [[VAR_18_:%.+]] = "onnx.ReverseSequence"([[VAR_17_]], [[VAR_14_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
+// CHECK:           [[VAR_19_:%.+]] = "onnx.Transpose"([[VAR_18_]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xf32>) -> tensor<1x1x3x3xf32>
+// CHECK:           [[VAR_20_:%.+]] = "onnx.Transpose"([[VAR_19_]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_11_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_10_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_9_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_8_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_7_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_6_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_5_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_4_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_3_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_29_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_26_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_32_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_27_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_28_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_25_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_35_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_22_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_36_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_23_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_37_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_24_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_38_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_21_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_39_:%.+]] = "onnx.Reshape"([[VAR_30_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_40_:%.+]] = "onnx.Reshape"([[VAR_31_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_41_:%.+]] = "onnx.Reshape"([[VAR_32_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_42_:%.+]] = "onnx.Reshape"([[VAR_33_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_43_:%.+]] = "onnx.Reshape"([[VAR_34_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_44_:%.+]] = "onnx.Reshape"([[VAR_35_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_45_:%.+]] = "onnx.Reshape"([[VAR_36_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_46_:%.+]] = "onnx.Reshape"([[VAR_37_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_47_:%.+]] = "onnx.Reshape"([[VAR_38_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_48_:%.+]] = "onnx.Concat"([[VAR_39_]], [[VAR_40_]], [[VAR_45_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_49_:%.+]] = "onnx.Concat"([[VAR_42_]], [[VAR_43_]], [[VAR_44_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_50_:%.+]] = "onnx.Concat"([[VAR_41_]], [[VAR_46_]], [[VAR_47_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_51_:%.+]] = "onnx.Reshape"([[VAR_48_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK-DAG:       [[VAR_52_:%.+]] = "onnx.Reshape"([[VAR_49_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK-DAG:       [[VAR_53_:%.+]] = "onnx.Reshape"([[VAR_50_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           [[VAR_54_:%.+]] = "onnx.Concat"([[VAR_51_]], [[VAR_52_]], [[VAR_53_]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
+// CHECK:           [[VAR_55_:%.+]] = "onnx.Reshape"([[VAR_54_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
+// CHECK:           onnx.Return [[VAR_55_]] : tensor<1x1x54x222xf32>
 // CHECK:         }
 }
 
@@ -283,53 +266,49 @@ func.func @test_convtrans_4phase_pads_0011(%arg0: tensor<1x128x10x16xf32>, %arg1
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [0, 0, 1, 1], strides = [2, 2]} : (tensor<1x128x10x16xf32>, tensor<128x32x3x3xf32>, tensor<32xf32>) -> tensor<1x32x20x32xf32>
   onnx.Return %1 : tensor<1x32x20x32xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_4phase_pads_0011(
-// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<1x128x10x16xf32>,
-// CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<128x32x3x3xf32>) -> tensor<1x32x20x32xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 32, 20, 32]> : tensor<4xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[2, 2, 32, 10, 16]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[10, 18]> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<[12, 16]> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[10, 16]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[12, 18]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<5> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<4> : tensor<2xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_18:.*]] = "onnx.NoValue"() {value} : () -> none
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<0.000000e+00> : tensor<f32>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<[0, 0, 0, 0, 0, 0, 1, 1]> : tensor<8xi64>
-// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<3> : tensor<3xi64>
-// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<2.000000e-02> : tensor<32xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<128x32x3x3xf32>) -> tensor<3x3x128x32xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.ReverseSequence"(%[[VAL_23]], %[[VAL_21]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.ReverseSequence"(%[[VAL_24]], %[[VAL_21]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Transpose"(%[[VAL_25]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x128x32xf32>) -> tensor<128x32x3x3xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Transpose"(%[[VAL_26]]) {perm = [1, 0, 2, 3]} : (tensor<128x32x3x3xf32>) -> tensor<32x128x3x3xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Pad"(%[[VAL_27]], %[[VAL_20]], %[[VAL_19]], %[[VAL_18]]) {mode = "constant"} : (tensor<32x128x3x3xf32>, tensor<8xi64>, tensor<f32>, none) -> tensor<32x128x4x4xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_15]], %[[VAL_14]], %[[VAL_17]], %[[VAL_16]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_13]], %[[VAL_12]], %[[VAL_17]], %[[VAL_16]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_11]], %[[VAL_10]], %[[VAL_17]], %[[VAL_16]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_9]], %[[VAL_8]], %[[VAL_17]], %[[VAL_16]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_32]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_29]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_30]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_31]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Slice"(%[[VAL_33]], %[[VAL_9]], %[[VAL_7]], %[[VAL_17]], %[[VAL_9]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Slice"(%[[VAL_34]], %[[VAL_15]], %[[VAL_6]], %[[VAL_17]], %[[VAL_9]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_35]], %[[VAL_13]], %[[VAL_5]], %[[VAL_17]], %[[VAL_9]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Slice"(%[[VAL_36]], %[[VAL_11]], %[[VAL_4]], %[[VAL_17]], %[[VAL_9]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.Concat"(%[[VAL_38]], %[[VAL_40]], %[[VAL_39]], %[[VAL_37]]) {axis = 1 : si64} : (tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>) -> tensor<1x128x10x16xf32>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x128x10x16xf32>, tensor<5xi64>) -> tensor<2x2x32x10x16xf32>
-// CHECK:           %[[VAL_43:.*]] = "onnx.Transpose"(%[[VAL_42]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x32x10x16xf32>) -> tensor<32x10x2x16x2xf32>
-// CHECK:           %[[VAL_44:.*]] = "onnx.Reshape"(%[[VAL_43]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<32x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x32x20x32xf32>
-// CHECK:           onnx.Return %[[VAL_44]] : tensor<1x32x20x32xf32>
+// CHECK-LABEL:  func.func @test_convtrans_4phase_pads_0011
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x128x10x16xf32>, [[PARAM_1_:%.+]]: tensor<128x32x3x3xf32>) -> tensor<1x32x20x32xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 32, 20, 32]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 32, 10, 16]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[10, 18]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[12, 16]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[10, 16]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<[12, 18]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<4> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_13_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<0.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<[0, 0, 0, 0, 0, 0, 1, 1]> : tensor<8xi64>
+// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_17_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<32xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<128x32x3x3xf32>) -> tensor<3x3x128x32xf32>
+// CHECK:           [[VAR_19_:%.+]] = "onnx.ReverseSequence"([[VAR_18_]], [[VAR_16_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
+// CHECK:           [[VAR_20_:%.+]] = "onnx.ReverseSequence"([[VAR_19_]], [[VAR_16_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
+// CHECK:           [[VAR_21_:%.+]] = "onnx.Transpose"([[VAR_20_]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x128x32xf32>) -> tensor<128x32x3x3xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Transpose"([[VAR_21_]]) {perm = [1, 0, 2, 3]} : (tensor<128x32x3x3xf32>) -> tensor<32x128x3x3xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Pad"([[VAR_22_]], [[VAR_15_]], [[VAR_14_]], [[VAR_13_]]) {mode = "constant"} : (tensor<32x128x3x3xf32>, tensor<8xi64>, tensor<f32>, none) -> tensor<32x128x4x4xf32>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_10_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_8_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_7_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_6_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_27_]], [[VAR_17_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_24_]], [[VAR_17_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_25_]], [[VAR_17_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_26_]], [[VAR_17_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_32_:%.+]] = "onnx.Slice"([[VAR_28_]], [[VAR_6_]], [[VAR_5_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_10_]], [[VAR_4_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Slice"([[VAR_30_]], [[VAR_8_]], [[VAR_3_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK-DAG:       [[VAR_35_:%.+]] = "onnx.Slice"([[VAR_31_]], [[VAR_7_]], [[VAR_2_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           [[VAR_36_:%.+]] = "onnx.Concat"([[VAR_33_]], [[VAR_35_]], [[VAR_34_]], [[VAR_32_]]) {axis = 1 : si64} : (tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>) -> tensor<1x128x10x16xf32>
+// CHECK:           [[VAR_37_:%.+]] = "onnx.Reshape"([[VAR_36_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x128x10x16xf32>, tensor<5xi64>) -> tensor<2x2x32x10x16xf32>
+// CHECK:           [[VAR_38_:%.+]] = "onnx.Transpose"([[VAR_37_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x32x10x16xf32>) -> tensor<32x10x2x16x2xf32>
+// CHECK:           [[VAR_39_:%.+]] = "onnx.Reshape"([[VAR_38_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<32x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x32x20x32xf32>
+// CHECK:           onnx.Return [[VAR_39_]] : tensor<1x32x20x32xf32>
 // CHECK:         }
 }
 
@@ -340,53 +319,49 @@ func.func @test_convtrans_4phase_pads_1100(%arg0: tensor<1x128x10x16xf32>, %arg1
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [1, 1, 0, 0], strides = [2, 2]} : (tensor<1x128x10x16xf32>, tensor<128x32x3x3xf32>, tensor<32xf32>) -> tensor<1x32x20x32xf32>
   onnx.Return %1 : tensor<1x32x20x32xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_4phase_pads_1100(
-// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<1x128x10x16xf32>,
-// CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<128x32x3x3xf32>) -> tensor<1x32x20x32xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 32, 20, 32]> : tensor<4xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[2, 2, 32, 10, 16]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[10, 18]> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<[12, 16]> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[10, 16]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[12, 18]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<5> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<4> : tensor<2xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_18:.*]] = "onnx.NoValue"() {value} : () -> none
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<0.000000e+00> : tensor<f32>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<[0, 0, 1, 1, 0, 0, 0, 0]> : tensor<8xi64>
-// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<3> : tensor<3xi64>
-// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<2.000000e-02> : tensor<32xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<128x32x3x3xf32>) -> tensor<3x3x128x32xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.ReverseSequence"(%[[VAL_23]], %[[VAL_21]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.ReverseSequence"(%[[VAL_24]], %[[VAL_21]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Transpose"(%[[VAL_25]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x128x32xf32>) -> tensor<128x32x3x3xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Transpose"(%[[VAL_26]]) {perm = [1, 0, 2, 3]} : (tensor<128x32x3x3xf32>) -> tensor<32x128x3x3xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Pad"(%[[VAL_27]], %[[VAL_20]], %[[VAL_19]], %[[VAL_18]]) {mode = "constant"} : (tensor<32x128x3x3xf32>, tensor<8xi64>, tensor<f32>, none) -> tensor<32x128x4x4xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_15]], %[[VAL_14]], %[[VAL_17]], %[[VAL_16]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_13]], %[[VAL_12]], %[[VAL_17]], %[[VAL_16]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_11]], %[[VAL_10]], %[[VAL_17]], %[[VAL_16]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_9]], %[[VAL_8]], %[[VAL_17]], %[[VAL_16]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_32]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_29]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_30]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_31]], %[[VAL_22]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Slice"(%[[VAL_33]], %[[VAL_9]], %[[VAL_7]], %[[VAL_17]], %[[VAL_9]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Slice"(%[[VAL_34]], %[[VAL_15]], %[[VAL_6]], %[[VAL_17]], %[[VAL_9]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_35]], %[[VAL_13]], %[[VAL_5]], %[[VAL_17]], %[[VAL_9]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Slice"(%[[VAL_36]], %[[VAL_11]], %[[VAL_4]], %[[VAL_17]], %[[VAL_9]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.Concat"(%[[VAL_38]], %[[VAL_40]], %[[VAL_39]], %[[VAL_37]]) {axis = 1 : si64} : (tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>) -> tensor<1x128x10x16xf32>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x128x10x16xf32>, tensor<5xi64>) -> tensor<2x2x32x10x16xf32>
-// CHECK:           %[[VAL_43:.*]] = "onnx.Transpose"(%[[VAL_42]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x32x10x16xf32>) -> tensor<32x10x2x16x2xf32>
-// CHECK:           %[[VAL_44:.*]] = "onnx.Reshape"(%[[VAL_43]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<32x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x32x20x32xf32>
-// CHECK:           onnx.Return %[[VAL_44]] : tensor<1x32x20x32xf32>
+// CHECK-LABEL:  func.func @test_convtrans_4phase_pads_1100
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x128x10x16xf32>, [[PARAM_1_:%.+]]: tensor<128x32x3x3xf32>) -> tensor<1x32x20x32xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 32, 20, 32]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 32, 10, 16]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[10, 18]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[12, 16]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[10, 16]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<[12, 18]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<4> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_13_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<0.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<[0, 0, 1, 1, 0, 0, 0, 0]> : tensor<8xi64>
+// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_17_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<32xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<128x32x3x3xf32>) -> tensor<3x3x128x32xf32>
+// CHECK:           [[VAR_19_:%.+]] = "onnx.ReverseSequence"([[VAR_18_]], [[VAR_16_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
+// CHECK:           [[VAR_20_:%.+]] = "onnx.ReverseSequence"([[VAR_19_]], [[VAR_16_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x128x32xf32>, tensor<3xi64>) -> tensor<3x3x128x32xf32>
+// CHECK:           [[VAR_21_:%.+]] = "onnx.Transpose"([[VAR_20_]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x128x32xf32>) -> tensor<128x32x3x3xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Transpose"([[VAR_21_]]) {perm = [1, 0, 2, 3]} : (tensor<128x32x3x3xf32>) -> tensor<32x128x3x3xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Pad"([[VAR_22_]], [[VAR_15_]], [[VAR_14_]], [[VAR_13_]]) {mode = "constant"} : (tensor<32x128x3x3xf32>, tensor<8xi64>, tensor<f32>, none) -> tensor<32x128x4x4xf32>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_10_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_8_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_7_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Slice"([[VAR_23_]], [[VAR_6_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_27_]], [[VAR_17_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_24_]], [[VAR_17_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_25_]], [[VAR_17_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_26_]], [[VAR_17_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_32_:%.+]] = "onnx.Slice"([[VAR_28_]], [[VAR_6_]], [[VAR_5_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_10_]], [[VAR_4_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Slice"([[VAR_30_]], [[VAR_8_]], [[VAR_3_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK-DAG:       [[VAR_35_:%.+]] = "onnx.Slice"([[VAR_31_]], [[VAR_7_]], [[VAR_2_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           [[VAR_36_:%.+]] = "onnx.Concat"([[VAR_33_]], [[VAR_35_]], [[VAR_34_]], [[VAR_32_]]) {axis = 1 : si64} : (tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>) -> tensor<1x128x10x16xf32>
+// CHECK:           [[VAR_37_:%.+]] = "onnx.Reshape"([[VAR_36_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x128x10x16xf32>, tensor<5xi64>) -> tensor<2x2x32x10x16xf32>
+// CHECK:           [[VAR_38_:%.+]] = "onnx.Transpose"([[VAR_37_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x32x10x16xf32>) -> tensor<32x10x2x16x2xf32>
+// CHECK:           [[VAR_39_:%.+]] = "onnx.Reshape"([[VAR_38_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<32x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x32x20x32xf32>
+// CHECK:           onnx.Return [[VAR_39_]] : tensor<1x32x20x32xf32>
 // CHECK:         }
 }
 
@@ -436,36 +411,33 @@ func.func @test_convtrans_4phase_kernel_shape_22(%arg0: tensor<1x288x8x96xf32>, 
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2,2], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [0,0,0,0], strides = [2, 2]} : (tensor<1x288x8x96xf32>, tensor<288x240x2x2xf32>, tensor<240xf32>) -> tensor<1x240x16x192xf32>
   onnx.Return %1 : tensor<1x240x16x192xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_22(
-// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<1x288x8x96xf32>,
-// CHECK-SAME:                                                     %[[VAL_1:.*]]: tensor<288x240x2x2xf32>) -> tensor<1x240x16x192xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 240, 16, 192]> : tensor<4xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[2, 2, 240, 8, 96]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<3> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[3, 2]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2.000000e-02> : tensor<240xf32>
-// CHECK:           %[[VAL_13:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<288x240x2x2xf32>) -> tensor<2x2x288x240xf32>
-// CHECK:           %[[VAL_14:.*]] = "onnx.ReverseSequence"(%[[VAL_13]], %[[VAL_11]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<2x2x288x240xf32>, tensor<2xi64>) -> tensor<2x2x288x240xf32>
-// CHECK:           %[[VAL_15:.*]] = "onnx.ReverseSequence"(%[[VAL_14]], %[[VAL_11]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<2x2x288x240xf32>, tensor<2xi64>) -> tensor<2x2x288x240xf32>
-// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_15]]) {perm = [2, 3, 0, 1]} : (tensor<2x2x288x240xf32>) -> tensor<288x240x2x2xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.Transpose"(%[[VAL_16]]) {perm = [1, 0, 2, 3]} : (tensor<288x240x2x2xf32>) -> tensor<240x288x2x2xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.Slice"(%[[VAL_17]], %[[VAL_9]], %[[VAL_11]], %[[VAL_10]], %[[VAL_11]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Slice"(%[[VAL_17]], %[[VAL_8]], %[[VAL_7]], %[[VAL_10]], %[[VAL_11]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Slice"(%[[VAL_17]], %[[VAL_6]], %[[VAL_10]], %[[VAL_10]], %[[VAL_11]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_17]], %[[VAL_5]], %[[VAL_4]], %[[VAL_10]], %[[VAL_11]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Concat"(%[[VAL_21]], %[[VAL_19]], %[[VAL_20]], %[[VAL_18]]) {axis = 0 : si64} : (tensor<240x288x1x1xf32>, tensor<240x288x1x1xf32>, tensor<240x288x1x1xf32>, tensor<240x288x1x1xf32>) -> tensor<960x288x1x1xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Concat"(%[[VAL_12]], %[[VAL_12]], %[[VAL_12]], %[[VAL_12]]) {axis = 0 : si64} : (tensor<240xf32>, tensor<240xf32>, tensor<240xf32>, tensor<240xf32>) -> tensor<960xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_23]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x288x8x96xf32>, tensor<960x288x1x1xf32>, tensor<960xf32>) -> tensor<1x960x8x96xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Reshape"(%[[VAL_24]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x960x8x96xf32>, tensor<5xi64>) -> tensor<2x2x240x8x96xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Transpose"(%[[VAL_25]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x240x8x96xf32>) -> tensor<240x8x2x96x2xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Reshape"(%[[VAL_26]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<240x8x2x96x2xf32>, tensor<4xi64>) -> tensor<1x240x16x192xf32>
-// CHECK:           onnx.Return %[[VAL_27]] : tensor<1x240x16x192xf32>
+// CHECK-LABEL:  func.func @test_convtrans_4phase_kernel_shape_22
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x288x8x96xf32>, [[PARAM_1_:%.+]]: tensor<288x240x2x2xf32>) -> tensor<1x240x16x192xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 240, 16, 192]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 240, 8, 96]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<240xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<288x240x2x2xf32>) -> tensor<2x2x288x240xf32>
+// CHECK:           [[VAR_10_:%.+]] = "onnx.ReverseSequence"([[VAR_9_]], [[VAR_7_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<2x2x288x240xf32>, tensor<2xi64>) -> tensor<2x2x288x240xf32>
+// CHECK:           [[VAR_11_:%.+]] = "onnx.ReverseSequence"([[VAR_10_]], [[VAR_7_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<2x2x288x240xf32>, tensor<2xi64>) -> tensor<2x2x288x240xf32>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.Transpose"([[VAR_11_]]) {perm = [2, 3, 0, 1]} : (tensor<2x2x288x240xf32>) -> tensor<288x240x2x2xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.Transpose"([[VAR_12_]]) {perm = [1, 0, 2, 3]} : (tensor<288x240x2x2xf32>) -> tensor<240x288x2x2xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_5_]], [[VAR_7_]], [[VAR_6_]], [[VAR_7_]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_4_]], [[VAR_7_]], [[VAR_6_]], [[VAR_7_]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_3_]], [[VAR_7_]], [[VAR_6_]], [[VAR_7_]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_13_]], [[VAR_2_]], [[VAR_7_]], [[VAR_6_]], [[VAR_7_]]) : (tensor<240x288x2x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<240x288x1x1xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Concat"([[VAR_17_]], [[VAR_15_]], [[VAR_16_]], [[VAR_14_]]) {axis = 0 : si64} : (tensor<240x288x1x1xf32>, tensor<240x288x1x1xf32>, tensor<240x288x1x1xf32>, tensor<240x288x1x1xf32>) -> tensor<960x288x1x1xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Concat"([[VAR_8_]], [[VAR_8_]], [[VAR_8_]], [[VAR_8_]]) {axis = 0 : si64} : (tensor<240xf32>, tensor<240xf32>, tensor<240xf32>, tensor<240xf32>) -> tensor<960xf32>
+// CHECK:           [[VAR_20_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_18_]], [[VAR_19_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x288x8x96xf32>, tensor<960x288x1x1xf32>, tensor<960xf32>) -> tensor<1x960x8x96xf32>
+// CHECK:           [[VAR_21_:%.+]] = "onnx.Reshape"([[VAR_20_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x960x8x96xf32>, tensor<5xi64>) -> tensor<2x2x240x8x96xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Transpose"([[VAR_21_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x240x8x96xf32>) -> tensor<240x8x2x96x2xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Reshape"([[VAR_22_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<240x8x2x96x2xf32>, tensor<4xi64>) -> tensor<1x240x16x192xf32>
+// CHECK:           onnx.Return [[VAR_23_]] : tensor<1x240x16x192xf32>
 // CHECK:         }
 }
 
@@ -476,41 +448,37 @@ func.func @test_convtrans_4phase_kernel_shape_44(%arg0: tensor<1x512x8x8xf32>, %
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [4,4], onnx_node_name = "share_proto/decoder_deconv_os16_deconv/BiasAdd", pads = [1,1,1,1], strides = [2, 2]} : (tensor<1x512x8x8xf32>, tensor<512x512x4x4xf32>, tensor<512xf32>) -> tensor<1x512x16x16xf32>
   onnx.Return %1 : tensor<1x512x16x16xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_44(
-// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<1x512x8x8xf32>,
-// CHECK-SAME:                                                     %[[VAL_1:.*]]: tensor<512x512x4x4xf32>) -> tensor<1x512x16x16xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 512, 16, 16]> : tensor<4xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[2, 2, 512, 8, 8]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<5> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<4> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<4> : tensor<4xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<2.000000e-02> : tensor<512xf32>
-// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x512x4x4xf32>) -> tensor<4x4x512x512xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.ReverseSequence"(%[[VAL_16]], %[[VAL_14]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x4x512x512xf32>, tensor<4xi64>) -> tensor<4x4x512x512xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_14]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<4x4x512x512xf32>, tensor<4xi64>) -> tensor<4x4x512x512xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [2, 3, 0, 1]} : (tensor<4x4x512x512xf32>) -> tensor<512x512x4x4xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2, 3]} : (tensor<512x512x4x4xf32>) -> tensor<512x512x4x4xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_11]], %[[VAL_10]], %[[VAL_13]], %[[VAL_12]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_8]], %[[VAL_13]], %[[VAL_12]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_13]], %[[VAL_12]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_5]], %[[VAL_4]], %[[VAL_13]], %[[VAL_12]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_24]], %[[VAL_15]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [0, 0, 1, 1], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_21]], %[[VAL_15]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 0, 0], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_22]], %[[VAL_15]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [0, 1, 1, 0], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_23]], %[[VAL_15]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 0, 0, 1], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Concat"(%[[VAL_26]], %[[VAL_28]], %[[VAL_27]], %[[VAL_25]]) {axis = 1 : si64} : (tensor<1x512x8x8xf32>, tensor<1x512x8x8xf32>, tensor<1x512x8x8xf32>, tensor<1x512x8x8xf32>) -> tensor<1x2048x8x8xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Reshape"(%[[VAL_29]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x2048x8x8xf32>, tensor<5xi64>) -> tensor<2x2x512x8x8xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Transpose"(%[[VAL_30]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x512x8x8xf32>) -> tensor<512x8x2x8x2xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Reshape"(%[[VAL_31]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<512x8x2x8x2xf32>, tensor<4xi64>) -> tensor<1x512x16x16xf32>
-// CHECK:           onnx.Return %[[VAL_32]] : tensor<1x512x16x16xf32>
+// CHECK-LABEL:  func.func @test_convtrans_4phase_kernel_shape_44
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x8x8xf32>, [[PARAM_1_:%.+]]: tensor<512x512x4x4xf32>) -> tensor<1x512x16x16xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 512, 16, 16]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 512, 8, 8]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<4> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<4> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<512xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<512x512x4x4xf32>) -> tensor<4x4x512x512xf32>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.ReverseSequence"([[VAR_11_]], [[VAR_9_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<4x4x512x512xf32>, tensor<4xi64>) -> tensor<4x4x512x512xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.ReverseSequence"([[VAR_12_]], [[VAR_9_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<4x4x512x512xf32>, tensor<4xi64>) -> tensor<4x4x512x512xf32>
+// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [2, 3, 0, 1]} : (tensor<4x4x512x512xf32>) -> tensor<512x512x4x4xf32>
+// CHECK:           [[VAR_15_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [1, 0, 2, 3]} : (tensor<512x512x4x4xf32>) -> tensor<512x512x4x4xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_6_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_4_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_3_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_2_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<512x512x4x4xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<512x512x2x2xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_19_]], [[VAR_10_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [0, 0, 1, 1], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_16_]], [[VAR_10_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 0, 0], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_17_]], [[VAR_10_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [0, 1, 1, 0], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_18_]], [[VAR_10_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 0, 0, 1], strides = [1, 1]} : (tensor<1x512x8x8xf32>, tensor<512x512x2x2xf32>, tensor<512xf32>) -> tensor<1x512x8x8xf32>
+// CHECK:           [[VAR_24_:%.+]] = "onnx.Concat"([[VAR_21_]], [[VAR_23_]], [[VAR_22_]], [[VAR_20_]]) {axis = 1 : si64} : (tensor<1x512x8x8xf32>, tensor<1x512x8x8xf32>, tensor<1x512x8x8xf32>, tensor<1x512x8x8xf32>) -> tensor<1x2048x8x8xf32>
+// CHECK:           [[VAR_25_:%.+]] = "onnx.Reshape"([[VAR_24_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x2048x8x8xf32>, tensor<5xi64>) -> tensor<2x2x512x8x8xf32>
+// CHECK:           [[VAR_26_:%.+]] = "onnx.Transpose"([[VAR_25_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x512x8x8xf32>) -> tensor<512x8x2x8x2xf32>
+// CHECK:           [[VAR_27_:%.+]] = "onnx.Reshape"([[VAR_26_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<512x8x2x8x2xf32>, tensor<4xi64>) -> tensor<1x512x16x16xf32>
+// CHECK:           onnx.Return [[VAR_27_]] : tensor<1x512x16x16xf32>
 // CHECK:         }
 }
 
@@ -522,40 +490,36 @@ func.func @test_convtrans_4phase_kernel_shape_66_lrelu(%arg0: tensor<1x512x10x16
   %2 = "onnx.LeakyRelu"(%1) {alpha = 1.000000e-01 : f32, onnx_node_name = "LeakyRelu3"} : (tensor<1x256x20x32xf32>) -> tensor<1x256x20x32xf32> 
   onnx.Return %2 : tensor<1x256x20x32xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_66_lrelu(
-// CHECK-SAME:                                                           %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
-// CHECK-SAME:                                                           %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[2, 2, 256, 10, 16]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<7> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<6> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<6> : tensor<6xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
-// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.ReverseSequence"(%[[VAL_16]], %[[VAL_14]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_14]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_11]], %[[VAL_10]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_8]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_5]], %[[VAL_4]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_22]], %[[VAL_23]], %[[VAL_21]]) {axis = 0 : si64} : (tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>) -> tensor<1024x512x3x3xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Concat"(%[[VAL_15]], %[[VAL_15]], %[[VAL_15]], %[[VAL_15]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_25]], %[[VAL_26]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x10x16xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.LeakyRelu"(%[[VAL_27]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1024x10x16xf32>) -> tensor<1x1024x10x16xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Reshape"(%[[VAL_28]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1024x10x16xf32>, tensor<5xi64>) -> tensor<2x2x256x10x16xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Transpose"(%[[VAL_29]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x10x16xf32>) -> tensor<256x10x2x16x2xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Reshape"(%[[VAL_30]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<256x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
-// CHECK:           onnx.Return %[[VAL_31]] : tensor<1x256x20x32xf32>
+// CHECK-LABEL:  func.func @test_convtrans_4phase_kernel_shape_66_lrelu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x10x16xf32>, [[PARAM_1_:%.+]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 256, 10, 16]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.ReverseSequence"([[VAR_11_]], [[VAR_9_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.ReverseSequence"([[VAR_12_]], [[VAR_9_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
+// CHECK:           [[VAR_15_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_6_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_4_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_3_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_2_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Concat"([[VAR_19_]], [[VAR_17_]], [[VAR_18_]], [[VAR_16_]]) {axis = 0 : si64} : (tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>) -> tensor<1024x512x3x3xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Concat"([[VAR_10_]], [[VAR_10_]], [[VAR_10_]], [[VAR_10_]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_20_]], [[VAR_21_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x10x16xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.LeakyRelu"([[VAR_22_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1024x10x16xf32>) -> tensor<1x1024x10x16xf32>
+// CHECK:           [[VAR_24_:%.+]] = "onnx.Reshape"([[VAR_23_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1024x10x16xf32>, tensor<5xi64>) -> tensor<2x2x256x10x16xf32>
+// CHECK:           [[VAR_25_:%.+]] = "onnx.Transpose"([[VAR_24_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x10x16xf32>) -> tensor<256x10x2x16x2xf32>
+// CHECK:           [[VAR_26_:%.+]] = "onnx.Reshape"([[VAR_25_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<256x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
+// CHECK:           onnx.Return [[VAR_26_]] : tensor<1x256x20x32xf32>
 // CHECK:         }
 }
 
@@ -567,40 +531,36 @@ func.func @test_convtrans_4phase_kernel_shape_66_relu(%arg0: tensor<1x512x10x16x
   %2 = "onnx.Relu"(%1) {onnx_node_name = "Relu3"} : (tensor<1x256x20x32xf32>) -> tensor<1x256x20x32xf32> 
   onnx.Return %2 : tensor<1x256x20x32xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_66_relu(
-// CHECK-SAME:                                                          %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
-// CHECK-SAME:                                                          %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[2, 2, 256, 10, 16]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<7> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<6> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<6> : tensor<6xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
-// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.ReverseSequence"(%[[VAL_16]], %[[VAL_14]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_14]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_11]], %[[VAL_10]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_8]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_5]], %[[VAL_4]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_22]], %[[VAL_23]], %[[VAL_21]]) {axis = 0 : si64} : (tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>) -> tensor<1024x512x3x3xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Concat"(%[[VAL_15]], %[[VAL_15]], %[[VAL_15]], %[[VAL_15]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_25]], %[[VAL_26]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x10x16xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Relu"(%[[VAL_27]]) : (tensor<1x1024x10x16xf32>) -> tensor<1x1024x10x16xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Reshape"(%[[VAL_28]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1024x10x16xf32>, tensor<5xi64>) -> tensor<2x2x256x10x16xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Transpose"(%[[VAL_29]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x10x16xf32>) -> tensor<256x10x2x16x2xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Reshape"(%[[VAL_30]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<256x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
-// CHECK:           onnx.Return %[[VAL_31]] : tensor<1x256x20x32xf32>
+// CHECK-LABEL:  func.func @test_convtrans_4phase_kernel_shape_66_relu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x10x16xf32>, [[PARAM_1_:%.+]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 256, 10, 16]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.ReverseSequence"([[VAR_11_]], [[VAR_9_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.ReverseSequence"([[VAR_12_]], [[VAR_9_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
+// CHECK:           [[VAR_15_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_6_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_4_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_3_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_2_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Concat"([[VAR_19_]], [[VAR_17_]], [[VAR_18_]], [[VAR_16_]]) {axis = 0 : si64} : (tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>) -> tensor<1024x512x3x3xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Concat"([[VAR_10_]], [[VAR_10_]], [[VAR_10_]], [[VAR_10_]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_20_]], [[VAR_21_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x10x16xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Relu"([[VAR_22_]]) : (tensor<1x1024x10x16xf32>) -> tensor<1x1024x10x16xf32>
+// CHECK:           [[VAR_24_:%.+]] = "onnx.Reshape"([[VAR_23_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1024x10x16xf32>, tensor<5xi64>) -> tensor<2x2x256x10x16xf32>
+// CHECK:           [[VAR_25_:%.+]] = "onnx.Transpose"([[VAR_24_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x10x16xf32>) -> tensor<256x10x2x16x2xf32>
+// CHECK:           [[VAR_26_:%.+]] = "onnx.Reshape"([[VAR_25_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<256x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
+// CHECK:           onnx.Return [[VAR_26_]] : tensor<1x256x20x32xf32>
 // CHECK:         }
 }
 
@@ -612,83 +572,74 @@ func.func @test_convtrans_9phase_lrelu(%arg0: tensor<1x1x18x74xf32>, %arg1: tens
   %2 = "onnx.LeakyRelu"(%1) {alpha = 1.000000e-01 : f32, onnx_node_name = "LeakyRelu3"} : (tensor<1x1x54x222xf32>) -> tensor<1x1x54x222xf32> 
   onnx.Return %2 : tensor<1x1x54x222xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_9phase_lrelu(
-// CHECK-SAME:                                           %[[VAL_0:.*]]: tensor<1x1x18x74xf32>,
-// CHECK-SAME:                                           %[[VAL_1:.*]]: tensor<1x1x3x3xf32>) -> tensor<1x1x54x222xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<5> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[3, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<[3, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<[5, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<[4, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<3> : tensor<2xi64>
-// CHECK:           %[[VAL_23:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_24:.*]] = onnx.Constant dense<3> : tensor<3xi64>
-// CHECK:           %[[VAL_25:.*]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xf32>) -> tensor<3x3x1x1xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.ReverseSequence"(%[[VAL_26]], %[[VAL_24]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.ReverseSequence"(%[[VAL_27]], %[[VAL_24]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Transpose"(%[[VAL_28]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xf32>) -> tensor<1x1x3x3xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Transpose"(%[[VAL_29]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_21]], %[[VAL_22]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_20]], %[[VAL_19]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_18]], %[[VAL_17]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_16]], %[[VAL_15]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_14]], %[[VAL_13]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_12]], %[[VAL_11]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_10]], %[[VAL_9]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_8]], %[[VAL_7]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_30]], %[[VAL_6]], %[[VAL_5]], %[[VAL_23]], %[[VAL_22]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_39]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.LeakyRelu"(%[[VAL_40]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_36]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_43:.*]] = "onnx.LeakyRelu"(%[[VAL_42]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_44:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_37]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_45:.*]] = "onnx.LeakyRelu"(%[[VAL_44]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_46:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_38]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_47:.*]] = "onnx.LeakyRelu"(%[[VAL_46]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_48:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_35]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_49:.*]] = "onnx.LeakyRelu"(%[[VAL_48]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_50:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_32]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_51:.*]] = "onnx.LeakyRelu"(%[[VAL_50]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_52:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_33]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_53:.*]] = "onnx.LeakyRelu"(%[[VAL_52]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_54:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_34]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_55:.*]] = "onnx.LeakyRelu"(%[[VAL_54]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_56:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_31]], %[[VAL_25]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_57:.*]] = "onnx.LeakyRelu"(%[[VAL_56]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_58:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_59:.*]] = "onnx.Reshape"(%[[VAL_43]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_60:.*]] = "onnx.Reshape"(%[[VAL_45]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_61:.*]] = "onnx.Reshape"(%[[VAL_47]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_62:.*]] = "onnx.Reshape"(%[[VAL_49]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_63:.*]] = "onnx.Reshape"(%[[VAL_51]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_64:.*]] = "onnx.Reshape"(%[[VAL_53]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_65:.*]] = "onnx.Reshape"(%[[VAL_55]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_66:.*]] = "onnx.Reshape"(%[[VAL_57]], %[[VAL_4]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_67:.*]] = "onnx.Concat"(%[[VAL_58]], %[[VAL_59]], %[[VAL_64]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_68:.*]] = "onnx.Concat"(%[[VAL_61]], %[[VAL_62]], %[[VAL_63]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_69:.*]] = "onnx.Concat"(%[[VAL_60]], %[[VAL_65]], %[[VAL_66]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_70:.*]] = "onnx.Reshape"(%[[VAL_67]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_71:.*]] = "onnx.Reshape"(%[[VAL_68]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_72:.*]] = "onnx.Reshape"(%[[VAL_69]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_73:.*]] = "onnx.Concat"(%[[VAL_70]], %[[VAL_71]], %[[VAL_72]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
-// CHECK:           %[[VAL_74:.*]] = "onnx.Reshape"(%[[VAL_73]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
-// CHECK:           onnx.Return %[[VAL_74]] : tensor<1x1x54x222xf32>
+// CHECK-LABEL:  func.func @test_convtrans_9phase_lrelu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x18x74xf32>, [[PARAM_1_:%.+]]: tensor<1x1x3x3xf32>) -> tensor<1x1x54x222xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<3> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<1xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xf32>) -> tensor<3x3x1x1xf32>
+// CHECK:           [[VAR_17_:%.+]] = "onnx.ReverseSequence"([[VAR_16_]], [[VAR_14_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
+// CHECK:           [[VAR_18_:%.+]] = "onnx.ReverseSequence"([[VAR_17_]], [[VAR_14_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xf32>, tensor<3xi64>) -> tensor<3x3x1x1xf32>
+// CHECK:           [[VAR_19_:%.+]] = "onnx.Transpose"([[VAR_18_]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xf32>) -> tensor<1x1x3x3xf32>
+// CHECK:           [[VAR_20_:%.+]] = "onnx.Transpose"([[VAR_19_]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_11_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_10_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_9_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_8_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_7_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_6_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_5_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_4_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Slice"([[VAR_20_]], [[VAR_3_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_30_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_29_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.LeakyRelu"([[VAR_30_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_32_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_26_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.LeakyRelu"([[VAR_32_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_27_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_35_:%.+]] = "onnx.LeakyRelu"([[VAR_34_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_36_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_28_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_37_:%.+]] = "onnx.LeakyRelu"([[VAR_36_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_38_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_25_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_39_:%.+]] = "onnx.LeakyRelu"([[VAR_38_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_40_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_22_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_41_:%.+]] = "onnx.LeakyRelu"([[VAR_40_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_42_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_23_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_43_:%.+]] = "onnx.LeakyRelu"([[VAR_42_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_44_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_24_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_45_:%.+]] = "onnx.LeakyRelu"([[VAR_44_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_46_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_21_]], [[VAR_15_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_47_:%.+]] = "onnx.LeakyRelu"([[VAR_46_]]) {alpha = 1.000000e-01 : f32} : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_48_:%.+]] = "onnx.Reshape"([[VAR_31_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_49_:%.+]] = "onnx.Reshape"([[VAR_33_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_50_:%.+]] = "onnx.Reshape"([[VAR_35_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_51_:%.+]] = "onnx.Reshape"([[VAR_37_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_52_:%.+]] = "onnx.Reshape"([[VAR_39_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_53_:%.+]] = "onnx.Reshape"([[VAR_41_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_54_:%.+]] = "onnx.Reshape"([[VAR_43_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_55_:%.+]] = "onnx.Reshape"([[VAR_45_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_56_:%.+]] = "onnx.Reshape"([[VAR_47_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_57_:%.+]] = "onnx.Concat"([[VAR_48_]], [[VAR_49_]], [[VAR_54_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_58_:%.+]] = "onnx.Concat"([[VAR_51_]], [[VAR_52_]], [[VAR_53_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_59_:%.+]] = "onnx.Concat"([[VAR_50_]], [[VAR_55_]], [[VAR_56_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_60_:%.+]] = "onnx.Reshape"([[VAR_57_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK-DAG:       [[VAR_61_:%.+]] = "onnx.Reshape"([[VAR_58_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           [[VAR_62_:%.+]] = "onnx.Reshape"([[VAR_59_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           [[VAR_63_:%.+]] = "onnx.Concat"([[VAR_60_]], [[VAR_61_]], [[VAR_62_]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
+// CHECK:           [[VAR_64_:%.+]] = "onnx.Reshape"([[VAR_63_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
+// CHECK:           onnx.Return [[VAR_64_]] : tensor<1x1x54x222xf32>
 // CHECK:         }
 }
 
@@ -750,39 +701,35 @@ func.func @test_convtrans_4phase_kernel_shape_66_lrelu_default_alpha(%arg0: tens
   %2 = "onnx.LeakyRelu"(%1) {onnx_node_name = "LeakyRelu3"} : (tensor<1x256x20x32xf32>) -> tensor<1x256x20x32xf32> 
   onnx.Return %2 : tensor<1x256x20x32xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_4phase_kernel_shape_66_lrelu_default_alpha(
-// CHECK-SAME:                                                                         %[[VAL_0:.*]]: tensor<1x512x10x16xf32>,
-// CHECK-SAME:                                                                         %[[VAL_1:.*]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[2, 2, 256, 10, 16]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<7> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<6> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<6> : tensor<6xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
-// CHECK:           %[[VAL_16:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_17:.*]] = "onnx.ReverseSequence"(%[[VAL_16]], %[[VAL_14]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_18:.*]] = "onnx.ReverseSequence"(%[[VAL_17]], %[[VAL_14]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
-// CHECK:           %[[VAL_19:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
-// CHECK:           %[[VAL_20:.*]] = "onnx.Transpose"(%[[VAL_19]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
-// CHECK:           %[[VAL_21:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_11]], %[[VAL_10]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_9]], %[[VAL_8]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_23:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_7]], %[[VAL_6]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Slice"(%[[VAL_20]], %[[VAL_5]], %[[VAL_4]], %[[VAL_13]], %[[VAL_12]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
-// CHECK:           %[[VAL_25:.*]] = "onnx.Concat"(%[[VAL_24]], %[[VAL_22]], %[[VAL_23]], %[[VAL_21]]) {axis = 0 : si64} : (tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>) -> tensor<1024x512x3x3xf32>
-// CHECK:           %[[VAL_26:.*]] = "onnx.Concat"(%[[VAL_15]], %[[VAL_15]], %[[VAL_15]], %[[VAL_15]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Conv"(%[[VAL_0]], %[[VAL_25]], %[[VAL_26]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x10x16xf32>
-// CHECK:           %[[VAL_28:.*]] = "onnx.LeakyRelu"(%[[VAL_27]]) {alpha = 0.00999999977 : f32} : (tensor<1x1024x10x16xf32>) -> tensor<1x1024x10x16xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Reshape"(%[[VAL_28]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1024x10x16xf32>, tensor<5xi64>) -> tensor<2x2x256x10x16xf32>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Transpose"(%[[VAL_29]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x10x16xf32>) -> tensor<256x10x2x16x2xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Reshape"(%[[VAL_30]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<256x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
-// CHECK:           onnx.Return %[[VAL_31]] : tensor<1x256x20x32xf32>
+// CHECK-LABEL:  func.func @test_convtrans_4phase_kernel_shape_66_lrelu_default_alpha
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x10x16xf32>, [[PARAM_1_:%.+]]: tensor<512x256x6x6xf32>) -> tensor<1x256x20x32xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 256, 20, 32]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 256, 10, 16]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<2.000000e-02> : tensor<256xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xf32>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_12_:%.+]] = "onnx.ReverseSequence"([[VAR_11_]], [[VAR_9_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_13_:%.+]] = "onnx.ReverseSequence"([[VAR_12_]], [[VAR_9_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xf32>, tensor<6xi64>) -> tensor<6x6x512x256xf32>
+// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xf32>) -> tensor<512x256x6x6xf32>
+// CHECK:           [[VAR_15_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xf32>) -> tensor<256x512x6x6xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_6_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_4_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_3_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_15_]], [[VAR_2_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Concat"([[VAR_19_]], [[VAR_17_]], [[VAR_18_]], [[VAR_16_]]) {axis = 0 : si64} : (tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>, tensor<256x512x3x3xf32>) -> tensor<1024x512x3x3xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.Concat"([[VAR_10_]], [[VAR_10_]], [[VAR_10_]], [[VAR_10_]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_20_]], [[VAR_21_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x10x16xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x10x16xf32>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.LeakyRelu"([[VAR_22_]]) {alpha = 0.00999999977 : f32} : (tensor<1x1024x10x16xf32>) -> tensor<1x1024x10x16xf32>
+// CHECK:           [[VAR_24_:%.+]] = "onnx.Reshape"([[VAR_23_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1024x10x16xf32>, tensor<5xi64>) -> tensor<2x2x256x10x16xf32>
+// CHECK:           [[VAR_25_:%.+]] = "onnx.Transpose"([[VAR_24_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x10x16xf32>) -> tensor<256x10x2x16x2xf32>
+// CHECK:           [[VAR_26_:%.+]] = "onnx.Reshape"([[VAR_25_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<256x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x256x20x32xf32>
+// CHECK:           onnx.Return [[VAR_26_]] : tensor<1x256x20x32xf32>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv_qdq.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose_phased_conv_qdq.mlir
@@ -82,67 +82,64 @@ func.func @test_convtrans_4phase_pads_0011(%arg0: tensor<1x128x10x16xf32>) -> te
   %12 = "onnx.QuantizeLinear"(%11, %0, %3) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x32x20x32xf32>, tensor<f32>, tensor<i8>) -> tensor<1x32x20x32xi8>
   %13 = "onnx.DequantizeLinear"(%12, %0, %3) {axis = 1 : si64} : (tensor<1x32x20x32xi8>, tensor<f32>, tensor<i8>) -> tensor<1x32x20x32xf32>
   onnx.Return %13 : tensor<1x32x20x32xf32>
-// CHECK-LABEL:   func.func @test_convtrans_4phase_pads_0011(
-// CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<1x128x10x16xf32>) -> tensor<1x32x20x32xf32> {
-// CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 32, 20, 32]> : tensor<4xi64>
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[2, 2, 32, 10, 16]> : tensor<5xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[10, 18]> : tensor<2xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<[12, 16]> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<[10, 16]> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[12, 18]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<5> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<4> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_17:.*]] = "onnx.NoValue"() {value} : () -> none
-// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<0> : tensor<i8>
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<[0, 0, 0, 0, 0, 0, 1, 1]> : tensor<8xi64>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<3> : tensor<3xi64>
-// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
-// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
-// CHECK:           %[[VAL_23:.*]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
-// CHECK:           %[[VAL_24:.*]] = onnx.Constant dense<2> : tensor<i8>
-// CHECK:           %[[VAL_25:.*]] = onnx.Constant dense<2> : tensor<128x32x3x3xi8>
-// CHECK:           %[[VAL_26:.*]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
-// CHECK:           %[[VAL_27:.*]] = onnx.Constant dense<2> : tensor<32xi8>
-// CHECK:           %[[VAL_28:.*]] = "onnx.DequantizeLinear"(%[[VAL_27]], %[[VAL_26]], %[[VAL_24]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<32xi8>, tensor<f32>, tensor<i8>) -> tensor<32xf32>
-// CHECK:           %[[VAL_29:.*]] = "onnx.QuantizeLinear"(%[[VAL_0]], %[[VAL_22]], %[[VAL_24]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x10x16xf32>, tensor<f32>, tensor<i8>) -> tensor<1x128x10x16xi8>
-// CHECK:           %[[VAL_30:.*]] = "onnx.DequantizeLinear"(%[[VAL_29]], %[[VAL_22]], %[[VAL_24]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x10x16xi8>, tensor<f32>, tensor<i8>) -> tensor<1x128x10x16xf32>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Transpose"(%[[VAL_25]]) {perm = [2, 3, 0, 1]} : (tensor<128x32x3x3xi8>) -> tensor<3x3x128x32xi8>
-// CHECK:           %[[VAL_32:.*]] = "onnx.ReverseSequence"(%[[VAL_31]], %[[VAL_20]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x128x32xi8>, tensor<3xi64>) -> tensor<3x3x128x32xi8>
-// CHECK:           %[[VAL_33:.*]] = "onnx.ReverseSequence"(%[[VAL_32]], %[[VAL_20]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x128x32xi8>, tensor<3xi64>) -> tensor<3x3x128x32xi8>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Transpose"(%[[VAL_33]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x128x32xi8>) -> tensor<128x32x3x3xi8>
-// CHECK:           %[[VAL_35:.*]] = "onnx.Transpose"(%[[VAL_34]]) {perm = [1, 0, 2, 3]} : (tensor<128x32x3x3xi8>) -> tensor<32x128x3x3xi8>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Pad"(%[[VAL_35]], %[[VAL_19]], %[[VAL_18]], %[[VAL_17]]) {mode = "constant"} : (tensor<32x128x3x3xi8>, tensor<8xi64>, tensor<i8>, none) -> tensor<32x128x4x4xi8>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Slice"(%[[VAL_36]], %[[VAL_14]], %[[VAL_13]], %[[VAL_16]], %[[VAL_15]]) : (tensor<32x128x4x4xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xi8>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Slice"(%[[VAL_36]], %[[VAL_12]], %[[VAL_11]], %[[VAL_16]], %[[VAL_15]]) : (tensor<32x128x4x4xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xi8>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_36]], %[[VAL_10]], %[[VAL_9]], %[[VAL_16]], %[[VAL_15]]) : (tensor<32x128x4x4xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xi8>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Slice"(%[[VAL_36]], %[[VAL_8]], %[[VAL_7]], %[[VAL_16]], %[[VAL_15]]) : (tensor<32x128x4x4xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xi8>
-// CHECK:           %[[VAL_41:.*]] = "onnx.DequantizeLinear"(%[[VAL_40]], %[[VAL_23]], %[[VAL_24]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<32x128x2x2xi8>, tensor<f32>, tensor<i8>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Conv"(%[[VAL_30]], %[[VAL_41]], %[[VAL_28]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_43:.*]] = "onnx.DequantizeLinear"(%[[VAL_37]], %[[VAL_23]], %[[VAL_24]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<32x128x2x2xi8>, tensor<f32>, tensor<i8>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_44:.*]] = "onnx.Conv"(%[[VAL_30]], %[[VAL_43]], %[[VAL_28]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_45:.*]] = "onnx.DequantizeLinear"(%[[VAL_38]], %[[VAL_23]], %[[VAL_24]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<32x128x2x2xi8>, tensor<f32>, tensor<i8>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_46:.*]] = "onnx.Conv"(%[[VAL_30]], %[[VAL_45]], %[[VAL_28]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_47:.*]] = "onnx.DequantizeLinear"(%[[VAL_39]], %[[VAL_23]], %[[VAL_24]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<32x128x2x2xi8>, tensor<f32>, tensor<i8>) -> tensor<32x128x2x2xf32>
-// CHECK:           %[[VAL_48:.*]] = "onnx.Conv"(%[[VAL_30]], %[[VAL_47]], %[[VAL_28]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
-// CHECK:           %[[VAL_49:.*]] = "onnx.Slice"(%[[VAL_42]], %[[VAL_8]], %[[VAL_6]], %[[VAL_16]], %[[VAL_8]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_50:.*]] = "onnx.Slice"(%[[VAL_44]], %[[VAL_14]], %[[VAL_5]], %[[VAL_16]], %[[VAL_8]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_51:.*]] = "onnx.Slice"(%[[VAL_46]], %[[VAL_12]], %[[VAL_4]], %[[VAL_16]], %[[VAL_8]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_52:.*]] = "onnx.Slice"(%[[VAL_48]], %[[VAL_10]], %[[VAL_3]], %[[VAL_16]], %[[VAL_8]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
-// CHECK:           %[[VAL_53:.*]] = "onnx.Concat"(%[[VAL_50]], %[[VAL_52]], %[[VAL_51]], %[[VAL_49]]) {axis = 1 : si64} : (tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>) -> tensor<1x128x10x16xf32>
-// CHECK:           %[[VAL_54:.*]] = "onnx.Reshape"(%[[VAL_53]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x128x10x16xf32>, tensor<5xi64>) -> tensor<2x2x32x10x16xf32>
-// CHECK:           %[[VAL_55:.*]] = "onnx.Transpose"(%[[VAL_54]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x32x10x16xf32>) -> tensor<32x10x2x16x2xf32>
-// CHECK:           %[[VAL_56:.*]] = "onnx.Reshape"(%[[VAL_55]], %[[VAL_1]]) {allowzero = 0 : si64} : (tensor<32x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x32x20x32xf32>
-// CHECK:           %[[VAL_57:.*]] = "onnx.QuantizeLinear"(%[[VAL_56]], %[[VAL_21]], %[[VAL_24]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x32x20x32xf32>, tensor<f32>, tensor<i8>) -> tensor<1x32x20x32xi8>
-// CHECK:           %[[VAL_58:.*]] = "onnx.DequantizeLinear"(%[[VAL_57]], %[[VAL_21]], %[[VAL_24]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x32x20x32xi8>, tensor<f32>, tensor<i8>) -> tensor<1x32x20x32xf32>
-// CHECK:           onnx.Return %[[VAL_58]] : tensor<1x32x20x32xf32>
+// CHECK-LABEL:  func.func @test_convtrans_4phase_pads_0011
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x128x10x16xf32>) -> tensor<1x32x20x32xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 32, 20, 32]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 32, 10, 16]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[10, 18]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[12, 16]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[10, 16]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<[12, 18]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<4> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_13_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<0> : tensor<i8>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<[0, 0, 0, 0, 0, 0, 1, 1]> : tensor<8xi64>
+// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_17_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = onnx.Constant dense<2> : tensor<i8>
+// CHECK-DAG:       [[VAR_21_:%.+]] = onnx.Constant dense<2> : tensor<128x32x3x3xi8>
+// CHECK-DAG:       [[VAR_22_:%.+]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = onnx.Constant dense<2> : tensor<32xi8>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.DequantizeLinear"([[VAR_23_]], [[VAR_22_]], [[VAR_20_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<32xi8>, tensor<f32>, tensor<i8>) -> tensor<32xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.QuantizeLinear"([[PARAM_0_]], [[VAR_18_]], [[VAR_20_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x10x16xf32>, tensor<f32>, tensor<i8>) -> tensor<1x128x10x16xi8>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.DequantizeLinear"([[VAR_25_]], [[VAR_18_]], [[VAR_20_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x10x16xi8>, tensor<f32>, tensor<i8>) -> tensor<1x128x10x16xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Transpose"([[VAR_21_]]) {perm = [2, 3, 0, 1]} : (tensor<128x32x3x3xi8>) -> tensor<3x3x128x32xi8>
+// CHECK:           [[VAR_28_:%.+]] = "onnx.ReverseSequence"([[VAR_27_]], [[VAR_16_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x128x32xi8>, tensor<3xi64>) -> tensor<3x3x128x32xi8>
+// CHECK:           [[VAR_29_:%.+]] = "onnx.ReverseSequence"([[VAR_28_]], [[VAR_16_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x128x32xi8>, tensor<3xi64>) -> tensor<3x3x128x32xi8>
+// CHECK:           [[VAR_30_:%.+]] = "onnx.Transpose"([[VAR_29_]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x128x32xi8>) -> tensor<128x32x3x3xi8>
+// CHECK:           [[VAR_31_:%.+]] = "onnx.Transpose"([[VAR_30_]]) {perm = [1, 0, 2, 3]} : (tensor<128x32x3x3xi8>) -> tensor<32x128x3x3xi8>
+// CHECK:           [[VAR_32_:%.+]] = "onnx.Pad"([[VAR_31_]], [[VAR_15_]], [[VAR_14_]], [[VAR_13_]]) {mode = "constant"} : (tensor<32x128x3x3xi8>, tensor<8xi64>, tensor<i8>, none) -> tensor<32x128x4x4xi8>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.Slice"([[VAR_32_]], [[VAR_10_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xi8>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Slice"([[VAR_32_]], [[VAR_8_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xi8>
+// CHECK-DAG:       [[VAR_35_:%.+]] = "onnx.Slice"([[VAR_32_]], [[VAR_7_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xi8>
+// CHECK-DAG:       [[VAR_36_:%.+]] = "onnx.Slice"([[VAR_32_]], [[VAR_6_]], [[VAR_9_]], [[VAR_12_]], [[VAR_11_]]) : (tensor<32x128x4x4xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<32x128x2x2xi8>
+// CHECK:           [[VAR_37_:%.+]] = "onnx.DequantizeLinear"([[VAR_36_]], [[VAR_19_]], [[VAR_20_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<32x128x2x2xi8>, tensor<f32>, tensor<i8>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_38_:%.+]] = "onnx.Conv"([[VAR_26_]], [[VAR_37_]], [[VAR_24_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_39_:%.+]] = "onnx.DequantizeLinear"([[VAR_33_]], [[VAR_19_]], [[VAR_20_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<32x128x2x2xi8>, tensor<f32>, tensor<i8>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_40_:%.+]] = "onnx.Conv"([[VAR_26_]], [[VAR_39_]], [[VAR_24_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_41_:%.+]] = "onnx.DequantizeLinear"([[VAR_34_]], [[VAR_19_]], [[VAR_20_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<32x128x2x2xi8>, tensor<f32>, tensor<i8>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_42_:%.+]] = "onnx.Conv"([[VAR_26_]], [[VAR_41_]], [[VAR_24_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_43_:%.+]] = "onnx.DequantizeLinear"([[VAR_35_]], [[VAR_19_]], [[VAR_20_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<32x128x2x2xi8>, tensor<f32>, tensor<i8>) -> tensor<32x128x2x2xf32>
+// CHECK-DAG:       [[VAR_44_:%.+]] = "onnx.Conv"([[VAR_26_]], [[VAR_43_]], [[VAR_24_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x128x10x16xf32>, tensor<32x128x2x2xf32>, tensor<32xf32>) -> tensor<1x32x11x17xf32>
+// CHECK-DAG:       [[VAR_45_:%.+]] = "onnx.Slice"([[VAR_38_]], [[VAR_6_]], [[VAR_5_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK-DAG:       [[VAR_46_:%.+]] = "onnx.Slice"([[VAR_40_]], [[VAR_10_]], [[VAR_4_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK-DAG:       [[VAR_47_:%.+]] = "onnx.Slice"([[VAR_42_]], [[VAR_8_]], [[VAR_3_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           [[VAR_48_:%.+]] = "onnx.Slice"([[VAR_44_]], [[VAR_7_]], [[VAR_2_]], [[VAR_12_]], [[VAR_6_]]) : (tensor<1x32x11x17xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x32x10x16xf32>
+// CHECK:           [[VAR_49_:%.+]] = "onnx.Concat"([[VAR_46_]], [[VAR_48_]], [[VAR_47_]], [[VAR_45_]]) {axis = 1 : si64} : (tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>, tensor<1x32x10x16xf32>) -> tensor<1x128x10x16xf32>
+// CHECK:           [[VAR_50_:%.+]] = "onnx.Reshape"([[VAR_49_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x128x10x16xf32>, tensor<5xi64>) -> tensor<2x2x32x10x16xf32>
+// CHECK:           [[VAR_51_:%.+]] = "onnx.Transpose"([[VAR_50_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x32x10x16xf32>) -> tensor<32x10x2x16x2xf32>
+// CHECK:           [[VAR_52_:%.+]] = "onnx.Reshape"([[VAR_51_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<32x10x2x16x2xf32>, tensor<4xi64>) -> tensor<1x32x20x32xf32>
+// CHECK:           [[VAR_53_:%.+]] = "onnx.QuantizeLinear"([[VAR_52_]], [[VAR_17_]], [[VAR_20_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x32x20x32xf32>, tensor<f32>, tensor<i8>) -> tensor<1x32x20x32xi8>
+// CHECK:           [[VAR_54_:%.+]] = "onnx.DequantizeLinear"([[VAR_53_]], [[VAR_17_]], [[VAR_20_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x32x20x32xi8>, tensor<f32>, tensor<i8>) -> tensor<1x32x20x32xf32>
+// CHECK:           onnx.Return [[VAR_54_]] : tensor<1x32x20x32xf32>
 // CHECK:         }
 // CONSTPROP-LABEL:   func.func @test_convtrans_4phase_pads_0011(
 // CONSTPROP-SAME:                                               %[[VAL_0:.*]]: tensor<1x128x10x16xf32>) -> tensor<1x32x20x32xf32> {
@@ -491,50 +488,47 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
     %13 = "onnx.DequantizeLinear"(%12, %0, %3) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
     onnx.Return %13 : tensor<1x256x10x42xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_stide22(
-// CHECK-SAME:                                      %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
-// CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[2, 2, 256, 5, 21]> : tensor<5xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<7> : tensor<2xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<6> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<6> : tensor<6xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<2> : tensor<i8>
-// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<2> : tensor<512x256x6x6xi8>
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<2> : tensor<256xi8>
-// CHECK:           %[[VAL_21:.*]] = "onnx.DequantizeLinear"(%[[VAL_20]], %[[VAL_19]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<256xi8>, tensor<f32>, tensor<i8>) -> tensor<256xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.QuantizeLinear"(%[[VAL_0]], %[[VAL_15]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x512x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xi8>
-// CHECK:           %[[VAL_23:.*]] = "onnx.DequantizeLinear"(%[[VAL_22]], %[[VAL_15]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xi8>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_25:.*]] = "onnx.ReverseSequence"(%[[VAL_24]], %[[VAL_13]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_26:.*]] = "onnx.ReverseSequence"(%[[VAL_25]], %[[VAL_13]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Transpose"(%[[VAL_26]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xi8>) -> tensor<512x256x6x6xi8>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Transpose"(%[[VAL_27]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xi8>) -> tensor<256x512x6x6xi8>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_10]], %[[VAL_9]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_8]], %[[VAL_7]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_6]], %[[VAL_5]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_4]], %[[VAL_3]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Concat"(%[[VAL_32]], %[[VAL_30]], %[[VAL_31]], %[[VAL_29]]) {axis = 0 : si64} : (tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>) -> tensor<1024x512x3x3xi8>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Concat"(%[[VAL_21]], %[[VAL_21]], %[[VAL_21]], %[[VAL_21]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.DequantizeLinear"(%[[VAL_33]], %[[VAL_16]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1024x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1024x512x3x3xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Conv"(%[[VAL_23]], %[[VAL_35]], %[[VAL_34]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x5x21xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Reshape"(%[[VAL_36]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1024x5x21xf32>, tensor<5xi64>) -> tensor<2x2x256x5x21xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Transpose"(%[[VAL_37]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x5x21xf32>) -> tensor<256x5x2x21x2xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Reshape"(%[[VAL_38]], %[[VAL_1]]) {allowzero = 0 : si64} : (tensor<256x5x2x21x2xf32>, tensor<4xi64>) -> tensor<1x256x10x42xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.QuantizeLinear"(%[[VAL_39]], %[[VAL_14]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CHECK:           %[[VAL_41:.*]] = "onnx.DequantizeLinear"(%[[VAL_40]], %[[VAL_14]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CHECK:           onnx.Return %[[VAL_41]] : tensor<1x256x10x42xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stide22
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 256, 5, 21]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<2> : tensor<i8>
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<2> : tensor<512x256x6x6xi8>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<2> : tensor<256xi8>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.DequantizeLinear"([[VAR_16_]], [[VAR_15_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<256xi8>, tensor<f32>, tensor<i8>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.QuantizeLinear"([[PARAM_0_]], [[VAR_11_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x512x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xi8>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.DequantizeLinear"([[VAR_18_]], [[VAR_11_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xi8>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_21_:%.+]] = "onnx.ReverseSequence"([[VAR_20_]], [[VAR_9_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.ReverseSequence"([[VAR_21_]], [[VAR_9_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Transpose"([[VAR_22_]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xi8>) -> tensor<512x256x6x6xi8>
+// CHECK:           [[VAR_24_:%.+]] = "onnx.Transpose"([[VAR_23_]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xi8>) -> tensor<256x512x6x6xi8>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_6_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_4_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_3_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_2_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Concat"([[VAR_28_]], [[VAR_26_]], [[VAR_27_]], [[VAR_25_]]) {axis = 0 : si64} : (tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>) -> tensor<1024x512x3x3xi8>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Concat"([[VAR_17_]], [[VAR_17_]], [[VAR_17_]], [[VAR_17_]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
+// CHECK:           [[VAR_31_:%.+]] = "onnx.DequantizeLinear"([[VAR_29_]], [[VAR_12_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1024x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1024x512x3x3xf32>
+// CHECK:           [[VAR_32_:%.+]] = "onnx.Conv"([[VAR_19_]], [[VAR_31_]], [[VAR_30_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x5x21xf32>
+// CHECK:           [[VAR_33_:%.+]] = "onnx.Reshape"([[VAR_32_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1024x5x21xf32>, tensor<5xi64>) -> tensor<2x2x256x5x21xf32>
+// CHECK:           [[VAR_34_:%.+]] = "onnx.Transpose"([[VAR_33_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x5x21xf32>) -> tensor<256x5x2x21x2xf32>
+// CHECK:           [[VAR_35_:%.+]] = "onnx.Reshape"([[VAR_34_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<256x5x2x21x2xf32>, tensor<4xi64>) -> tensor<1x256x10x42xf32>
+// CHECK:           [[VAR_36_:%.+]] = "onnx.QuantizeLinear"([[VAR_35_]], [[VAR_10_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
+// CHECK:           [[VAR_37_:%.+]] = "onnx.DequantizeLinear"([[VAR_36_]], [[VAR_10_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
+// CHECK:           onnx.Return [[VAR_37_]] : tensor<1x256x10x42xf32>
 // CHECK:         }
 // CONSTPROP-LABEL:   func.func @test_convtrans_stide22(
 // CONSTPROP-SAME:                                      %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
@@ -582,51 +576,48 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
     %14 = "onnx.DequantizeLinear"(%13, %0, %3) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
     onnx.Return %14 : tensor<1x256x10x42xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_stride22_with_relu(
-// CHECK-SAME:                                                 %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
-// CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[2, 2, 256, 5, 21]> : tensor<5xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<7> : tensor<2xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<6> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<6> : tensor<6xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<2> : tensor<i8>
-// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<2> : tensor<512x256x6x6xi8>
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<2> : tensor<256xi8>
-// CHECK:           %[[VAL_21:.*]] = "onnx.DequantizeLinear"(%[[VAL_20]], %[[VAL_19]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<256xi8>, tensor<f32>, tensor<i8>) -> tensor<256xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.QuantizeLinear"(%[[VAL_0]], %[[VAL_15]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x512x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xi8>
-// CHECK:           %[[VAL_23:.*]] = "onnx.DequantizeLinear"(%[[VAL_22]], %[[VAL_15]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xi8>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_25:.*]] = "onnx.ReverseSequence"(%[[VAL_24]], %[[VAL_13]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_26:.*]] = "onnx.ReverseSequence"(%[[VAL_25]], %[[VAL_13]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Transpose"(%[[VAL_26]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xi8>) -> tensor<512x256x6x6xi8>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Transpose"(%[[VAL_27]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xi8>) -> tensor<256x512x6x6xi8>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_10]], %[[VAL_9]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_8]], %[[VAL_7]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_6]], %[[VAL_5]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_4]], %[[VAL_3]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Concat"(%[[VAL_32]], %[[VAL_30]], %[[VAL_31]], %[[VAL_29]]) {axis = 0 : si64} : (tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>) -> tensor<1024x512x3x3xi8>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Concat"(%[[VAL_21]], %[[VAL_21]], %[[VAL_21]], %[[VAL_21]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.DequantizeLinear"(%[[VAL_33]], %[[VAL_16]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1024x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1024x512x3x3xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Conv"(%[[VAL_23]], %[[VAL_35]], %[[VAL_34]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x5x21xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Relu"(%[[VAL_36]]) : (tensor<1x1024x5x21xf32>) -> tensor<1x1024x5x21xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_37]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1024x5x21xf32>, tensor<5xi64>) -> tensor<2x2x256x5x21xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Transpose"(%[[VAL_38]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x5x21xf32>) -> tensor<256x5x2x21x2xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_39]], %[[VAL_1]]) {allowzero = 0 : si64} : (tensor<256x5x2x21x2xf32>, tensor<4xi64>) -> tensor<1x256x10x42xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.QuantizeLinear"(%[[VAL_40]], %[[VAL_14]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CHECK:           %[[VAL_42:.*]] = "onnx.DequantizeLinear"(%[[VAL_41]], %[[VAL_14]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CHECK:           onnx.Return %[[VAL_42]] : tensor<1x256x10x42xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride22_with_relu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 256, 5, 21]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<2> : tensor<i8>
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<2> : tensor<512x256x6x6xi8>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<2> : tensor<256xi8>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.DequantizeLinear"([[VAR_16_]], [[VAR_15_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<256xi8>, tensor<f32>, tensor<i8>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.QuantizeLinear"([[PARAM_0_]], [[VAR_11_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x512x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xi8>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.DequantizeLinear"([[VAR_18_]], [[VAR_11_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xi8>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_21_:%.+]] = "onnx.ReverseSequence"([[VAR_20_]], [[VAR_9_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.ReverseSequence"([[VAR_21_]], [[VAR_9_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Transpose"([[VAR_22_]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xi8>) -> tensor<512x256x6x6xi8>
+// CHECK:           [[VAR_24_:%.+]] = "onnx.Transpose"([[VAR_23_]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xi8>) -> tensor<256x512x6x6xi8>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_6_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_4_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_3_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_2_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Concat"([[VAR_28_]], [[VAR_26_]], [[VAR_27_]], [[VAR_25_]]) {axis = 0 : si64} : (tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>) -> tensor<1024x512x3x3xi8>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Concat"([[VAR_17_]], [[VAR_17_]], [[VAR_17_]], [[VAR_17_]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
+// CHECK:           [[VAR_31_:%.+]] = "onnx.DequantizeLinear"([[VAR_29_]], [[VAR_12_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1024x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1024x512x3x3xf32>
+// CHECK:           [[VAR_32_:%.+]] = "onnx.Conv"([[VAR_19_]], [[VAR_31_]], [[VAR_30_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x5x21xf32>
+// CHECK:           [[VAR_33_:%.+]] = "onnx.Relu"([[VAR_32_]]) : (tensor<1x1024x5x21xf32>) -> tensor<1x1024x5x21xf32>
+// CHECK:           [[VAR_34_:%.+]] = "onnx.Reshape"([[VAR_33_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1024x5x21xf32>, tensor<5xi64>) -> tensor<2x2x256x5x21xf32>
+// CHECK:           [[VAR_35_:%.+]] = "onnx.Transpose"([[VAR_34_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x5x21xf32>) -> tensor<256x5x2x21x2xf32>
+// CHECK:           [[VAR_36_:%.+]] = "onnx.Reshape"([[VAR_35_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<256x5x2x21x2xf32>, tensor<4xi64>) -> tensor<1x256x10x42xf32>
+// CHECK:           [[VAR_37_:%.+]] = "onnx.QuantizeLinear"([[VAR_36_]], [[VAR_10_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
+// CHECK:           [[VAR_38_:%.+]] = "onnx.DequantizeLinear"([[VAR_37_]], [[VAR_10_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
+// CHECK:           onnx.Return [[VAR_38_]] : tensor<1x256x10x42xf32>
 // CHECK:         }
 // CONSTPROP-LABEL:   func.func @test_convtrans_stride22_with_relu(
 // CONSTPROP-SAME:                                                 %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
@@ -674,51 +665,48 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
     %13 = "onnx.QuantizeLinear"(%12, %0, %3) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
     %14 = "onnx.DequantizeLinear"(%13, %0, %3) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
     onnx.Return %14 : tensor<1x256x10x42xf32>
-// CHECK-LABEL:   func.func @test_convtrans_stride22_with_lrelu(
-// CHECK-SAME:                                                  %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
-// CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[2, 2, 256, 5, 21]> : tensor<5xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<7> : tensor<2xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<6> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<6> : tensor<6xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<2> : tensor<i8>
-// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<2> : tensor<512x256x6x6xi8>
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<2> : tensor<256xi8>
-// CHECK:           %[[VAL_21:.*]] = "onnx.DequantizeLinear"(%[[VAL_20]], %[[VAL_19]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<256xi8>, tensor<f32>, tensor<i8>) -> tensor<256xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.QuantizeLinear"(%[[VAL_0]], %[[VAL_15]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x512x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xi8>
-// CHECK:           %[[VAL_23:.*]] = "onnx.DequantizeLinear"(%[[VAL_22]], %[[VAL_15]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xi8>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_25:.*]] = "onnx.ReverseSequence"(%[[VAL_24]], %[[VAL_13]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_26:.*]] = "onnx.ReverseSequence"(%[[VAL_25]], %[[VAL_13]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Transpose"(%[[VAL_26]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xi8>) -> tensor<512x256x6x6xi8>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Transpose"(%[[VAL_27]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xi8>) -> tensor<256x512x6x6xi8>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_10]], %[[VAL_9]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_8]], %[[VAL_7]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_6]], %[[VAL_5]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_4]], %[[VAL_3]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Concat"(%[[VAL_32]], %[[VAL_30]], %[[VAL_31]], %[[VAL_29]]) {axis = 0 : si64} : (tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>) -> tensor<1024x512x3x3xi8>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Concat"(%[[VAL_21]], %[[VAL_21]], %[[VAL_21]], %[[VAL_21]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.DequantizeLinear"(%[[VAL_33]], %[[VAL_16]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1024x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1024x512x3x3xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Conv"(%[[VAL_23]], %[[VAL_35]], %[[VAL_34]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x5x21xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.LeakyRelu"(%[[VAL_36]]) {alpha = 0.00999999977 : f32} : (tensor<1x1024x5x21xf32>) -> tensor<1x1024x5x21xf32>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Reshape"(%[[VAL_37]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1024x5x21xf32>, tensor<5xi64>) -> tensor<2x2x256x5x21xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Transpose"(%[[VAL_38]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x5x21xf32>) -> tensor<256x5x2x21x2xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_39]], %[[VAL_1]]) {allowzero = 0 : si64} : (tensor<256x5x2x21x2xf32>, tensor<4xi64>) -> tensor<1x256x10x42xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.QuantizeLinear"(%[[VAL_40]], %[[VAL_14]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CHECK:           %[[VAL_42:.*]] = "onnx.DequantizeLinear"(%[[VAL_41]], %[[VAL_14]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CHECK:           onnx.Return %[[VAL_42]] : tensor<1x256x10x42xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride22_with_lrelu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 256, 5, 21]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<2> : tensor<i8>
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<2> : tensor<512x256x6x6xi8>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<2> : tensor<256xi8>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.DequantizeLinear"([[VAR_16_]], [[VAR_15_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<256xi8>, tensor<f32>, tensor<i8>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.QuantizeLinear"([[PARAM_0_]], [[VAR_11_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x512x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xi8>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.DequantizeLinear"([[VAR_18_]], [[VAR_11_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xi8>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_21_:%.+]] = "onnx.ReverseSequence"([[VAR_20_]], [[VAR_9_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.ReverseSequence"([[VAR_21_]], [[VAR_9_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Transpose"([[VAR_22_]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xi8>) -> tensor<512x256x6x6xi8>
+// CHECK:           [[VAR_24_:%.+]] = "onnx.Transpose"([[VAR_23_]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xi8>) -> tensor<256x512x6x6xi8>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_6_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_4_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_3_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_2_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Concat"([[VAR_28_]], [[VAR_26_]], [[VAR_27_]], [[VAR_25_]]) {axis = 0 : si64} : (tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>) -> tensor<1024x512x3x3xi8>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Concat"([[VAR_17_]], [[VAR_17_]], [[VAR_17_]], [[VAR_17_]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
+// CHECK:           [[VAR_31_:%.+]] = "onnx.DequantizeLinear"([[VAR_29_]], [[VAR_12_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1024x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1024x512x3x3xf32>
+// CHECK:           [[VAR_32_:%.+]] = "onnx.Conv"([[VAR_19_]], [[VAR_31_]], [[VAR_30_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x5x21xf32>
+// CHECK:           [[VAR_33_:%.+]] = "onnx.LeakyRelu"([[VAR_32_]]) {alpha = 0.00999999977 : f32} : (tensor<1x1024x5x21xf32>) -> tensor<1x1024x5x21xf32>
+// CHECK:           [[VAR_34_:%.+]] = "onnx.Reshape"([[VAR_33_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1024x5x21xf32>, tensor<5xi64>) -> tensor<2x2x256x5x21xf32>
+// CHECK:           [[VAR_35_:%.+]] = "onnx.Transpose"([[VAR_34_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x5x21xf32>) -> tensor<256x5x2x21x2xf32>
+// CHECK:           [[VAR_36_:%.+]] = "onnx.Reshape"([[VAR_35_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<256x5x2x21x2xf32>, tensor<4xi64>) -> tensor<1x256x10x42xf32>
+// CHECK:           [[VAR_37_:%.+]] = "onnx.QuantizeLinear"([[VAR_36_]], [[VAR_10_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
+// CHECK:           [[VAR_38_:%.+]] = "onnx.DequantizeLinear"([[VAR_37_]], [[VAR_10_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
+// CHECK:           onnx.Return [[VAR_38_]] : tensor<1x256x10x42xf32>
 // CHECK:         }
 // CONSTPROP-LABEL:   func.func @test_convtrans_stride22_with_lrelu(
 // CONSTPROP-SAME:                                                  %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
@@ -768,53 +756,50 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
     %15 = "onnx.QuantizeLinear"(%14, %0, %3) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
     %16 = "onnx.DequantizeLinear"(%15, %0, %3) {axis = 1 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
     onnx.Return %16 : tensor<1x256x10x42xf32>
-// CHECK-LABEL:   func.func @test_convtrans_stride22_with_qdq_relu(
-// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
-// CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[2, 2, 256, 5, 21]> : tensor<5xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<7> : tensor<2xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<[6, 7]> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[7, 6]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<6> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<6> : tensor<6xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<2> : tensor<i8>
-// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<2> : tensor<512x256x6x6xi8>
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<2> : tensor<256xi8>
-// CHECK:           %[[VAL_21:.*]] = "onnx.DequantizeLinear"(%[[VAL_20]], %[[VAL_19]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<256xi8>, tensor<f32>, tensor<i8>) -> tensor<256xf32>
-// CHECK:           %[[VAL_22:.*]] = "onnx.QuantizeLinear"(%[[VAL_0]], %[[VAL_15]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x512x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xi8>
-// CHECK:           %[[VAL_23:.*]] = "onnx.DequantizeLinear"(%[[VAL_22]], %[[VAL_15]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
-// CHECK:           %[[VAL_24:.*]] = "onnx.Transpose"(%[[VAL_18]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xi8>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_25:.*]] = "onnx.ReverseSequence"(%[[VAL_24]], %[[VAL_13]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_26:.*]] = "onnx.ReverseSequence"(%[[VAL_25]], %[[VAL_13]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
-// CHECK:           %[[VAL_27:.*]] = "onnx.Transpose"(%[[VAL_26]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xi8>) -> tensor<512x256x6x6xi8>
-// CHECK:           %[[VAL_28:.*]] = "onnx.Transpose"(%[[VAL_27]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xi8>) -> tensor<256x512x6x6xi8>
-// CHECK:           %[[VAL_29:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_10]], %[[VAL_9]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_30:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_8]], %[[VAL_7]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_31:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_6]], %[[VAL_5]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_32:.*]] = "onnx.Slice"(%[[VAL_28]], %[[VAL_4]], %[[VAL_3]], %[[VAL_12]], %[[VAL_11]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
-// CHECK:           %[[VAL_33:.*]] = "onnx.Concat"(%[[VAL_32]], %[[VAL_30]], %[[VAL_31]], %[[VAL_29]]) {axis = 0 : si64} : (tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>) -> tensor<1024x512x3x3xi8>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Concat"(%[[VAL_21]], %[[VAL_21]], %[[VAL_21]], %[[VAL_21]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
-// CHECK:           %[[VAL_35:.*]] = "onnx.DequantizeLinear"(%[[VAL_33]], %[[VAL_16]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1024x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1024x512x3x3xf32>
-// CHECK:           %[[VAL_36:.*]] = "onnx.Conv"(%[[VAL_23]], %[[VAL_35]], %[[VAL_34]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x5x21xf32>
-// CHECK:           %[[VAL_37:.*]] = "onnx.QuantizeLinear"(%[[VAL_36]], %[[VAL_14]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1024x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1024x5x21xi8>
-// CHECK:           %[[VAL_38:.*]] = "onnx.DequantizeLinear"(%[[VAL_37]], %[[VAL_14]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1024x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1024x5x21xf32>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Relu"(%[[VAL_38]]) : (tensor<1x1024x5x21xf32>) -> tensor<1x1024x5x21xf32>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Reshape"(%[[VAL_39]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1024x5x21xf32>, tensor<5xi64>) -> tensor<2x2x256x5x21xf32>
-// CHECK:           %[[VAL_41:.*]] = "onnx.Transpose"(%[[VAL_40]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x5x21xf32>) -> tensor<256x5x2x21x2xf32>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Reshape"(%[[VAL_41]], %[[VAL_1]]) {allowzero = 0 : si64} : (tensor<256x5x2x21x2xf32>, tensor<4xi64>) -> tensor<1x256x10x42xf32>
-// CHECK:           %[[VAL_43:.*]] = "onnx.QuantizeLinear"(%[[VAL_42]], %[[VAL_14]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
-// CHECK:           %[[VAL_44:.*]] = "onnx.DequantizeLinear"(%[[VAL_43]], %[[VAL_14]], %[[VAL_17]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
-// CHECK:           onnx.Return %[[VAL_44]] : tensor<1x256x10x42xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride22_with_qdq_relu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 256, 10, 42]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 2, 256, 5, 21]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<6> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<6> : tensor<6xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<2> : tensor<i8>
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<2> : tensor<512x256x6x6xi8>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<2> : tensor<256xi8>
+// CHECK-DAG:       [[VAR_17_:%.+]] = "onnx.DequantizeLinear"([[VAR_16_]], [[VAR_15_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<256xi8>, tensor<f32>, tensor<i8>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = "onnx.QuantizeLinear"([[PARAM_0_]], [[VAR_11_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x512x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xi8>
+// CHECK-DAG:       [[VAR_19_:%.+]] = "onnx.DequantizeLinear"([[VAR_18_]], [[VAR_11_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x512x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x512x5x21xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = "onnx.Transpose"([[VAR_14_]]) {perm = [2, 3, 0, 1]} : (tensor<512x256x6x6xi8>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_21_:%.+]] = "onnx.ReverseSequence"([[VAR_20_]], [[VAR_9_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_22_:%.+]] = "onnx.ReverseSequence"([[VAR_21_]], [[VAR_9_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<6x6x512x256xi8>, tensor<6xi64>) -> tensor<6x6x512x256xi8>
+// CHECK:           [[VAR_23_:%.+]] = "onnx.Transpose"([[VAR_22_]]) {perm = [2, 3, 0, 1]} : (tensor<6x6x512x256xi8>) -> tensor<512x256x6x6xi8>
+// CHECK:           [[VAR_24_:%.+]] = "onnx.Transpose"([[VAR_23_]]) {perm = [1, 0, 2, 3]} : (tensor<512x256x6x6xi8>) -> tensor<256x512x6x6xi8>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_6_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_26_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_4_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_27_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_3_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_28_:%.+]] = "onnx.Slice"([[VAR_24_]], [[VAR_2_]], [[VAR_5_]], [[VAR_8_]], [[VAR_7_]]) : (tensor<256x512x6x6xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<256x512x3x3xi8>
+// CHECK-DAG:       [[VAR_29_:%.+]] = "onnx.Concat"([[VAR_28_]], [[VAR_26_]], [[VAR_27_]], [[VAR_25_]]) {axis = 0 : si64} : (tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>, tensor<256x512x3x3xi8>) -> tensor<1024x512x3x3xi8>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Concat"([[VAR_17_]], [[VAR_17_]], [[VAR_17_]], [[VAR_17_]]) {axis = 0 : si64} : (tensor<256xf32>, tensor<256xf32>, tensor<256xf32>, tensor<256xf32>) -> tensor<1024xf32>
+// CHECK:           [[VAR_31_:%.+]] = "onnx.DequantizeLinear"([[VAR_29_]], [[VAR_12_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1024x512x3x3xi8>, tensor<f32>, tensor<i8>) -> tensor<1024x512x3x3xf32>
+// CHECK:           [[VAR_32_:%.+]] = "onnx.Conv"([[VAR_19_]], [[VAR_31_]], [[VAR_30_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x512x5x21xf32>, tensor<1024x512x3x3xf32>, tensor<1024xf32>) -> tensor<1x1024x5x21xf32>
+// CHECK:           [[VAR_33_:%.+]] = "onnx.QuantizeLinear"([[VAR_32_]], [[VAR_10_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1024x5x21xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1024x5x21xi8>
+// CHECK:           [[VAR_34_:%.+]] = "onnx.DequantizeLinear"([[VAR_33_]], [[VAR_10_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1024x5x21xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1024x5x21xf32>
+// CHECK:           [[VAR_35_:%.+]] = "onnx.Relu"([[VAR_34_]]) : (tensor<1x1024x5x21xf32>) -> tensor<1x1024x5x21xf32>
+// CHECK:           [[VAR_36_:%.+]] = "onnx.Reshape"([[VAR_35_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1024x5x21xf32>, tensor<5xi64>) -> tensor<2x2x256x5x21xf32>
+// CHECK:           [[VAR_37_:%.+]] = "onnx.Transpose"([[VAR_36_]]) {perm = [2, 3, 0, 4, 1]} : (tensor<2x2x256x5x21xf32>) -> tensor<256x5x2x21x2xf32>
+// CHECK:           [[VAR_38_:%.+]] = "onnx.Reshape"([[VAR_37_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<256x5x2x21x2xf32>, tensor<4xi64>) -> tensor<1x256x10x42xf32>
+// CHECK:           [[VAR_39_:%.+]] = "onnx.QuantizeLinear"([[VAR_38_]], [[VAR_10_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x256x10x42xf32>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xi8>
+// CHECK:           [[VAR_40_:%.+]] = "onnx.DequantizeLinear"([[VAR_39_]], [[VAR_10_]], [[VAR_13_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x256x10x42xi8>, tensor<f32>, tensor<i8>) -> tensor<1x256x10x42xf32>
+// CHECK:           onnx.Return [[VAR_40_]] : tensor<1x256x10x42xf32>
 // CHECK:         }
 // CONSTPROP-LABEL:   func.func @test_convtrans_stride22_with_qdq_relu(
 // CONSTPROP-SAME:                                                     %[[VAL_0:.*]]: tensor<1x512x5x21xf32>) -> tensor<1x256x10x42xf32> {
@@ -863,93 +848,85 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
     %12 = "onnx.QuantizeLinear"(%11, %0, %3) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x54x222xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
     %13 = "onnx.DequantizeLinear"(%12, %0, %3) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
     onnx.Return %13 : tensor<1x1x54x222xf32>
-// CHECK-LABEL:   func.func @test_convtrans_stride33(
-// CHECK-SAME:                                       %[[VAL_0:.*]]: tensor<1x1x18x74xf32>) -> tensor<1x1x54x222xf32> {
-// CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<5> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[3, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<4> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<[3, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<[5, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<[4, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<3> : tensor<2xi64>
-// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_23:.*]] = onnx.Constant dense<3> : tensor<3xi64>
-// CHECK:           %[[VAL_24:.*]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
-// CHECK:           %[[VAL_25:.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
-// CHECK:           %[[VAL_26:.*]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
-// CHECK:           %[[VAL_27:.*]] = onnx.Constant dense<2> : tensor<i8>
-// CHECK:           %[[VAL_28:.*]] = onnx.Constant dense<2> : tensor<1x1x3x3xi8>
-// CHECK:           %[[VAL_29:.*]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
-// CHECK:           %[[VAL_30:.*]] = onnx.Constant dense<2> : tensor<1xi8>
-// CHECK:           %[[VAL_31:.*]] = "onnx.DequantizeLinear"(%[[VAL_30]], %[[VAL_29]], %[[VAL_27]]) {{.*}} : (tensor<1xi8>, tensor<f32>, tensor<i8>) -> tensor<1xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.QuantizeLinear"(%[[VAL_0]], %[[VAL_25]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_33:.*]] = "onnx.DequantizeLinear"(%[[VAL_32]], %[[VAL_25]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Transpose"(%[[VAL_28]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xi8>) -> tensor<3x3x1x1xi8>
-// CHECK:           %[[VAL_35:.*]] = "onnx.ReverseSequence"(%[[VAL_34]], %[[VAL_23]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
-// CHECK:           %[[VAL_36:.*]] = "onnx.ReverseSequence"(%[[VAL_35]], %[[VAL_23]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Transpose"(%[[VAL_36]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xi8>) -> tensor<1x1x3x3xi8>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Transpose"(%[[VAL_37]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xi8>) -> tensor<1x1x3x3xi8>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_20]], %[[VAL_21]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_19]], %[[VAL_18]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_41:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_17]], %[[VAL_16]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_15]], %[[VAL_14]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_43:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_13]], %[[VAL_12]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_44:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_11]], %[[VAL_10]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_45:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_9]], %[[VAL_8]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_46:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_7]], %[[VAL_6]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_47:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_5]], %[[VAL_4]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_48:.*]] = "onnx.DequantizeLinear"(%[[VAL_47]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_49:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_48]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_50:.*]] = "onnx.DequantizeLinear"(%[[VAL_44]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_51:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_50]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_52:.*]] = "onnx.DequantizeLinear"(%[[VAL_45]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_53:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_52]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_54:.*]] = "onnx.DequantizeLinear"(%[[VAL_46]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_55:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_54]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_56:.*]] = "onnx.DequantizeLinear"(%[[VAL_43]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_57:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_56]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_58:.*]] = "onnx.DequantizeLinear"(%[[VAL_40]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_59:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_58]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_60:.*]] = "onnx.DequantizeLinear"(%[[VAL_41]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_61:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_60]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_62:.*]] = "onnx.DequantizeLinear"(%[[VAL_42]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_63:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_62]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_64:.*]] = "onnx.DequantizeLinear"(%[[VAL_39]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_65:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_64]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_66:.*]] = "onnx.Reshape"(%[[VAL_49]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_67:.*]] = "onnx.Reshape"(%[[VAL_51]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_68:.*]] = "onnx.Reshape"(%[[VAL_53]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_69:.*]] = "onnx.Reshape"(%[[VAL_55]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_70:.*]] = "onnx.Reshape"(%[[VAL_57]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_71:.*]] = "onnx.Reshape"(%[[VAL_59]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_72:.*]] = "onnx.Reshape"(%[[VAL_61]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_73:.*]] = "onnx.Reshape"(%[[VAL_63]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_74:.*]] = "onnx.Reshape"(%[[VAL_65]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_75:.*]] = "onnx.Concat"(%[[VAL_66]], %[[VAL_67]], %[[VAL_72]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_76:.*]] = "onnx.Concat"(%[[VAL_69]], %[[VAL_70]], %[[VAL_71]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_77:.*]] = "onnx.Concat"(%[[VAL_68]], %[[VAL_73]], %[[VAL_74]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_78:.*]] = "onnx.Reshape"(%[[VAL_75]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_79:.*]] = "onnx.Reshape"(%[[VAL_76]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_80:.*]] = "onnx.Reshape"(%[[VAL_77]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_81:.*]] = "onnx.Concat"(%[[VAL_78]], %[[VAL_79]], %[[VAL_80]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
-// CHECK:           %[[VAL_82:.*]] = "onnx.Reshape"(%[[VAL_81]], %[[VAL_1]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_83:.*]] = "onnx.QuantizeLinear"(%[[VAL_82]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x54x222xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_84:.*]] = "onnx.DequantizeLinear"(%[[VAL_83]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           onnx.Return %[[VAL_84]] : tensor<1x1x54x222xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride33
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x18x74xf32>) -> tensor<1x1x54x222xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<3> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = onnx.Constant dense<2> : tensor<i8>
+// CHECK-DAG:       [[VAR_19_:%.+]] = onnx.Constant dense<2> : tensor<1x1x3x3xi8>
+// CHECK-DAG:       [[VAR_20_:%.+]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = onnx.Constant dense<2> : tensor<1xi8>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.DequantizeLinear"([[VAR_21_]], [[VAR_20_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1xi8>, tensor<f32>, tensor<i8>) -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.QuantizeLinear"([[PARAM_0_]], [[VAR_16_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.DequantizeLinear"([[VAR_23_]], [[VAR_16_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Transpose"([[VAR_19_]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xi8>) -> tensor<3x3x1x1xi8>
+// CHECK:           [[VAR_26_:%.+]] = "onnx.ReverseSequence"([[VAR_25_]], [[VAR_14_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
+// CHECK:           [[VAR_27_:%.+]] = "onnx.ReverseSequence"([[VAR_26_]], [[VAR_14_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
+// CHECK:           [[VAR_28_:%.+]] = "onnx.Transpose"([[VAR_27_]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xi8>) -> tensor<1x1x3x3xi8>
+// CHECK:           [[VAR_29_:%.+]] = "onnx.Transpose"([[VAR_28_]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xi8>) -> tensor<1x1x3x3xi8>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_11_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_10_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_32_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_9_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_8_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_7_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_35_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_6_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_36_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_5_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_37_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_4_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_38_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_3_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK:           [[VAR_39_:%.+]] = "onnx.DequantizeLinear"([[VAR_38_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_40_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_39_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_41_:%.+]] = "onnx.DequantizeLinear"([[VAR_35_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_42_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_41_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_43_:%.+]] = "onnx.DequantizeLinear"([[VAR_36_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_44_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_43_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_45_:%.+]] = "onnx.DequantizeLinear"([[VAR_37_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_46_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_45_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_47_:%.+]] = "onnx.DequantizeLinear"([[VAR_34_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_48_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_47_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_49_:%.+]] = "onnx.DequantizeLinear"([[VAR_31_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_50_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_49_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_51_:%.+]] = "onnx.DequantizeLinear"([[VAR_32_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_52_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_51_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_53_:%.+]] = "onnx.DequantizeLinear"([[VAR_33_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_54_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_53_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_55_:%.+]] = "onnx.DequantizeLinear"([[VAR_30_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_56_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_55_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_57_:%.+]] = "onnx.Reshape"([[VAR_40_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_58_:%.+]] = "onnx.Reshape"([[VAR_42_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_59_:%.+]] = "onnx.Reshape"([[VAR_44_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_60_:%.+]] = "onnx.Reshape"([[VAR_46_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_61_:%.+]] = "onnx.Reshape"([[VAR_48_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_62_:%.+]] = "onnx.Reshape"([[VAR_50_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_63_:%.+]] = "onnx.Reshape"([[VAR_52_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_64_:%.+]] = "onnx.Reshape"([[VAR_54_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_65_:%.+]] = "onnx.Reshape"([[VAR_56_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_66_:%.+]] = "onnx.Concat"([[VAR_57_]], [[VAR_58_]], [[VAR_63_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_67_:%.+]] = "onnx.Concat"([[VAR_60_]], [[VAR_61_]], [[VAR_62_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_68_:%.+]] = "onnx.Concat"([[VAR_59_]], [[VAR_64_]], [[VAR_65_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_69_:%.+]] = "onnx.Reshape"([[VAR_66_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK-DAG:       [[VAR_70_:%.+]] = "onnx.Reshape"([[VAR_67_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           [[VAR_71_:%.+]] = "onnx.Reshape"([[VAR_68_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           [[VAR_72_:%.+]] = "onnx.Concat"([[VAR_69_]], [[VAR_70_]], [[VAR_71_]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
+// CHECK:           [[VAR_73_:%.+]] = "onnx.Reshape"([[VAR_72_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
+// CHECK:           [[VAR_74_:%.+]] = "onnx.QuantizeLinear"([[VAR_73_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x54x222xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
+// CHECK:           [[VAR_75_:%.+]] = "onnx.DequantizeLinear"([[VAR_74_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
+// CHECK:           onnx.Return [[VAR_75_]] : tensor<1x1x54x222xf32>
 // CHECK:         }
 // CONSTPROP-LABEL:   func.func @test_convtrans_stride33(
 // CONSTPROP-SAME:                                       %[[VAL_0:.*]]: tensor<1x1x18x74xf32>) -> tensor<1x1x54x222xf32> {
@@ -1035,102 +1012,94 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
     %14 = "onnx.DequantizeLinear"(%13, %0, %3) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
     onnx.Return %14 : tensor<1x1x54x222xf32>
 
-// CHECK-LABEL:   func.func @test_convtrans_stride33_with_relu(
-// CHECK-SAME:                                                 %[[VAL_0:.*]]: tensor<1x1x18x74xf32>) -> tensor<1x1x54x222xf32> {
-// CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<5> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[3, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<4> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<[3, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<[5, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<[4, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<3> : tensor<2xi64>
-// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_23:.*]] = onnx.Constant dense<3> : tensor<3xi64>
-// CHECK:           %[[VAL_24:.*]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
-// CHECK:           %[[VAL_25:.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
-// CHECK:           %[[VAL_26:.*]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
-// CHECK:           %[[VAL_27:.*]] = onnx.Constant dense<2> : tensor<i8>
-// CHECK:           %[[VAL_28:.*]] = onnx.Constant dense<2> : tensor<1x1x3x3xi8>
-// CHECK:           %[[VAL_29:.*]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
-// CHECK:           %[[VAL_30:.*]] = onnx.Constant dense<2> : tensor<1xi8>
-// CHECK:           %[[VAL_31:.*]] = "onnx.DequantizeLinear"(%[[VAL_30]], %[[VAL_29]], %[[VAL_27]]) {{.*}} : (tensor<1xi8>, tensor<f32>, tensor<i8>) -> tensor<1xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.QuantizeLinear"(%[[VAL_0]], %[[VAL_25]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_33:.*]] = "onnx.DequantizeLinear"(%[[VAL_32]], %[[VAL_25]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Transpose"(%[[VAL_28]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xi8>) -> tensor<3x3x1x1xi8>
-// CHECK:           %[[VAL_35:.*]] = "onnx.ReverseSequence"(%[[VAL_34]], %[[VAL_23]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
-// CHECK:           %[[VAL_36:.*]] = "onnx.ReverseSequence"(%[[VAL_35]], %[[VAL_23]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Transpose"(%[[VAL_36]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xi8>) -> tensor<1x1x3x3xi8>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Transpose"(%[[VAL_37]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xi8>) -> tensor<1x1x3x3xi8>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_20]], %[[VAL_21]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_19]], %[[VAL_18]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_41:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_17]], %[[VAL_16]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_15]], %[[VAL_14]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_43:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_13]], %[[VAL_12]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_44:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_11]], %[[VAL_10]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_45:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_9]], %[[VAL_8]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_46:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_7]], %[[VAL_6]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_47:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_5]], %[[VAL_4]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_48:.*]] = "onnx.DequantizeLinear"(%[[VAL_47]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_49:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_48]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_50:.*]] = "onnx.Relu"(%[[VAL_49]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_51:.*]] = "onnx.DequantizeLinear"(%[[VAL_44]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_52:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_51]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_53:.*]] = "onnx.Relu"(%[[VAL_52]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_54:.*]] = "onnx.DequantizeLinear"(%[[VAL_45]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_55:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_54]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_56:.*]] = "onnx.Relu"(%[[VAL_55]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_57:.*]] = "onnx.DequantizeLinear"(%[[VAL_46]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_58:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_57]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_59:.*]] = "onnx.Relu"(%[[VAL_58]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_60:.*]] = "onnx.DequantizeLinear"(%[[VAL_43]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_61:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_60]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_62:.*]] = "onnx.Relu"(%[[VAL_61]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_63:.*]] = "onnx.DequantizeLinear"(%[[VAL_40]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_64:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_63]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_65:.*]] = "onnx.Relu"(%[[VAL_64]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_66:.*]] = "onnx.DequantizeLinear"(%[[VAL_41]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_67:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_66]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_68:.*]] = "onnx.Relu"(%[[VAL_67]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_69:.*]] = "onnx.DequantizeLinear"(%[[VAL_42]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_70:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_69]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_71:.*]] = "onnx.Relu"(%[[VAL_70]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_72:.*]] = "onnx.DequantizeLinear"(%[[VAL_39]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_73:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_72]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_74:.*]] = "onnx.Relu"(%[[VAL_73]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_75:.*]] = "onnx.Reshape"(%[[VAL_50]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_76:.*]] = "onnx.Reshape"(%[[VAL_53]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_77:.*]] = "onnx.Reshape"(%[[VAL_56]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_78:.*]] = "onnx.Reshape"(%[[VAL_59]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_79:.*]] = "onnx.Reshape"(%[[VAL_62]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_80:.*]] = "onnx.Reshape"(%[[VAL_65]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_81:.*]] = "onnx.Reshape"(%[[VAL_68]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_82:.*]] = "onnx.Reshape"(%[[VAL_71]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_83:.*]] = "onnx.Reshape"(%[[VAL_74]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_84:.*]] = "onnx.Concat"(%[[VAL_75]], %[[VAL_76]], %[[VAL_81]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_85:.*]] = "onnx.Concat"(%[[VAL_78]], %[[VAL_79]], %[[VAL_80]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_86:.*]] = "onnx.Concat"(%[[VAL_77]], %[[VAL_82]], %[[VAL_83]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_87:.*]] = "onnx.Reshape"(%[[VAL_84]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_88:.*]] = "onnx.Reshape"(%[[VAL_85]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_89:.*]] = "onnx.Reshape"(%[[VAL_86]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_90:.*]] = "onnx.Concat"(%[[VAL_87]], %[[VAL_88]], %[[VAL_89]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
-// CHECK:           %[[VAL_91:.*]] = "onnx.Reshape"(%[[VAL_90]], %[[VAL_1]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_92:.*]] = "onnx.QuantizeLinear"(%[[VAL_91]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x54x222xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_93:.*]] = "onnx.DequantizeLinear"(%[[VAL_92]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           onnx.Return %[[VAL_93]] : tensor<1x1x54x222xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride33_with_relu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x18x74xf32>) -> tensor<1x1x54x222xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<3> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = onnx.Constant dense<2> : tensor<i8>
+// CHECK-DAG:       [[VAR_19_:%.+]] = onnx.Constant dense<2> : tensor<1x1x3x3xi8>
+// CHECK-DAG:       [[VAR_20_:%.+]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = onnx.Constant dense<2> : tensor<1xi8>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.DequantizeLinear"([[VAR_21_]], [[VAR_20_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1xi8>, tensor<f32>, tensor<i8>) -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.QuantizeLinear"([[PARAM_0_]], [[VAR_16_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.DequantizeLinear"([[VAR_23_]], [[VAR_16_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Transpose"([[VAR_19_]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xi8>) -> tensor<3x3x1x1xi8>
+// CHECK:           [[VAR_26_:%.+]] = "onnx.ReverseSequence"([[VAR_25_]], [[VAR_14_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
+// CHECK:           [[VAR_27_:%.+]] = "onnx.ReverseSequence"([[VAR_26_]], [[VAR_14_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
+// CHECK:           [[VAR_28_:%.+]] = "onnx.Transpose"([[VAR_27_]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xi8>) -> tensor<1x1x3x3xi8>
+// CHECK:           [[VAR_29_:%.+]] = "onnx.Transpose"([[VAR_28_]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xi8>) -> tensor<1x1x3x3xi8>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_11_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_10_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_32_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_9_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_8_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_7_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_35_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_6_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_36_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_5_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_37_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_4_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_38_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_3_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK:           [[VAR_39_:%.+]] = "onnx.DequantizeLinear"([[VAR_38_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_40_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_39_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_41_:%.+]] = "onnx.Relu"([[VAR_40_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_42_:%.+]] = "onnx.DequantizeLinear"([[VAR_35_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_43_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_42_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_44_:%.+]] = "onnx.Relu"([[VAR_43_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_45_:%.+]] = "onnx.DequantizeLinear"([[VAR_36_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_46_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_45_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_47_:%.+]] = "onnx.Relu"([[VAR_46_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_48_:%.+]] = "onnx.DequantizeLinear"([[VAR_37_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_49_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_48_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_50_:%.+]] = "onnx.Relu"([[VAR_49_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_51_:%.+]] = "onnx.DequantizeLinear"([[VAR_34_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_52_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_51_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_53_:%.+]] = "onnx.Relu"([[VAR_52_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_54_:%.+]] = "onnx.DequantizeLinear"([[VAR_31_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_55_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_54_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_56_:%.+]] = "onnx.Relu"([[VAR_55_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_57_:%.+]] = "onnx.DequantizeLinear"([[VAR_32_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_58_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_57_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_59_:%.+]] = "onnx.Relu"([[VAR_58_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_60_:%.+]] = "onnx.DequantizeLinear"([[VAR_33_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_61_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_60_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_62_:%.+]] = "onnx.Relu"([[VAR_61_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_63_:%.+]] = "onnx.DequantizeLinear"([[VAR_30_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_64_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_63_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_65_:%.+]] = "onnx.Relu"([[VAR_64_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_66_:%.+]] = "onnx.Reshape"([[VAR_41_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_67_:%.+]] = "onnx.Reshape"([[VAR_44_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_68_:%.+]] = "onnx.Reshape"([[VAR_47_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_69_:%.+]] = "onnx.Reshape"([[VAR_50_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_70_:%.+]] = "onnx.Reshape"([[VAR_53_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_71_:%.+]] = "onnx.Reshape"([[VAR_56_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_72_:%.+]] = "onnx.Reshape"([[VAR_59_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_73_:%.+]] = "onnx.Reshape"([[VAR_62_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_74_:%.+]] = "onnx.Reshape"([[VAR_65_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_75_:%.+]] = "onnx.Concat"([[VAR_66_]], [[VAR_67_]], [[VAR_72_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_76_:%.+]] = "onnx.Concat"([[VAR_69_]], [[VAR_70_]], [[VAR_71_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_77_:%.+]] = "onnx.Concat"([[VAR_68_]], [[VAR_73_]], [[VAR_74_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_78_:%.+]] = "onnx.Reshape"([[VAR_75_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK-DAG:       [[VAR_79_:%.+]] = "onnx.Reshape"([[VAR_76_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           [[VAR_80_:%.+]] = "onnx.Reshape"([[VAR_77_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           [[VAR_81_:%.+]] = "onnx.Concat"([[VAR_78_]], [[VAR_79_]], [[VAR_80_]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
+// CHECK:           [[VAR_82_:%.+]] = "onnx.Reshape"([[VAR_81_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
+// CHECK:           [[VAR_83_:%.+]] = "onnx.QuantizeLinear"([[VAR_82_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x54x222xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
+// CHECK:           [[VAR_84_:%.+]] = "onnx.DequantizeLinear"([[VAR_83_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
+// CHECK:           onnx.Return [[VAR_84_]] : tensor<1x1x54x222xf32>
 // CHECK:         }
 // CONSTPROP-LABEL:   func.func @test_convtrans_stride33_with_relu(
 // CONSTPROP-SAME:                                                 %[[VAL_0:.*]]: tensor<1x1x18x74xf32>) -> tensor<1x1x54x222xf32> {
@@ -1226,120 +1195,112 @@ func.func @test_convtrans_stride11_with_qdq_relu(%arg0: tensor<1x1x12x44xf32>, %
     %15 = "onnx.QuantizeLinear"(%14, %0, %3) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x1x54x222xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
     %16 = "onnx.DequantizeLinear"(%15, %0, %3) {axis = 1 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
     onnx.Return %16 : tensor<1x1x54x222xf32>
-// CHECK-LABEL:   func.func @test_convtrans_stride33_with_qdq_relu(
-// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<1x1x18x74xf32>) -> tensor<1x1x54x222xf32> {
-// CHECK:           %[[VAL_1:.*]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
-// CHECK:           %[[VAL_2:.*]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
-// CHECK:           %[[VAL_3:.*]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
-// CHECK:           %[[VAL_4:.*]] = onnx.Constant dense<5> : tensor<2xi64>
-// CHECK:           %[[VAL_5:.*]] = onnx.Constant dense<2> : tensor<2xi64>
-// CHECK:           %[[VAL_6:.*]] = onnx.Constant dense<[4, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_7:.*]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-// CHECK:           %[[VAL_8:.*]] = onnx.Constant dense<[3, 5]> : tensor<2xi64>
-// CHECK:           %[[VAL_9:.*]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
-// CHECK:           %[[VAL_10:.*]] = onnx.Constant dense<[5, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_11:.*]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_12:.*]] = onnx.Constant dense<4> : tensor<2xi64>
-// CHECK:           %[[VAL_13:.*]] = onnx.Constant dense<1> : tensor<2xi64>
-// CHECK:           %[[VAL_14:.*]] = onnx.Constant dense<[3, 4]> : tensor<2xi64>
-// CHECK:           %[[VAL_15:.*]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
-// CHECK:           %[[VAL_16:.*]] = onnx.Constant dense<[5, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_17:.*]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_18:.*]] = onnx.Constant dense<[4, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_19:.*]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
-// CHECK:           %[[VAL_20:.*]] = onnx.Constant dense<0> : tensor<2xi64>
-// CHECK:           %[[VAL_21:.*]] = onnx.Constant dense<3> : tensor<2xi64>
-// CHECK:           %[[VAL_22:.*]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
-// CHECK:           %[[VAL_23:.*]] = onnx.Constant dense<3> : tensor<3xi64>
-// CHECK:           %[[VAL_24:.*]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
-// CHECK:           %[[VAL_25:.*]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
-// CHECK:           %[[VAL_26:.*]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
-// CHECK:           %[[VAL_27:.*]] = onnx.Constant dense<2> : tensor<i8>
-// CHECK:           %[[VAL_28:.*]] = onnx.Constant dense<2> : tensor<1x1x3x3xi8>
-// CHECK:           %[[VAL_29:.*]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
-// CHECK:           %[[VAL_30:.*]] = onnx.Constant dense<2> : tensor<1xi8>
-// CHECK:           %[[VAL_31:.*]] = "onnx.DequantizeLinear"(%[[VAL_30]], %[[VAL_29]], %[[VAL_27]]) {{.*}} : (tensor<1xi8>, tensor<f32>, tensor<i8>) -> tensor<1xf32>
-// CHECK:           %[[VAL_32:.*]] = "onnx.QuantizeLinear"(%[[VAL_0]], %[[VAL_25]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_33:.*]] = "onnx.DequantizeLinear"(%[[VAL_32]], %[[VAL_25]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_34:.*]] = "onnx.Transpose"(%[[VAL_28]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xi8>) -> tensor<3x3x1x1xi8>
-// CHECK:           %[[VAL_35:.*]] = "onnx.ReverseSequence"(%[[VAL_34]], %[[VAL_23]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
-// CHECK:           %[[VAL_36:.*]] = "onnx.ReverseSequence"(%[[VAL_35]], %[[VAL_23]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
-// CHECK:           %[[VAL_37:.*]] = "onnx.Transpose"(%[[VAL_36]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xi8>) -> tensor<1x1x3x3xi8>
-// CHECK:           %[[VAL_38:.*]] = "onnx.Transpose"(%[[VAL_37]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xi8>) -> tensor<1x1x3x3xi8>
-// CHECK:           %[[VAL_39:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_20]], %[[VAL_21]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_40:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_19]], %[[VAL_18]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_41:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_17]], %[[VAL_16]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_42:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_15]], %[[VAL_14]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_43:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_13]], %[[VAL_12]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_44:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_11]], %[[VAL_10]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_45:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_9]], %[[VAL_8]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_46:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_7]], %[[VAL_6]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_47:.*]] = "onnx.Slice"(%[[VAL_38]], %[[VAL_5]], %[[VAL_4]], %[[VAL_22]], %[[VAL_21]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
-// CHECK:           %[[VAL_48:.*]] = "onnx.DequantizeLinear"(%[[VAL_47]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_49:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_48]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_50:.*]] = "onnx.QuantizeLinear"(%[[VAL_49]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_51:.*]] = "onnx.DequantizeLinear"(%[[VAL_50]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_52:.*]] = "onnx.Relu"(%[[VAL_51]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_53:.*]] = "onnx.DequantizeLinear"(%[[VAL_44]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_54:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_53]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_55:.*]] = "onnx.QuantizeLinear"(%[[VAL_54]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_56:.*]] = "onnx.DequantizeLinear"(%[[VAL_55]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_57:.*]] = "onnx.Relu"(%[[VAL_56]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_58:.*]] = "onnx.DequantizeLinear"(%[[VAL_45]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_59:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_58]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_60:.*]] = "onnx.QuantizeLinear"(%[[VAL_59]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_61:.*]] = "onnx.DequantizeLinear"(%[[VAL_60]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_62:.*]] = "onnx.Relu"(%[[VAL_61]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_63:.*]] = "onnx.DequantizeLinear"(%[[VAL_46]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_64:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_63]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_65:.*]] = "onnx.QuantizeLinear"(%[[VAL_64]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_66:.*]] = "onnx.DequantizeLinear"(%[[VAL_65]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_67:.*]] = "onnx.Relu"(%[[VAL_66]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_68:.*]] = "onnx.DequantizeLinear"(%[[VAL_43]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_69:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_68]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_70:.*]] = "onnx.QuantizeLinear"(%[[VAL_69]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_71:.*]] = "onnx.DequantizeLinear"(%[[VAL_70]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_72:.*]] = "onnx.Relu"(%[[VAL_71]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_73:.*]] = "onnx.DequantizeLinear"(%[[VAL_40]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_74:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_73]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_75:.*]] = "onnx.QuantizeLinear"(%[[VAL_74]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_76:.*]] = "onnx.DequantizeLinear"(%[[VAL_75]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_77:.*]] = "onnx.Relu"(%[[VAL_76]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_78:.*]] = "onnx.DequantizeLinear"(%[[VAL_41]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_79:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_78]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_80:.*]] = "onnx.QuantizeLinear"(%[[VAL_79]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_81:.*]] = "onnx.DequantizeLinear"(%[[VAL_80]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_82:.*]] = "onnx.Relu"(%[[VAL_81]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_83:.*]] = "onnx.DequantizeLinear"(%[[VAL_42]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_84:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_83]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_85:.*]] = "onnx.QuantizeLinear"(%[[VAL_84]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_86:.*]] = "onnx.DequantizeLinear"(%[[VAL_85]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_87:.*]] = "onnx.Relu"(%[[VAL_86]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_88:.*]] = "onnx.DequantizeLinear"(%[[VAL_39]], %[[VAL_26]], %[[VAL_27]]) {{.*}} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
-// CHECK:           %[[VAL_89:.*]] = "onnx.Conv"(%[[VAL_33]], %[[VAL_88]], %[[VAL_31]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_90:.*]] = "onnx.QuantizeLinear"(%[[VAL_89]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
-// CHECK:           %[[VAL_91:.*]] = "onnx.DequantizeLinear"(%[[VAL_90]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_92:.*]] = "onnx.Relu"(%[[VAL_91]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
-// CHECK:           %[[VAL_93:.*]] = "onnx.Reshape"(%[[VAL_52]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_94:.*]] = "onnx.Reshape"(%[[VAL_57]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_95:.*]] = "onnx.Reshape"(%[[VAL_62]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_96:.*]] = "onnx.Reshape"(%[[VAL_67]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_97:.*]] = "onnx.Reshape"(%[[VAL_72]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_98:.*]] = "onnx.Reshape"(%[[VAL_77]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_99:.*]] = "onnx.Reshape"(%[[VAL_82]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_100:.*]] = "onnx.Reshape"(%[[VAL_87]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_101:.*]] = "onnx.Reshape"(%[[VAL_92]], %[[VAL_3]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
-// CHECK:           %[[VAL_102:.*]] = "onnx.Concat"(%[[VAL_93]], %[[VAL_94]], %[[VAL_99]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_103:.*]] = "onnx.Concat"(%[[VAL_96]], %[[VAL_97]], %[[VAL_98]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_104:.*]] = "onnx.Concat"(%[[VAL_95]], %[[VAL_100]], %[[VAL_101]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
-// CHECK:           %[[VAL_105:.*]] = "onnx.Reshape"(%[[VAL_102]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_106:.*]] = "onnx.Reshape"(%[[VAL_103]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_107:.*]] = "onnx.Reshape"(%[[VAL_104]], %[[VAL_2]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
-// CHECK:           %[[VAL_108:.*]] = "onnx.Concat"(%[[VAL_105]], %[[VAL_106]], %[[VAL_107]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
-// CHECK:           %[[VAL_109:.*]] = "onnx.Reshape"(%[[VAL_108]], %[[VAL_1]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
-// CHECK:           %[[VAL_110:.*]] = "onnx.QuantizeLinear"(%[[VAL_109]], %[[VAL_24]], %[[VAL_27]]) {{.*}}: (tensor<1x1x54x222xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
-// CHECK:           %[[VAL_111:.*]] = "onnx.DequantizeLinear"(%[[VAL_110]], %[[VAL_24]], %[[VAL_27]]) {{.*}} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
-// CHECK:           onnx.Return %[[VAL_111]] : tensor<1x1x54x222xf32>
+// CHECK-LABEL:  func.func @test_convtrans_stride33_with_qdq_relu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x18x74xf32>) -> tensor<1x1x54x222xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 1, 54, 222]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 1, 18, 1, 222]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 1, 18, 74, 1]> : tensor<5xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<[0, 2]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<[2, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<1> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<[0, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<[1, 0]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<0> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<3> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<3> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = onnx.Constant dense<1.22070313E-4> : tensor<f32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = onnx.Constant dense<2> : tensor<i8>
+// CHECK-DAG:       [[VAR_19_:%.+]] = onnx.Constant dense<2> : tensor<1x1x3x3xi8>
+// CHECK-DAG:       [[VAR_20_:%.+]] = onnx.Constant dense<3.125000e-02> : tensor<f32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = onnx.Constant dense<2> : tensor<1xi8>
+// CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.DequantizeLinear"([[VAR_21_]], [[VAR_20_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1xi8>, tensor<f32>, tensor<i8>) -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = "onnx.QuantizeLinear"([[PARAM_0_]], [[VAR_16_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK-DAG:       [[VAR_24_:%.+]] = "onnx.DequantizeLinear"([[VAR_23_]], [[VAR_16_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = "onnx.Transpose"([[VAR_19_]]) {perm = [2, 3, 0, 1]} : (tensor<1x1x3x3xi8>) -> tensor<3x3x1x1xi8>
+// CHECK:           [[VAR_26_:%.+]] = "onnx.ReverseSequence"([[VAR_25_]], [[VAR_14_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
+// CHECK:           [[VAR_27_:%.+]] = "onnx.ReverseSequence"([[VAR_26_]], [[VAR_14_]]) {batch_axis = 0 : si64, time_axis = 1 : si64} : (tensor<3x3x1x1xi8>, tensor<3xi64>) -> tensor<3x3x1x1xi8>
+// CHECK:           [[VAR_28_:%.+]] = "onnx.Transpose"([[VAR_27_]]) {perm = [2, 3, 0, 1]} : (tensor<3x3x1x1xi8>) -> tensor<1x1x3x3xi8>
+// CHECK:           [[VAR_29_:%.+]] = "onnx.Transpose"([[VAR_28_]]) {perm = [1, 0, 2, 3]} : (tensor<1x1x3x3xi8>) -> tensor<1x1x3x3xi8>
+// CHECK-DAG:       [[VAR_30_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_11_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_31_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_10_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_32_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_9_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_33_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_8_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_7_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_35_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_6_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_36_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_5_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_37_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_4_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK-DAG:       [[VAR_38_:%.+]] = "onnx.Slice"([[VAR_29_]], [[VAR_3_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]]) : (tensor<1x1x3x3xi8>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x1x1x1xi8>
+// CHECK:           [[VAR_39_:%.+]] = "onnx.DequantizeLinear"([[VAR_38_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_40_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_39_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           [[VAR_41_:%.+]] = "onnx.QuantizeLinear"([[VAR_40_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           [[VAR_42_:%.+]] = "onnx.DequantizeLinear"([[VAR_41_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_43_:%.+]] = "onnx.Relu"([[VAR_42_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_44_:%.+]] = "onnx.DequantizeLinear"([[VAR_35_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_45_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_44_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           [[VAR_46_:%.+]] = "onnx.QuantizeLinear"([[VAR_45_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           [[VAR_47_:%.+]] = "onnx.DequantizeLinear"([[VAR_46_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_48_:%.+]] = "onnx.Relu"([[VAR_47_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_49_:%.+]] = "onnx.DequantizeLinear"([[VAR_36_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_50_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_49_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           [[VAR_51_:%.+]] = "onnx.QuantizeLinear"([[VAR_50_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           [[VAR_52_:%.+]] = "onnx.DequantizeLinear"([[VAR_51_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_53_:%.+]] = "onnx.Relu"([[VAR_52_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_54_:%.+]] = "onnx.DequantizeLinear"([[VAR_37_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_55_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_54_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           [[VAR_56_:%.+]] = "onnx.QuantizeLinear"([[VAR_55_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           [[VAR_57_:%.+]] = "onnx.DequantizeLinear"([[VAR_56_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_58_:%.+]] = "onnx.Relu"([[VAR_57_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_59_:%.+]] = "onnx.DequantizeLinear"([[VAR_34_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_60_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_59_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           [[VAR_61_:%.+]] = "onnx.QuantizeLinear"([[VAR_60_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           [[VAR_62_:%.+]] = "onnx.DequantizeLinear"([[VAR_61_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_63_:%.+]] = "onnx.Relu"([[VAR_62_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_64_:%.+]] = "onnx.DequantizeLinear"([[VAR_31_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_65_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_64_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           [[VAR_66_:%.+]] = "onnx.QuantizeLinear"([[VAR_65_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           [[VAR_67_:%.+]] = "onnx.DequantizeLinear"([[VAR_66_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_68_:%.+]] = "onnx.Relu"([[VAR_67_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_69_:%.+]] = "onnx.DequantizeLinear"([[VAR_32_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_70_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_69_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           [[VAR_71_:%.+]] = "onnx.QuantizeLinear"([[VAR_70_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           [[VAR_72_:%.+]] = "onnx.DequantizeLinear"([[VAR_71_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_73_:%.+]] = "onnx.Relu"([[VAR_72_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_74_:%.+]] = "onnx.DequantizeLinear"([[VAR_33_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_75_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_74_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           [[VAR_76_:%.+]] = "onnx.QuantizeLinear"([[VAR_75_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           [[VAR_77_:%.+]] = "onnx.DequantizeLinear"([[VAR_76_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_78_:%.+]] = "onnx.Relu"([[VAR_77_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_79_:%.+]] = "onnx.DequantizeLinear"([[VAR_30_]], [[VAR_17_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x1x1xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x1x1xf32>
+// CHECK:           [[VAR_80_:%.+]] = "onnx.Conv"([[VAR_24_]], [[VAR_79_]], [[VAR_22_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x18x74xf32>, tensor<1x1x1x1xf32>, tensor<1xf32>) -> tensor<1x1x18x74xf32>
+// CHECK:           [[VAR_81_:%.+]] = "onnx.QuantizeLinear"([[VAR_80_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x18x74xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xi8>
+// CHECK:           [[VAR_82_:%.+]] = "onnx.DequantizeLinear"([[VAR_81_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x18x74xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_83_:%.+]] = "onnx.Relu"([[VAR_82_]]) : (tensor<1x1x18x74xf32>) -> tensor<1x1x18x74xf32>
+// CHECK-DAG:       [[VAR_84_:%.+]] = "onnx.Reshape"([[VAR_43_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_85_:%.+]] = "onnx.Reshape"([[VAR_48_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_86_:%.+]] = "onnx.Reshape"([[VAR_53_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_87_:%.+]] = "onnx.Reshape"([[VAR_58_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_88_:%.+]] = "onnx.Reshape"([[VAR_63_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_89_:%.+]] = "onnx.Reshape"([[VAR_68_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_90_:%.+]] = "onnx.Reshape"([[VAR_73_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_91_:%.+]] = "onnx.Reshape"([[VAR_78_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_92_:%.+]] = "onnx.Reshape"([[VAR_83_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74xf32>, tensor<5xi64>) -> tensor<1x1x18x74x1xf32>
+// CHECK-DAG:       [[VAR_93_:%.+]] = "onnx.Concat"([[VAR_84_]], [[VAR_85_]], [[VAR_90_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_94_:%.+]] = "onnx.Concat"([[VAR_87_]], [[VAR_88_]], [[VAR_89_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_95_:%.+]] = "onnx.Concat"([[VAR_86_]], [[VAR_91_]], [[VAR_92_]]) {axis = -1 : si64} : (tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>, tensor<1x1x18x74x1xf32>) -> tensor<1x1x18x74x3xf32>
+// CHECK-DAG:       [[VAR_96_:%.+]] = "onnx.Reshape"([[VAR_93_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK-DAG:       [[VAR_97_:%.+]] = "onnx.Reshape"([[VAR_94_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           [[VAR_98_:%.+]] = "onnx.Reshape"([[VAR_95_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<1x1x18x74x3xf32>, tensor<5xi64>) -> tensor<1x1x18x1x222xf32>
+// CHECK:           [[VAR_99_:%.+]] = "onnx.Concat"([[VAR_96_]], [[VAR_97_]], [[VAR_98_]]) {axis = -2 : si64} : (tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>, tensor<1x1x18x1x222xf32>) -> tensor<1x1x18x3x222xf32>
+// CHECK:           [[VAR_100_:%.+]] = "onnx.Reshape"([[VAR_99_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x1x18x3x222xf32>, tensor<4xi64>) -> tensor<1x1x54x222xf32>
+// CHECK:           [[VAR_101_:%.+]] = "onnx.QuantizeLinear"([[VAR_100_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x1x54x222xf32>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xi8>
+// CHECK:           [[VAR_102_:%.+]] = "onnx.DequantizeLinear"([[VAR_101_]], [[VAR_15_]], [[VAR_18_]]) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x1x54x222xi8>, tensor<f32>, tensor<i8>) -> tensor<1x1x54x222xf32>
+// CHECK:           onnx.Return [[VAR_102_]] : tensor<1x1x54x222xf32>
 // CHECK:         }
 // CONSTPROP-LABEL:   func.func @test_convtrans_stride33_with_qdq_relu(
 // CONSTPROP-SAME:                                                     %[[VAL_0:.*]]: tensor<1x1x18x74xf32>) -> tensor<1x1x54x222xf32> {

--- a/test/mlir/onnx/onnx_fold.mlir
+++ b/test/mlir/onnx/onnx_fold.mlir
@@ -74,10 +74,11 @@ func.func @test_slice_reverse_tensor(%arg0: tensor<3x2xi64>) -> tensor<3x2xi64> 
 
 // CHECK-LABEL:  func.func @test_slice_reverse_tensor
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2xi64>) -> tensor<3x2xi64> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<-1> : tensor<1xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<-9223372036854775807> : tensor<1xi64>
-// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK:           [[VAR_3_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_0_]]) {onnx_node_name = "/Slice"} : (tensor<3x2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3x2xi64>
+// CHECK-DAG:       [[STEPS_:%.+]] = onnx.Constant dense<-1> : tensor<1xi64>
+// CHECK-DAG:       [[ENDS_:%.+]] = onnx.Constant dense<-9223372036854775807> : tensor<1xi64>
+// CHECK-DAG:       [[AXES_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[STARTS_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Slice"([[PARAM_0_]], [[STARTS_]], [[ENDS_]], [[AXES_]], [[STEPS_]]) {onnx_node_name = "/Slice"} : (tensor<3x2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3x2xi64>
 // CHECK:           return [[VAR_3_]] : tensor<3x2xi64>
 
 // -----


### PR DESCRIPTION
Implemented in shape inference instead as separate canonicalization pattern, to follow onnx-mlir style.
This makes it easier for other patterns to reason about slices and exposes more CSR opportunities.
