### PR TITLE
Fix Windows C1083 by using full path for Passes.h.inc include

### DIFF
--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -131,6 +131,7 @@ add_onnx_mlir_library(OMONNXRewrite
   xmc/TransferSoftmaxAxisToLastPass.cpp
 
   DEPENDS
+  OMONNXTransformsIncGen
   OMONNXDecomposeIncGen
   OMONNXDecomposeConvTransposeIncGen
   OMPublicPassIncGen
@@ -159,6 +160,7 @@ add_onnx_mlir_library(OMHybridTransform
   ONNXHybridTransformPass.cpp
 
   DEPENDS
+  OMONNXTransformsIncGen
   OMPublicPassIncGen
 
   LINK_LIBS PUBLIC

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2144,7 +2144,7 @@ Value normalizeConstantOp(
 
 namespace onnx_mlir {
 #define GEN_PASS_DEF_DECOMPOSEONNXTOONNXPASS
-#include "Passes.h.inc"
+#include "src/Dialect/ONNX/Transforms/Passes.h.inc"
 } // namespace onnx_mlir
 
 namespace {

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -40,7 +40,7 @@ using namespace onnx_mlir;
 
 namespace onnx_mlir {
 #define GEN_PASS_DEF_ONNXHYBRIDTRANSFORMPASS
-#include "Passes.h.inc"
+#include "src/Dialect/ONNX/Transforms/Passes.h.inc"
 } // namespace onnx_mlir
 
 namespace {


### PR DESCRIPTION
The tablegen-generated Passes.h.inc only exists in the build tree and is included elsewhere via its project-root-relative path (e.g. in src/Pass/Passes.hpp), which resolves through -I<build_dir>.

Decompose.cpp and ONNXHybridTransformPass.cpp used a bare `#include "Passes.h.inc"` in their GEN_PASS_DEF sections. A bare include is searched relative to the including source file's directory first and only resolves if the per-directory build path is on the include search list. On Windows that build subdir is not on the include path, so the include fails deterministically:

  Decompose.cpp(2147,1): error C1083: Cannot open include file: 'Passes.h.inc'

Use the full project-root-relative path to match the rest of the codebase and declare a direct dependency on OMONNXTransformsIncGen for the libraries that include the generated header.