### PR TITLE
add flag for keeping sin/cos cache in GQA decomposition

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -113,8 +113,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
       opts.enableConvTransposeDecomposeToPhasedConv,
       opts.enableConvTranspose1dDecomposeToPhasedConv,
       opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
-      opts.enableGroupQueryAttentionDecompose,
-      opts.enableSplitToSliceDecompose,
+      opts.enableGroupQueryAttentionDecompose, opts.enableSplitToSliceDecompose,
       opts.enableGroupQueryAttentionCacheSlicing));
   if (!opts.disableRecomposeOption)
     pm.addNestedPass<func::FuncOp>(

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -114,7 +114,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
       opts.enableConvTranspose1dDecomposeToPhasedConv,
       opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
       opts.enableGroupQueryAttentionDecompose,
-      opts.enableSplitToSliceDecompose));
+      opts.enableSplitToSliceDecompose,
+      opts.enableGroupQueryAttentionCacheSlicing));
   if (!opts.disableRecomposeOption)
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::createRecomposeONNXToONNXPass(/*target=*/""));
@@ -127,7 +128,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
         opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
         opts.enableGroupQueryAttentionDecompose,
-        opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean));
+        opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean,
+        opts.enableGroupQueryAttentionCacheSlicing));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
@@ -140,7 +142,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
               opts.enableConvTranspose1dDecomposeToPhasedConv,
               opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
               opts.enableGroupQueryAttentionDecompose,
-              opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean));
+              opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean,
+              opts.enableGroupQueryAttentionCacheSlicing));
     }
     // If quark quantized legalization is enabled, do a last const prop after it
     // so that we cover any remaining Cast -> Cast patterns that weren't covered
@@ -200,7 +203,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         opts.enableConvTranspose1dDecomposeToPhasedConv,
         opts.enableInstanceNormDecompose, opts.enableMatmulNBitsDecompose,
         opts.enableGroupQueryAttentionDecompose,
-        opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean));
+        opts.enableSplitToSliceDecompose, opts.enablGAPToReduceMean,
+        opts.enableGroupQueryAttentionCacheSlicing));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -20,6 +20,7 @@ struct OnnxToMlirOptions {
   bool enableInstanceNormDecompose = true;
   bool enableMatmulNBitsDecompose = false;
   bool enableGroupQueryAttentionDecompose = true;
+  bool enableGroupQueryAttentionCacheSlicing = true;
   bool enableRemoveDqQAroundOp = false;
   bool enableRemoveBinary = false;
   bool enableFusePadIntoAvgpool = false;

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -3282,8 +3282,12 @@ struct MicrosoftSkipSimplifiedLayerNorm : public CustomOpToOnnxOps {
 };
 
 struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
-  MicrosoftGroupQueryAttention(MLIRContext *ctx, PatternBenefit b = 1)
-      : CustomOpToOnnxOps(ctx, MicrosoftDomainName, "GroupQueryAttention", b) {}
+  MicrosoftGroupQueryAttention(
+      MLIRContext *ctx, bool enableCacheSlicing = true, PatternBenefit b = 1)
+      : CustomOpToOnnxOps(ctx, MicrosoftDomainName, "GroupQueryAttention", b),
+        enableCacheSlicing(enableCacheSlicing) {}
+
+  bool enableCacheSlicing;
 
   LogicalResult matchAndRewriteImpl(
       ONNXCustomOp customOp, PatternRewriter &rewriter) const final {
@@ -3408,63 +3412,92 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
     ONNXRotaryEmbeddingOp ropeKey;
     if (doRotary && doRotary.getSInt() > 0) {
       assert(numIn >= 9 && !isNoneValue(cosCache) && !isNoneValue(sinCache));
-      // If do_rotary = 1 and no position ids are provided, we need to slice and
-      // transform the cos and sin caches to have shape:
-      // [batch_size, sequence_length, head_size / 2].
+      // If do_rotary = 1 and no position ids are provided, we need to slice
+      // and transform the cos and sin caches to have shape:
+      // [batch_size, sequence_length, head_size / 2]. When
+      // enableCacheSlicing is false, skip the slice/reshape/expand and pass
+      // the original cos/sin caches through unchanged.
       if (numIn < 10 || isNoneValue(positionIds)) {
         positionIds = none;
 
-        auto pastKeyType = cast<ShapedType>(pastKey.getType());
+        if (enableCacheSlicing) {
+          auto pastKeyType = cast<ShapedType>(pastKey.getType());
 
-        // Assuming the sequence length is the same kv_sequence_length
-        const int64_t seqLen = queryType.getShape()[1];
-        const int64_t pastSeqLen = pastKeyType.getShape()[2];
-        const int64_t totalSeqLen = pastSeqLen + seqLen;
+          // Assuming the sequence length is the same kv_sequence_length
+          const int64_t seqLen = queryType.getShape()[1];
+          const int64_t pastSeqLen = pastKeyType.getShape()[2];
+          const int64_t totalSeqLen = pastSeqLen + seqLen;
 
-        // The slice mimics indexing the cos/sin caches using the default
-        // pos_ids: [past_seq_len..total_seq_len].
-        onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(
-            rewriter, loc);
-        Value startsConst = create.onnx.constantInt64({pastSeqLen});
-        Value endsConst = create.onnx.constantInt64({totalSeqLen});
-        Value axesConst = create.onnx.constantInt64({0});
-        Value stepsConst = create.onnx.constantInt64({1});
-        toCheck.append({startsConst, endsConst, axesConst, stepsConst});
+          // The slice mimics indexing the cos/sin caches using the default
+          // pos_ids: [past_seq_len..total_seq_len].
+          onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(
+              rewriter, loc);
+          Value startsConst = create.onnx.constantInt64({pastSeqLen});
+          Value endsConst = create.onnx.constantInt64({totalSeqLen});
+          Value axesConst = create.onnx.constantInt64({0});
+          Value stepsConst = create.onnx.constantInt64({1});
+          toCheck.append({startsConst, endsConst, axesConst, stepsConst});
 
-        auto elementType = getElementTypeOrSelf(cosCache.getType());
-        auto cacheSlicedType =
-            RankedTensorType::get({seqLen, headSize / 2}, elementType);
-        auto cosCacheSliced = rewriter.create<ONNXSliceOp>(loc, cacheSlicedType,
-            cosCache, startsConst, endsConst, axesConst, stepsConst);
-        auto sinCacheSliced = rewriter.create<ONNXSliceOp>(loc, cacheSlicedType,
-            sinCache, startsConst, endsConst, axesConst, stepsConst);
-        toCheck.append({cosCacheSliced, sinCacheSliced});
+          auto elementType = getElementTypeOrSelf(cosCache.getType());
+          auto cacheSlicedType =
+              RankedTensorType::get({seqLen, headSize / 2}, elementType);
+          auto cosCacheSliced =
+              rewriter.create<ONNXSliceOp>(loc, cacheSlicedType, cosCache,
+                  startsConst, endsConst, axesConst, stepsConst);
+          auto sinCacheSliced =
+              rewriter.create<ONNXSliceOp>(loc, cacheSlicedType, sinCache,
+                  startsConst, endsConst, axesConst, stepsConst);
+          toCheck.append({cosCacheSliced, sinCacheSliced});
 
-        // reshape to [1, sequence_length, head_size / 2]
-        auto cache3dType =
-            RankedTensorType::get({1, seqLen, headSize / 2}, elementType);
-        auto reshapeShapeConst =
-            create.onnx.constantInt64({1, seqLen, headSize / 2});
-        cosCache =
-            create.onnx.reshape(cache3dType, cosCacheSliced, reshapeShapeConst);
-        sinCache =
-            create.onnx.reshape(cache3dType, sinCacheSliced, reshapeShapeConst);
-        toCheck.append({reshapeShapeConst, cosCache, sinCache});
+          // reshape to [1, sequence_length, head_size / 2]
+          auto cache3dType =
+              RankedTensorType::get({1, seqLen, headSize / 2}, elementType);
+          auto reshapeShapeConst =
+              create.onnx.constantInt64({1, seqLen, headSize / 2});
+          cosCache = create.onnx.reshape(
+              cache3dType, cosCacheSliced, reshapeShapeConst);
+          sinCache = create.onnx.reshape(
+              cache3dType, sinCacheSliced, reshapeShapeConst);
+          toCheck.append({reshapeShapeConst, cosCache, sinCache});
 
-        // Assume total/past sequence length is the same for every batch and
-        // broadcast the default pos_ids to get cos/sin caches with shape:
-        // [batch_size, sequence_length, head_size / 2]
-        int64_t batchSize = queryType.getShape()[0];
-        if (batchSize != 1) {
-          auto cacheBroadcastType = RankedTensorType::get(
-              {batchSize, seqLen, headSize / 2}, elementType);
-          auto broadcastShapeConst =
-              create.onnx.constantInt64({batchSize, seqLen, headSize / 2});
-          cosCache = create.onnx.expand(
-              cacheBroadcastType, cosCache, broadcastShapeConst);
-          sinCache = create.onnx.expand(
-              cacheBroadcastType, sinCache, broadcastShapeConst);
-          toCheck.append({broadcastShapeConst, cosCache, sinCache});
+          // Assume total/past sequence length is the same for every batch
+          // and broadcast the default pos_ids to get cos/sin caches with
+          // shape: [batch_size, sequence_length, head_size / 2]
+          int64_t batchSize = queryType.getShape()[0];
+          if (batchSize != 1) {
+            auto cacheBroadcastType = RankedTensorType::get(
+                {batchSize, seqLen, headSize / 2}, elementType);
+            auto broadcastShapeConst =
+                create.onnx.constantInt64({batchSize, seqLen, headSize / 2});
+            cosCache = create.onnx.expand(
+                cacheBroadcastType, cosCache, broadcastShapeConst);
+            sinCache = create.onnx.expand(
+                cacheBroadcastType, sinCache, broadcastShapeConst);
+            toCheck.append({broadcastShapeConst, cosCache, sinCache});
+          }
+        } else {
+          // Synthesize position_ids = [pastSeqLen, .., totalSeqLen-1]
+          // broadcast to [batch_size, seq_len]. Same semantics as the
+          // original slicing, but the cos/sin caches are passed through
+          // unchanged so the cache stays complete.
+          auto pastKeyType = cast<ShapedType>(pastKey.getType());
+          const int64_t seqLen = queryType.getShape()[1];
+          const int64_t pastSeqLen = pastKeyType.getShape()[2];
+          const int64_t totalSeqLen = pastSeqLen + seqLen;
+          const int64_t batchSize = queryType.getShape()[0];
+
+          SmallVector<Attribute> elements;
+          elements.reserve(batchSize * seqLen);
+          for (int64_t b = 0; b < batchSize; ++b)
+            for (int64_t i = pastSeqLen; i < totalSeqLen; ++i)
+              elements.push_back(rewriter.getI64IntegerAttr(i));
+
+          auto positionIdsType = RankedTensorType::get(
+              {batchSize, seqLen}, rewriter.getIntegerType(64));
+          positionIds = rewriter.create<ONNXConstantOp>(loc, Attribute(),
+              DenseElementsAttr::get(
+                  positionIdsType, ArrayRef<Attribute>(elements)));
+          toCheck.push_back(positionIds);
         }
       }
 
@@ -4327,7 +4360,8 @@ struct DecomposeONNXToONNXPass
       bool enableInstanceNormDecompose = true,
       bool enableMatmulNBitsDecompose = false,
       bool enableGroupQueryAttentionDecompose = true,
-      bool enableSplitToSliceDecompose = false) {
+      bool enableSplitToSliceDecompose = false,
+      bool enableGroupQueryAttentionCacheSlicing = true) {
     this->target = target;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
     this->enableConvTransposeDecomposeToPhasedConv =
@@ -4339,6 +4373,8 @@ struct DecomposeONNXToONNXPass
     this->enableGroupQueryAttentionDecompose =
         enableGroupQueryAttentionDecompose;
     this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
+    this->enableGroupQueryAttentionCacheSlicing =
+        enableGroupQueryAttentionCacheSlicing;
   }
 
   DecomposeONNXToONNXPass(const DecomposeONNXToONNXPass &pass)
@@ -4357,6 +4393,8 @@ struct DecomposeONNXToONNXPass
         pass.enableGroupQueryAttentionDecompose.getValue();
     this->enableSplitToSliceDecompose =
         pass.enableSplitToSliceDecompose.getValue();
+    this->enableGroupQueryAttentionCacheSlicing =
+        pass.enableGroupQueryAttentionCacheSlicing.getValue();
   }
 
   StringRef getArgument() const override { return "decompose-onnx"; }
@@ -4407,6 +4445,13 @@ struct DecomposeONNXToONNXPass
       llvm::cl::desc("Enable decomposition of Split to Slice operations"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableGroupQueryAttentionCacheSlicing{*this,
+      "enable-groupqueryattention-cache-slicing",
+      llvm::cl::desc("Enable slicing of cos/sin caches during decomposing "
+                     "GroupQueryAttention. Set to false for keeping cache "
+                     "and synthesize position_ids instead."),
+      ::llvm::cl::init(true)};
+
   void runOnOperation() final;
 
   typedef PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>>
@@ -4421,7 +4466,7 @@ void DecomposeONNXToONNXPass::runOnOperation() {
       enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableMatmulNBitsDecompose, enableGroupQueryAttentionDecompose,
-      enableSplitToSliceDecompose);
+      enableSplitToSliceDecompose, enableGroupQueryAttentionCacheSlicing);
   patterns.insert<ReplaceCastLikeByCastPattern>(context);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
@@ -4443,7 +4488,8 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
-    bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose) {
+    bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose,
+    bool enableGroupQueryAttentionCacheSlicing) {
   MLIRContext *context = patterns.getContext();
   populateWithGenerated(patterns);
   if (enableConvTransposeDecompose)
@@ -4473,7 +4519,8 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
   patterns.insert<SimplifiedLayerNorm>(context);
   patterns.insert<MicrosoftSkipSimplifiedLayerNorm>(context);
   if (enableGroupQueryAttentionDecompose)
-    patterns.insert<MicrosoftGroupQueryAttention>(context);
+    patterns.insert<MicrosoftGroupQueryAttention>(
+        context, enableGroupQueryAttentionCacheSlicing);
   patterns.insert<MicrosoftRotaryEmbedding>(context);
   if (enableMatmulNBitsDecompose)
     patterns.insert<MicrosoftMatmulNBits>(context);
@@ -4502,10 +4549,11 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createDecomposeONNXToONNXPass(
     bool enableConvTransposeDecomposeToPhasedConv,
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
-    bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose) {
+    bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose,
+    bool enableGroupQueryAttentionCacheSlicing) {
   return std::make_unique<DecomposeONNXToONNXPass>(target,
       enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableMatmulNBitsDecompose, enableGroupQueryAttentionDecompose,
-      enableSplitToSliceDecompose);
+      enableSplitToSliceDecompose, enableGroupQueryAttentionCacheSlicing);
 }

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -32,7 +32,8 @@ void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
     bool enableGroupQueryAttentionDecompose,
-    bool enableSplitToSliceDecompose = false);
+    bool enableSplitToSliceDecompose = false,
+    bool enableGroupQueryAttentionCacheSlicing = true);
 
 } // namespace onnx_mlir
 #endif

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -140,6 +140,13 @@ struct ONNXHybridTransformPass
           "Enable canonicalize from GlobalAveragePool to ReduceMean"),
       ::llvm::cl::init(true)};
 
+  Option<bool> enableGroupQueryAttentionCacheSlicing{*this,
+      "enable-groupqueryattention-cache-slicing",
+      llvm::cl::desc("Enable slicing of cos/sin caches during decomposing "
+                     "GroupQueryAttention. Set to false for keeping cache "
+                     "and synthesize position_ids instead."),
+      ::llvm::cl::init(true)};
+
   FrozenRewritePatternSet patterns;
 
   ONNXHybridTransformPass(bool enableRecomposition,
@@ -149,7 +156,7 @@ struct ONNXHybridTransformPass
       bool enableConvTranspose1dDecomposeToPhasedConv,
       bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
       bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose,
-      bool enablGAPToReduceMean) {
+      bool enablGAPToReduceMean, bool enableGroupQueryAttentionCacheSlicing) {
     this->recomposition = enableRecomposition;
     this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
     this->enableConvTransposeDecompose = enableConvTransposeDecompose;
@@ -163,6 +170,8 @@ struct ONNXHybridTransformPass
         enableGroupQueryAttentionDecompose;
     this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
     this->enablGAPToReduceMean = enablGAPToReduceMean;
+    this->enableGroupQueryAttentionCacheSlicing =
+        enableGroupQueryAttentionCacheSlicing;
   }
 
   ONNXHybridTransformPass(const ONNXHybridTransformPass &pass)
@@ -218,7 +227,8 @@ struct ONNXHybridTransformPass
           enableConvTransposeDecomposeToPhasedConv,
           enableConvTranspose1dDecomposeToPhasedConv,
           enableInstanceNormDecompose, enableMatmulNBitsDecompose,
-          enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose);
+          enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
+          enableGroupQueryAttentionCacheSlicing);
     }
 
     if (recomposition) {
@@ -266,11 +276,12 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
     bool enableConvTranspose1dDecomposeToPhasedConv,
     bool enableInstanceNormDecompose, bool enableMatmulNBitsDecompose,
     bool enableGroupQueryAttentionDecompose, bool enableSplitToSliceDecompose,
-    bool enablGAPToReduceMean) {
+    bool enablGAPToReduceMean, bool enableGroupQueryAttentionCacheSlicing) {
   return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
       enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
       enableConvTransposeDecomposeToPhasedConv,
       enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
       enableMatmulNBitsDecompose, enableGroupQueryAttentionDecompose,
-      enableSplitToSliceDecompose, enablGAPToReduceMean);
+      enableSplitToSliceDecompose, enablGAPToReduceMean,
+      enableGroupQueryAttentionCacheSlicing);
 }

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -44,7 +44,8 @@ std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
     bool enableInstanceNormDecompose = true,
     bool enableMatmulNBitsDecompose = false,
     bool enableGroupQueryAttentionDecompose = true,
-    bool enableSplitToSliceDecompose = false);
+    bool enableSplitToSliceDecompose = false,
+    bool enableGroupQueryAttentionCacheSlicing = true);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "");
 
@@ -94,7 +95,8 @@ std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
     bool enableInstanceNormDecompose = true,
     bool enableMatmulNBitsDecompose = false,
     bool enableGroupQueryAttentionDecompose = true,
-    bool enableSplitToSliceDecompose = false, bool enablGAPToReduceMean = true);
+    bool enableSplitToSliceDecompose = false, bool enablGAPToReduceMean = true,
+    bool enableGroupQueryAttentionCacheSlicing = true);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/test/mlir/onnx/onnx_decompose_gqa_unsliced_cache.mlir
+++ b/test/mlir/onnx/onnx_decompose_gqa_unsliced_cache.mlir
@@ -1,0 +1,120 @@
+// RUN: onnx-mlir-opt --decompose-onnx="enable-groupqueryattention-cache-slicing=false" %s -split-input-file | FileCheck %s
+
+// When enable-groupqueryattention-cache-slicing is false, the cos/sin caches
+// must be passed through to onnx.RotaryEmbedding without any Slice/Reshape/
+// Expand, and the position_ids that the slicing would have implicitly
+// selected must be materialized as a constant tensor of shape
+// [batch_size, sequence_length] with values [past_seq_len .. total_seq_len-1]
+// per batch row.
+
+func.func @gqa_unsliced_cache_packed(
+  %qkv: tensor<1x1x6144xf32>,
+  %past_k: tensor<1x16x256x96xf32>,
+  %past_v: tensor<1x16x256x96xf32>,
+  %cos_cache: tensor<4096x48xf32>,
+  %sin_cache: tensor<4096x48xf32>
+) -> (tensor<1x1x3072xf32>, tensor<1x16x257x96xf32>, tensor<1x16x257x96xf32>) {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %total_seqlen = "onnx.Constant"() {value = dense<256> : tensor<i32>} : () -> tensor<i32>
+  %seqlens = "onnx.Constant"() {value = dense<255> : tensor<1x1xi32>} : () -> tensor<1x1xi32>
+  %out, %present_k, %present_v = "onnx.Custom"(%qkv, %none, %none, %past_k, %past_v, %seqlens, %total_seqlen, %cos_cache, %sin_cache) {
+    domain_name = "com.microsoft",
+    function_name = "GroupQueryAttention",
+    do_rotary = 1 : si64,
+    kv_num_heads = 16 : si64,
+    num_heads = 32 : si64
+  }: (tensor<1x1x6144xf32>, none, none, tensor<1x16x256x96xf32>, tensor<1x16x256x96xf32>, tensor<1x1xi32>, tensor<i32>, tensor<4096x48xf32>, tensor<4096x48xf32>) -> (tensor<1x1x3072xf32>, tensor<1x16x257x96xf32>, tensor<1x16x257x96xf32>)
+  return %out, %present_k, %present_v : tensor<1x1x3072xf32>, tensor<1x16x257x96xf32>, tensor<1x16x257x96xf32>
+}
+// CHECK-LABEL:   func.func @gqa_unsliced_cache_packed(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<1x1x6144xf32>,
+// CHECK-SAME:                                          %[[VAL_1:.*]]: tensor<1x16x256x96xf32>, %[[VAL_2:.*]]: tensor<1x16x256x96xf32>,
+// CHECK-SAME:                                          %[[COS_CACHE:.*]]: tensor<4096x48xf32>,
+// CHECK-SAME:                                          %[[SIN_CACHE:.*]]: tensor<4096x48xf32>)
+// CHECK-NOT: "onnx.Slice"
+// CHECK-NOT: "onnx.Reshape"
+// CHECK-NOT: "onnx.Expand"
+// CHECK-DAG:       %[[POS_IDS:.*]] = onnx.Constant dense<256> : tensor<1x1xi64>
+// CHECK:           %[[VAL_8:.*]] = "onnx.RotaryEmbedding"({{.*}}, %[[COS_CACHE]], %[[SIN_CACHE]], %[[POS_IDS]])
+// CHECK-SAME:          : (tensor<1x1x3072xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, tensor<1x1xi64>) -> tensor<1x1x3072xf32>
+// CHECK:           %[[VAL_9:.*]] = "onnx.RotaryEmbedding"({{.*}}, %[[COS_CACHE]], %[[SIN_CACHE]], %[[POS_IDS]])
+// CHECK-SAME:          : (tensor<1x1x1536xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, tensor<1x1xi64>) -> tensor<1x1x1536xf32>
+// CHECK:           "onnx.Attention"(%[[VAL_8]], %[[VAL_9]],
+
+// -----
+
+// Multi-step prefill (seq_len > 1) with batch > 1 and a non-zero past length:
+// the synthesized position_ids must be a 2D constant tensor with one row per
+// batch containing [past_seq_len .. total_seq_len-1].
+
+func.func @gqa_unsliced_cache_prefill_batched(
+  %q: tensor<2x4x3072xf32>,
+  %k: tensor<2x4x1536xf32>,
+  %v: tensor<2x4x1536xf32>,
+  %past_k: tensor<2x16x8x96xf32>,
+  %past_v: tensor<2x16x8x96xf32>,
+  %cos_cache: tensor<4096x48xf32>,
+  %sin_cache: tensor<4096x48xf32>
+) -> (tensor<2x4x3072xf32>, tensor<2x16x12x96xf32>, tensor<2x16x12x96xf32>) {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %total_seqlen = "onnx.Constant"() {value = dense<12> : tensor<i32>} : () -> tensor<i32>
+  %seqlens = "onnx.Constant"() {value = dense<11> : tensor<2x1xi32>} : () -> tensor<2x1xi32>
+  %out, %present_k, %present_v = "onnx.Custom"(%q, %k, %v, %past_k, %past_v, %seqlens, %total_seqlen, %cos_cache, %sin_cache) {
+    domain_name = "com.microsoft",
+    function_name = "GroupQueryAttention",
+    do_rotary = 1 : si64,
+    kv_num_heads = 16 : si64,
+    num_heads = 32 : si64
+  }: (tensor<2x4x3072xf32>, tensor<2x4x1536xf32>, tensor<2x4x1536xf32>, tensor<2x16x8x96xf32>, tensor<2x16x8x96xf32>, tensor<2x1xi32>, tensor<i32>, tensor<4096x48xf32>, tensor<4096x48xf32>) -> (tensor<2x4x3072xf32>, tensor<2x16x12x96xf32>, tensor<2x16x12x96xf32>)
+  return %out, %present_k, %present_v : tensor<2x4x3072xf32>, tensor<2x16x12x96xf32>, tensor<2x16x12x96xf32>
+}
+// CHECK-LABEL:   func.func @gqa_unsliced_cache_prefill_batched
+// CHECK-NOT: "onnx.Slice"
+// CHECK-NOT: "onnx.Reshape"
+// CHECK-NOT: "onnx.Expand"
+// CHECK-DAG:       %[[POS_IDS:.*]] = onnx.Constant dense<{{\[}}[8, 9, 10, 11], [8, 9, 10, 11]]> : tensor<2x4xi64>
+// CHECK:           "onnx.RotaryEmbedding"({{.*}}, %[[POS_IDS]])
+// CHECK-SAME:          : (tensor<2x4x3072xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, tensor<2x4xi64>) -> tensor<2x4x3072xf32>
+// CHECK:           "onnx.RotaryEmbedding"({{.*}}, %[[POS_IDS]])
+// CHECK-SAME:          : (tensor<2x4x1536xf32>, tensor<4096x48xf32>, tensor<4096x48xf32>, tensor<2x4xi64>) -> tensor<2x4x1536xf32>
+// CHECK:           "onnx.Attention"
+
+// -----
+
+// When position_ids is provided by the caller, the synthesis path is not
+// taken even with the flag set: the existing position_ids flows through
+// directly and no Slice/Reshape/Expand is added.
+
+func.func @gqa_unsliced_cache_with_user_position_ids(
+  %q: tensor<1x4x3072xf32>,
+  %k: tensor<1x4x1536xf32>,
+  %v: tensor<1x4x1536xf32>,
+  %past_k: tensor<1x16x8x96xf32>,
+  %past_v: tensor<1x16x8x96xf32>,
+  %cos_cache: tensor<4096x48xf32>,
+  %sin_cache: tensor<4096x48xf32>,
+  %pos_ids: tensor<1x4xi64>
+) -> (tensor<1x4x3072xf32>, tensor<1x16x12x96xf32>, tensor<1x16x12x96xf32>) {
+  %total_seqlen = "onnx.Constant"() {value = dense<12> : tensor<i32>} : () -> tensor<i32>
+  %seqlens = "onnx.Constant"() {value = dense<11> : tensor<1x1xi32>} : () -> tensor<1x1xi32>
+  %out, %present_k, %present_v = "onnx.Custom"(%q, %k, %v, %past_k, %past_v, %seqlens, %total_seqlen, %cos_cache, %sin_cache, %pos_ids) {
+    domain_name = "com.microsoft",
+    function_name = "GroupQueryAttention",
+    do_rotary = 1 : si64,
+    kv_num_heads = 16 : si64,
+    num_heads = 32 : si64
+  }: (tensor<1x4x3072xf32>, tensor<1x4x1536xf32>, tensor<1x4x1536xf32>, tensor<1x16x8x96xf32>, tensor<1x16x8x96xf32>, tensor<1x1xi32>, tensor<i32>, tensor<4096x48xf32>, tensor<4096x48xf32>, tensor<1x4xi64>) -> (tensor<1x4x3072xf32>, tensor<1x16x12x96xf32>, tensor<1x16x12x96xf32>)
+  return %out, %present_k, %present_v : tensor<1x4x3072xf32>, tensor<1x16x12x96xf32>, tensor<1x16x12x96xf32>
+}
+// CHECK-LABEL:   func.func @gqa_unsliced_cache_with_user_position_ids(
+// CHECK-SAME:                                                          %[[Q:.*]]: tensor<1x4x3072xf32>,
+// CHECK-SAME:                                                          %[[K:.*]]: tensor<1x4x1536xf32>, %[[V:.*]]: tensor<1x4x1536xf32>,
+// CHECK-SAME:                                                          %[[PAST_K:.*]]: tensor<1x16x8x96xf32>, %[[PAST_V:.*]]: tensor<1x16x8x96xf32>,
+// CHECK-SAME:                                                          %[[COS_CACHE:.*]]: tensor<4096x48xf32>, %[[SIN_CACHE:.*]]: tensor<4096x48xf32>,
+// CHECK-SAME:                                                          %[[POS_IDS:.*]]: tensor<1x4xi64>)
+// CHECK-NOT: "onnx.Slice"
+// CHECK-NOT: "onnx.Reshape"
+// CHECK-NOT: "onnx.Expand"
+// CHECK:           %[[VAL_Q:.*]] = "onnx.RotaryEmbedding"(%[[Q]], %[[COS_CACHE]], %[[SIN_CACHE]], %[[POS_IDS]])
+// CHECK:           %[[VAL_K:.*]] = "onnx.RotaryEmbedding"(%[[K]], %[[COS_CACHE]], %[[SIN_CACHE]], %[[POS_IDS]])
+// CHECK:           "onnx.Attention"(%[[VAL_Q]], %[[VAL_K]],


### PR DESCRIPTION
## Summary

Add a new option `enableGroupQueryAttentionCacheSlicing` to the `decompose-onnx` and `onnx-hybrid-transform` passes (default `true`, preserving existing behavior). When set to `false`, the Microsoft GroupQueryAttention decomposition no longer emits `Slice`/`Reshape`/`Expand` on the cos/sin caches when `do_rotary=1` and `position_ids` is missing. Instead the original full cos/sin caches are passed through to `onnx.RotaryEmbedding` unchanged, and a constant `position_ids` tensor (`[past_seq_len .. total_seq_len-1]` per batch row) is synthesized to preserve the original slicing semantics.

The flag is plumbed through `getDecomposeONNXToONNXPatterns`, `createDecomposeONNXToONNXPass`, the `DecomposeONNXToONNXPass` / `ONNXHybridTransformPass` option lists, and `OnnxToMlirOptions`.

## Test plan

- [x] New lit test `test/mlir/onnx/onnx_decompose_gqa_unsliced_cache.mlir` covers decode, batched prefill, and the case where the caller already provides `position_ids`.
- [x] Existing GQA decompose tests continue to pass (default `true` keeps old slicing behavior).
