### PR TITLE
Revert: Skip scasts while updating ResultNames

### DIFF
--- a/src/Dialect/ONNX/Transforms/QuantTypes.cpp
+++ b/src/Dialect/ONNX/Transforms/QuantTypes.cpp
@@ -151,6 +151,7 @@ public:
 
     auto scast = rewriter.create<quant::StorageCastOp>(
         dqOp.getLoc(), qTensorType, dqOp.getX());
+    ResultNamesUpdater().notifyOperationReplaced(dqOp, scast.getResult());
     rewriter.replaceOp(dqOp, scast);
     return success();
   }
@@ -176,6 +177,9 @@ public:
     auto qTensorType = cast<TensorType>(qOp.getType()).clone(qType);
     rewriter.modifyOpInPlace(qOp, [&]() { qOp.getX().setType(qTensorType); });
 
+    // Copy the ResultName of qOp to parentOp
+    ResultNamesUpdater().notifyOperationReplaced(qOp, qOp.getX());
+
     auto scast = rewriter.create<quant::StorageCastOp>(
         qOp.getLoc(), qOp.getY().getType(), qOp.getX());
     rewriter.replaceOp(qOp, scast);
@@ -196,12 +200,7 @@ class QuantTypesPass
     auto *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<DQToSCast, QToSCast>(ctx);
-
-    GreedyRewriteConfig config;
-    ResultNamesUpdater rnUpdater;
-    config.listener = &rnUpdater;
-
-    if (failed(applyPatternsGreedily(func, std::move(patterns), config)))
+    if (failed(applyPatternsGreedily(func, std::move(patterns))))
       signalPassFailure();
   }
 };

--- a/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
+++ b/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
@@ -5,7 +5,6 @@
 #include <unordered_set>
 
 #include <llvm/ADT/STLExtras.h>
-#include <mlir/Dialect/Quant/IR/Quant.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Value.h>
@@ -58,33 +57,12 @@ void inferTensorNames(ValueRange replOperands) {
   } while (workList.size() > 0 && wlen > workList.size());
 }
 
-Value skipSCast(Operation *replacement) {
-  if (auto scast = dyn_cast_if_present<quant::StorageCastOp>(replacement)) {
-    // Second check to avoid (scast -> scast) and similar cases
-    if (auto newRepl = scast.getInput().getDefiningOp();
-        newRepl && !isa<quant::StorageCastOp, ONNXDequantizeLinearOp,
-                       ONNXQuantizeLinearOp>(newRepl))
-      return scast.getInput();
-  }
-  return nullptr;
-}
-
-OpResult skipSCast(OpResult value) {
-  if (auto newRepl = skipSCast(value.getOwner()))
-    return cast<OpResult>(newRepl);
-  return value;
-}
-
 } // namespace
 
 void ResultNamesUpdater::notifyOperationReplaced(
     Operation *op, Operation *replacement) {
   if (!op->hasAttrOfType<ArrayAttr>("ResultNames"))
     return;
-
-  // Skip scasts
-  if (auto newRepl = skipSCast(replacement))
-    return notifyOperationReplaced(op, newRepl);
 
   // First, copy the ResultNames attribute for the last value
   auto resultNamesArray = op->getAttrOfType<ArrayAttr>("ResultNames");
@@ -109,7 +87,6 @@ void ResultNamesUpdater::notifyOperationReplaced(
   MLIRContext *ctx = op->getContext();
   for (auto [name, value] : llvm::zip_equal(resultNamesArray, replacement)) {
     if (OpResult replResult = dyn_cast<OpResult>(value)) {
-      replResult = skipSCast(replResult);
       Operation *replOp = replResult.getOwner();
 
       // Get new or existing ResultNames

--- a/test/mlir/onnx/onnx_quanttypes.mlir
+++ b/test/mlir/onnx/onnx_quanttypes.mlir
@@ -306,11 +306,18 @@ func.func @layernorm_quant_types_resultnames(%arg0: tensor<1x128x768xui16>) -> t
   %12 = "onnx.DequantizeLinear"(%5, %6, %7) {ResultNames = ["dq_bias"], axis = 1 : si64, block_size = 0 : si64} : (tensor<768xi32>, tensor<f32>, tensor<i32>) -> tensor<768xf32>
   %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%10, %11, %12) {ResultNames = ["ln0", "ln1", "ln2"], axis = -1 : si64, epsilon = 9.99999996E-13 : f32, stash_type = 1 : si64} : (tensor<1x128x768xf32>, tensor<768xf32>, tensor<768xf32>) -> (tensor<1x128x768xf32>, none, none)
   %13 = "onnx.QuantizeLinear"(%Y, %9, %8) {ResultNames = ["q_ln_out"], axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
-  return %13 : tensor<1x128x768xui16>
+  %14 = "onnx.DequantizeLinear"(%13, %9, %8) {ResultNames = ["dq_relu_in"], axis = 1 : si64, block_size = 0 : si64} : (tensor<1x128x768xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xf32>
+  %15 = "onnx.Relu"(%14) {ResultNames = ["relu_out"]} : (tensor<1x128x768xf32>) -> tensor<1x128x768xf32>
+  %16 = "onnx.QuantizeLinear"(%15, %9, %8) {ResultNames = ["q_relu_out"], axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<1x128x768xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x768xui16>
+  return %16 : tensor<1x128x768xui16>
 }
+
 
 // CHECK-LABEL: @layernorm_quant_types_resultnames
 // CHECK: onnx.LayerNormalization
 // CHECK-SAME: ResultNames = ["q_ln_out", "ln1", "ln2"]
 // CHECK-SAME: (tensor<1x128x768x!quant.uniform<u16:f32, 5.1213039114372805E-5:38292>>, tensor<768x!quant.uniform<u8:f32, 0.0038560051470994949>>, tensor<768x!quant.uniform<i32:f32, 1.9747774615552771E-7>>)
 // CHECK-SAME: -> (tensor<1x128x768x!quant.uniform<u16:f32, 2.3420652723871171E-4:47366>>, none, none)
+// CHECK-NEXT: onnx.Relu
+// CHECK-SAME: ResultNames = ["q_relu_out"]
+// CHECK-SAME: (tensor<1x128x768x!quant.uniform<u16:f32, 2.3420652723871171E-4:47366>>) -> tensor<1x128x768x!quant.uniform<u16:f32, 2.3420652723871171E-4:47366>>


### PR DESCRIPTION
The reason for adding the change was that when replacing Op with `scast -> newOp -> scast`, there is no need to copy the ResultNames from second scast to newOp. The ResultNamesUpdater can be used directly. But this caused a new issue:

In `scast -> newOp -> scast -> scast -> newOp2 -> scast`, while folding inner 2 scasts, the ResultNamesUpdater listener is called. It updates the ResultName of newOp with ResultName of 2nd scast.
We don't want that. This can only be done by not using the ResultNamesUpdater as a listener when such scast folding may happen.