### PR TITLE
[xmc] ReplaceQDQEltwise allow widening shared i8 constants to i16

### DIFF
--- a/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
@@ -257,7 +257,7 @@ static void maybeWidenNarrowConstOperand(PatternRewriter &rewriter,
     return;
 
   auto constOp = narrowSide.getDefiningOp<ONNXConstantOp>();
-  if (!constOp || !constOp->hasOneUse())
+  if (!constOp)
     return;
 
   auto valueAttr =

--- a/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
@@ -290,7 +290,8 @@ static void maybeWidenNarrowConstOperand(PatternRewriter &rewriter,
       continue;
     auto candidateVal =
         mlir::dyn_cast_or_null<DenseElementsAttr>(candidate.getValueAttr());
-    if (candidateVal && candidateVal.getNumElements() == valueAttr.getNumElements()) {
+    if (candidateVal &&
+        candidateVal.getNumElements() == valueAttr.getNumElements()) {
       bool valuesMatch = true;
       auto candIt = candidateVal.getValues<llvm::APInt>().begin();
       for (llvm::APInt v : valueAttr.getValues<llvm::APInt>()) {

--- a/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
+++ b/src/Dialect/ONNX/Transforms/xmc/ReplaceQDQEltwisePass.cpp
@@ -277,24 +277,56 @@ static void maybeWidenNarrowConstOperand(PatternRewriter &rewriter,
           isSigned, 16));
 
   auto wideTensorTy = RankedTensorType::get(narrowTy.getShape(), wideQ);
-  auto wideStorageTensorTy =
-      RankedTensorType::get(narrowTy.getShape(), wideStorTy);
 
-  llvm::SmallVector<llvm::APInt, 16> widened;
-  widened.reserve(valueAttr.getNumElements());
-  for (llvm::APInt v : valueAttr.getValues<llvm::APInt>())
-    widened.push_back(isSigned ? v.sext(16) : v.zext(16));
-  auto wideDense = DenseElementsAttr::get(
-      wideStorageTensorTy, llvm::ArrayRef<llvm::APInt>(widened));
-  auto wideValueAttr = rewriter.getNamedAttr("value", wideDense);
+  // Reuse an existing widened constant if a previous pattern match already
+  // created one for the same narrow constant (avoids duplicating memory).
+  // Match requires identical type AND identical dense values.
+  Value wideResult;
+  for (Operation &sibling : constOp->getBlock()->getOperations()) {
+    auto candidate = mlir::dyn_cast<ONNXConstantOp>(&sibling);
+    if (!candidate || candidate == constOp)
+      continue;
+    if (candidate.getResult().getType() != wideTensorTy)
+      continue;
+    auto candidateVal =
+        mlir::dyn_cast_or_null<DenseElementsAttr>(candidate.getValueAttr());
+    if (candidateVal && candidateVal.getNumElements() == valueAttr.getNumElements()) {
+      bool valuesMatch = true;
+      auto candIt = candidateVal.getValues<llvm::APInt>().begin();
+      for (llvm::APInt v : valueAttr.getValues<llvm::APInt>()) {
+        llvm::APInt expected = isSigned ? v.sext(16) : v.zext(16);
+        if (*candIt != expected) {
+          valuesMatch = false;
+          break;
+        }
+        ++candIt;
+      }
+      if (valuesMatch) {
+        wideResult = candidate.getResult();
+        break;
+      }
+    }
+  }
 
-  auto wideConstOp = rewriter.create<ONNXConstantOp>(loc, wideTensorTy,
-      ValueRange{}, llvm::ArrayRef<NamedAttribute>{wideValueAttr});
+  if (!wideResult) {
+    auto wideStorageTensorTy =
+        RankedTensorType::get(narrowTy.getShape(), wideStorTy);
+    llvm::SmallVector<llvm::APInt, 16> widened;
+    widened.reserve(valueAttr.getNumElements());
+    for (llvm::APInt v : valueAttr.getValues<llvm::APInt>())
+      widened.push_back(isSigned ? v.sext(16) : v.zext(16));
+    auto wideDense = DenseElementsAttr::get(
+        wideStorageTensorTy, llvm::ArrayRef<llvm::APInt>(widened));
+    auto wideValueAttr = rewriter.getNamedAttr("value", wideDense);
+    auto wideConstOp = rewriter.create<ONNXConstantOp>(loc, wideTensorTy,
+        ValueRange{}, llvm::ArrayRef<NamedAttribute>{wideValueAttr});
+    wideResult = wideConstOp.getResult();
+  }
 
   if (narrowIsA)
-    a = wideConstOp.getResult();
+    a = wideResult;
   else
-    b = wideConstOp.getResult();
+    b = wideResult;
 
   if (constOp->use_empty())
     rewriter.eraseOp(constOp);

--- a/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
+++ b/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
@@ -902,8 +902,8 @@ func.func @widen_skipped_same_width_i16(
 }
 
 // -----
-// Multi-use narrow constant: each use gets its own widened i16 copy.
-// The original i8 constant is erased once all uses are replaced.
+// Multi-use narrow constant: a single widened i16 constant is created and
+// shared by all users. The original i8 constant is erased.
 // CHECK-LABEL: func.func @widen_multi_use_const
 func.func @widen_multi_use_const(
     %arg0: tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
@@ -923,8 +923,53 @@ func.func @widen_multi_use_const(
   return %m0, %m1 : tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
                     tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>
 
+  // No i8 constant should remain (original erased).
   // CHECK-NOT: !quant.uniform<i8
+  // Exactly one i16 constant created and reused by both fused ops.
   // CHECK: onnx.Constant {{.*}} : tensor<1x16x1x1x!quant.uniform<i16:f32, 2.500000e-01>>
+  // CHECK-NOT: onnx.Constant {{.*}} : tensor<1x16x1x1x!quant.uniform<i16:f32, 2.500000e-01>>
+  // CHECK: "onnx.XCOMPILERFusedEltwise"
+  // CHECK: "onnx.XCOMPILERFusedEltwise"
+  // CHECK-NOT: !quant.uniform<i8
+}
+
+// -----
+// Three users sharing the same i8 constant, all with i16 on the other side.
+// A single widened i16 constant is created and reused by all three.
+// CHECK-LABEL: func.func @widen_reuse_three_users
+func.func @widen_reuse_three_users(
+    %arg0: tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+    %arg1: tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+    %arg2: tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>)
+    -> (tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+        tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+        tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>) {
+  %c = "onnx.Constant"() {value = dense<42> : tensor<1x16x1x1xi8>} :
+      () -> tensor<1x16x1x1x!quant.uniform<i8:f32, 0.1:0>>
+  %m0 = "onnx.Mul"(%arg0, %c) :
+      (tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+       tensor<1x16x1x1x!quant.uniform<i8:f32, 0.1:0>>)
+      -> tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>
+  %m1 = "onnx.Add"(%arg1, %c) :
+      (tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+       tensor<1x16x1x1x!quant.uniform<i8:f32, 0.1:0>>)
+      -> tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>
+  %m2 = "onnx.Sub"(%arg2, %c) :
+      (tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+       tensor<1x16x1x1x!quant.uniform<i8:f32, 0.1:0>>)
+      -> tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>
+  return %m0, %m1, %m2 :
+      tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+      tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+      tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>
+
+  // No i8 remaining.
+  // CHECK-NOT: !quant.uniform<i8
+  // One i16 constant, reused by all three fused ops.
+  // CHECK: onnx.Constant {{.*}} : tensor<1x16x1x1x!quant.uniform<i16:f32, 1.000000e-01>>
+  // CHECK-NOT: onnx.Constant {{.*}} : tensor<1x16x1x1x!quant.uniform<i16:f32, 1.000000e-01>>
+  // CHECK: "onnx.XCOMPILERFusedEltwise"
+  // CHECK: "onnx.XCOMPILERFusedEltwise"
   // CHECK: "onnx.XCOMPILERFusedEltwise"
   // CHECK-NOT: !quant.uniform<i8
 }

--- a/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
+++ b/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
@@ -928,3 +928,33 @@ func.func @widen_multi_use_const(
   // CHECK: "onnx.XCOMPILERFusedEltwise"
   // CHECK-NOT: !quant.uniform<i8
 }
+
+// -----
+// Mixed-width users: shared i8 constant has one user with i16 activation
+// and another with i8 activation. Only the i16 user gets a widened copy;
+// the i8 user keeps the original constant.
+// CHECK-LABEL: func.func @widen_per_user_mixed_width
+func.func @widen_per_user_mixed_width(
+    %arg0: tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+    %arg1: tensor<1x16x8x8x!quant.uniform<i8:f32, 0.03:0>>)
+    -> (tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+        tensor<1x16x8x8x!quant.uniform<i8:f32, 0.03:0>>) {
+  %c = "onnx.Constant"() {value = dense<5> : tensor<1x16x1x1xi8>} :
+      () -> tensor<1x16x1x1x!quant.uniform<i8:f32, 0.25:0>>
+  %m0 = "onnx.Mul"(%arg0, %c) :
+      (tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+       tensor<1x16x1x1x!quant.uniform<i8:f32, 0.25:0>>)
+      -> tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>
+  %m1 = "onnx.Mul"(%arg1, %c) :
+      (tensor<1x16x8x8x!quant.uniform<i8:f32, 0.03:0>>,
+       tensor<1x16x1x1x!quant.uniform<i8:f32, 0.25:0>>)
+      -> tensor<1x16x8x8x!quant.uniform<i8:f32, 0.03:0>>
+  return %m0, %m1 : tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
+                    tensor<1x16x8x8x!quant.uniform<i8:f32, 0.03:0>>
+
+  // i16 user gets widened constant, i8 user keeps original
+  // CHECK-DAG: onnx.Constant {{.*}} : tensor<1x16x1x1x!quant.uniform<i16:f32, 2.500000e-01>>
+  // CHECK-DAG: onnx.Constant {{.*}} : tensor<1x16x1x1x!quant.uniform<i8:f32, 2.500000e-01>>
+  // CHECK: "onnx.XCOMPILERFusedEltwise"
+  // CHECK: "onnx.XCOMPILERFusedEltwise"
+}

--- a/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
+++ b/test/mlir/onnx/xmc/replace_qdq_eltwise.mlir
@@ -902,11 +902,10 @@ func.func @widen_skipped_same_width_i16(
 }
 
 // -----
-// Multi-use narrow constant: helper refuses to widen (single-use gate).
-// The original i8 onnx.Constant survives; nothing prevents fusion, but the
-// fused op may end up with mismatched-width operands (handled later).
-// CHECK-LABEL: func.func @widen_skipped_multi_use_const
-func.func @widen_skipped_multi_use_const(
+// Multi-use narrow constant: each use gets its own widened i16 copy.
+// The original i8 constant is erased once all uses are replaced.
+// CHECK-LABEL: func.func @widen_multi_use_const
+func.func @widen_multi_use_const(
     %arg0: tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
     %arg1: tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>)
     -> (tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
@@ -924,6 +923,8 @@ func.func @widen_skipped_multi_use_const(
   return %m0, %m1 : tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>,
                     tensor<1x16x8x8x!quant.uniform<i16:f32, 0.05:0>>
 
-  // CHECK: onnx.Constant {{.*}} : tensor<1x16x1x1x!quant.uniform<i8:f32, 2.500000e-01>>
-  // CHECK-NOT: : tensor<1x16x1x1x!quant.uniform<i16
+  // CHECK-NOT: !quant.uniform<i8
+  // CHECK: onnx.Constant {{.*}} : tensor<1x16x1x1x!quant.uniform<i16:f32, 2.500000e-01>>
+  // CHECK: "onnx.XCOMPILERFusedEltwise"
+  // CHECK-NOT: !quant.uniform<i8
 }


### PR DESCRIPTION
Remove the hasOneUse restriction from maybeWidenNarrowConstOperand so that shared i8 constants are widened to i16 when paired with i16 activations in binary eltwise ops. The function already creates a new widened constant per call site and only erases the original when all uses are gone, so the single-use guard was unnecessarily restrictive.