### PR TITLE
Add canonicalization patterns to Sink DQ and Hoist Q trough dataformat ops.

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -47,6 +47,7 @@ std::string opsForCall;                                // common for both
 bool disableKrnlOpFusion;                              // common for both
 bool disableQuantZeroPoint;                            // common for both
 bool enableUnsafeMathOptimizations;                    // common for both
+bool enableQDQDataMovementCanonicalization;            // common for both
 bool enableKrnlBufferReuse;                            // common for both
 std::string onnxTransformOptions;                      // onnx-mlir only
 bool enableQuarkQuantizerLegalization;                 // common for both
@@ -265,6 +266,15 @@ static llvm::cl::opt<bool, true> enableUnsafeMathOptimizationsOpt(
         "(default=true)."),
     llvm::cl::location(enableUnsafeMathOptimizations), llvm::cl::init(true),
     llvm::cl::cat(OnnxMlirCommonOptions));
+
+static llvm::cl::opt<bool, true> enableQDQDataMovementCanonicalizationOpt(
+    "enable-qdq-data-movement-canonicalization",
+    llvm::cl::desc(
+        "Enable canonicalization patterns that move "
+        "DequantizeLinear/QuantizeLinear through data-movement and view ops "
+        "(default=false)."),
+    llvm::cl::location(enableQDQDataMovementCanonicalization),
+    llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
 
 static llvm::cl::opt<bool, true> enableKrnlBufferReuseOpt(
     "enable-krnl-buffer-reuse",

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -82,6 +82,7 @@ extern std::string opsForCall;                                // common for both
 extern bool disableKrnlOpFusion;                              // common for both
 extern bool disableQuantZeroPoint;                            // common for both
 extern bool enableUnsafeMathOptimizations;                    // common for both
+extern bool enableQDQDataMovementCanonicalization;            // common for both
 extern bool enableKrnlBufferReuse;                            // common for both
 extern bool enableSafeCodeGen;                                // common for both
 extern bool disableMemRefPrefetch;                            // common for both

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -68,6 +68,8 @@ void configurePasses() {
       onnxConstPropExpansionBound, onnxConstPropDisablePatterns,
       disableConstantProp);
   configureUnsafeMathCanonicalization(enableUnsafeMathOptimizations);
+  configureQDQDataMovementCanonicalization(
+      enableQDQDataMovementCanonicalization);
 #ifdef ONNX_MLIR_ENABLE_KRNL
   configureOnnxToKrnlLoweringPass(optReport == OptReport::Parallel,
       enableParallel, parallelizeOps, optReport == OptReport::Simd,
@@ -244,6 +246,8 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
     opts.hybrid.recomposition &= !disableRecomposeOption;
     opts.disableBatchNormDecompose = disableBatchNormDecompose;
     opts.enableUnsafeMathOptimizations = enableUnsafeMathOptimizations;
+    opts.enableQDQDataMovementCanonicalization =
+        enableQDQDataMovementCanonicalization;
     opts.enableONNXHybridPass = enableONNXHybridPass;
     opts.enableConvOptPass = enableConvOptPass;
     opts.enableSimdDataLayout = enableSimdDataLayout;

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -49,6 +49,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   // this function.
   configureBatchNormCanonicalization(opts.disableBatchNormDecompose);
   configureUnsafeMathCanonicalization(opts.enableUnsafeMathOptimizations);
+  configureQDQDataMovementCanonicalization(
+      opts.enableQDQDataMovementCanonicalization);
 
   if (!donotScrubDisposableElementsAttr)
     pm.addInstrumentation(

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -33,6 +33,7 @@ struct OnnxToMlirOptions {
 
   bool disableBatchNormDecompose = false;
   bool enableUnsafeMathOptimizations = true;
+  bool enableQDQDataMovementCanonicalization = false;
   bool enableONNXHybridPass = true;
   bool enableConvOptPass = true;
   bool enableSimdDataLayout = false;

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -35,6 +35,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
 #include "src/Dialect/Mlir/DialectBuilder.hpp"
@@ -3676,34 +3677,15 @@ bool haveSamePerTensorQuantizationParams(
              getElementType(rhs.getY().getType());
 }
 
-void getDataInputs(ONNXConcatOp concatOp, SmallVectorImpl<Value> &dataInputs) {
-  llvm::copy(concatOp.getInputs(), std::back_inserter(dataInputs));
-}
-
-void getDataInputs(ONNXExpandOp expandOp, SmallVectorImpl<Value> &dataInputs) {
-  dataInputs.push_back(expandOp.getInput());
-}
-
-void getDataInputs(ONNXPadOp padOp, SmallVectorImpl<Value> &dataInputs) {
-  dataInputs.push_back(padOp.getData());
-}
-
-void getDataInputs(
-    ONNXReshapeOp reshapeOp, SmallVectorImpl<Value> &dataInputs) {
-  dataInputs.push_back(reshapeOp.getData());
-}
-
-void getDataInputs(ONNXSliceOp sliceOp, SmallVectorImpl<Value> &dataInputs) {
-  dataInputs.push_back(sliceOp.getData());
-}
-
-void getDataInputs(ONNXTileOp tileOp, SmallVectorImpl<Value> &dataInputs) {
-  dataInputs.push_back(tileOp.getInput());
-}
-
-void getDataInputs(
-    ONNXTransposeOp transposeOp, SmallVectorImpl<Value> &dataInputs) {
-  dataInputs.push_back(transposeOp.getData());
+void getDataInputs(Operation *op, SmallVectorImpl<Value> &dataInputs) {
+  llvm::TypeSwitch<Operation *>(op)
+      .Case<ONNXConcatOp>([&](ONNXConcatOp concatOp) {
+        llvm::copy(concatOp.getInputs(), std::back_inserter(dataInputs));
+      })
+      .Case<ONNXExpandOp, ONNXPadOp, ONNXReshapeOp, ONNXSliceOp, ONNXTileOp,
+          ONNXTransposeOp>([&](Operation *movementOp) {
+        dataInputs.push_back(movementOp->getOperand(0));
+      });
 }
 
 bool doesDataMovementOpUseQuantizedElementType(Operation *op) {
@@ -3751,7 +3733,7 @@ public:
           op, "data movement op uses quantized element types");
 
     SmallVector<Value> dataInputs;
-    getDataInputs(op, dataInputs);
+    getDataInputs(op.getOperation(), dataInputs);
 
     IRMapping mapping;
     ONNXDequantizeLinearOp commonDQOp;
@@ -3823,7 +3805,7 @@ public:
           quantOp, "data movement op uses quantized element types");
 
     SmallVector<Value> dataInputs;
-    getDataInputs(dataMovementOp, dataInputs);
+    getDataInputs(dataMovementOp.getOperation(), dataInputs);
 
     Type quantizedElementType = getElementType(quantOp.getY().getType());
     IRMapping mapping;

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -27,9 +27,11 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
@@ -50,6 +52,9 @@ static bool disableBatchNormDecompose = false;
 
 // Populated by configureUnsafeMathCanonicalization().
 static bool enableUnsafeMath = true;
+
+// Populated by configureQDQDataMovementCanonicalization().
+static bool enableQDQDataMovementCanonicalization = false;
 
 using namespace mlir;
 using namespace onnx_mlir;
@@ -3642,6 +3647,213 @@ public:
     return success();
   }
 };
+namespace {
+bool hasScalarConstantQDQParams(ONNXDequantizeLinearOp op) {
+  return isScalarConstantTensor(op.getXScale()) &&
+         isScalarConstantTensor(op.getXZeroPoint());
+}
+
+bool hasScalarConstantQDQParams(ONNXQuantizeLinearOp op) {
+  return isScalarConstantTensor(op.getYScale()) &&
+         isScalarConstantTensor(op.getYZeroPoint());
+}
+
+bool sameConstantValue(Value lhs, Value rhs) {
+  ElementsAttr lhsAttr = getElementAttributeFromONNXValue(lhs);
+  ElementsAttr rhsAttr = getElementAttributeFromONNXValue(rhs);
+  return lhsAttr && rhsAttr &&
+         compareValueFromElementAttribute(lhsAttr, rhsAttr);
+}
+
+bool haveSamePerTensorQuantizationParams(
+    ONNXDequantizeLinearOp lhs, ONNXDequantizeLinearOp rhs) {
+  return hasScalarConstantQDQParams(lhs) && hasScalarConstantQDQParams(rhs) &&
+         sameConstantValue(lhs.getXScale(), rhs.getXScale()) &&
+         sameConstantValue(lhs.getXZeroPoint(), rhs.getXZeroPoint()) &&
+         getElementType(lhs.getX().getType()) ==
+             getElementType(rhs.getX().getType()) &&
+         getElementType(lhs.getY().getType()) ==
+             getElementType(rhs.getY().getType());
+}
+
+void getDataInputs(ONNXConcatOp concatOp, SmallVectorImpl<Value> &dataInputs) {
+  llvm::copy(concatOp.getInputs(), std::back_inserter(dataInputs));
+}
+
+void getDataInputs(ONNXExpandOp expandOp, SmallVectorImpl<Value> &dataInputs) {
+  dataInputs.push_back(expandOp.getInput());
+}
+
+void getDataInputs(ONNXPadOp padOp, SmallVectorImpl<Value> &dataInputs) {
+  dataInputs.push_back(padOp.getData());
+}
+
+void getDataInputs(
+    ONNXReshapeOp reshapeOp, SmallVectorImpl<Value> &dataInputs) {
+  dataInputs.push_back(reshapeOp.getData());
+}
+
+void getDataInputs(ONNXSliceOp sliceOp, SmallVectorImpl<Value> &dataInputs) {
+  dataInputs.push_back(sliceOp.getData());
+}
+
+void getDataInputs(ONNXTileOp tileOp, SmallVectorImpl<Value> &dataInputs) {
+  dataInputs.push_back(tileOp.getInput());
+}
+
+void getDataInputs(
+    ONNXTransposeOp transposeOp, SmallVectorImpl<Value> &dataInputs) {
+  dataInputs.push_back(transposeOp.getData());
+}
+
+bool doesDataMovementOpUseQuantizedElementType(Operation *op) {
+  for (Value operand : op->getOperands())
+    if (onnx_mlir::hasQuantizedElementType(operand))
+      return true;
+  for (Value result : op->getResults())
+    if (onnx_mlir::hasQuantizedElementType(result))
+      return true;
+  return false;
+}
+
+LogicalResult hasSupportedQDQMovementSemantics(
+    Operation *op, PatternRewriter &rewriter) {
+  if (auto padOp = dyn_cast<ONNXPadOp>(op)) {
+    // Constant-mode Pad needs fill-value quantization, not implemented yet
+    if (padOp.getMode() == "constant" || !isNoneValue(padOp.getConstantValue()))
+      return rewriter.notifyMatchFailure(
+          padOp, "constant-mode Pad movement needs fill value quantization");
+    return success();
+  }
+
+  if (isa<ONNXConcatOp, ONNXExpandOp, ONNXReshapeOp, ONNXSliceOp, ONNXTileOp,
+          ONNXTransposeOp>(op))
+    return success();
+
+  return rewriter.notifyMatchFailure(
+      op, "QDQ movement semantics are not explicitly supported for this op");
+}
+
+} // namespace
+
+template <typename T>
+class SinkDequantLinearOpAfterDataMovementOp : public OpRewritePattern<T> {
+public:
+  using OpRewritePattern<T>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      T op, PatternRewriter &rewriter) const override {
+
+    if (failed(hasSupportedQDQMovementSemantics(op.getOperation(), rewriter)))
+      return failure();
+    if (doesDataMovementOpUseQuantizedElementType(op.getOperation()))
+      return rewriter.notifyMatchFailure(
+          op, "data movement op uses quantized element types");
+
+    SmallVector<Value> dataInputs;
+    getDataInputs(op, dataInputs);
+
+    IRMapping mapping;
+    ONNXDequantizeLinearOp commonDQOp;
+    SmallVector<Location> fusedLoc{op.getLoc()};
+    for (Value dataInput : dataInputs) {
+      auto dqOp = dataInput.getDefiningOp<ONNXDequantizeLinearOp>();
+      if (!dqOp || !hasScalarConstantQDQParams(dqOp))
+        return rewriter.notifyMatchFailure(
+            op, "data input is not per-tensor DequantizeLinear");
+      if (commonDQOp && !haveSamePerTensorQuantizationParams(commonDQOp, dqOp))
+        return rewriter.notifyMatchFailure(
+            op, "data input DequantizeLinear parameters differ by value");
+      commonDQOp = commonDQOp ? commonDQOp : dqOp;
+      fusedLoc.push_back(dqOp.getLoc());
+      mapping.map(dqOp.getY(), dqOp.getX());
+    }
+    if (!commonDQOp)
+      return rewriter.notifyMatchFailure(op, "no DequantizeLinear inputs");
+
+    SmallVector<Value> newInputs;
+    for (Value operand : op->getOperands())
+      newInputs.push_back(mapping.lookupOrDefault(operand));
+
+    auto opShapedType = dyn_cast<ShapedType>(op.getType());
+    if (!opShapedType)
+      return rewriter.notifyMatchFailure(op, "op result is not shaped");
+
+    const Location newLoc = rewriter.getFusedLoc(fusedLoc);
+    auto newOp = rewriter.create<T>(newLoc,
+        TypeRange{
+            opShapedType.clone(getElementType(commonDQOp.getX().getType()))},
+        ValueRange{newInputs}, op->getAttrs());
+
+    auto newDQOp = rewriter.create<ONNXDequantizeLinearOp>(newLoc, op.getType(),
+        newOp.getResult(), commonDQOp.getXScale(), commonDQOp.getXZeroPoint(),
+        commonDQOp.getAxisAttr(), commonDQOp.getBlockSizeAttr());
+
+    rewriter.replaceOp(op, newDQOp.getResult());
+    return success();
+  }
+};
+
+template <typename T>
+class BubbleUpQuantLinearOpBeforeDataMovementOp
+    : public OpRewritePattern<ONNXQuantizeLinearOp> {
+public:
+  using OpRewritePattern<ONNXQuantizeLinearOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXQuantizeLinearOp quantOp, PatternRewriter &rewriter) const override {
+    auto dataMovementOp = quantOp.getX().getDefiningOp<T>();
+    if (!dataMovementOp)
+      return rewriter.notifyMatchFailure(
+          quantOp, "QuantizeLinear input is not a supported data movement op");
+
+    Value dataMovementResult = quantOp.getX();
+    if (!dataMovementResult.hasOneUse())
+      return rewriter.notifyMatchFailure(
+          quantOp, "data movement result has multiple users");
+    if (!hasScalarConstantQDQParams(quantOp))
+      return rewriter.notifyMatchFailure(
+          quantOp, "QuantizeLinear parameters are not per-tensor constants");
+    if (failed(hasSupportedQDQMovementSemantics(
+            dataMovementOp.getOperation(), rewriter)))
+      return failure();
+    if (doesDataMovementOpUseQuantizedElementType(
+            dataMovementOp.getOperation()))
+      return rewriter.notifyMatchFailure(
+          quantOp, "data movement op uses quantized element types");
+
+    SmallVector<Value> dataInputs;
+    getDataInputs(dataMovementOp, dataInputs);
+
+    Type quantizedElementType = getElementType(quantOp.getY().getType());
+    IRMapping mapping;
+    SmallVector<Location> fusedLoc{quantOp.getLoc(), dataMovementOp.getLoc()};
+    const Location newLoc = rewriter.getFusedLoc(fusedLoc);
+    for (Value dataInput : dataInputs) {
+      auto dataInputShapedType = dyn_cast<ShapedType>(dataInput.getType());
+      if (!dataInputShapedType)
+        return rewriter.notifyMatchFailure(
+            quantOp, "data movement input is not shaped");
+
+      auto newQOp = rewriter.create<ONNXQuantizeLinearOp>(newLoc,
+          dataInputShapedType.clone(quantizedElementType), dataInput,
+          quantOp.getYScale(), quantOp.getYZeroPoint(), quantOp.getAxisAttr(),
+          quantOp.getBlockSizeAttr(), quantOp.getOutputDtypeAttr(),
+          quantOp.getSaturateAttr());
+      mapping.map(dataInput, newQOp.getResult());
+    }
+
+    SmallVector<Value> newInputs;
+    for (Value operand : dataMovementOp->getOperands())
+      newInputs.push_back(mapping.lookupOrDefault(operand));
+
+    auto newOp = rewriter.create<T>(newLoc, TypeRange{quantOp.getType()},
+        ValueRange{newInputs}, dataMovementOp->getAttrs());
+
+    rewriter.replaceOp(quantOp, newOp.getResult());
+    return success();
+  }
+};
 
 // =============================================================================
 /// Register optimization patterns as "canonicalization" patterns.
@@ -4056,6 +4268,27 @@ void ONNXWhereOp::getCanonicalizationPatterns(
 void ONNXDequantizeLinearOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {}
 
+void onnx_mlir::populateQDQDataMovementCanonicalizationPatterns(
+    RewritePatternSet &patterns, PatternBenefit benefit) {
+  patterns.add<SinkDequantLinearOpAfterDataMovementOp<ONNXConcatOp>,
+      SinkDequantLinearOpAfterDataMovementOp<ONNXExpandOp>,
+      SinkDequantLinearOpAfterDataMovementOp<ONNXPadOp>,
+      SinkDequantLinearOpAfterDataMovementOp<ONNXReshapeOp>,
+      SinkDequantLinearOpAfterDataMovementOp<ONNXSliceOp>,
+      SinkDequantLinearOpAfterDataMovementOp<ONNXTileOp>,
+      SinkDequantLinearOpAfterDataMovementOp<ONNXTransposeOp>>(
+      patterns.getContext(), benefit);
+
+  patterns.add<BubbleUpQuantLinearOpBeforeDataMovementOp<ONNXConcatOp>,
+      BubbleUpQuantLinearOpBeforeDataMovementOp<ONNXExpandOp>,
+      BubbleUpQuantLinearOpBeforeDataMovementOp<ONNXPadOp>,
+      BubbleUpQuantLinearOpBeforeDataMovementOp<ONNXReshapeOp>,
+      BubbleUpQuantLinearOpBeforeDataMovementOp<ONNXSliceOp>,
+      BubbleUpQuantLinearOpBeforeDataMovementOp<ONNXTileOp>,
+      BubbleUpQuantLinearOpBeforeDataMovementOp<ONNXTransposeOp>>(
+      patterns.getContext(), benefit);
+}
+
 void onnx_mlir::configureBatchNormCanonicalization(
     bool disableBatchNormDecomposeOption) {
   disableBatchNormDecompose = disableBatchNormDecomposeOption;
@@ -4064,4 +4297,14 @@ void onnx_mlir::configureBatchNormCanonicalization(
 void onnx_mlir::configureUnsafeMathCanonicalization(
     bool enableUnsafeMathOptimizations) {
   enableUnsafeMath = enableUnsafeMathOptimizations;
+}
+
+void onnx_mlir::configureQDQDataMovementCanonicalization(
+    bool enableQDQDataMovementCanonicalizationOption) {
+  enableQDQDataMovementCanonicalization =
+      enableQDQDataMovementCanonicalizationOption;
+}
+
+bool onnx_mlir::isQDQDataMovementCanonicalizationEnabled() {
+  return enableQDQDataMovementCanonicalization;
 }

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -147,6 +147,9 @@ struct ONNXHybridTransformPass
         }
         op.getCanonicalizationPatterns(cumulativePatterns, context);
       }
+
+      if (isQDQDataMovementCanonicalizationEnabled())
+        populateQDQDataMovementCanonicalizationPatterns(cumulativePatterns);
     }
 
     if (constantPropagation) {

--- a/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
+++ b/src/Dialect/ONNX/Transforms/ResultNamesUpdater.cpp
@@ -15,6 +15,7 @@
 
 #include "src/Dialect/ONNX/TensorName.hpp"
 #include "src/Dialect/ONNX/Transforms/ResultNamesUpdater.hpp"
+#include "src/Pass/Passes.hpp"
 
 using namespace mlir;
 
@@ -164,6 +165,9 @@ struct CanonicalizeWithResultNamesPass
       dialect->getCanonicalizationPatterns(patterns);
     for (auto regOp : ctx->getRegisteredOperations())
       regOp.getCanonicalizationPatterns(patterns, ctx);
+
+    if (isQDQDataMovementCanonicalizationEnabled())
+      populateQDQDataMovementCanonicalizationPatterns(patterns);
 
     GreedyRewriteConfig config;
     ResultNamesUpdater rnUpdater;

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -22,6 +22,7 @@
 #include <optional>
 #include <string>
 
+#include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/ArrayRef.h"
 
 namespace mlir {
@@ -65,6 +66,15 @@ void configureBatchNormCanonicalization(bool disableBatchNormDecompose);
 
 // Configure patterns that are not numerically safe.
 void configureUnsafeMathCanonicalization(bool enableUnsafeMathOptimizations);
+
+// Configure QDQ canonicalizations for data-movement/view ONNX ops.
+void configureQDQDataMovementCanonicalization(
+    bool enableQDQDataMovementCanonicalization);
+
+bool isQDQDataMovementCanonicalizationEnabled();
+
+void populateQDQDataMovementCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::PatternBenefit benefit = 1);
 
 std::unique_ptr<mlir::Pass> createConstPropONNXToONNXPass(
     bool enableQDQ = false);

--- a/test/mlir/onnx/onnx_canonicalization_qdq_data_movement.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_qdq_data_movement.mlir
@@ -1,0 +1,256 @@
+// RUN: onnx-mlir-opt --enable-qdq-data-movement-canonicalization --canonicalize-with-rn %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --canonicalize-with-rn %s -split-input-file | FileCheck %s --check-prefix=NOOPT
+
+// -----
+
+func.func @transpose_moves_dq_and_q(%arg0: tensor<1x2x3xui8>, %arg1: tensor<1x2x3xf32>) -> (tensor<1x3x2xf32>, tensor<1x3x2xui8>) {
+  %s = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %z = onnx.Constant dense<128> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%arg0, %s, %z) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x2x3xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2x3xf32>
+  %t0 = "onnx.Transpose"(%dq) {perm = [0, 2, 1]} : (tensor<1x2x3xf32>) -> tensor<1x3x2xf32>
+  %t1 = "onnx.Transpose"(%arg1) {perm = [0, 2, 1]} : (tensor<1x2x3xf32>) -> tensor<1x3x2xf32>
+  %q = "onnx.QuantizeLinear"(%t1, %s, %z) {axis = 1 : si64, block_size = 0 : si64, saturate = 1 : si64} : (tensor<1x3x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x3x2xui8>
+  return %t0, %q : tensor<1x3x2xf32>, tensor<1x3x2xui8>
+}
+
+// NOOPT-LABEL: func.func @transpose_moves_dq_and_q
+// NOOPT:       "onnx.DequantizeLinear"
+// NOOPT:       "onnx.Transpose"
+// NOOPT:       "onnx.Transpose"
+// NOOPT:       "onnx.QuantizeLinear"
+
+// CHECK-LABEL: func.func @transpose_moves_dq_and_q
+// CHECK-SAME:  (%[[QI:.*]]: tensor<1x2x3xui8>, %[[FI:.*]]: tensor<1x2x3xf32>)
+// CHECK-DAG:   %[[S:.*]] = onnx.Constant dense<2.500000e-01> : tensor<f32>
+// CHECK-DAG:   %[[Z:.*]] = onnx.Constant dense<128> : tensor<ui8>
+// CHECK-DAG:   %[[TQ:.*]] = "onnx.Transpose"(%[[QI]]) {perm = [0, 2, 1]} : (tensor<1x2x3xui8>) -> tensor<1x3x2xui8>
+// CHECK-DAG:   %[[DQ:.*]] = "onnx.DequantizeLinear"(%[[TQ]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x3x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x3x2xf32>
+// CHECK-DAG:   %[[QF:.*]] = "onnx.QuantizeLinear"(%[[FI]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x2x3xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x2x3xui8>
+// CHECK-DAG:   %[[TQI:.*]] = "onnx.Transpose"(%[[QF]]) {perm = [0, 2, 1]} : (tensor<1x2x3xui8>) -> tensor<1x3x2xui8>
+// CHECK:       return %[[DQ]], %[[TQI]]
+
+// -----
+
+func.func @quant_result_multi_use_moved(%arg0: tensor<1x2x3xf32>) -> (tensor<1x3x2xui8>, tensor<1x3x2xui8>) {
+  %s = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %z = onnx.Constant dense<128> : tensor<ui8>
+  %t = "onnx.Transpose"(%arg0) {perm = [0, 2, 1]} : (tensor<1x2x3xf32>) -> tensor<1x3x2xf32>
+  %q = "onnx.QuantizeLinear"(%t, %s, %z) {axis = 1 : si64, block_size = 0 : si64, saturate = 1 : si64} : (tensor<1x3x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x3x2xui8>
+  return %q, %q : tensor<1x3x2xui8>, tensor<1x3x2xui8>
+}
+
+// CHECK-LABEL: func.func @quant_result_multi_use_moved
+// CHECK-SAME:  (%[[FI:.*]]: tensor<1x2x3xf32>)
+// CHECK-DAG:   %[[S:.*]] = onnx.Constant dense<2.500000e-01> : tensor<f32>
+// CHECK-DAG:   %[[Z:.*]] = onnx.Constant dense<128> : tensor<ui8>
+// CHECK-DAG:   %[[QF:.*]] = "onnx.QuantizeLinear"(%[[FI]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x2x3xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x2x3xui8>
+// CHECK-DAG:   %[[TQI:.*]] = "onnx.Transpose"(%[[QF]]) {perm = [0, 2, 1]} : (tensor<1x2x3xui8>) -> tensor<1x3x2xui8>
+// CHECK:       return %[[TQI]], %[[TQI]]
+
+// -----
+
+func.func @quant_input_multi_use_not_moved(%arg0: tensor<1x2x3xf32>) -> (tensor<1x3x2xf32>, tensor<1x3x2xui8>) {
+  %s = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %z = onnx.Constant dense<128> : tensor<ui8>
+  %t = "onnx.Transpose"(%arg0) {perm = [0, 2, 1]} : (tensor<1x2x3xf32>) -> tensor<1x3x2xf32>
+  %q = "onnx.QuantizeLinear"(%t, %s, %z) {axis = 1 : si64, block_size = 0 : si64, saturate = 1 : si64} : (tensor<1x3x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x3x2xui8>
+  return %t, %q : tensor<1x3x2xf32>, tensor<1x3x2xui8>
+}
+
+// CHECK-LABEL: func.func @quant_input_multi_use_not_moved
+// CHECK-SAME:  (%[[FI:.*]]: tensor<1x2x3xf32>)
+// CHECK-DAG:   %[[S:.*]] = onnx.Constant dense<2.500000e-01> : tensor<f32>
+// CHECK-DAG:   %[[Z:.*]] = onnx.Constant dense<128> : tensor<ui8>
+// CHECK:       %[[T:.*]] = "onnx.Transpose"(%[[FI]]) {perm = [0, 2, 1]} : (tensor<1x2x3xf32>) -> tensor<1x3x2xf32>
+// CHECK-NEXT:  %[[Q:.*]] = "onnx.QuantizeLinear"(%[[T]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x3x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x3x2xui8>
+// CHECK-NEXT:  return %[[T]], %[[Q]]
+
+// -----
+
+func.func @reshape_moves_dq_and_q(%arg0: tensor<1x4xui8>, %arg1: tensor<1x4xf32>) -> (tensor<2x2xf32>, tensor<2x2xui8>) {
+  %s = onnx.Constant dense<1.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<42> : tensor<ui8>
+  %shape = onnx.Constant dense<[2, 2]> : tensor<2xi64>
+  %dq = "onnx.DequantizeLinear"(%arg0, %s, %z) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x4xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x4xf32>
+  %r0 = "onnx.Reshape"(%dq, %shape) {allowzero = 0 : si64} : (tensor<1x4xf32>, tensor<2xi64>) -> tensor<2x2xf32>
+  %r1 = "onnx.Reshape"(%arg1, %shape) {allowzero = 0 : si64} : (tensor<1x4xf32>, tensor<2xi64>) -> tensor<2x2xf32>
+  %q = "onnx.QuantizeLinear"(%r1, %s, %z) {axis = 1 : si64, block_size = 0 : si64, saturate = 1 : si64} : (tensor<2x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<2x2xui8>
+  return %r0, %q : tensor<2x2xf32>, tensor<2x2xui8>
+}
+
+// CHECK-LABEL: func.func @reshape_moves_dq_and_q
+// CHECK-SAME:  (%[[QI:.*]]: tensor<1x4xui8>, %[[FI:.*]]: tensor<1x4xf32>)
+// CHECK-DAG:   %[[S:.*]] = onnx.Constant dense<1.000000e-01> : tensor<f32>
+// CHECK-DAG:   %[[Z:.*]] = onnx.Constant dense<42> : tensor<ui8>
+// CHECK-DAG:   %[[SHAPE:.*]] = onnx.Constant dense<2> : tensor<2xi64>
+// CHECK-DAG:   %[[RQ:.*]] = "onnx.Reshape"(%[[QI]], %[[SHAPE]]) {allowzero = 0 : si64} : (tensor<1x4xui8>, tensor<2xi64>) -> tensor<2x2xui8>
+// CHECK-DAG:   %[[DQ:.*]] = "onnx.DequantizeLinear"(%[[RQ]], %[[S]], %[[Z]]) {{.*}} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+// CHECK-DAG:   %[[QF:.*]] = "onnx.QuantizeLinear"(%[[FI]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x4xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x4xui8>
+// CHECK-DAG:   %[[RQI:.*]] = "onnx.Reshape"(%[[QF]], %[[SHAPE]]) {allowzero = 0 : si64} : (tensor<1x4xui8>, tensor<2xi64>) -> tensor<2x2xui8>
+// CHECK:       return %[[DQ]], %[[RQI]]
+
+// -----
+
+func.func @slice_moves_dq_and_q(%arg0: tensor<1x4xui8>, %arg1: tensor<1x4xf32>) -> (tensor<1x2xf32>, tensor<1x2xui8>) {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %s = onnx.Constant dense<1.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<128> : tensor<ui8>
+  %starts = onnx.Constant dense<1> : tensor<1xi64>
+  %ends = onnx.Constant dense<3> : tensor<1xi64>
+  %dq = "onnx.DequantizeLinear"(%arg0, %s, %z) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x4xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x4xf32>
+  %sl0 = "onnx.Slice"(%dq, %starts, %ends, %none, %none) : (tensor<1x4xf32>, tensor<1xi64>, tensor<1xi64>, none, none) -> tensor<1x2xf32>
+  %sl1 = "onnx.Slice"(%arg1, %starts, %ends, %none, %none) : (tensor<1x4xf32>, tensor<1xi64>, tensor<1xi64>, none, none) -> tensor<1x2xf32>
+  %q = "onnx.QuantizeLinear"(%sl1, %s, %z) {axis = 1 : si64, block_size = 0 : si64, saturate = 1 : si64} : (tensor<1x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x2xui8>
+  return %sl0, %q : tensor<1x2xf32>, tensor<1x2xui8>
+}
+
+// CHECK-LABEL: func.func @slice_moves_dq_and_q
+// CHECK-SAME:  (%[[QI:.*]]: tensor<1x4xui8>, %[[FI:.*]]: tensor<1x4xf32>)
+// CHECK-DAG:   %[[S:.*]] = onnx.Constant dense<1.000000e-01> : tensor<f32>
+// CHECK-DAG:   %[[Z:.*]] = onnx.Constant dense<128> : tensor<ui8>
+// CHECK-DAG:   %[[NONE:.*]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:   %[[STARTS:.*]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK-DAG:   %[[ENDS:.*]] = onnx.Constant dense<3> : tensor<1xi64>
+// CHECK-DAG:   %[[SLQ:.*]] = "onnx.Slice"(%[[QI]], %[[STARTS]], %[[ENDS]], %[[NONE]], %[[NONE]]) : (tensor<1x4xui8>, tensor<1xi64>, tensor<1xi64>, none, none) -> tensor<1x2xui8>
+// CHECK-DAG:   %[[DQ:.*]] = "onnx.DequantizeLinear"(%[[SLQ]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+// CHECK-DAG:   %[[QF:.*]] = "onnx.QuantizeLinear"(%[[FI]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x4xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x4xui8>
+// CHECK-DAG:   %[[SLQI:.*]] = "onnx.Slice"(%[[QF]], %[[STARTS]], %[[ENDS]], %[[NONE]], %[[NONE]]) : (tensor<1x4xui8>, tensor<1xi64>, tensor<1xi64>, none, none) -> tensor<1x2xui8>
+// CHECK:       return %[[DQ]], %[[SLQI]]
+
+// -----
+
+func.func @pad_reflect_moves_dq_and_q(%arg0: tensor<1x4xui8>, %arg1: tensor<1x4xf32>) -> (tensor<1x6xf32>, tensor<1x6xui8>) {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<128> : tensor<ui8>
+  %pads = onnx.Constant dense<[0, 1, 0, 1]> : tensor<4xi64>
+  %dq = "onnx.DequantizeLinear"(%arg0, %s, %z) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x4xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x4xf32>
+  %p0 = "onnx.Pad"(%dq, %pads, %none, %none) {mode = "reflect"} : (tensor<1x4xf32>, tensor<4xi64>, none, none) -> tensor<1x6xf32>
+  %p1 = "onnx.Pad"(%arg1, %pads, %none, %none) {mode = "reflect"} : (tensor<1x4xf32>, tensor<4xi64>, none, none) -> tensor<1x6xf32>
+  %q = "onnx.QuantizeLinear"(%p1, %s, %z) {axis = 1 : si64, block_size = 0 : si64, saturate = 1 : si64} : (tensor<1x6xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x6xui8>
+  return %p0, %q : tensor<1x6xf32>, tensor<1x6xui8>
+}
+
+// CHECK-LABEL: func.func @pad_reflect_moves_dq_and_q
+// CHECK-SAME:  (%[[QI:.*]]: tensor<1x4xui8>, %[[FI:.*]]: tensor<1x4xf32>)
+// CHECK-DAG:   %[[S:.*]] = onnx.Constant dense<5.000000e-01> : tensor<f32>
+// CHECK-DAG:   %[[Z:.*]] = onnx.Constant dense<128> : tensor<ui8>
+// CHECK-DAG:   %[[NONE:.*]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:   %[[PADS:.*]] = onnx.Constant dense<[0, 1, 0, 1]> : tensor<4xi64>
+// CHECK-DAG:   %[[PQ:.*]] = "onnx.Pad"(%[[QI]], %[[PADS]], %[[NONE]], %[[NONE]]) {mode = "reflect"} : (tensor<1x4xui8>, tensor<4xi64>, none, none) -> tensor<1x6xui8>
+// CHECK-DAG:   %[[DQ:.*]] = "onnx.DequantizeLinear"(%[[PQ]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x6xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x6xf32>
+// CHECK-DAG:   %[[QF:.*]] = "onnx.QuantizeLinear"(%[[FI]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x4xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x4xui8>
+// CHECK-DAG:   %[[PQI:.*]] = "onnx.Pad"(%[[QF]], %[[PADS]], %[[NONE]], %[[NONE]]) {mode = "reflect"} : (tensor<1x4xui8>, tensor<4xi64>, none, none) -> tensor<1x6xui8>
+// CHECK:       return %[[DQ]], %[[PQI]]
+
+// -----
+
+func.func @pad_constant_not_moved(%arg0: tensor<1x2xui8>, %arg1: tensor<1x2xf32>) -> (tensor<1x4xf32>, tensor<1x4xui8>) {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %s = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<128> : tensor<ui8>
+  %pads = onnx.Constant dense<[0, 1, 0, 1]> : tensor<4xi64>
+  %dq = "onnx.DequantizeLinear"(%arg0, %s, %z) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+  %p0 = "onnx.Pad"(%dq, %pads, %none, %none) {mode = "constant"} : (tensor<1x2xf32>, tensor<4xi64>, none, none) -> tensor<1x4xf32>
+  %p1 = "onnx.Pad"(%arg1, %pads, %none, %none) {mode = "constant"} : (tensor<1x2xf32>, tensor<4xi64>, none, none) -> tensor<1x4xf32>
+  %q = "onnx.QuantizeLinear"(%p1, %s, %z) {axis = 1 : si64, block_size = 0 : si64, saturate = 1 : si64} : (tensor<1x4xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x4xui8>
+  return %p0, %q : tensor<1x4xf32>, tensor<1x4xui8>
+}
+
+// CHECK-LABEL: func.func @pad_constant_not_moved
+// CHECK:       "onnx.DequantizeLinear"
+// CHECK:       "onnx.Pad"
+// CHECK:       "onnx.Pad"
+// CHECK:       "onnx.QuantizeLinear"
+
+// -----
+
+func.func @concat_moves_dq_and_q(%arg0: tensor<1x2xui8>, %arg1: tensor<1x3xui8>, %arg2: tensor<1x2xf32>, %arg3: tensor<1x3xf32>) -> (tensor<1x5xf32>, tensor<1x5xui8>) {
+  %s0 = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %z0 = onnx.Constant dense<128> : tensor<ui8>
+  %s1 = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %z1 = onnx.Constant dense<128> : tensor<ui8>
+  %dq0 = "onnx.DequantizeLinear"(%arg0, %s0, %z0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+  %dq1 = "onnx.DequantizeLinear"(%arg1, %s1, %z1) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x3xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x3xf32>
+  %c0 = "onnx.Concat"(%dq0, %dq1) {axis = 1 : si64} : (tensor<1x2xf32>, tensor<1x3xf32>) -> tensor<1x5xf32>
+  %c1 = "onnx.Concat"(%arg2, %arg3) {axis = 1 : si64} : (tensor<1x2xf32>, tensor<1x3xf32>) -> tensor<1x5xf32>
+  %q = "onnx.QuantizeLinear"(%c1, %s0, %z0) {axis = 1 : si64, block_size = 0 : si64, saturate = 1 : si64} : (tensor<1x5xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x5xui8>
+  return %c0, %q : tensor<1x5xf32>, tensor<1x5xui8>
+}
+
+// CHECK-LABEL: func.func @concat_moves_dq_and_q
+// CHECK-SAME:  (%[[QI0:.*]]: tensor<1x2xui8>, %[[QI1:.*]]: tensor<1x3xui8>, %[[FI0:.*]]: tensor<1x2xf32>, %[[FI1:.*]]: tensor<1x3xf32>)
+// CHECK-DAG:   %[[S:.*]] = onnx.Constant dense<2.500000e-01> : tensor<f32>
+// CHECK-DAG:   %[[Z:.*]] = onnx.Constant dense<128> : tensor<ui8>
+// CHECK-DAG:   %[[CQ:.*]] = "onnx.Concat"(%[[QI0]], %[[QI1]]) {axis = 1 : si64} : (tensor<1x2xui8>, tensor<1x3xui8>) -> tensor<1x5xui8>
+// CHECK-DAG:   %[[DQ:.*]] = "onnx.DequantizeLinear"(%[[CQ]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x5xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x5xf32>
+// CHECK-DAG:   %[[QF0:.*]] = "onnx.QuantizeLinear"(%[[FI0]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x2xui8>
+// CHECK-DAG:   %[[QF1:.*]] = "onnx.QuantizeLinear"(%[[FI1]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x3xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x3xui8>
+// CHECK-DAG:   %[[CQI:.*]] = "onnx.Concat"(%[[QF0]], %[[QF1]]) {axis = 1 : si64} : (tensor<1x2xui8>, tensor<1x3xui8>) -> tensor<1x5xui8>
+// CHECK:       return %[[DQ]], %[[CQI]]
+
+// -----
+
+func.func @tile_moves_dq_and_q(%arg0: tensor<2xui8>, %arg1: tensor<2xf32>) -> (tensor<4xf32>, tensor<4xui8>) {
+  %s = onnx.Constant dense<1.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<128> : tensor<ui8>
+  %repeats = onnx.Constant dense<2> : tensor<1xi64>
+  %dq = "onnx.DequantizeLinear"(%arg0, %s, %z) {axis = 1 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  %t0 = "onnx.Tile"(%dq, %repeats) : (tensor<2xf32>, tensor<1xi64>) -> tensor<4xf32>
+  %t1 = "onnx.Tile"(%arg1, %repeats) : (tensor<2xf32>, tensor<1xi64>) -> tensor<4xf32>
+  %q = "onnx.QuantizeLinear"(%t1, %s, %z) {axis = 1 : si64, block_size = 0 : si64, saturate = 1 : si64} : (tensor<4xf32>, tensor<f32>, tensor<ui8>) -> tensor<4xui8>
+  return %t0, %q : tensor<4xf32>, tensor<4xui8>
+}
+
+// CHECK-LABEL: func.func @tile_moves_dq_and_q
+// CHECK-SAME:  (%[[QI:.*]]: tensor<2xui8>, %[[FI:.*]]: tensor<2xf32>)
+// CHECK-DAG:   %[[S:.*]] = onnx.Constant dense<1.000000e-01> : tensor<f32>
+// CHECK-DAG:   %[[Z:.*]] = onnx.Constant dense<128> : tensor<ui8>
+// CHECK-DAG:   %[[REPEATS:.*]] = onnx.Constant dense<2> : tensor<1xi64>
+// CHECK-DAG:   %[[TQ:.*]] = "onnx.Tile"(%[[QI]], %[[REPEATS]]) : (tensor<2xui8>, tensor<1xi64>) -> tensor<4xui8>
+// CHECK-DAG:   %[[DQ:.*]] = "onnx.DequantizeLinear"(%[[TQ]], %[[S]], %[[Z]]) {{.*}} : (tensor<4xui8>, tensor<f32>, tensor<ui8>) -> tensor<4xf32>
+// CHECK-DAG:   %[[QF:.*]] = "onnx.QuantizeLinear"(%[[FI]], %[[S]], %[[Z]]) {{.*}} : (tensor<2xf32>, tensor<f32>, tensor<ui8>) -> tensor<2xui8>
+// CHECK-DAG:   %[[TQI:.*]] = "onnx.Tile"(%[[QF]], %[[REPEATS]]) : (tensor<2xui8>, tensor<1xi64>) -> tensor<4xui8>
+// CHECK:       return %[[DQ]], %[[TQI]]
+
+// -----
+
+func.func @expand_moves_dq_and_q(%arg0: tensor<1x2xui8>, %arg1: tensor<1x2xf32>) -> (tensor<3x2xf32>, tensor<3x2xui8>) {
+  %s = onnx.Constant dense<1.000000e-01> : tensor<f32>
+  %z = onnx.Constant dense<128> : tensor<ui8>
+  %shape = onnx.Constant dense<[3, 2]> : tensor<2xi64>
+  %dq = "onnx.DequantizeLinear"(%arg0, %s, %z) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+  %e0 = "onnx.Expand"(%dq, %shape) : (tensor<1x2xf32>, tensor<2xi64>) -> tensor<3x2xf32>
+  %e1 = "onnx.Expand"(%arg1, %shape) : (tensor<1x2xf32>, tensor<2xi64>) -> tensor<3x2xf32>
+  %q = "onnx.QuantizeLinear"(%e1, %s, %z) {axis = 1 : si64, block_size = 0 : si64, saturate = 1 : si64} : (tensor<3x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<3x2xui8>
+  return %e0, %q : tensor<3x2xf32>, tensor<3x2xui8>
+}
+
+// CHECK-LABEL: func.func @expand_moves_dq_and_q
+// CHECK-SAME:  (%[[QI:.*]]: tensor<1x2xui8>, %[[FI:.*]]: tensor<1x2xf32>)
+// CHECK-DAG:   %[[S:.*]] = onnx.Constant dense<1.000000e-01> : tensor<f32>
+// CHECK-DAG:   %[[Z:.*]] = onnx.Constant dense<128> : tensor<ui8>
+// CHECK-DAG:   %[[SHAPE:.*]] = onnx.Constant dense<[3, 2]> : tensor<2xi64>
+// CHECK-DAG:   %[[EQ:.*]] = "onnx.Expand"(%[[QI]], %[[SHAPE]]) : (tensor<1x2xui8>, tensor<2xi64>) -> tensor<3x2xui8>
+// CHECK-DAG:   %[[DQ:.*]] = "onnx.DequantizeLinear"(%[[EQ]], %[[S]], %[[Z]]) {{.*}} : (tensor<3x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<3x2xf32>
+// CHECK-DAG:   %[[QF:.*]] = "onnx.QuantizeLinear"(%[[FI]], %[[S]], %[[Z]]) {{.*}} : (tensor<1x2xf32>, tensor<f32>, tensor<ui8>) -> tensor<1x2xui8>
+// CHECK-DAG:   %[[EQI:.*]] = "onnx.Expand"(%[[QF]], %[[SHAPE]]) : (tensor<1x2xui8>, tensor<2xi64>) -> tensor<3x2xui8>
+// CHECK:       return %[[DQ]], %[[EQI]]
+
+// -----
+
+func.func @concat_different_param_values_not_moved(%arg0: tensor<1x2xui8>, %arg1: tensor<1x3xui8>) -> tensor<1x5xf32> {
+  %s0 = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %z0 = onnx.Constant dense<128> : tensor<ui8>
+  %s1 = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %z1 = onnx.Constant dense<128> : tensor<ui8>
+  %dq0 = "onnx.DequantizeLinear"(%arg0, %s0, %z0) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+  %dq1 = "onnx.DequantizeLinear"(%arg1, %s1, %z1) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x3xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x3xf32>
+  %concat = "onnx.Concat"(%dq0, %dq1) {axis = 1 : si64} : (tensor<1x2xf32>, tensor<1x3xf32>) -> tensor<1x5xf32>
+  return %concat : tensor<1x5xf32>
+}
+
+// CHECK-LABEL: func.func @concat_different_param_values_not_moved
+// CHECK:       "onnx.DequantizeLinear"
+// CHECK:       "onnx.DequantizeLinear"
+// CHECK:       "onnx.Concat"


### PR DESCRIPTION
Limited to per-tensor quantization.

Disabled by default for now. .

Together with a future fold DQ-> Q pattern this will get rid of many Q/DQ around  datamovement ops.

Credit to @roberteg16  .

Flag name is temporary, i plan to refactor the flag handling more