### PR TITLE
Convert hybrid transform and decompose pass to use Tablegen for boilerplate code and option handling.

### DIFF
--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -89,6 +89,8 @@ function(add_onnx_mlir_dialect_doc dialect dialect_tablegen_file)
 endfunction()
 add_custom_target(onnx-mlir-docs)
 
+add_custom_target(OMPublicPassIncGen)
+
 # Create the list of supported ops. Pass the input file to scan, and the target architecture.
 # Target will create a docs/SupportedONNXOps-<arch>.md file listed
 # Useful options are "--notes", "--unsupported". Check python documentOps.py -h for more info.
@@ -181,6 +183,7 @@ function(add_onnx_mlir_library name)
 
   add_library(${name} ${ARG_UNPARSED_ARGUMENTS})
   llvm_update_compile_flags(${name})
+  add_dependencies(${name} OMPublicPassIncGen)
 
   if (ARG_DEPENDS)
     add_dependencies(${name} ${ARG_DEPENDS})
@@ -260,6 +263,7 @@ function(add_onnx_mlir_executable name)
   endif()
 
   llvm_update_compile_flags(${name})
+  add_dependencies(${name} OMPublicPassIncGen)
 
   if (ARG_DEPENDS)
     add_dependencies(${name} ${ARG_DEPENDS})

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -150,8 +150,10 @@ void addONNXToZHighPasses(mlir::PassManager &pm) {
   if (enableONNXHybridPass) {
     // For starters only illustrating the new hybrid pass by replacing 3 passes
     // here. The plan is to replace most of the passes in addONNXToMLIRPasses.
+    ONNXHybridTransformPassOptions hybridOptions;
+    hybridOptions.recomposition = !disableRecomposeOption;
     pm.addNestedPass<func::FuncOp>(
-        onnx_mlir::createONNXHybridTransformPass(!disableRecomposeOption));
+        onnx_mlir::createONNXHybridTransformPass(hybridOptions));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -107,6 +107,9 @@ add_onnx_mlir_library(OMOnnxToMlirPasses
   
   EXCLUDE_FROM_OM_LIBS
 
+  DEPENDS
+  OMPublicPassIncGen
+
   INCLUDE_DIRS PRIVATE
   ${FILE_GENERATE_DIR}
 
@@ -129,6 +132,9 @@ add_onnx_mlir_library(OMCompilerPasses
   CompilerPasses.cpp
 
   EXCLUDE_FROM_OM_LIBS
+
+  DEPENDS
+  OMPublicPassIncGen
 
   INCLUDE_DIRS PRIVATE
   ${FILE_GENERATE_DIR}

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -48,8 +48,7 @@ bool disableKrnlOpFusion;                              // common for both
 bool disableQuantZeroPoint;                            // common for both
 bool enableUnsafeMathOptimizations;                    // common for both
 bool enableKrnlBufferReuse;                            // common for both
-bool enableConvTransposeDecomposeToPhasedConv;         // common for both
-bool enableConvTranspose1dDecomposeToPhasedConv;       // common for both
+std::string onnxTransformOptions;                      // onnx-mlir only
 bool enableQuarkQuantizerLegalization;                 // common for both
 bool disableBatchNormDecompose;                        // common for both
 bool enableSafeCodeGen;                                // common for both
@@ -93,7 +92,6 @@ bool enableParallel;                       // onnx-mlir only
 bool disableSimdOption;                    // onnx-mlir only
 bool enableFastMathOption;                 // onnx-mlir only
 bool disableRecomposeOption;               // onnx-mlir only
-bool enableConvTransposeDecomposeOption;   // onnx-mlir only
 bool enableSimdDataLayout;                 // onnx-mlir only
 bool verifyInputTensors;                   // onnx-mlir only
 bool allowSorting;                         // onnx-mlir only
@@ -307,27 +305,14 @@ static llvm::cl::opt<bool, true> disableRecomposeOptionOpt("disable-recompose",
     llvm::cl::location(disableRecomposeOption), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 
-static llvm::cl::opt<bool, true> disableConvTranposeDecomposeOptionOpt(
-    "enable-convtranspose-decompose",
-    llvm::cl::desc("Enable decomposition of ONNX ConvTranspose operator."),
-    llvm::cl::location(enableConvTransposeDecomposeOption),
-    llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
-
-static llvm::cl::opt<bool, true> enableConvTransposeDecomposeTo4ConvOptionOpt(
-    "enable-convtranspose-decompose-phased-conv",
-    llvm::cl::desc("Enable decomposition of ONNX ConvTranspose operator to 4 "
-                   "phased Conv."),
-    llvm::cl::location(enableConvTransposeDecomposeToPhasedConv),
-    llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
-
-static llvm::cl::opt<bool, true>
-    enableConvTranspose1dDecomposeToPhasedConvOptionOpt(
-        "enable-convtranspose-1d-decompose-phased-conv",
-        llvm::cl::desc(
-            "Enable decomposition of ONNX ConvTranspose 1D operator to "
-            "phased Conv."),
-        llvm::cl::location(enableConvTranspose1dDecomposeToPhasedConv),
-        llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
+static llvm::cl::opt<std::string, true> onnxTransformOptionsOpt(
+    "onnx-transform-options",
+    llvm::cl::desc("Options forwarded to ONNX transform passes. Syntax is "
+                   "space-separated pass options, e.g. "
+                   "\"enable-convtranspose=true "
+                   "enable-instancenorm-decompose=false\"."),
+    llvm::cl::location(onnxTransformOptions), llvm::cl::init(""),
+    llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<bool, true> enableQuarkQuantizerLegalizationOptionOpt(
     "enable-quark-quantizer-legalization",

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -85,8 +85,7 @@ extern bool enableUnsafeMathOptimizations;                    // common for both
 extern bool enableKrnlBufferReuse;                            // common for both
 extern bool enableSafeCodeGen;                                // common for both
 extern bool disableMemRefPrefetch;                            // common for both
-extern bool enableConvTransposeDecomposeToPhasedConv;         // common for both
-extern bool enableConvTranspose1dDecomposeToPhasedConv;       // common for both
+extern std::string onnxTransformOptions;                      // onnx-mlir only
 extern bool enableQuarkQuantizerLegalization;                 // common for both
 extern bool disableBatchNormDecompose;                        // common for both
 extern uint64_t compilationNumThreads;                        // common for both
@@ -128,7 +127,6 @@ extern bool enableParallel;                       // onnx-mlir only
 extern bool disableSimdOption;                    // onnx-mlir only
 extern bool enableFastMathOption;                 // onnx-mlir only
 extern bool disableRecomposeOption;               // onnx-mlir only
-extern bool enableConvTransposeDecomposeOption;   // onnx-mlir only
 extern bool enableSimdDataLayout;                 // onnx-mlir only
 extern bool verifyInputTensors;                   // onnx-mlir only
 extern bool allowSorting;                         // onnx-mlir only

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -31,6 +31,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Transforms/Passes.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -234,14 +235,14 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
   //       the CPU specific transformations.
   if (inputIRLevel <= ONNXLevel && emissionTarget >= EmitONNXIR) {
     OnnxToMlirOptions opts;
-    opts.enableQuarkQuantizedLegalization = enableQuarkQuantizedLegalization;
-    opts.enableConvTransposeDecompose = enableConvTransposeDecomposeOption;
-    opts.enableConvTransposeDecomposeToPhasedConv =
-        enableConvTransposeDecomposeToPhasedConv;
-    opts.enableConvTranspose1dDecomposeToPhasedConv =
-        enableConvTranspose1dDecomposeToPhasedConv;
+    if (auto parsed = parseONNXHybridTransformPassOptions(onnxTransformOptions))
+      opts.hybrid = std::move(*parsed);
+    else
+      llvm::report_fatal_error("failed to parse --onnx-transform-options");
+    opts.hybrid.quarkQuantizedOpsLegalization =
+        enableQuarkQuantizedLegalization;
+    opts.hybrid.recomposition &= !disableRecomposeOption;
     opts.disableBatchNormDecompose = disableBatchNormDecompose;
-    opts.disableRecomposeOption = disableRecomposeOption;
     opts.enableUnsafeMathOptimizations = enableUnsafeMathOptimizations;
     opts.enableONNXHybridPass = enableONNXHybridPass;
     opts.enableConvOptPass = enableConvOptPass;
@@ -258,9 +259,9 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
     opts.instrumentStage = instrumentStage;
     opts.enableXMCPasses = enableXMCPasses;
     if (enableXMCPasses) {
-      opts.enableInstanceNormDecompose = false;
-      opts.enableGroupNormDecompose = false;
-      opts.enableConvTransposeDecomposeToPhasedConv = false;
+      opts.hybrid.enableInstanceNormDecompose = false;
+      opts.hybrid.enableGroupNormDecompose = false;
+      opts.hybrid.enableConvTransposeDecomposeToPhasedConv = false;
     }
 
     addONNXToMLIRPasses(pm, /*target CPU*/ false,

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -20,6 +20,21 @@
 using namespace mlir;
 namespace onnx_mlir {
 
+// Return a copy of the hybrid options with the sub-passes that are not
+// not part of the decompose-only stage disabled.
+static ONNXHybridTransformPassOptions getDecomposeOnlyOptions(
+    ONNXHybridTransformPassOptions options) {
+  options.shapeInference = false;
+  options.canonicalization = false;
+  options.constantPropagation = false;
+  options.qdqConstProp = false;
+  options.decomposition = true;
+  options.recomposition = false;
+  options.quarkQuantizedOpsLegalization = false;
+  options.enableRotaryEmbeddingRecompose = false;
+  return options;
+}
+
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     bool donotScrubDisposableElementsAttr, OnnxToMlirOptions opts) {
   // This is a transition from previous static passes to full dynamic passes
@@ -40,64 +55,33 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
         std::make_unique<DisposableGarbageCollector>(pm.getContext()));
 
   // Decompose first. Eliminates some unsupported ops without shape inference.
-  pm.addNestedPass<func::FuncOp>(onnx_mlir::createDecomposeONNXToONNXPass(
-      /*target=*/"", opts.enableConvTransposeDecompose,
-      opts.enableConvTransposeDecomposeToPhasedConv,
-      opts.enableConvTranspose1dDecomposeToPhasedConv,
-      opts.enableInstanceNormDecompose, opts.enableGroupNormDecompose,
-      opts.enableMatmulNBitsDecompose, opts.enableGroupQueryAttentionDecompose,
-      opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
-      opts.enableLstmSeqDecompose, opts.enableReduceL2Decompose,
-      opts.enableGatherToSlice, opts.enableHardSwishDecompose,
-      opts.enableGroupQueryAttentionCacheSlicing));
-  if (!opts.disableRecomposeOption)
+  pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
+      getDecomposeOnlyOptions(opts.hybrid)));
+  if (opts.hybrid.recomposition)
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass(
-        /*target=*/"", opts.enableRotaryEmbeddingRecompose));
+        /*target=*/"", opts.hybrid.enableRotaryEmbeddingRecompose));
 
   if (opts.enableONNXHybridPass) {
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
-        !opts.disableRecomposeOption, opts.enableQuarkQuantizedLegalization,
-        opts.enableConvTransposeDecompose,
-        opts.enableConvTransposeDecomposeToPhasedConv,
-        opts.enableConvTranspose1dDecomposeToPhasedConv,
-        opts.enableInstanceNormDecompose, opts.enableGroupNormDecompose,
-        opts.enableMatmulNBitsDecompose,
-        opts.enableGroupQueryAttentionDecompose,
-        opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
-        opts.enableGAPToReduceMean, opts.enableLstmSeqDecompose,
-        opts.enableGatherToSlice, opts.enableReduceL2Decompose,
-        opts.enableRotaryEmbeddingRecompose, opts.enableQDQConstProp,
-        opts.enableHardSwishDecompose,
-        opts.enableGroupQueryAttentionCacheSlicing));
+    pm.addNestedPass<func::FuncOp>(
+        onnx_mlir::createONNXHybridTransformPass(opts.hybrid));
     // Convolution Optimization for CPU: enable when there are no accelerators.
     if (targetCPU && opts.enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
           opts.enableSimdDataLayout && !opts.disableSimdOption));
+      ONNXHybridTransformPassOptions hybridOptions = opts.hybrid;
+      hybridOptions.quarkQuantizedOpsLegalization = false;
       pm.addNestedPass<func::FuncOp>(
-          onnx_mlir::createONNXHybridTransformPass(!opts.disableRecomposeOption,
-              /*enableQuarkQuantizedOpsLegalization=*/false,
-              opts.enableConvTransposeDecompose,
-              opts.enableConvTransposeDecomposeToPhasedConv,
-              opts.enableConvTranspose1dDecomposeToPhasedConv,
-              opts.enableInstanceNormDecompose, opts.enableGroupNormDecompose,
-              opts.enableMatmulNBitsDecompose,
-              opts.enableGroupQueryAttentionDecompose,
-              opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
-              opts.enableGAPToReduceMean, opts.enableLstmSeqDecompose,
-              opts.enableGatherToSlice, opts.enableReduceL2Decompose,
-              opts.enableRotaryEmbeddingRecompose, opts.enableQDQConstProp,
-              opts.enableHardSwishDecompose,
-              opts.enableGroupQueryAttentionCacheSlicing));
+          onnx_mlir::createONNXHybridTransformPass(hybridOptions));
     }
     // If quark quantized legalization is enabled, do a last const prop after it
     // so that we cover any remaining Cast -> Cast patterns that weren't covered
     // by the pass.
-    if (opts.enableQuarkQuantizedLegalization) {
+    if (opts.hybrid.quarkQuantizedOpsLegalization) {
       configureConstPropONNXToONNXPass(/*roundFPToInt=*/false,
           /*expansionBound=*/-1, /*disabledPatterns=*/{""},
           /*constantPropIsDisabled=*/false);
       pm.addNestedPass<func::FuncOp>(
-          onnx_mlir::createConstPropONNXToONNXPass(opts.enableQDQConstProp));
+          onnx_mlir::createConstPropONNXToONNXPass(opts.hybrid.qdqConstProp));
     }
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
@@ -112,27 +96,28 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::createLegalizeQuarkQuantizedOpsPass());
     pm.addNestedPass<func::FuncOp>(
-        onnx_mlir::createConstPropONNXToONNXPass(opts.enableQDQConstProp));
+        onnx_mlir::createConstPropONNXToONNXPass(opts.hybrid.qdqConstProp));
     if (opts.onnxOpTransformThreshold > 0) {
       // Dynamic iterate in ONNXOpTransformPass
       pm.addPass(onnx_mlir::createONNXOpTransformPass(
           opts.onnxOpTransformThreshold, opts.onnxOpTransformReport, targetCPU,
           opts.enableSimdDataLayout && !opts.disableSimdOption,
-          opts.enableConvOptPass, !opts.disableRecomposeOption));
+          opts.enableConvOptPass, opts.hybrid.recomposition));
     } else {
       // Statically add extra passes
       for (int i = 0; i < opts.repeatOnnxTransform; i++) {
         pm.addPass(onnx_mlir::createCanonicalizeWithResultNamesPass());
         pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
         pm.addNestedPass<func::FuncOp>(
-            onnx_mlir::createConstPropONNXToONNXPass(opts.enableQDQConstProp));
+            onnx_mlir::createConstPropONNXToONNXPass(opts.hybrid.qdqConstProp));
       }
     }
   }
 
   // Simplify shape-related ops.
   pm.addPass(onnx_mlir::createSimplifyShapeRelatedOpsPass(
-      opts.enableQuarkQuantizedLegalization, opts.enableGAPToReduceMean));
+      opts.hybrid.quarkQuantizedOpsLegalization,
+      opts.hybrid.enableGAPToReduceMean));
 
   // Canonicalizing Q-DQ related ops
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createQDQCanonicalizePass(
@@ -141,20 +126,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   // One more call to ONNX shape inference/canonicalization/... to update
   // shape if possible.
   if (opts.enableONNXHybridPass) {
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass(
-        !opts.disableRecomposeOption, opts.enableQuarkQuantizedLegalization,
-        opts.enableConvTransposeDecompose,
-        opts.enableConvTransposeDecomposeToPhasedConv,
-        opts.enableConvTranspose1dDecomposeToPhasedConv,
-        opts.enableInstanceNormDecompose, opts.enableGroupNormDecompose,
-        opts.enableMatmulNBitsDecompose,
-        opts.enableGroupQueryAttentionDecompose,
-        opts.enableSplitToSliceDecompose, opts.enableConcatFuse,
-        opts.enableGAPToReduceMean, opts.enableLstmSeqDecompose,
-        opts.enableGatherToSlice, opts.enableReduceL2Decompose,
-        opts.enableRotaryEmbeddingRecompose, opts.enableQDQConstProp,
-        opts.enableHardSwishDecompose,
-        opts.enableGroupQueryAttentionCacheSlicing));
+    pm.addNestedPass<func::FuncOp>(
+        onnx_mlir::createONNXHybridTransformPass(opts.hybrid));
   } else {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(onnx_mlir::createCanonicalizeWithResultNamesPass());

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -13,6 +13,7 @@
 #define ONNX_MLIR_ONNX_TO_MLIR_PASSES_H
 
 #include "src/Compiler/CompilerOptionEnums.hpp"
+#include "src/Pass/Passes.hpp"
 #include <string>
 
 namespace mlir {
@@ -24,36 +25,18 @@ class PassManager;
 namespace onnx_mlir {
 
 struct OnnxToMlirOptions {
-  bool enableQuarkQuantizedLegalization = false;
-  bool enableConvTransposeDecompose = false;
-  bool enableConvTransposeDecomposeToPhasedConv = false;
-  bool enableConvTranspose1dDecomposeToPhasedConv = false;
-  bool enableInstanceNormDecompose = true;
-  bool enableGroupNormDecompose = true;
-  bool enableReduceL2Decompose = true;
-  bool enableMatmulNBitsDecompose = false;
-  bool enableGroupQueryAttentionDecompose = true;
-  bool enableConcatFuse = true;
-  bool enableGroupQueryAttentionCacheSlicing = true;
+  ONNXHybridTransformPassOptions hybrid;
   bool enableRemoveDqQAroundOp = false;
   bool enableRemoveBinary = false;
   bool enableFusePadIntoAvgpool = false;
   bool enableXMCPasses = false;
-  bool enableSplitToSliceDecompose = false;
-  bool enableLstmSeqDecompose = false;
-  bool enableGatherToSlice = true;
-  bool enableRotaryEmbeddingRecompose = false;
-  bool enableQDQConstProp = false;
-  bool enableHardSwishDecompose = true;
 
   bool disableBatchNormDecompose = false;
-  bool disableRecomposeOption = false;
   bool enableUnsafeMathOptimizations = true;
   bool enableONNXHybridPass = true;
   bool enableConvOptPass = true;
   bool enableSimdDataLayout = false;
   bool disableSimdOption = false;
-  bool enableGAPToReduceMean = true;
 
   bool enableMatmulAddFusion = true;
   bool enableMatmulToConv = true;

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name ONNXTransforms
+              "-I${ONNX_MLIR_SRC_ROOT}")
+add_public_tablegen_target(OMONNXTransformsIncGen)
+add_dependencies(OMPublicPassIncGen OMONNXTransformsIncGen)
+
 add_onnx_mlir_rewriter(Decompose)
 add_onnx_mlir_rewriter(DecomposeConvTranspose)
 add_onnx_mlir_rewriter(DecomposeConvTransposePhased)
@@ -126,6 +132,7 @@ add_onnx_mlir_library(OMONNXRewrite
   DEPENDS
   OMONNXDecomposeIncGen
   OMONNXDecomposeConvTransposeIncGen
+  OMPublicPassIncGen
   OMONNXDecomposeConvTransposePhasedIncGen
   OMONNXDecomposeConvTranspose1dPhasedIncGen
   OMONNXConstPropIncGen
@@ -149,6 +156,9 @@ add_onnx_mlir_library(OMOpTransform
 
 add_onnx_mlir_library(OMHybridTransform
   ONNXHybridTransformPass.cpp
+
+  DEPENDS
+  OMPublicPassIncGen
 
   LINK_LIBS PUBLIC
   OMONNXOps

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2142,6 +2142,11 @@ Value normalizeConstantOp(
 
 } // namespace onnx_mlir
 
+namespace onnx_mlir {
+#define GEN_PASS_DEF_DECOMPOSEONNXTOONNXPASS
+#include "Passes.h.inc"
+} // namespace onnx_mlir
+
 namespace {
 /// Include the patterns defined in the Declarative Rewrite framework.
 #include "src/Dialect/ONNX/Transforms/ONNXDecompose.inc"
@@ -2215,10 +2220,14 @@ struct SoftmaxPattern : public OpRewritePattern<ONNXSoftmaxOp> {
   }
 };
 
-void populateDecomposingONNXBeforeStablehloPatterns(
+} // namespace
+
+void onnx_mlir::populateDecomposingONNXBeforeStablehloPatterns(
     RewritePatternSet &patterns, MLIRContext *ctx) {
   patterns.add<SoftmaxPattern>(ctx);
 }
+
+namespace {
 
 #endif
 
@@ -4725,156 +4734,10 @@ public:
 };
 
 struct DecomposeONNXToONNXPass
-    : public PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>> {
-  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DecomposeONNXToONNXPass)
-
-  DecomposeONNXToONNXPass(const std::string &target,
-      bool enableConvTransposeDecompose = false,
-      bool enableConvTransposeDecomposeToPhasedConv = false,
-      bool enableConvTranspose1dDecomposeToPhasedConv = false,
-      bool enableInstanceNormDecompose = true,
-      bool enableGroupNormDecompose = true,
-      bool enableMatmulNBitsDecompose = false,
-      bool enableGroupQueryAttentionDecompose = true,
-      bool enableSplitToSliceDecompose = false, bool enableConcatFuse = true,
-      bool enableLstmSeqDecompose = false, bool enableReduceL2Decompose = true,
-      bool enableGatherToSlice = true, bool enableHardSwishDecompose = true,
-      bool enableGroupQueryAttentionCacheSlicing = true) {
-    this->target = target;
-    this->enableConvTransposeDecompose = enableConvTransposeDecompose;
-    this->enableConvTransposeDecomposeToPhasedConv =
-        enableConvTransposeDecomposeToPhasedConv;
-    this->enableConvTranspose1dDecomposeToPhasedConv =
-        enableConvTranspose1dDecomposeToPhasedConv;
-    this->enableInstanceNormDecompose = enableInstanceNormDecompose;
-    this->enableGroupNormDecompose = enableGroupNormDecompose;
-    this->enableMatmulNBitsDecompose = enableMatmulNBitsDecompose;
-    this->enableGroupQueryAttentionDecompose =
-        enableGroupQueryAttentionDecompose;
-    this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
-    this->enableConcatFuse = enableConcatFuse;
-    this->enableLstmSeqDecompose = enableLstmSeqDecompose;
-    this->enableReduceL2Decompose = enableReduceL2Decompose;
-    this->enableGatherToSlice = enableGatherToSlice;
-    this->enableHardSwishDecompose = enableHardSwishDecompose;
-    this->enableGroupQueryAttentionCacheSlicing =
-        enableGroupQueryAttentionCacheSlicing;
-  }
-
-  DecomposeONNXToONNXPass(const DecomposeONNXToONNXPass &pass)
-      : mlir::PassWrapper<DecomposeONNXToONNXPass,
-            OperationPass<func::FuncOp>>() {
-    this->target = pass.target.getValue();
-    this->enableConvTransposeDecompose =
-        pass.enableConvTransposeDecompose.getValue();
-    this->enableConvTransposeDecomposeToPhasedConv =
-        pass.enableConvTransposeDecomposeToPhasedConv.getValue();
-    this->enableInstanceNormDecompose =
-        pass.enableInstanceNormDecompose.getValue();
-    this->enableGroupNormDecompose = pass.enableGroupNormDecompose.getValue();
-    this->enableMatmulNBitsDecompose =
-        pass.enableMatmulNBitsDecompose.getValue();
-    this->enableGroupQueryAttentionDecompose =
-        pass.enableGroupQueryAttentionDecompose.getValue();
-    this->enableSplitToSliceDecompose =
-        pass.enableSplitToSliceDecompose.getValue();
-    this->enableConcatFuse = pass.enableConcatFuse.getValue();
-    this->enableLstmSeqDecompose = pass.enableLstmSeqDecompose.getValue();
-    this->enableReduceL2Decompose = pass.enableReduceL2Decompose.getValue();
-    this->enableGatherToSlice = pass.enableGatherToSlice.getValue();
-    this->enableHardSwishDecompose = pass.enableHardSwishDecompose.getValue();
-    this->enableGroupQueryAttentionCacheSlicing =
-        pass.enableGroupQueryAttentionCacheSlicing.getValue();
-  }
-
-  StringRef getArgument() const override { return "decompose-onnx"; }
-
-  StringRef getDescription() const override {
-    return "Decompose ONNX operations into composition of other ONNX "
-           "operations.";
-  }
-
-  Option<std::string> target{*this, "target",
-      llvm::cl::desc("Target Dialect to decompose into"), ::llvm::cl::init("")};
-
-  Option<bool> enableConvTransposeDecompose{*this, "enable-convtranspose",
-      llvm::cl::desc("Enable decomposition of ConvTranspose"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableConvTransposeDecomposeToPhasedConv{*this,
-      "enable-convtranspose-phased",
-      llvm::cl::desc("Enable decomposition of ONNX ConvTranspose operator to 4 "
-                     "phased Conv"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableConvTranspose1dDecomposeToPhasedConv{*this,
-      "enable-convtranspose-1d-phased",
-      llvm::cl::desc(
-          "Enable decomposition of ONNX ConvTranspose 1D operator to "
-          "phased Conv"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableInstanceNormDecompose{*this,
-      "enable-instancenorm-decompose",
-      llvm::cl::desc("Enable decomposition of InstanceNormalization to "
-                     "LayerNormalization"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableGroupNormDecompose{*this, "enable-groupnorm-decompose",
-      llvm::cl::desc("Enable decomposition of GroupNormalization to "
-                     "LayerNormalization"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableMatmulNBitsDecompose{*this, "enable-matmulnbits-decompose",
-      llvm::cl::desc("Enable decomposition of Microsoft MatmulNBits to "
-                     "dequantize linear and matmul ops"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableGroupQueryAttentionDecompose{*this,
-      "enable-groupqueryattention-decompose",
-      llvm::cl::desc("Enable decomposition of Microsoft GroupQueryAttention to "
-                     "onnx.Attention and onnx.RotaryEmbedding ops"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableSplitToSliceDecompose{*this, "enable-split-to-slice",
-      llvm::cl::desc("Enable decomposition of Split to Slice operations"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableConcatFuse{*this, "enable-concat-fuse",
-      llvm::cl::desc("Enable ConcatFusePattern rewriter"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableLstmSeqDecompose{*this, "enable-lstm-seq-decomposition",
-      llvm::cl::desc("Enable sequence-length decomposition of LSTM (unroll a "
-                     "seq_len>1 LSTM into a chain of seq_len=1 LSTMs)"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableReduceL2Decompose{*this, "enable-reducel2-decompose",
-      llvm::cl::desc("Enable decomposition of ReduceL2 to "
-                     "Sqrt(ReduceSumSquare(x))"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableGatherToSlice{*this, "enable-gather-to-slice",
-      llvm::cl::desc(
-          "Enable decomposition of Gather with scalar index to Slice+Reshape"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableHardSwishDecompose{*this, "enable-hardswish-decompose",
-      llvm::cl::desc("Enable decomposition of HardSwish into "
-                     "x * HardSigmoid(x) (alpha=1/6, beta=0.5)"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableGroupQueryAttentionCacheSlicing{*this,
-      "enable-groupqueryattention-cache-slicing",
-      llvm::cl::desc("Enable slicing of cos/sin caches during decomposing "
-                     "GroupQueryAttention. Set to false for keeping cache "
-                     "and synthesize position_ids instead."),
-      ::llvm::cl::init(true)};
-
+    : public onnx_mlir::impl::DecomposeONNXToONNXPassBase<
+          DecomposeONNXToONNXPass> {
+  using Base::Base;
   void runOnOperation() final;
-
-  typedef PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>>
-      BaseType;
 };
 
 void DecomposeONNXToONNXPass::runOnOperation() {
@@ -4889,7 +4752,6 @@ void DecomposeONNXToONNXPass::runOnOperation() {
       enableConcatFuse, enableLstmSeqDecompose, enableReduceL2Decompose,
       /*disableGenericDecompositions=*/false, enableGatherToSlice,
       enableHardSwishDecompose, enableGroupQueryAttentionCacheSlicing);
-  patterns.insert<ReplaceCastLikeByCastPattern>(context);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
   if (this->target == "stablehlo") {
@@ -4984,28 +4846,11 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
   if (enableGatherToSlice)
     patterns.insert<DecomposeGatherToSlicePattern>(context);
 
+  patterns.insert<ReplaceCastLikeByCastPattern>(context);
+
   // TODO: consider whether to include SoftmaxPattern here
 }
 
-/*!
- * Create a DecomposeONNX pass.
- */
-std::unique_ptr<mlir::Pass> onnx_mlir::createDecomposeONNXToONNXPass(
-    const std::string &target, bool enableConvTransposeDecompose,
-    bool enableConvTransposeDecomposeToPhasedConv,
-    bool enableConvTranspose1dDecomposeToPhasedConv,
-    bool enableInstanceNormDecompose, bool enableGroupNormDecompose,
-    bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
-    bool enableSplitToSliceDecompose, bool enableConcatFuse,
-    bool enableLstmSeqDecompose, bool enableReduceL2Decompose,
-    bool enableGatherToSlice, bool enableHardSwishDecompose,
-    bool enableGroupQueryAttentionCacheSlicing) {
-  return std::make_unique<DecomposeONNXToONNXPass>(target,
-      enableConvTransposeDecompose, enableConvTransposeDecomposeToPhasedConv,
-      enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
-      enableGroupNormDecompose, enableMatmulNBitsDecompose,
-      enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
-      enableConcatFuse, enableLstmSeqDecompose, enableReduceL2Decompose,
-      enableGatherToSlice, enableHardSwishDecompose,
-      enableGroupQueryAttentionCacheSlicing);
-}
+// createDecomposeONNXToONNXPass() and createDecomposeONNXToONNXPass(options)
+// are auto-generated by GEN_PASS_DEF_DECOMPOSEONNXTOONNXPASS above; no
+// manual definition is needed here.

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -41,5 +41,10 @@ void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableHardSwishDecompose = true,
     bool enableGroupQueryAttentionCacheSlicing = true);
 
+#ifdef ONNX_MLIR_ENABLE_STABLEHLO
+void populateDecomposingONNXBeforeStablehloPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *ctx);
+#endif
+
 } // namespace onnx_mlir
 #endif

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -38,6 +38,11 @@
 using namespace mlir;
 using namespace onnx_mlir;
 
+namespace onnx_mlir {
+#define GEN_PASS_DEF_ONNXHYBRIDTRANSFORMPASS
+#include "Passes.h.inc"
+} // namespace onnx_mlir
+
 namespace {
 
 // The pass combines patterns for shape inference and other ONNX-to-ONNX
@@ -61,180 +66,52 @@ namespace {
 // were calibrated to the model https://huggingface.co/xlnet-large-cased
 // which has 1882 func ops and needs config.maxNumRewrites > 232 to converge.
 struct ONNXHybridTransformPass
-    : public PassWrapper<ONNXHybridTransformPass, OperationPass<func::FuncOp>> {
-  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ONNXHybridTransformPass)
-
-  Option<bool> shapeInference{*this, "shape-inference",
-      llvm::cl::desc("Enable shape inference in hybrid transform"),
-      llvm::cl::init(true)};
-
-  Option<bool> canonicalization{*this, "canonicalization",
-      llvm::cl::desc("Enable canonicalization in hybrid transform"),
-      llvm::cl::init(true)};
-
-  Option<bool> constantPropagation{*this, "constant-propagation",
-      llvm::cl::desc("Enable constant propagation in hybrid transform"),
-      llvm::cl::init(true)};
-
-  Option<bool> qdqConstProp{*this, "qdq-const-prop",
-      llvm::cl::desc("Enable constant propagation for QDQ"),
-      llvm::cl::init(false)};
-
-  Option<bool> decomposition{*this, "decomposition",
-      llvm::cl::desc("Enable decomposition in hybrid transform"),
-      llvm::cl::init(true)};
-
-  Option<bool> recomposition{*this, "recomposition",
-      llvm::cl::desc("Enable recomposition in hybrid transform"),
-      llvm::cl::init(true)};
-
-  Option<bool> quarkQuantizedOpsLegalization{*this,
-      "quark-quantized-ops-legalization",
-      llvm::cl::desc(
-          "Enable legalization quark-quantized operations from F32 -> BF16"),
-      llvm::cl::init(false)};
-
-  Option<int> maxNumRewritesOffset{*this, "max-num-rewrites-offset",
-      llvm::cl::desc("Rewrites limit: -1 means no limit, otherwise "
-                     "added to func #ops * max-num-rewrites-multiplier"),
-      llvm::cl::init(20)};
-
-  Option<float> maxNumRewritesMultiplier{*this, "max-num-rewrites-multiplier",
-      llvm::cl::desc("Rewrites limit factor"), llvm::cl::init(0.2)};
-
-  Option<bool> enableConvTransposeDecompose{*this, "enable-convtranspose",
-      llvm::cl::desc("Enable decomposition of ConvTranspose"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableConvTransposeDecomposeToPhasedConv{*this,
-      "enable-convtranspose-phased",
-      llvm::cl::desc("Enable decomposition of ONNX ConvTranspose operator to 4 "
-                     "phased Conv"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableConvTranspose1dDecomposeToPhasedConv{*this,
-      "enable-convtranspose-1d-phased",
-      llvm::cl::desc(
-          "Enable decomposition of ONNX ConvTranspose 1D operator to "
-          "phased Conv"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableReduceL2Decompose{*this, "enable-reducel2-decompose",
-      llvm::cl::desc("Enable decomposition of ReduceL2 to "
-                     "Sqrt(ReduceSumSquare(x))"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableInstanceNormDecompose{*this,
-      "enable-instancenorm-decompose",
-      llvm::cl::desc("Enable decomposition of InstanceNormalization to "
-                     "LayerNormalization"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableGroupNormDecompose{*this, "enable-groupnorm-decompose",
-      llvm::cl::desc("Enable decomposition of GroupNormalization to "
-                     "LayerNormalization"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableMatmulNBitsDecompose{*this, "enable-matmulnbits-decompose",
-      llvm::cl::desc("Enable decomposition of Microsoft MatmulNBits to "
-                     "dequantize linear and matmul ops"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableGroupQueryAttentionDecompose{*this,
-      "enable-groupqueryattention-decompose",
-      llvm::cl::desc("Enable decomposition of Microsoft GroupQueryAttention to "
-                     "onnx.Attention and onnx.RotaryEmbedding ops"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableSplitToSliceDecompose{*this,
-      "enable-split-to-slice-decompose",
-      llvm::cl::desc("Enable decomposition of Split to Slice"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableConcatFuse{*this, "enable-concat-fuse",
-      llvm::cl::desc("Enable ConcatFusePattern in decomposition pass"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableGAPToReduceMean{*this,
-      "enable-globalaveragepool-to-reducemean",
-      llvm::cl::desc(
-          "Enable canonicalize from GlobalAveragePool to ReduceMean"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableLstmSeqDecompose{*this, "enable-lstm-seq-decomposition",
-      llvm::cl::desc("Enable sequence-length decomposition of LSTM (unroll a "
-                     "seq_len>1 LSTM into a chain of seq_len=1 LSTMs)"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableGatherToSlice{*this, "enable-gather-to-slice",
-      llvm::cl::desc(
-          "Enable decomposition of Gather with scalar index to Slice+Reshape"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableRotaryEmbeddingRecompose{*this,
-      "enable-rotary-embedding-recompose",
-      llvm::cl::desc("Recompose LlamaRotaryEmbedding style RoPE "
-                     "into onnx.RotaryEmbedding"),
-      ::llvm::cl::init(false)};
-
-  Option<bool> enableHardSwishDecompose{*this, "enable-hardswish-decompose",
-      llvm::cl::desc("Enable decomposition of HardSwish into "
-                     "x * HardSigmoid(x) (alpha=1/6, beta=0.5)"),
-      ::llvm::cl::init(true)};
-
-  Option<bool> enableGroupQueryAttentionCacheSlicing{*this,
-      "enable-groupqueryattention-cache-slicing",
-      llvm::cl::desc("Enable slicing of cos/sin caches during decomposing "
-                     "GroupQueryAttention. Set to false for keeping cache "
-                     "and synthesize position_ids instead."),
-      ::llvm::cl::init(true)};
-
+    : public onnx_mlir::impl::ONNXHybridTransformPassBase<
+          ONNXHybridTransformPass> {
+  using Base::Base;
   FrozenRewritePatternSet patterns;
 
-  ONNXHybridTransformPass(bool enableRecomposition,
-      bool enableQuarkQuantizedOpsLegalization,
-      bool enableConvTransposeDecompose,
-      bool enableConvTransposeDecomposeToPhasedConv,
-      bool enableConvTranspose1dDecomposeToPhasedConv,
-      bool enableInstanceNormDecompose, bool enableGroupNormDecompose,
-      bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
-      bool enableSplitToSliceDecompose, bool enableConcatFuse,
-      bool enableGAPToReduceMean, bool enableLstmSeqDecompose = false,
-      bool enableGatherToSlice = true, bool enableReduceL2Decompose = true,
-      bool enableRotaryEmbeddingRecompose = false,
-      bool enableQDQConstProp = false, bool enableHardSwishDecompose = true,
-      bool enableGroupQueryAttentionCacheSlicing = true) {
-    this->recomposition = enableRecomposition;
-    this->quarkQuantizedOpsLegalization = enableQuarkQuantizedOpsLegalization;
-    this->enableConvTransposeDecompose = enableConvTransposeDecompose;
-    this->enableConvTransposeDecomposeToPhasedConv =
-        enableConvTransposeDecomposeToPhasedConv;
-    this->enableConvTranspose1dDecomposeToPhasedConv =
-        enableConvTranspose1dDecomposeToPhasedConv;
-    this->enableInstanceNormDecompose = enableInstanceNormDecompose;
-    this->enableGroupNormDecompose = enableGroupNormDecompose;
-    this->enableMatmulNBitsDecompose = enableMatmulNBitsDecompose;
-    this->enableGroupQueryAttentionDecompose =
-        enableGroupQueryAttentionDecompose;
-    this->enableSplitToSliceDecompose = enableSplitToSliceDecompose;
-    this->enableConcatFuse = enableConcatFuse;
-    this->enableGAPToReduceMean = enableGAPToReduceMean;
-    this->enableLstmSeqDecompose = enableLstmSeqDecompose;
-    this->enableReduceL2Decompose = enableReduceL2Decompose;
-    this->enableGatherToSlice = enableGatherToSlice;
-    this->enableRotaryEmbeddingRecompose = enableRotaryEmbeddingRecompose;
-    this->qdqConstProp = enableQDQConstProp;
-    this->enableHardSwishDecompose = enableHardSwishDecompose;
-    this->enableGroupQueryAttentionCacheSlicing =
-        enableGroupQueryAttentionCacheSlicing;
-  }
-
   ONNXHybridTransformPass(const ONNXHybridTransformPass &pass)
-      : patterns(pass.patterns) {
+      : Base(pass), patterns(pass.patterns) {
     copyOptionValuesFrom(&pass);
   }
 
-  StringRef getArgument() const override { return "onnx-hybrid-transform"; }
+  // TODO: Remove once MLIR exposes a direct way to read a pass's option struct
+  // back from its Pass::Option<T> members.
+  [[nodiscard]] onnx_mlir::ONNXHybridTransformPassOptions getOptions() const {
+    onnx_mlir::ONNXHybridTransformPassOptions options;
+    options.shapeInference = shapeInference;
+    options.canonicalization = canonicalization;
+    options.constantPropagation = constantPropagation;
+    options.qdqConstProp = qdqConstProp;
+    options.decomposition = decomposition;
+    options.recomposition = recomposition;
+    options.quarkQuantizedOpsLegalization = quarkQuantizedOpsLegalization;
+    options.maxNumRewritesOffset = maxNumRewritesOffset;
+    options.maxNumRewritesMultiplier = maxNumRewritesMultiplier;
+    options.enableGAPToReduceMean = enableGAPToReduceMean;
+    options.enableRotaryEmbeddingRecompose = enableRotaryEmbeddingRecompose;
+    options.target = target;
+    options.enableConvTransposeDecompose = enableConvTransposeDecompose;
+    options.enableConvTransposeDecomposeToPhasedConv =
+        enableConvTransposeDecomposeToPhasedConv;
+    options.enableConvTranspose1dDecomposeToPhasedConv =
+        enableConvTranspose1dDecomposeToPhasedConv;
+    options.enableInstanceNormDecompose = enableInstanceNormDecompose;
+    options.enableGroupNormDecompose = enableGroupNormDecompose;
+    options.enableMatmulNBitsDecompose = enableMatmulNBitsDecompose;
+    options.enableGroupQueryAttentionDecompose =
+        enableGroupQueryAttentionDecompose;
+    options.enableSplitToSliceDecompose = enableSplitToSliceDecompose;
+    options.enableConcatFuse = enableConcatFuse;
+    options.enableLstmSeqDecompose = enableLstmSeqDecompose;
+    options.enableReduceL2Decompose = enableReduceL2Decompose;
+    options.enableGatherToSlice = enableGatherToSlice;
+    options.enableHardSwishDecompose = enableHardSwishDecompose;
+    options.enableGroupQueryAttentionCacheSlicing =
+        enableGroupQueryAttentionCacheSlicing;
+    return options;
+  }
 
   LogicalResult initialize(MLIRContext *context) override {
     RewritePatternSet cumulativePatterns(context);
@@ -287,6 +164,13 @@ struct ONNXHybridTransformPass
           enableReduceL2Decompose,
           /*disableGenericDecompositions=*/false, enableGatherToSlice,
           enableHardSwishDecompose, enableGroupQueryAttentionCacheSlicing);
+
+#ifdef ONNX_MLIR_ENABLE_STABLEHLO
+      if (target == "stablehlo") {
+        populateDecomposingONNXBeforeStablehloPatterns(
+            cumulativePatterns, context);
+      }
+#endif
     }
 
     if (recomposition) {
@@ -326,32 +210,29 @@ struct ONNXHybridTransformPass
                    << maxNumRewritesMultiplier.getValue() << "\n\n";
     }
 
-    inferFunctionReturnShapes(f);
+    if (shapeInference)
+      inferFunctionReturnShapes(f);
   }
 }; // namespace
 
 } // namespace
 
-std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
-    bool enableRecomposition, bool enableQuarkQuantizedOpsLegalization,
-    bool enableConvTransposeDecompose,
-    bool enableConvTransposeDecomposeToPhasedConv,
-    bool enableConvTranspose1dDecomposeToPhasedConv,
-    bool enableInstanceNormDecompose, bool enableGroupNormDecompose,
-    bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
-    bool enableSplitToSliceDecompose, bool enableConcatFuse,
-    bool enableGAPToReduceMean, bool enableLstmSeqDecompose,
-    bool enableGatherToSlice, bool enableReduceL2Decompose,
-    bool enableRotaryEmbeddingRecompose, bool enableQDQConstProp,
-    bool enableHardSwishDecompose, bool enableGroupQueryAttentionCacheSlicing) {
-  return std::make_unique<ONNXHybridTransformPass>(enableRecomposition,
-      enableQuarkQuantizedOpsLegalization, enableConvTransposeDecompose,
-      enableConvTransposeDecomposeToPhasedConv,
-      enableConvTranspose1dDecomposeToPhasedConv, enableInstanceNormDecompose,
-      enableGroupNormDecompose, enableMatmulNBitsDecompose,
-      enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
-      enableConcatFuse, enableGAPToReduceMean, enableLstmSeqDecompose,
-      enableGatherToSlice, enableReduceL2Decompose,
-      enableRotaryEmbeddingRecompose, enableQDQConstProp,
-      enableHardSwishDecompose, enableGroupQueryAttentionCacheSlicing);
+std::optional<onnx_mlir::ONNXHybridTransformPassOptions>
+onnx_mlir::parseONNXHybridTransformPassOptions(const std::string &options) {
+  ONNXHybridTransformPass pass;
+  if (options.empty())
+    return pass.getOptions();
+
+  std::string error;
+  llvm::raw_string_ostream errorStream(error);
+  auto errorHandler = [&](const Twine &message) {
+    errorStream << message;
+    return failure();
+  };
+  if (failed(pass.initializeOptions(options, errorHandler))) {
+    llvm::errs() << "invalid --onnx-transform-options: " << errorStream.str();
+    return std::nullopt;
+  }
+
+  return pass.getOptions();
 }

--- a/src/Dialect/ONNX/Transforms/Passes.td
+++ b/src/Dialect/ONNX/Transforms/Passes.td
@@ -13,6 +13,10 @@ include "mlir/Pass/PassBase.td"
 
 def ONNXDecomposePatternOptions {
   list<Option> options = [
+    Option<"target", "target", "std::string", /*default=*/"\"\"",
+           "Target dialect to decompose into (e.g. stablehlo); "
+           "empty string means the default ONNX-to-ONNX decomposition.">,
+
     Option<"enableConvTransposeDecompose", "enable-convtranspose",
            "bool", /*default=*/"false",
            "Enable decomposition of ConvTranspose.">,
@@ -86,14 +90,6 @@ def ONNXDecomposePatternOptions {
   ];
 }
 
-def ONNXDecomposePassOptions {
-  list<Option> options = [
-    Option<"target", "target", "std::string", /*default=*/"\"\"",
-           "Target dialect to decompose into (e.g. stablehlo); "
-           "empty string means the default ONNX-to-ONNX decomposition.">
-  ] # ONNXDecomposePatternOptions.options;
-}
-
 def ONNXHybridTransformOptions {
   list<Option> options = [
     Option<"shapeInference", "shape-inference",
@@ -149,7 +145,7 @@ def DecomposeONNXToONNXPass : Pass<"decompose-onnx", "::mlir::func::FuncOp"> {
     createDecomposeONNXToONNXPass().
   }];
 
-  let options = ONNXDecomposePassOptions.options;
+  let options = ONNXDecomposePatternOptions.options;
 }
 
 def ONNXHybridTransformPass
@@ -162,5 +158,5 @@ def ONNXHybridTransformPass
   }];
 
   let options =
-      ONNXHybridTransformOptions.options # ONNXDecomposePassOptions.options;
+      ONNXHybridTransformOptions.options # ONNXDecomposePatternOptions.options;
 }

--- a/src/Dialect/ONNX/Transforms/Passes.td
+++ b/src/Dialect/ONNX/Transforms/Passes.td
@@ -1,0 +1,166 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===- Passes.td - ONNX Transform Passes -------------------*- tablegen -*-===//
+//
+// Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
+//===----------------------------------------------------------------------===//
+
+include "mlir/Pass/PassBase.td"
+
+def ONNXDecomposePatternOptions {
+  list<Option> options = [
+    Option<"enableConvTransposeDecompose", "enable-convtranspose",
+           "bool", /*default=*/"false",
+           "Enable decomposition of ConvTranspose.">,
+
+    Option<"enableConvTransposeDecomposeToPhasedConv",
+           "enable-convtranspose-phased",
+           "bool", /*default=*/"false",
+           "Enable decomposition of ONNX ConvTranspose operator to "
+           "4 phased Conv.">,
+
+    Option<"enableConvTranspose1dDecomposeToPhasedConv",
+           "enable-convtranspose-1d-phased",
+           "bool", /*default=*/"false",
+           "Enable decomposition of ONNX ConvTranspose 1D operator to "
+           "phased Conv.">,
+
+    Option<"enableInstanceNormDecompose", "enable-instancenorm-decompose",
+           "bool", /*default=*/"true",
+           "Enable decomposition of InstanceNormalization to "
+           "LayerNormalization.">,
+
+    Option<"enableGroupNormDecompose", "enable-groupnorm-decompose",
+           "bool", /*default=*/"true",
+           "Enable decomposition of GroupNormalization to "
+           "LayerNormalization.">,
+
+    Option<"enableMatmulNBitsDecompose", "enable-matmulnbits-decompose",
+           "bool", /*default=*/"false",
+           "Enable decomposition of Microsoft MatmulNBits to "
+           "DequantizeLinear and Matmul ops.">,
+
+    Option<"enableGroupQueryAttentionDecompose",
+           "enable-groupqueryattention-decompose",
+           "bool", /*default=*/"true",
+           "Enable decomposition of Microsoft GroupQueryAttention to "
+           "onnx.Attention and onnx.RotaryEmbedding ops.">,
+
+    Option<"enableSplitToSliceDecompose", "enable-split-to-slice",
+           "bool", /*default=*/"false",
+           "Enable decomposition of Split to Slice operations.">,
+
+    Option<"enableConcatFuse", "enable-concat-fuse",
+           "bool", /*default=*/"true",
+           "Enable ConcatFusePattern rewriter.">,
+
+    Option<"enableLstmSeqDecompose", "enable-lstm-seq-decomposition",
+           "bool", /*default=*/"false",
+           "Enable sequence-length decomposition of LSTM (unroll a "
+           "seq_len>1 LSTM into a chain of seq_len=1 LSTMs).">,
+
+    Option<"enableReduceL2Decompose", "enable-reducel2-decompose",
+           "bool", /*default=*/"true",
+           "Enable decomposition of ReduceL2 to Sqrt(ReduceSumSquare(x)).">,
+
+    Option<"enableGatherToSlice", "enable-gather-to-slice",
+           "bool", /*default=*/"true",
+           "Enable decomposition of Gather with scalar index to "
+           "Slice+Reshape.">,
+
+    Option<"enableHardSwishDecompose", "enable-hardswish-decompose",
+           "bool", /*default=*/"true",
+           "Enable decomposition of HardSwish into "
+           "x * HardSigmoid(x) (alpha=1/6, beta=0.5).">,
+
+    Option<"enableGroupQueryAttentionCacheSlicing",
+           "enable-groupqueryattention-cache-slicing",
+           "bool", /*default=*/"true",
+           "Enable slicing of cos/sin caches during GroupQueryAttention "
+           "decomposition. Set to false to keep the cache and synthesize "
+           "position_ids instead.">
+  ];
+}
+
+def ONNXDecomposePassOptions {
+  list<Option> options = [
+    Option<"target", "target", "std::string", /*default=*/"\"\"",
+           "Target dialect to decompose into (e.g. stablehlo); "
+           "empty string means the default ONNX-to-ONNX decomposition.">
+  ] # ONNXDecomposePatternOptions.options;
+}
+
+def ONNXHybridTransformOptions {
+  list<Option> options = [
+    Option<"shapeInference", "shape-inference",
+           "bool", /*default=*/"true",
+           "Enable shape inference in hybrid transform.">,
+    Option<"canonicalization", "canonicalization",
+           "bool", /*default=*/"true",
+           "Enable canonicalization in hybrid transform.">,
+    Option<"constantPropagation", "constant-propagation",
+           "bool", /*default=*/"true",
+           "Enable constant propagation in hybrid transform.">,
+    Option<"qdqConstProp", "qdq-const-prop",
+           "bool", /*default=*/"false",
+           "Enable constant propagation for QDQ.">,
+    Option<"decomposition", "decomposition",
+           "bool", /*default=*/"true",
+           "Enable decomposition in hybrid transform.">,
+    Option<"recomposition", "recomposition",
+           "bool", /*default=*/"true",
+           "Enable recomposition in hybrid transform.">,
+    Option<"quarkQuantizedOpsLegalization",
+           "quark-quantized-ops-legalization",
+           "bool", /*default=*/"false",
+           "Enable legalization of quark-quantized operations from F32 to BF16.">,
+    Option<"maxNumRewritesOffset", "max-num-rewrites-offset",
+           "int", /*default=*/"20",
+           "Rewrites limit: -1 means no limit, otherwise added to "
+           "func #ops * max-num-rewrites-multiplier.">,
+    Option<"maxNumRewritesMultiplier", "max-num-rewrites-multiplier",
+           "float", /*default=*/"0.2",
+           "Rewrites limit factor.">,
+    Option<"enableGAPToReduceMean", "enable-globalaveragepool-to-reducemean",
+           "bool", /*default=*/"true",
+           "Enable canonicalize from GlobalAveragePool to ReduceMean.">,
+    Option<"enableRotaryEmbeddingRecompose",
+           "enable-rotary-embedding-recompose",
+           "bool", /*default=*/"false",
+           "Recompose LlamaRotaryEmbedding style RoPE into "
+           "onnx.RotaryEmbedding.">
+  ];
+}
+
+def DecomposeONNXToONNXPass : Pass<"decompose-onnx", "::mlir::func::FuncOp"> {
+  let summary = "Decompose ONNX operations into composition of other ONNX "
+                "operations.";
+  let description = [{
+    This pass rewrites ONNX operations into equivalent compositions of simpler
+    ONNX operations.  It is applied before shape inference so there is no
+    expectation of ranked tensor types at this point.
+
+    Individual decompositions can be enabled or disabled via the options below.
+    The pass-level defaults match the programmatic defaults used by
+    createDecomposeONNXToONNXPass().
+  }];
+
+  let options = ONNXDecomposePassOptions.options;
+}
+
+def ONNXHybridTransformPass
+    : Pass<"onnx-hybrid-transform", "::mlir::func::FuncOp"> {
+  let summary = "Run shape inference, canonicalization, constant propagation, "
+                "decomposition, and recomposition together.";
+  let description = [{
+    This pass applies ONNX-to-ONNX transforms with one greedy rewrite driver.
+    Decomposition-related options are shared with the decompose-onnx pass.
+  }];
+
+  let options =
+      ONNXHybridTransformOptions.options # ONNXDecomposePassOptions.options;
+}

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -19,6 +19,7 @@
 #define ONNX_MLIR_PASSES_H
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "llvm/ADT/ArrayRef.h"
@@ -30,6 +31,13 @@ class Pass;
 
 namespace onnx_mlir {
 
+#define GEN_PASS_DECL
+#include "src/Dialect/ONNX/Transforms/Passes.h.inc"
+#undef GEN_PASS_DECL
+
+[[nodiscard]] std::optional<ONNXHybridTransformPassOptions>
+parseONNXHybridTransformPassOptions(const std::string &options);
+
 /// Pass for removing DisposableElementsAttr attributes.
 std::unique_ptr<mlir::Pass> createScrubDisposablePass(bool closeAfter = true);
 
@@ -39,19 +47,6 @@ std::unique_ptr<mlir::Pass> createONNXOpTransformPass(int threshold,
     bool report, bool targetCPU, bool enableSimdDataLayoutOpt,
     bool enableConvOptPass, bool enableRecomposeOptPass);
 
-/// Pass for rewriting inside frontend dialect.
-std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(
-    const std::string &target = "", bool enableConvTransposeDecompose = false,
-    bool enableConvTransposeDecomposeToPhasedConv = false,
-    bool enableConvTranspose1dDecomposeToPhasedConv = false,
-    bool enableInstanceNormDecompose = true,
-    bool enableGroupNormDecompose = true,
-    bool enableMatmulNBitsDecompose = false,
-    bool enableGroupQueryAttentionDecompose = true,
-    bool enableSplitToSliceDecompose = false, bool enableConcatFuse = false,
-    bool enableLstmSeqDecompose = false, bool enableReduceL2Decompose = true,
-    bool enableGatherToSlice = true, bool enableHardSwishDecompose = true,
-    bool enableGroupQueryAttentionCacheSlicing = true);
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "", bool enableRotaryEmbeddingRecompose = false,
     bool enableReduceL2Recompositions = false);
@@ -115,24 +110,6 @@ std::unique_ptr<mlir::Pass> createSimplifyShapeRelatedOpsPass(
 
 /// Pass for replacing ONNXReturnOp with func::ReturnOp.
 std::unique_ptr<mlir::Pass> createStandardFuncReturnPass();
-
-/// Pass that combines multiple ONNX dialect transformations,
-/// including shape inference.
-std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
-    bool enableRecomposition, bool enableQuarkQuantizedOpsLegalization = false,
-    bool enableConvTransposeDecompose = false,
-    bool enableConvTransposeDecomposeToPhasedConv = false,
-    bool enableConvTranspose1dDecomposeToPhasedConv = false,
-    bool enableInstanceNormDecompose = true,
-    bool enableGroupNormDecompose = true,
-    bool enableMatmulNBitsDecompose = false,
-    bool enableGroupQueryAttentionDecompose = true,
-    bool enableSplitToSliceDecompose = false, bool enableConcatFuse = true,
-    bool enablGAPToReduceMean = true, bool enableLstmSeqDecompose = false,
-    bool enableGatherToSlice = true, bool enableReduceL2Decompose = true,
-    bool enableRotaryEmbeddingRecompose = false,
-    bool enableQDQConstProp = false, bool enableHardSwishDecompose = true,
-    bool enableGroupQueryAttentionCacheSlicing = true);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -306,7 +306,7 @@ void registerOMPasses(int optLevel) {
   });
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
-    return createONNXHybridTransformPass(/*recompose ops*/ true);
+    return createONNXHybridTransformPass();
   });
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {

--- a/test/mlir/onnx/onnx_hybrid_transform_with_quark_legalize_ops.mlir
+++ b/test/mlir/onnx/onnx_hybrid_transform_with_quark_legalize_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt -onnx-hybrid-transform="canonicalization=true constant-propagation=true decomposition=true enable-convtranspose=false enable-convtranspose-1d-phased=false enable-convtranspose-phased=true enable-instancenorm-decompose=true enable-split-to-slice-decompose=false max-num-rewrites-multiplier=2.000000e-01 max-num-rewrites-offset=20 quark-quantized-ops-legalization=true recomposition=true shape-inference=true" %s | FileCheck %s
+// RUN: onnx-mlir-opt -onnx-hybrid-transform="canonicalization=true constant-propagation=true decomposition=true enable-convtranspose=false enable-convtranspose-1d-phased=false enable-convtranspose-phased=true enable-instancenorm-decompose=true enable-split-to-slice=false max-num-rewrites-multiplier=2.000000e-01 max-num-rewrites-offset=20 quark-quantized-ops-legalization=true recomposition=true shape-inference=true" %s | FileCheck %s
 
 // Illustrates the interaction between 
 


### PR DESCRIPTION
This removes some of the duplication of options between these passes.

Also make the hybrid pass in decomopse-only mode and the decompose pass run the same patterns.

This changes the interface of onnx-mlir slightly, onnx-mlir-opt stays the same.

I plan to port the other passes in a follow up.

This will require small downstream changes