### PR TITLE
disable gather decomposition from ONNXHybridTransformPass

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -160,23 +160,25 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableGroupQueryAttentionDecompose,
         opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
         opts.enableGAPToReduceMean, opts.enableLstmSeqDecompose,
-        opts.enableReduceL2Decompose, opts.enableRotaryEmbeddingRecompose));
+        opts.enableGatherToSlice, opts.enableReduceL2Decompose,
+        opts.enableRotaryEmbeddingRecompose));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
           opts.enableSimdDataLayout && !opts.disableSimdOption));
-      pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
-          !opts.disableRecomposeOption,
-          /*enableQuarkQuantizedOpsLegalization=*/false,
-          opts.enableConvTransposeDecompose,
-          opts.enableConvTransposeDecomposeToPhasedConv,
-          opts.enableConvTranspose1dDecomposeToPhasedConv,
-          opts.enableInstanceNormDecompose, opts.enableGroupNormDecompose,
-          opts.enableMatmulNBitsDecompose,
-          opts.enableGroupQueryAttentionDecompose,
-          opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
-          opts.enableGAPToReduceMean, opts.enableLstmSeqDecompose,
-          opts.enableReduceL2Decompose, opts.enableRotaryEmbeddingRecompose));
+      pm.addNestedPass<func::FuncOp>(
+          onnx_mlir::createONNXHybridTransformPass(!opts.disableRecomposeOption,
+              /*enableQuarkQuantizedOpsLegalization=*/false,
+              opts.enableConvTransposeDecompose,
+              opts.enableConvTransposeDecomposeToPhasedConv,
+              opts.enableConvTranspose1dDecomposeToPhasedConv,
+              opts.enableInstanceNormDecompose, opts.enableGroupNormDecompose,
+              opts.enableMatmulNBitsDecompose,
+              opts.enableGroupQueryAttentionDecompose,
+              opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
+              opts.enableGAPToReduceMean, opts.enableLstmSeqDecompose,
+              opts.enableGatherToSlice, opts.enableReduceL2Decompose,
+              opts.enableRotaryEmbeddingRecompose));
     }
     // If quark quantized legalization is enabled, do a last const prop after it
     // so that we cover any remaining Cast -> Cast patterns that weren't covered
@@ -239,7 +241,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableGroupQueryAttentionDecompose,
         opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
         opts.enableGAPToReduceMean, opts.enableLstmSeqDecompose,
-        opts.enableReduceL2Decompose, opts.enableRotaryEmbeddingRecompose));
+        opts.enableGatherToSlice, opts.enableReduceL2Decompose,
+        opts.enableRotaryEmbeddingRecompose));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(onnx_mlir::createCanonicalizeWithResultNamesPass());

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -162,6 +162,11 @@ struct ONNXHybridTransformPass
                      "seq_len>1 LSTM into a chain of seq_len=1 LSTMs)"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableGatherToSlice{*this, "enable-gather-to-slice",
+      llvm::cl::desc(
+          "Enable decomposition of Gather with scalar index to Slice+Reshape"),
+      ::llvm::cl::init(true)};
+
   Option<bool> enableRotaryEmbeddingRecompose{*this,
       "enable-rotary-embedding-recompose",
       llvm::cl::desc("Recompose LlamaRotaryEmbedding style RoPE "
@@ -179,7 +184,7 @@ struct ONNXHybridTransformPass
       bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
       bool enableSplitToSliceDecompose, bool enableConcatFuse,
       bool enableGAPToReduceMean, bool enableLstmSeqDecompose = false,
-      bool enableReduceL2Decompose = true,
+      bool enableGatherToSlice = true, bool enableReduceL2Decompose = true,
       bool enableRotaryEmbeddingRecompose = false) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
@@ -198,6 +203,7 @@ struct ONNXHybridTransformPass
     this->enableGAPToReduceMean = enableGAPToReduceMean;
     this->enableLstmSeqDecompose = enableLstmSeqDecompose;
     this->enableReduceL2Decompose = enableReduceL2Decompose;
+    this->enableGatherToSlice = enableGatherToSlice;
     this->enableRotaryEmbeddingRecompose = enableRotaryEmbeddingRecompose;
   }
 
@@ -257,7 +263,7 @@ struct ONNXHybridTransformPass
           enableMatmulNBitsDecompose, enableGroupQueryAttentionDecompose,
           enableSplitToSliceDecompose, enableConcatFuse, enableLstmSeqDecompose,
           enableReduceL2Decompose,
-          /*disableGenericDecompositions=*/false);
+          /*disableGenericDecompositions=*/false, enableGatherToSlice);
     }
 
     if (recomposition) {
@@ -312,7 +318,8 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
     bool enableSplitToSliceDecompose, bool enableConcatFuse,
     bool enableGAPToReduceMean, bool enableLstmSeqDecompose,
-    bool enableReduceL2Decompose, bool enableRotaryEmbeddingRecompose) {
+    bool enableGatherToSlice, bool enableReduceL2Decompose,
+    bool enableRotaryEmbeddingRecompose) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,
@@ -320,5 +327,6 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
       enableGroupNormDecompose, enableMatmulNBitsDecompose,
       enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
       enableConcatFuse, enableGAPToReduceMean, enableLstmSeqDecompose,
-      enableReduceL2Decompose, enableRotaryEmbeddingRecompose);
+      enableGatherToSlice, enableReduceL2Decompose,
+      enableRotaryEmbeddingRecompose);
 }

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -119,7 +119,7 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableGroupQueryAttentionDecompose = true,
     bool enableSplitToSliceDecompose = false, bool enableConcatFuse = true,
     bool enablGAPToReduceMean = true, bool enableLstmSeqDecompose = false,
-    bool enableReduceL2Decompose = true,
+    bool enableGatherToSlice = true, bool enableReduceL2Decompose = true,
     bool enableRotaryEmbeddingRecompose = false);
 
 /// Pass for analyzing unknown dimension in ONNX operations.


### PR DESCRIPTION
- Thread the `enableGatherToSlice` flag through `ONNXHybridTransformPass`
  so that callers (e.g. flexml with `use-quant-types=1`) can disable the
  Gather→Slice+Reshape decomposition end-to-end.
- The standalone `DecomposeONNXToONNXPass` already respected the flag,
  but the Hybrid pass called `getDecomposeONNXToONNXPatterns` without it,
  causing the decomposition to fire via the default `true` value.
- Added `enableGatherToSlice` as a pass `Option`, constructor parameter,
  and forwarded it from all three `createONNXHybridTransformPass` call
  sites in `OnnxToMlirPasses.cpp`.