### PR TITLE
Add HardSwish recomposition, optionally disable decomposition

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -144,7 +144,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
       opts.enableMatmulNBitsDecompose, opts.enableGroupQueryAttentionDecompose,
       opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
       opts.enableLstmSeqDecompose, opts.enableReduceL2Decompose,
-      opts.enableGatherToSlice));
+      opts.enableGatherToSlice, opts.enableHardSwishDecompose));
   if (!opts.disableRecomposeOption)
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass(
         /*target=*/"", opts.enableRotaryEmbeddingRecompose));
@@ -161,7 +161,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
         opts.enableGAPToReduceMean, opts.enableLstmSeqDecompose,
         opts.enableGatherToSlice, opts.enableReduceL2Decompose,
-        opts.enableRotaryEmbeddingRecompose, opts.enableQDQConstProp));
+        opts.enableRotaryEmbeddingRecompose, opts.enableQDQConstProp,
+        opts.enableHardSwishDecompose));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
@@ -178,7 +179,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
               opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
               opts.enableGAPToReduceMean, opts.enableLstmSeqDecompose,
               opts.enableGatherToSlice, opts.enableReduceL2Decompose,
-              opts.enableRotaryEmbeddingRecompose, opts.enableQDQConstProp));
+              opts.enableRotaryEmbeddingRecompose, opts.enableQDQConstProp,
+              opts.enableHardSwishDecompose));
     }
     // If quark quantized legalization is enabled, do a last const prop after it
     // so that we cover any remaining Cast -> Cast patterns that weren't covered
@@ -243,7 +245,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
         opts.enableGAPToReduceMean, opts.enableLstmSeqDecompose,
         opts.enableGatherToSlice, opts.enableReduceL2Decompose,
-        opts.enableRotaryEmbeddingRecompose, opts.enableQDQConstProp));
+        opts.enableRotaryEmbeddingRecompose, opts.enableQDQConstProp,
+        opts.enableHardSwishDecompose));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(onnx_mlir::createCanonicalizeWithResultNamesPass());

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -43,6 +43,7 @@ struct OnnxToMlirOptions {
   bool enableGatherToSlice = true;
   bool enableRotaryEmbeddingRecompose = false;
   bool enableQDQConstProp = false;
+  bool enableHardSwishDecompose = true;
 
   bool disableBatchNormDecompose = false;
   bool disableRecomposeOption = false;

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -714,6 +714,12 @@ bool isConstOf(Value constValue, double n) {
   return ElementsAttrBuilder::allEqual(constElements, w);
 }
 
+bool isFloatAttrApprox(mlir::FloatAttr attr, double expected, double epsilon) {
+  if (!attr)
+    return false;
+  return std::fabs(attr.getValueAsDouble() - expected) <= epsilon;
+}
+
 // Convert type to MLIR type.
 // A complete list of types can be found in:
 // <onnx-mlir-build-folder>/third_party/onnx/onnx/onnx.pb.h

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -293,6 +293,10 @@ WideNum asWideNum(double n, mlir::Type elemType);
 /// Checks whether a constant tensor's elements are all equal to a given scalar.
 bool isConstOf(mlir::Value constValue, double n);
 
+/// True if \p attr is non-null and its numeric value differs from \p expected
+/// by at most \p epsilon (using \p attr's value converted to double).
+bool isFloatAttrApprox(mlir::FloatAttr attr, double expected, double epsilon);
+
 mlir::Type convertONNXTypeToMLIRType(
     mlir::Builder &builder, onnx::TensorProto_DataType onnxType);
 

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -4705,7 +4705,7 @@ struct DecomposeONNXToONNXPass
       bool enableGroupQueryAttentionDecompose = true,
       bool enableSplitToSliceDecompose = false, bool enableConcatFuse = true,
       bool enableLstmSeqDecompose = false, bool enableReduceL2Decompose = true,
-      bool enableGatherToSlice = true) {
+      bool enableGatherToSlice = true, bool enableHardSwishDecompose = true) {
     this->target = target;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
     this->enableConvTransposeDecomposeToPhasedConv =
@@ -4722,6 +4722,7 @@ struct DecomposeONNXToONNXPass
     this->enableLstmSeqDecompose = enableLstmSeqDecompose;
     this->enableReduceL2Decompose = enableReduceL2Decompose;
     this->enableGatherToSlice = enableGatherToSlice;
+    this->enableHardSwishDecompose = enableHardSwishDecompose;
   }
 
   DecomposeONNXToONNXPass(const DecomposeONNXToONNXPass &pass)
@@ -4745,6 +4746,7 @@ struct DecomposeONNXToONNXPass
     this->enableLstmSeqDecompose = pass.enableLstmSeqDecompose.getValue();
     this->enableReduceL2Decompose = pass.enableReduceL2Decompose.getValue();
     this->enableGatherToSlice = pass.enableGatherToSlice.getValue();
+    this->enableHardSwishDecompose = pass.enableHardSwishDecompose.getValue();
   }
 
   StringRef getArgument() const override { return "decompose-onnx"; }
@@ -4819,6 +4821,11 @@ struct DecomposeONNXToONNXPass
           "Enable decomposition of Gather with scalar index to Slice+Reshape"),
       ::llvm::cl::init(true)};
 
+  Option<bool> enableHardSwishDecompose{*this, "enable-hardswish-decompose",
+      llvm::cl::desc("Enable decomposition of HardSwish into "
+                     "x * HardSigmoid(x) (alpha=1/6, beta=0.5)"),
+      ::llvm::cl::init(true)};
+
   void runOnOperation() final;
 
   typedef PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>>
@@ -4835,7 +4842,8 @@ void DecomposeONNXToONNXPass::runOnOperation() {
       enableGroupNormDecompose, enableMatmulNBitsDecompose,
       enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
       enableConcatFuse, enableLstmSeqDecompose, enableReduceL2Decompose,
-      /*disableGenericDecompositions=*/false, enableGatherToSlice);
+      /*disableGenericDecompositions=*/false, enableGatherToSlice,
+      enableHardSwishDecompose);
   patterns.insert<ReplaceCastLikeByCastPattern>(context);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
@@ -4860,7 +4868,8 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
     bool enableSplitToSliceDecompose, bool enableConcatFuse,
     bool enableLstmSeqDecompose, bool enableReduceL2Decompose,
-    bool disableGenericDecompositions, bool enableGatherToSlice) {
+    bool disableGenericDecompositions, bool enableGatherToSlice,
+    bool enableHardSwishDecompose) {
   MLIRContext *context = patterns.getContext();
   if (!disableGenericDecompositions)
     populateWithGenerated(patterns);
@@ -4884,8 +4893,9 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     patterns.insert<onnx_mlir::DecomposeEinsumPattern>(context);
   if (enableConcatFuse)
     patterns.insert<ConcatFusePattern>(context);
-  if (!disableGenericDecompositions) {
+  if (enableHardSwishDecompose)
     patterns.insert<DecomposeHardSwishPattern>(context);
+  if (!disableGenericDecompositions) {
     // Decompose CustomOp FusedMatMul introduced by onnxruntime:
     // https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.FusedMatMul
     patterns.insert<CustomOpFuseMatMulPattern>(context);
@@ -4942,12 +4952,12 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createDecomposeONNXToONNXPass(
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
     bool enableSplitToSliceDecompose, bool enableConcatFuse,
     bool enableLstmSeqDecompose, bool enableReduceL2Decompose,
-    bool enableGatherToSlice) {
+    bool enableGatherToSlice, bool enableHardSwishDecompose) {
   return std::make_unique<DecomposeONNXToONNXPass>(target,
       enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableGroupNormDecompose, enableMatmulNBitsDecompose,
       enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
       enableConcatFuse, enableLstmSeqDecompose, enableReduceL2Decompose,
-      enableGatherToSlice);
+      enableGatherToSlice, enableHardSwishDecompose);
 }

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -37,7 +37,8 @@ void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
     bool enableSplitToSliceDecompose, bool enableConcatFuse,
     bool enableLstmSeqDecompose = false, bool enableReduceL2Decompose = true,
-    bool disableGenericDecompositions = false, bool enableGatherToSlice = true);
+    bool disableGenericDecompositions = false, bool enableGatherToSlice = true,
+    bool enableHardSwishDecompose = true);
 
 } // namespace onnx_mlir
 #endif

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -177,6 +177,11 @@ struct ONNXHybridTransformPass
                      "into onnx.RotaryEmbedding"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableHardSwishDecompose{*this, "enable-hardswish-decompose",
+      llvm::cl::desc("Enable decomposition of HardSwish into "
+                     "x * HardSigmoid(x) (alpha=1/6, beta=0.5)"),
+      ::llvm::cl::init(true)};
+
   FrozenRewritePatternSet patterns;
 
   ONNXHybridTransformPass(bool enableRecomposition,
@@ -190,7 +195,7 @@ struct ONNXHybridTransformPass
       bool enableGAPToReduceMean, bool enableLstmSeqDecompose = false,
       bool enableGatherToSlice = true, bool enableReduceL2Decompose = true,
       bool enableRotaryEmbeddingRecompose = false,
-      bool enableQDQConstProp = false) {
+      bool enableQDQConstProp = false, bool enableHardSwishDecompose = true) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
@@ -211,6 +216,7 @@ struct ONNXHybridTransformPass
     this->enableGatherToSlice = enableGatherToSlice;
     this->enableRotaryEmbeddingRecompose = enableRotaryEmbeddingRecompose;
     this->qdqConstProp = enableQDQConstProp;
+    this->enableHardSwishDecompose = enableHardSwishDecompose;
   }
 
   ONNXHybridTransformPass(const ONNXHybridTransformPass &pass)
@@ -269,7 +275,8 @@ struct ONNXHybridTransformPass
           enableMatmulNBitsDecompose, enableGroupQueryAttentionDecompose,
           enableSplitToSliceDecompose, enableConcatFuse, enableLstmSeqDecompose,
           enableReduceL2Decompose,
-          /*disableGenericDecompositions=*/false, enableGatherToSlice);
+          /*disableGenericDecompositions=*/false, enableGatherToSlice,
+          enableHardSwishDecompose);
     }
 
     if (recomposition) {
@@ -325,7 +332,8 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableSplitToSliceDecompose, bool enableConcatFuse,
     bool enableGAPToReduceMean, bool enableLstmSeqDecompose,
     bool enableGatherToSlice, bool enableReduceL2Decompose,
-    bool enableRotaryEmbeddingRecompose, bool enableQDQConstProp) {
+    bool enableRotaryEmbeddingRecompose, bool enableQDQConstProp,
+    bool enableHardSwishDecompose) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,
@@ -334,5 +342,6 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
       enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
       enableConcatFuse, enableGAPToReduceMean, enableLstmSeqDecompose,
       enableGatherToSlice, enableReduceL2Decompose,
-      enableRotaryEmbeddingRecompose, enableQDQConstProp);
+      enableRotaryEmbeddingRecompose, enableQDQConstProp,
+      enableHardSwishDecompose);
 }

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -809,6 +809,42 @@ struct RecomposeHardSigmoidFromMulClipPattern
   }
 };
 
+/// Recomposes Mul(x, HardSigmoid(x)) {alpha=1/6, beta=0.5} back into HardSwish
+struct RecomposeHardSwishFromMulPattern : public OpRewritePattern<ONNXMulOp> {
+  using OpRewritePattern<ONNXMulOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXMulOp mulOp, PatternRewriter &rewriter) const final {
+    using namespace onnx_mlir;
+
+    if (hasQuantizedElementType(mulOp.getResult()))
+      return rewriter.notifyMatchFailure(
+          mulOp, "HardSwish recompose is not valid on quantized types");
+
+    Value x = mulOp.getOperand(0);
+    auto hardSigmoidOp = mulOp.getOperand(1).getDefiningOp<ONNXHardSigmoidOp>();
+    if (!hardSigmoidOp)
+      return failure();
+    if (hardSigmoidOp.getX() != x)
+      return rewriter.notifyMatchFailure(
+          mulOp, "Mul lhs and HardSigmoid input are not the same SSA value");
+    FloatAttr alphaAttr = hardSigmoidOp.getAlphaAttr();
+    FloatAttr betaAttr = hardSigmoidOp.getBetaAttr();
+    constexpr double eps = 1e-5;
+    if (!isFloatAttrApprox(alphaAttr, 1.0 / 6.0, eps) ||
+        !isFloatAttrApprox(betaAttr, 0.5, eps))
+      return rewriter.notifyMatchFailure(
+          hardSigmoidOp, "alpha or beta is not 1/6 or 0.5");
+
+    auto loc = mlir::FusedLoc::get(
+        rewriter.getContext(), {mulOp.getLoc(), hardSigmoidOp.getLoc()});
+    Value hardSwishOp =
+        rewriter.create<ONNXHardSwishOp>(loc, mulOp.getType(), x);
+    rewriter.replaceOp(mulOp, hardSwishOp);
+    return success();
+  }
+};
+
 struct RecomposeGeluFromMulPattern : public OpRewritePattern<ONNXMulOp> {
   using OpRewritePattern<ONNXMulOp>::OpRewritePattern;
 
@@ -2032,6 +2068,7 @@ void onnx_mlir::getRecomposeONNXToONNXPatterns(
     mlir::RewritePatternSet &patterns, bool enableRotaryEmbeddingRecompose,
     bool enableReduceL2Recompositions) {
   MLIRContext *context = patterns.getContext();
+  patterns.insert<RecomposeHardSwishFromMulPattern>(context);
   patterns.insert<RecomposeHardSigmoidFromMulClipPattern>(context);
   patterns.insert<RecomposeGeluFromMulPattern>(context);
   patterns.insert<RecomposeLayerNormFromDivPattern<ONNXDivOp, false>>(context);

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -50,7 +50,7 @@ std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
     bool enableGroupQueryAttentionDecompose = true,
     bool enableSplitToSliceDecompose = false, bool enableConcatFuse = false,
     bool enableLstmSeqDecompose = false, bool enableReduceL2Decompose = true,
-    bool enableGatherToSlice = true);
+    bool enableGatherToSlice = true, bool enableHardSwishDecompose = true);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "", bool enableRotaryEmbeddingRecompose = false,
     bool enableReduceL2Recompositions = false);
@@ -122,7 +122,7 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enablGAPToReduceMean = true, bool enableLstmSeqDecompose = false,
     bool enableGatherToSlice = true, bool enableReduceL2Decompose = true,
     bool enableRotaryEmbeddingRecompose = false,
-    bool enableQDQConstProp = false);
+    bool enableQDQConstProp = false, bool enableHardSwishDecompose = true);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/test/mlir/onnx/onnx_recompose.mlir
+++ b/test/mlir/onnx/onnx_recompose.mlir
@@ -976,3 +976,68 @@ func.func @test_hardsigmoid_clip_mul_add_default_alpha_beta(%arg0 : tensor<?x?x3
 // CHECK:           return [[VAR_0_]] : tensor<?x?x3072xf32>
 // CHECK:         }
 }
+
+// -----
+
+// HardSwish(x) = x * HardSigmoid(x) with alpha=1/6, beta=0.5
+func.func @test_hardswish_from_mul_hardsigmoid(%arg0 : tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+  %0 = "onnx.HardSigmoid"(%arg0) {alpha = 0.166666672 : f32, beta = 5.000000e-01 : f32} : (tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+  %1 = "onnx.Mul"(%arg0, %0) : (tensor<?x?x3072xf32>, tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+  return %1 : tensor<?x?x3072xf32>
+
+// CHECK-LABEL:  func.func @test_hardswish_from_mul_hardsigmoid
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+// CHECK-NOT:       "onnx.HardSigmoid"
+// CHECK-NOT:       "onnx.Mul"
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSwish"([[PARAM_0_]]) : (tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+// CHECK:           return [[VAR_0_]] : tensor<?x?x3072xf32>
+// CHECK:         }
+}
+
+// -----
+
+// Mul(x, HardSigmoid(x)) with alpha=0.2 should not match HardSwish pattern
+func.func @test_hardswish_from_mul_hardsigmoid_wrong_alpha(%arg0 : tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+  %0 = "onnx.HardSigmoid"(%arg0) {alpha = 2.000000e-01 : f32, beta = 5.000000e-01 : f32} : (tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+  %1 = "onnx.Mul"(%arg0, %0) : (tensor<?x?x3072xf32>, tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+  return %1 : tensor<?x?x3072xf32>
+
+// CHECK-LABEL:  func.func @test_hardswish_from_mul_hardsigmoid_wrong_alpha
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+// CHECK-NOT:       "onnx.HardSwish"
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]]) {alpha = 2.000000e-01 : f32, beta = 5.000000e-01 : f32} : (tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_0_]]) : (tensor<?x?x3072xf32>, tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+// CHECK:           return [[VAR_1_]] : tensor<?x?x3072xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_hardswish_from_mul_hardsigmoid_wrong_beta(%arg0 : tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+  %0 = "onnx.HardSigmoid"(%arg0) {alpha = 0.166666672 : f32, beta = 3.000000e-01 : f32} : (tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+  %1 = "onnx.Mul"(%arg0, %0) : (tensor<?x?x3072xf32>, tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+  return %1 : tensor<?x?x3072xf32>
+
+// CHECK-LABEL:  func.func @test_hardswish_from_mul_hardsigmoid_wrong_beta
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+// CHECK-NOT:       "onnx.HardSwish"
+// CHECK:           [[VAR_0_:%.+]] = "onnx.HardSigmoid"([[PARAM_0_]]) {alpha = 0.166666672 : f32, beta = 3.000000e-01 : f32} : (tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_0_]]) : (tensor<?x?x3072xf32>, tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+// CHECK:           return [[VAR_1_]] : tensor<?x?x3072xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_hardswish_from_mul_hardsigmoid_wrong_input(%arg0 : tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32> {
+  %0 = "onnx.Constant"() {value=dense<[7.0]> : tensor<1xf32>} : () -> tensor<1xf32>
+  %1 = "onnx.HardSigmoid"(%arg0) {alpha = 0.166666672 : f32, beta = 5.000000e-01 : f32} : (tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+  %2 = "onnx.Mul"(%0, %1) : (tensor<1xf32>, tensor<?x?x3072xf32>) -> tensor<?x?x3072xf32>
+  return %2 : tensor<?x?x3072xf32>
+
+// CHECK-LABEL:  func.func @test_hardswish_from_mul_hardsigmoid_wrong_input
+// CHECK-NOT:       "onnx.HardSwish"
+// CHECK:           "onnx.HardSigmoid"
+// CHECK:           "onnx.Mul"
+// CHECK:         }
+}


### PR DESCRIPTION
Decomposition: Added a flag which toggles whether the HardSwish decomposition should run. Default=True to keep old behavior.
Recomposition: Added the opposite pattern as recomposition (see below). Also added positive and negative LIT tests.

Mul(x, HardSigmoid(x)) --> HardSwish(x)        where alpha=1/6 and beta=0.5