### PR TITLE
Add combined RedundantOpReductionPass mirroring xcompiler exec() for QDQ models

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -120,6 +120,9 @@ void addXmcMlirPasses(mlir::OpPassManager &pm, OnnxToMlirOptions opts) {
 
   pm.addNestedPass<func::FuncOp>(
       onnx_mlir::createAddRequantForOutputConvPass());
+
+  pm.addNestedPass<func::FuncOp>(onnx_mlir::createRedundantOpReductionPass());
+
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
 }
 

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -61,6 +61,7 @@ add_onnx_mlir_library(OMONNXRewrite
   xmc/MergeSliceConcatPass.cpp
   xmc/CombineTransposePair.cpp
   xmc/MergeContinuousStridedSlice.cpp
+  xmc/RedundantOpReductionPass.cpp
   xmc/RemoveContinuousTransposeWithReshape.cpp
   xmc/RemoveUselessQLinearPoolPass.cpp
   xmc/ReplaceErfToGeluPass.cpp

--- a/src/Dialect/ONNX/Transforms/xmc/RedundantOpReductionPass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/RedundantOpReductionPass.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "src/Pass/Passes.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+static void addRedundantOpReductionSubPasses(OpPassManager &pm) {
+  // Mirrors xcompiler RedundantOpReductionPass::exec() for QDQ models.
+  pm.addPass(createMergeContinuousStridedSlicePass());
+  pm.addPass(createRemoveContinuousTransposeWithReshapePass());
+  pm.addPass(createRemoveSemanticallyUselessOpsPass());
+  pm.addPass(createRemoveUselessQLinearPoolPass());
+  pm.addPass(createConvertQDQToRequantizePass());
+  pm.addPass(createConvertSCastPairToRequantizePass());
+  pm.addPass(createONNXTransposeOptimizationPass());
+  pm.addPass(createCombineTransposePairPass());
+  pm.addPass(createCanonicalizeWithResultNamesPass());
+}
+
+struct RedundantOpReductionPass
+    : public PassWrapper<RedundantOpReductionPass,
+          OperationPass<func::FuncOp>> {
+  StringRef getArgument() const override { return "redundant-op-reduction"; }
+  StringRef getDescription() const override {
+    return "Combined redundant-op reduction (mirrors xcompiler "
+           "RedundantOpReductionPass for QDQ models)";
+  }
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    OpPassManager pm(func.getOperationName());
+    addRedundantOpReductionSubPasses(pm);
+    if (failed(runPipeline(pm, func)))
+      signalPassFailure();
+  }
+};
+
+std::unique_ptr<mlir::Pass> createRedundantOpReductionPass() {
+  return std::make_unique<RedundantOpReductionPass>();
+}
+
+} // namespace onnx_mlir

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -151,6 +151,10 @@ std::unique_ptr<mlir::Pass> createMergeStridedSliceConcatConvPass();
 /// Pass for merging continuous chained Slice operations with quantized types.
 std::unique_ptr<mlir::Pass> createMergeContinuousStridedSlicePass();
 
+/// Combined redundant-op reduction pass (mirrors xcompiler
+/// RedundantOpReductionPass for QDQ models).
+std::unique_ptr<mlir::Pass> createRedundantOpReductionPass();
+
 std::unique_ptr<mlir::Pass> createONNXTransposeOptimizationPass();
 
 /// Pass to combine two transpose with same input and same perm.

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -382,6 +382,8 @@ void registerOMPasses(int optLevel) {
   mlir::registerPass(createFoldQuantizedBinary);
   mlir::registerPass(createXmcFoldQuantizedBinary);
 
+  mlir::registerPass(createRedundantOpReductionPass);
+
   mlir::PassPipelineRegistration<>("xmc-passes", "Run all XMC xcompiler passes",
       [](mlir::OpPassManager &pm) { addXmcMlirPasses(pm); });
 


### PR DESCRIPTION

Introduces a single -redundant-op-reduction func pass that runs the QDQ-relevant

sub-passes (merge-continuous-strided-slice, remove-continuous-transpose-with-reshape,

remove-semantically-useless-ops, remove-useless-qlinear-pool, convert-qdq-to-requantize,

convert-scast-pair-to-requantize, onnx-transpose-optimization, combine-transpose-pair,

canonicalize-with-result-names) in one go

eg : to add pass  pm.addNestedPass<func::FuncOp>(onnx_mlir::createRedundantOpReductionPass())