### PR TITLE
Fuse 1x1 convs into consumer convs

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -1607,6 +1607,7 @@ def ONNXConstantOfShapeOp:ONNX_Op<"ConstantOfShape",
 
 def ONNXConvOp:ONNX_Op<"Conv",
   [Pure, OpVersionTrait<22>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Conv operation";
   let description = [{
   The convolution operator consumes an input tensor and a filter, and

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4077,16 +4077,19 @@ struct NormalizeConvAutoPadPattern : public OpRewritePattern<ONNXConvOp> {
 
     // Nothing to do if already normalised.
     if (autoPad == "NOTSET" && convOp.getPads().has_value())
-      return failure();
+      return rewriter.notifyMatchFailure(
+          convOp, "auto_pad is already NOTSET with explicit pads");
 
     // Require ranked weight to derive spatial rank and kernel sizes.
     const Value W = convOp.getW();
     if (!hasShapeAndRank(W))
-      return failure();
+      return rewriter.notifyMatchFailure(
+          convOp, "weight is unranked or missing shape");
     const auto wShape = cast<ShapedType>(W.getType()).getShape();
     const int64_t spatialRank = static_cast<int64_t>(wShape.size()) - 2;
     if (spatialRank < 1)
-      return failure();
+      return rewriter.notifyMatchFailure(
+          convOp, "spatial rank must be at least 1");
 
     // Pads are stored as [x1_begin, x2_begin, ..., x1_end, x2_end, ...].
     // Initialise to zero; VALID and NOTSET-without-pads leave them that way.
@@ -4096,7 +4099,8 @@ struct NormalizeConvAutoPadPattern : public OpRewritePattern<ONNXConvOp> {
       // Pad computation requires static input spatial dims.
       const Value X = convOp.getX();
       if (!hasShapeAndRank(X))
-        return failure();
+        return rewriter.notifyMatchFailure(
+            convOp, "input is unranked or missing shape");
       const auto xShape = cast<ShapedType>(X.getType()).getShape();
 
       const auto stridesOpt = convOp.getStrides();
@@ -4107,7 +4111,8 @@ struct NormalizeConvAutoPadPattern : public OpRewritePattern<ONNXConvOp> {
       for (int64_t i = 0; i < spatialRank; ++i) {
         const int64_t inputSize = xShape[2 + i];
         if (inputSize == ShapedType::kDynamic)
-          return failure(); // cannot compute pads statically
+          return rewriter.notifyMatchFailure(
+              convOp, "dynamic spatial dim: cannot compute pads statically");
 
         const int64_t kernelSize = kernelShapeOpt.has_value()
                                        ? ArrayAttrIntVal(kernelShapeOpt, i)
@@ -4145,10 +4150,248 @@ struct NormalizeConvAutoPadPattern : public OpRewritePattern<ONNXConvOp> {
   }
 };
 
+//===----------------------------------------------------------------------===//
+// Fuse conv1x1 -> convKxK into a single convKxK.
+//
+// Fires when:
+//   - conv1 is 1x1, stride/dilation 1, group 1, zero pads.
+//   - conv2 consumes conv1's single output, same stride/dilation/group
+//     constraints.
+//   - auto_pad is NOTSET on both
+//   - No extra op is needed for the bias fold: conv2 pads are all zero OR
+//     b1 is None / all-zeros.
+//
+// The fused weight Wf[Cout,Cin,K,K] = W2 x W1 (channel contraction):
+//   Wf[n,c,i,j] = sum_m W1[m,c] * W2[n,m,i,j]
+//
+// The fused bias bf[Cout]:
+//   bf[n] = b2[n] + sum_m (sum_{i,j} W2[n,m,i,j]) * b1[m]
+//
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+// True when every element of the optional I64 array attr equals 1.
+// An absent attribute is treated as "all ones"
+bool isAllOnes(std::optional<ArrayAttr> attrOpt) {
+  if (!attrOpt.has_value())
+    return true;
+  return llvm::all_of(attrOpt->getAsValueRange<IntegerAttr>(),
+      [](const APInt &v) { return v == 1; });
+}
+
+// True when every element of the optional I64 array attr equals 0.
+// An absent attribute is treated as "all zeros"
+bool isAllZeros(std::optional<ArrayAttr> attrOpt) {
+  if (!attrOpt.has_value())
+    return true;
+  return llvm::all_of(attrOpt->getAsValueRange<IntegerAttr>(),
+      [](const APInt &v) { return v == 0; });
+}
+
+// True when val is None or a dense constant whose every element is 0.
+bool isNoneOrZero(Value val) { return isNoneValue(val) || isConstOf(val, 0.0); }
+
+struct FuseConv1x1IntoConvPattern : public OpRewritePattern<ONNXConvOp> {
+  using OpRewritePattern<ONNXConvOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXConvOp conv2, PatternRewriter &rewriter) const override {
+
+    // ---- Match conv1 -------------------------------------------------
+    const Value conv2X = conv2.getX();
+    auto *defOp = conv2X.getDefiningOp();
+    if (!defOp)
+      return rewriter.notifyMatchFailure(
+          conv2, "input has no defining op (block argument)");
+    auto conv1 = dyn_cast<ONNXConvOp>(defOp);
+    if (!conv1)
+      return rewriter.notifyMatchFailure(
+          conv2, "producer of input is not an ONNXConvOp");
+    // conv1's result must be consumed only by conv2.
+    if (!conv2X.hasOneUse())
+      return rewriter.notifyMatchFailure(
+          conv2, "conv1 result has multiple uses");
+
+    // ---- Common attribute constraints --------------------------------
+    if (conv1.getAutoPad() != "NOTSET" || conv2.getAutoPad() != "NOTSET")
+      return rewriter.notifyMatchFailure(conv2,
+          "auto_pad not yet normalised to NOTSET (run "
+          "NormalizeConvAutoPadPattern first)");
+    if (conv1.getGroup() != 1 || conv2.getGroup() != 1)
+      return rewriter.notifyMatchFailure(conv2, "group != 1");
+    if (!isAllOnes(conv1.getStrides()) || !isAllOnes(conv2.getStrides()))
+      return rewriter.notifyMatchFailure(conv2, "strides != 1");
+    if (!isAllOnes(conv1.getDilations()) || !isAllOnes(conv2.getDilations()))
+      return rewriter.notifyMatchFailure(conv2, "dilations != 1");
+
+    // ---- conv1 must be 1x1 with zero pads ---------------------------
+    const Value W1 = conv1.getW();
+    if (!hasStaticShape(W1.getType()))
+      return rewriter.notifyMatchFailure(
+          conv2, "conv1 weight has dynamic or unknown shape");
+    const auto w1Shape = cast<ShapedType>(W1.getType()).getShape();
+    // w1Shape = [Cmid, Cin/group, k1, k2, ...]; all spatial dims must be 1.
+    const int64_t w1Rank = w1Shape.size();
+    if (w1Rank < 3)
+      return rewriter.notifyMatchFailure(
+          conv2, "conv1 weight rank must be at least 3");
+    for (int64_t i = 2; i < w1Rank; ++i)
+      if (w1Shape[i] != 1)
+        return rewriter.notifyMatchFailure(
+            conv2, "conv1 is not a 1x1 conv (spatial kernel dim != 1)");
+    if (!isAllZeros(conv1.getPads()))
+      return rewriter.notifyMatchFailure(conv2, "conv1 has nonzero pads");
+
+    // ---- Require conv2 weight to also have a fully static shape ------
+    const Value W2 = conv2.getW();
+    if (!hasStaticShape(W2.getType()))
+      return rewriter.notifyMatchFailure(
+          conv2, "conv2 weight has dynamic or unknown shape");
+    const auto w2Shape = cast<ShapedType>(W2.getType()).getShape();
+    // w2Shape = [Cout, Cmid, K, K]; require at least rank 3.
+    if (static_cast<int64_t>(w2Shape.size()) < 3)
+      return rewriter.notifyMatchFailure(
+          conv2, "conv2 weight rank must be at least 3");
+    // Cmid must match between W1 and W2.
+    if (w1Shape[0] != w2Shape[1])
+      return rewriter.notifyMatchFailure(
+          conv2, "Cmid mismatch between conv1 and conv2 weights");
+
+    // Element types must match.
+    const Type elemType = getElementTypeOrSelf(W1.getType());
+    if (elemType != getElementTypeOrSelf(W2.getType()))
+      return rewriter.notifyMatchFailure(
+          conv2, "weight element types do not match");
+
+    // ---- Require constant weights for fold-ability ------------------
+    if (!isDenseONNXConstant(W1))
+      return rewriter.notifyMatchFailure(
+          conv2, "conv1 weight is not a dense ONNX constant");
+    if (!isDenseONNXConstant(W2))
+      return rewriter.notifyMatchFailure(
+          conv2, "conv2 weight is not a dense ONNX constant");
+
+    // ---- Bias constraints -------------------------------------------
+    const Value b1 = conv1.getB();
+    const Value b2 = conv2.getB();
+
+    // bias fold is exact only when conv2 pads are all zero
+    // or b1 contributes nothing (None or zero).
+    const bool conv2PadsAllZero = isAllZeros(conv2.getPads());
+    if (!conv2PadsAllZero && !isNoneOrZero(b1))
+      return rewriter.notifyMatchFailure(conv2,
+          "conv2 has nonzero pads and conv1 has nonzero bias: "
+          "bias fold would require a spatially-varying correction");
+
+    if (!isNoneOrZero(b1) && !isDenseONNXConstant(b1))
+      return rewriter.notifyMatchFailure(
+          conv2, "conv1 bias is not a dense ONNX constant");
+
+    // ---- Build fused weight -----------------------------------------
+    // Wf[Cout,Cin,K...] = einsum("mc,nm...->nc...", W1_flat, W2)
+    //
+    // Using matmul:
+    //   W1_flat = reshape(W1, [Cmid, Cin])
+    //   W2_flat = reshape(W2, [Cout, Cmid, K*K])    (K*K = product of spatial
+    //   dims) W2_t    = transpose(W2_flat, [0,2,1])        [Cout, K*K, Cmid]
+    //   Wf_flat = matmul(W2_t, W1_flat)              [Cout, K*K, Cin]
+    //   Wf_perm = transpose(Wf_flat, [0,2,1])        [Cout, Cin, K*K]
+    //   Wf      = reshape(Wf_perm, [Cout, Cin, K, K, ...])
+
+    const Location fusedLoc =
+        rewriter.getFusedLoc({conv1.getLoc(), conv2.getLoc()});
+    OnnxBuilder ob(rewriter, fusedLoc);
+
+    const int64_t cin = w1Shape[1];
+    const int64_t cmid = w1Shape[0];
+    const int64_t cout = w2Shape[0];
+    const int64_t spatialRank = static_cast<int64_t>(w2Shape.size()) - 2;
+    const int64_t kProd = std::accumulate(w2Shape.begin() + 2, w2Shape.end(),
+        int64_t{1}, std::multiplies<int64_t>());
+
+    // W1_flat [Cmid, Cin]
+    const Value w1Flat =
+        ob.reshape(RankedTensorType::get({cmid, cin}, elemType), W1,
+            ob.constantInt64({cmid, cin}));
+
+    // W2_flat [Cout, Cmid, K*K]
+    const Value w2Flat =
+        ob.reshape(RankedTensorType::get({cout, cmid, kProd}, elemType), W2,
+            ob.constantInt64({cout, cmid, kProd}));
+
+    // W2_t [Cout, K*K, Cmid]
+    const Value w2T = ob.transposeInt64(w2Flat, {0, 2, 1});
+
+    // Wf_flat [Cout, K*K, Cin]
+    const Value wfFlat = ob.matmul(
+        RankedTensorType::get({cout, kProd, cin}, elemType), w2T, w1Flat);
+
+    // Wf_perm [Cout, Cin, K*K]
+    const Value wfPerm = ob.transposeInt64(wfFlat, {0, 2, 1});
+
+    // Wf [Cout, Cin, K, K, ...]
+    SmallVector<int64_t> wfShape = {cout, cin};
+    wfShape.append(w2Shape.begin() + 2, w2Shape.end());
+    const Value Wf = ob.reshape(RankedTensorType::get(wfShape, elemType),
+        wfPerm, ob.constantInt64(wfShape));
+
+    // ---- Build fused bias -------------------------------------------
+    // bf = b2  (if b1 is None/zero)
+    // bf = MatMul(ReduceSum(W2,[2..]), b1) + b2  (if b1 nonzero and pads=0)
+    Value bf;
+    if (isNoneOrZero(b1)) {
+      // b1 contributes nothing; carry b2 through unchanged (may be None).
+      bf = b2;
+    } else {
+      // conv2PadsAllZero and isDenseONNXConstant(b1) guaranteed by previous
+      // guards.
+      // S[Cout, Cmid] = ReduceSum(W2, axes=[2,3,...]) over all spatial
+      // dims.
+      SmallVector<int64_t> spatialAxes;
+      for (int64_t i = 0; i < spatialRank; ++i)
+        spatialAxes.push_back(2 + i);
+      const Value axes = ob.constantInt64(spatialAxes);
+      const Value wSum =
+          ob.reduceSum(RankedTensorType::get({cout, cmid}, elemType), W2, axes,
+              /*keepDims=*/false);
+
+      // b1_contrib[Cout] = MatMul([Cout,Cmid], [Cmid]) -> [Cout]
+      const Value b1Contrib =
+          ob.matmul(RankedTensorType::get({cout}, elemType), wSum, b1);
+
+      if (isNoneValue(b2))
+        bf = b1Contrib;
+      else
+        bf = ob.add(b1Contrib, b2);
+    }
+
+    // ---- Build attrs for the fused conv -----------------------------
+    // kernelShape and pads come from conv2; strides and dilations are
+    // always 1 (verified by isAllOnes checks above).
+    const SmallVector<int64_t> kernelShape(w2Shape.begin() + 2, w2Shape.end());
+    SmallVector<int64_t> pads(2 * spatialRank, 0);
+    if (conv2.getPads().has_value())
+      for (int64_t i = 0; i < 2 * spatialRank; ++i)
+        pads[i] = ArrayAttrIntVal(conv2.getPads(), i);
+    const SmallVector<int64_t> ones(spatialRank, 1); // strides and dilations
+
+    // ---- Create fused conv and replace conv2 ------------------------
+    const Value fusedConv = ob.conv(conv2.getY().getType(), conv1.getX(), Wf,
+        bf, "NOTSET", ones, /*group=*/1, kernelShape, pads, ones);
+
+    rewriter.replaceOp(conv2, fusedConv);
+    return success();
+  }
+};
+
+} // namespace
+
 /// on the ONNXConvOp.
 void ONNXConvOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<NormalizeConvAutoPadPattern>(context);
+  results.insert<FuseConv1x1IntoConvPattern>(context);
 }
 
 void onnx_mlir::configureBatchNormCanonicalization(

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4283,6 +4283,16 @@ struct FuseConv1x1IntoConvPattern : public OpRewritePattern<ONNXConvOp> {
       return rewriter.notifyMatchFailure(
           conv2, "weight element types do not match");
 
+    const Value b1 = conv1.getB();
+    const Value b2 = conv2.getB();
+
+    if (hasQuantizedElementType(conv1.getX()) || hasQuantizedElementType(W1) ||
+        hasQuantizedElementType(b1) || hasQuantizedElementType(conv1.getY()) ||
+        hasQuantizedElementType(W2) || hasQuantizedElementType(b2) ||
+        hasQuantizedElementType(conv2.getY()))
+      return rewriter.notifyMatchFailure(
+          conv2, "quantized Conv fusion is not supported");
+
     // ---- Require constant weights for fold-ability ------------------
     if (!isDenseONNXConstant(W1))
       return rewriter.notifyMatchFailure(
@@ -4292,9 +4302,6 @@ struct FuseConv1x1IntoConvPattern : public OpRewritePattern<ONNXConvOp> {
           conv2, "conv2 weight is not a dense ONNX constant");
 
     // ---- Bias constraints -------------------------------------------
-    const Value b1 = conv1.getB();
-    const Value b2 = conv2.getB();
-
     // The b1 contribution is spatially uniform only when conv2 pads are all
     // zero, unless b1 contributes nothing (None or zero).
     const bool conv2PadsAllZero = isAllZeros(conv2.getPads());

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4055,6 +4055,102 @@ void ONNXWhereOp::getCanonicalizationPatterns(
 void ONNXDequantizeLinearOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {}
 
+//===----------------------------------------------------------------------===//
+// ONNXConvOp canonicalization
+//===----------------------------------------------------------------------===//
+
+// Normalize auto_pad to NOTSET with explicit pads.
+//
+// SAME_UPPER / SAME_LOWER: compute the padding required to keep the output
+// the same spatial size as the input (with ceil-division for stride > 1).
+// VALID: all pads are zero.
+// NOTSET with no pads attribute: fill with zeros.
+//
+// Requires static input spatial dims for SAME_*
+// After the rewrite auto_pad == "NOTSET" and pads holds the explicit values.
+struct NormalizeConvAutoPadPattern : public OpRewritePattern<ONNXConvOp> {
+  using OpRewritePattern<ONNXConvOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXConvOp convOp, PatternRewriter &rewriter) const override {
+    const StringRef autoPad = convOp.getAutoPad();
+
+    // Nothing to do if already normalised.
+    if (autoPad == "NOTSET" && convOp.getPads().has_value())
+      return failure();
+
+    // Require ranked weight to derive spatial rank and kernel sizes.
+    const Value W = convOp.getW();
+    if (!hasShapeAndRank(W))
+      return failure();
+    const auto wShape = cast<ShapedType>(W.getType()).getShape();
+    const int64_t spatialRank = static_cast<int64_t>(wShape.size()) - 2;
+    if (spatialRank < 1)
+      return failure();
+
+    // Pads are stored as [x1_begin, x2_begin, ..., x1_end, x2_end, ...].
+    // Initialise to zero; VALID and NOTSET-without-pads leave them that way.
+    SmallVector<int64_t> pads(2 * spatialRank, 0);
+
+    if (autoPad == "SAME_UPPER" || autoPad == "SAME_LOWER") {
+      // Pad computation requires static input spatial dims.
+      const Value X = convOp.getX();
+      if (!hasShapeAndRank(X))
+        return failure();
+      const auto xShape = cast<ShapedType>(X.getType()).getShape();
+
+      const auto stridesOpt = convOp.getStrides();
+      const auto dilationsOpt = convOp.getDilations();
+      const auto kernelShapeOpt = convOp.getKernelShape();
+      const bool isSameUpper = (autoPad == "SAME_UPPER");
+
+      for (int64_t i = 0; i < spatialRank; ++i) {
+        const int64_t inputSize = xShape[2 + i];
+        if (inputSize == ShapedType::kDynamic)
+          return failure(); // cannot compute pads statically
+
+        const int64_t kernelSize = kernelShapeOpt.has_value()
+                                       ? ArrayAttrIntVal(kernelShapeOpt, i)
+                                       : wShape[2 + i];
+        const int64_t stride =
+            stridesOpt.has_value() ? ArrayAttrIntVal(stridesOpt, i) : 1;
+        const int64_t dilation =
+            dilationsOpt.has_value() ? ArrayAttrIntVal(dilationsOpt, i) : 1;
+
+        // ONNX SAME padding spec: outputSize = ceil(inputSize / stride).
+        const int64_t outputSize = (inputSize + stride - 1) / stride;
+        // Solve for the total pad from the output-size formula:
+        //   outputSize = floor((inputSize + totalPad - effectiveKernel) /
+        //   stride) + 1
+        // where effectiveKernel = (kernelSize - 1) * dilation + 1.
+        const int64_t sumOfPad = std::max<int64_t>(
+            0, (outputSize - 1) * stride + ((kernelSize - 1) * dilation + 1) -
+                   inputSize);
+
+        // SAME_UPPER adds the extra pad (when sumOfPad is odd) at the end;
+        // SAME_LOWER adds it at the beginning.
+        const int64_t padBegin =
+            isSameUpper ? sumOfPad / 2 : sumOfPad - sumOfPad / 2;
+        const int64_t padEnd = sumOfPad - padBegin;
+        pads[i] = padBegin;
+        pads[spatialRank + i] = padEnd;
+      }
+    }
+
+    rewriter.modifyOpInPlace(convOp, [&] {
+      convOp.setAutoPadAttr(rewriter.getStringAttr("NOTSET"));
+      convOp.setPadsAttr(rewriter.getI64ArrayAttr(pads));
+    });
+    return success();
+  }
+};
+
+/// on the ONNXConvOp.
+void ONNXConvOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<NormalizeConvAutoPadPattern>(context);
+}
+
 void onnx_mlir::configureBatchNormCanonicalization(
     bool disableBatchNormDecomposeOption) {
   disableBatchNormDecompose = disableBatchNormDecomposeOption;

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4122,15 +4122,29 @@ struct NormalizeConvAutoPadPattern : public OpRewritePattern<ONNXConvOp> {
         const int64_t dilation =
             dilationsOpt.has_value() ? ArrayAttrIntVal(dilationsOpt, i) : 1;
 
-        // ONNX SAME padding spec: outputSize = ceil(inputSize / stride).
+        // ONNX SAME padding fixes the output size first:
+        //   outputSize = ceil(inputSize / stride).
         const int64_t outputSize = (inputSize + stride - 1) / stride;
-        // Solve for the total pad from the output-size formula:
+        // The last output window starts at (outputSize - 1) * stride and spans
+        // effectiveKernel input positions. The padded input must be large
+        // enough to cover that window:
+        //
+        //   inputSize + totalPad >=
+        //     (outputSize - 1) * stride + effectiveKernel
+        //
+        // Therefore the minimum total pad is:
+        //   totalPad = max(0,
+        //       (outputSize - 1) * stride + effectiveKernel - inputSize)
+        //
+        // This is equivalent to inverting:
         //   outputSize = floor((inputSize + totalPad - effectiveKernel) /
         //   stride) + 1
-        // where effectiveKernel = (kernelSize - 1) * dilation + 1.
+        // The floor is accounted for by choosing the minimum totalPad that
+        // reaches the next output window; no extra floor is applied to
+        // totalPad itself.
+        const int64_t effectiveKernel = (kernelSize - 1) * dilation + 1;
         const int64_t sumOfPad = std::max<int64_t>(
-            0, (outputSize - 1) * stride + ((kernelSize - 1) * dilation + 1) -
-                   inputSize);
+            0, (outputSize - 1) * stride + effectiveKernel - inputSize);
 
         // SAME_UPPER adds the extra pad (when sumOfPad is odd) at the end;
         // SAME_LOWER adds it at the beginning.

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -34,6 +34,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
 
 #include "src/Dialect/Mlir/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/DialectBuilder.hpp"
@@ -4086,10 +4087,10 @@ struct NormalizeConvAutoPadPattern : public OpRewritePattern<ONNXConvOp> {
       return rewriter.notifyMatchFailure(
           convOp, "weight is unranked or missing shape");
     const auto wShape = cast<ShapedType>(W.getType()).getShape();
-    const int64_t spatialRank = static_cast<int64_t>(wShape.size()) - 2;
-    if (spatialRank < 1)
-      return rewriter.notifyMatchFailure(
-          convOp, "spatial rank must be at least 1");
+    const int64_t firstSpatialDimAxis = 2;
+    const int64_t spatialRank =
+        static_cast<int64_t>(wShape.size()) - firstSpatialDimAxis;
+    assert(spatialRank >= 1 && "conv must have at least one spatial dim");
 
     // Pads are stored as [x1_begin, x2_begin, ..., x1_end, x2_end, ...].
     // Initialise to zero; VALID and NOTSET-without-pads leave them that way.
@@ -4105,18 +4106,15 @@ struct NormalizeConvAutoPadPattern : public OpRewritePattern<ONNXConvOp> {
 
       const auto stridesOpt = convOp.getStrides();
       const auto dilationsOpt = convOp.getDilations();
-      const auto kernelShapeOpt = convOp.getKernelShape();
       const bool isSameUpper = (autoPad == "SAME_UPPER");
 
       for (int64_t i = 0; i < spatialRank; ++i) {
-        const int64_t inputSize = xShape[2 + i];
+        const int64_t inputSize = xShape[firstSpatialDimAxis + i];
         if (inputSize == ShapedType::kDynamic)
           return rewriter.notifyMatchFailure(
               convOp, "dynamic spatial dim: cannot compute pads statically");
 
-        const int64_t kernelSize = kernelShapeOpt.has_value()
-                                       ? ArrayAttrIntVal(kernelShapeOpt, i)
-                                       : wShape[2 + i];
+        const int64_t kernelSize = wShape[firstSpatialDimAxis + i];
         const int64_t stride =
             stridesOpt.has_value() ? ArrayAttrIntVal(stridesOpt, i) : 1;
         const int64_t dilation =
@@ -4124,7 +4122,7 @@ struct NormalizeConvAutoPadPattern : public OpRewritePattern<ONNXConvOp> {
 
         // ONNX SAME padding fixes the output size first:
         //   outputSize = ceil(inputSize / stride).
-        const int64_t outputSize = (inputSize + stride - 1) / stride;
+        const int64_t outputSize = llvm::divideCeil(inputSize, stride);
         // The last output window starts at (outputSize - 1) * stride and spans
         // effectiveKernel input positions. The padded input must be large
         // enough to cover that window:
@@ -4166,6 +4164,13 @@ struct NormalizeConvAutoPadPattern : public OpRewritePattern<ONNXConvOp> {
 
 //===----------------------------------------------------------------------===//
 // Fuse conv1x1 -> convKxK into a single convKxK.
+//
+// A 1x1 convolution only mixes channels independently at each spatial
+// position. When it feeds exactly one following convolution, the channel mixing
+// can be folded into the following convolution's weights. If the first bias is
+// nonzero, it can also be folded into the following bias as long as the second
+// convolution has no padding; with padding the first bias contribution would be
+// smaller at border pixels and could not be represented by one constant bias.
 //
 // Fires when:
 //   - conv1 is 1x1, stride/dilation 1, group 1, zero pads.
@@ -4290,8 +4295,8 @@ struct FuseConv1x1IntoConvPattern : public OpRewritePattern<ONNXConvOp> {
     const Value b1 = conv1.getB();
     const Value b2 = conv2.getB();
 
-    // bias fold is exact only when conv2 pads are all zero
-    // or b1 contributes nothing (None or zero).
+    // The b1 contribution is spatially uniform only when conv2 pads are all
+    // zero, unless b1 contributes nothing (None or zero).
     const bool conv2PadsAllZero = isAllZeros(conv2.getPads());
     if (!conv2PadsAllZero && !isNoneOrZero(b1))
       return rewriter.notifyMatchFailure(conv2,
@@ -4300,15 +4305,19 @@ struct FuseConv1x1IntoConvPattern : public OpRewritePattern<ONNXConvOp> {
 
     if (!isNoneOrZero(b1) && !isDenseONNXConstant(b1))
       return rewriter.notifyMatchFailure(
-          conv2, "conv1 bias is not a dense ONNX constant");
+          conv1, "conv1 bias is not a dense ONNX constant");
+    if (!isNoneOrZero(b2) && !isDenseONNXConstant(b2))
+      return rewriter.notifyMatchFailure(
+          conv2, "conv2 bias is not a dense ONNX constant");
 
     // ---- Build fused weight -----------------------------------------
     // Wf[Cout,Cin,K...] = einsum("mc,nm...->nc...", W1_flat, W2)
     //
     // Using matmul:
     //   W1_flat = reshape(W1, [Cmid, Cin])
-    //   W2_flat = reshape(W2, [Cout, Cmid, K*K])    (K*K = product of spatial
-    //   dims) W2_t    = transpose(W2_flat, [0,2,1])        [Cout, K*K, Cmid]
+    //   W2_flat = reshape(W2, [Cout, Cmid, K*K])
+    //             (K*K = product of spatial dims)
+    //   W2_t    = transpose(W2_flat, [0,2,1])        [Cout, K*K, Cmid]
     //   Wf_flat = matmul(W2_t, W1_flat)              [Cout, K*K, Cin]
     //   Wf_perm = transpose(Wf_flat, [0,2,1])        [Cout, Cin, K*K]
     //   Wf      = reshape(Wf_perm, [Cout, Cin, K, K, ...])
@@ -4358,7 +4367,7 @@ struct FuseConv1x1IntoConvPattern : public OpRewritePattern<ONNXConvOp> {
       // b1 contributes nothing; carry b2 through unchanged (may be None).
       bf = b2;
     } else {
-      // conv2PadsAllZero and isDenseONNXConstant(b1) guaranteed by previous
+      // conv2PadsAllZero and dense constant biases are guaranteed by previous
       // guards.
       // S[Cout, Cmid] = ReduceSum(W2, axes=[2,3,...]) over all spatial
       // dims.

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -522,14 +522,7 @@ bool hasShapeAndRank(Operation *op) {
 }
 
 bool isInQuantizedDomain(Operation *op, Value result) {
-  auto hasQuantElt = [](Type t) -> bool {
-    auto shaped = mlir::dyn_cast_if_present<ShapedType>(t);
-    if (!shaped)
-      return false;
-    Type elt = shaped.getElementType();
-    return elt && mlir::isa<mlir::quant::QuantizedType>(elt);
-  };
-  if (result && hasQuantElt(result.getType()))
+  if (result && hasQuantizedElementType(result))
     return true;
   // `op` may be null when `updateType` is invoked outside an op-typing
   // context (e.g. ONNXToTOSALegalizeUtils::CreateOpAndInfer passes
@@ -538,7 +531,7 @@ bool isInQuantizedDomain(Operation *op, Value result) {
   if (!op)
     return false;
   for (Value operand : op->getOperands())
-    if (operand && hasQuantElt(operand.getType()))
+    if (operand && hasQuantizedElementType(operand))
       return true;
   return false;
 }
@@ -1188,6 +1181,8 @@ bool hasQuantizedElementType(mlir::Type type) {
 }
 
 bool hasQuantizedElementType(mlir::Value value) {
+  if (isNoneValue(value))
+    return false;
   return hasQuantizedElementType(value.getType());
 }
 

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -1040,7 +1040,7 @@ func.func @test_fuse_add_conv(%arg0 : tensor<1x1x28x28xf32>, %arg1 : tensor<8x1x
 // CHECK-LABEL:  func.func @test_fuse_add_conv
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>, [[PARAM_1_:%.+]]: tensor<8x1x5x5xf32>) -> tensor<1x8x28x28xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[-0.161539719, -0.433835655, 0.091641359, -0.0168522168, -0.0650264397, -0.131737873, 0.0204175506, -0.121110231]> : tensor<8xf32>
-// CHECK:           [[VAR_1_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<1x8x28x28xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], pads = [2, 2, 2, 2], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<1x8x28x28xf32>
 // CHECK:           onnx.Return [[VAR_1_]] : tensor<1x8x28x28xf32>
 }
 
@@ -1055,7 +1055,7 @@ func.func @test_fuse_add_conv_bias(%arg0 : tensor<1x1x28x28xf32>, %arg1 : tensor
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>, [[PARAM_1_:%.+]]: tensor<8x1x5x5xf32>, [[PARAM_2_:%.+]]: tensor<8xf32>) -> tensor<1x8x28x28xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[-0.161539719, -0.433835655, 0.091641359, -0.0168522168, -0.0650264397, -0.131737873, 0.0204175506, -0.121110231]> : tensor<8xf32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Add"([[PARAM_2_]], [[VAR_0_]]) : (tensor<8xf32>, tensor<8xf32>) -> tensor<8xf32>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_1_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<1x8x28x28xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], pads = [2, 2, 2, 2], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<1x8x28x28xf32>
 // CHECK:           onnx.Return [[VAR_2_]] : tensor<1x8x28x28xf32>
 }
 
@@ -1109,7 +1109,7 @@ func.func @test_fuse_add_conv_with_scalar_const(%arg0 : tensor<1x1x28x28xf32>, %
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>, [[PARAM_1_:%.+]]: tensor<8x1x5x5xf32>) -> tensor<1x8x28x28xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<f32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.NoValue"() {value} : () -> none
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_1_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, none) -> tensor<1x8x28x28xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", pads = [2, 2, 2, 2], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, none) -> tensor<1x8x28x28xf32>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[VAR_2_]], [[VAR_0_]]) : (tensor<1x8x28x28xf32>, tensor<f32>) -> tensor<1x8x28x28xf32>
 // CHECK:           onnx.Return [[VAR_3_]] : tensor<1x8x28x28xf32>
 // CHECK:         }
@@ -1488,7 +1488,7 @@ func.func @test_fuse_mul_conv_rank_3D(%arg0: tensor<1x1x28x28xf32>) -> tensor<*x
   // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK:           [[VAR_4_:%.+]] = "onnx.Reshape"([[VAR_1_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<8x1x1xf32>, tensor<4xi64>) -> tensor<8x1x1x1xf32>
   // CHECK:           [[VAR_5_:%.+]] = "onnx.Mul"([[VAR_4_]], [[VAR_2_]]) : (tensor<8x1x1x1xf32>, tensor<8x1x2x2xf32>) -> tensor<8x1x2x2xf32>
-  // CHECK:           [[VAR_6_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_5_]], [[VAR_3_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2, 2], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x2x2xf32>, none) -> tensor<1x8x27x27xf32>
+  // CHECK:           [[VAR_6_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_5_]], [[VAR_3_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2, 2], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x2x2xf32>, none) -> tensor<1x8x27x27xf32>
   // CHECK:           onnx.Return [[VAR_6_]] : tensor<1x8x27x27xf32>
 }
 

--- a/test/mlir/onnx/onnx_conv_1x1_fusion.mlir
+++ b/test/mlir/onnx/onnx_conv_1x1_fusion.mlir
@@ -1,0 +1,431 @@
+// RUN: onnx-mlir-opt --onnx-hybrid-transform %s -split-input-file | FileCheck %s
+
+// -----
+
+func.func @test_fuse_conv1x1_basic(
+    %x: tensor<1x3x8x8xf32>) -> tensor<1x8x6x6xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %b1 = onnx.Constant dense<0.5> : tensor<4xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %b2 = onnx.Constant dense<2.0> : tensor<8xf32>
+  %c1 = "onnx.Conv"(%x, %w1, %b1) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %b2) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
+  onnx.Return %c2 : tensor<1x8x6x6xf32>
+
+
+// CHECK-LABEL:  func.func @test_fuse_conv1x1_basic
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>) -> tensor<1x8x6x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<4.000000e+00> : tensor<8x3x3x3xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<2.000000e+01> : tensor<8xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x8x6x6xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_fuse_conv1x1_no_bias(
+    %x: tensor<1x3x8x8xf32>) -> tensor<1x8x6x6xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %c1 = "onnx.Conv"(%x, %w1, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x6x6xf32>
+  onnx.Return %c2 : tensor<1x8x6x6xf32>
+
+
+// CHECK-LABEL:  func.func @test_fuse_conv1x1_no_bias
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>) -> tensor<1x8x6x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<4.000000e+00> : tensor<8x3x3x3xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_1_]], [[VAR_0_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<8x3x3x3xf32>, none) -> tensor<1x8x6x6xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x8x6x6xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_fuse_conv1x1_same_upper_b1_zero(
+    %x: tensor<1x3x8x8xf32>) -> tensor<1x8x8x8xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %b1 = onnx.Constant dense<0.0> : tensor<4xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %b2 = onnx.Constant dense<2.0> : tensor<8xf32>
+  %c1 = "onnx.Conv"(%x, %w1, %b1) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %b2) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>
+  onnx.Return %c2 : tensor<1x8x8x8xf32>
+
+
+// CHECK-LABEL:  func.func @test_fuse_conv1x1_same_upper_b1_zero
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>) -> tensor<1x8x8x8xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<8xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<4.000000e+00> : tensor<8x3x3x3xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_1_]], [[VAR_0_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x8x8x8xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_no_fuse_padded_nonzero_b1(
+    %x: tensor<1x3x8x8xf32>) -> tensor<1x8x8x8xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %b1 = onnx.Constant dense<0.5> : tensor<4xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %b2 = onnx.Constant dense<2.0> : tensor<8xf32>
+  %c1 = "onnx.Conv"(%x, %w1, %b1) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %b2) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>
+  onnx.Return %c2 : tensor<1x8x8x8xf32>
+
+
+// CHECK-LABEL:  func.func @test_no_fuse_padded_nonzero_b1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>) -> tensor<1x8x8x8xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x3x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<8x4x3x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<8xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+// CHECK:           [[VAR_5_:%.+]] = "onnx.Conv"([[VAR_4_]], [[VAR_2_]], [[VAR_3_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>
+// CHECK:           onnx.Return [[VAR_5_]] : tensor<1x8x8x8xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_no_fuse_multiple_uses(
+    %x: tensor<1x3x8x8xf32>) -> (tensor<1x8x6x6xf32>, tensor<1x4x8x8xf32>) {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %c1 = "onnx.Conv"(%x, %w1, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x6x6xf32>
+  onnx.Return %c2, %c1 : tensor<1x8x6x6xf32>, tensor<1x4x8x8xf32>
+
+
+// CHECK-LABEL:  func.func @test_no_fuse_multiple_uses
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>) -> (tensor<1x8x6x6xf32>, tensor<1x4x8x8xf32>) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x3x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<8x4x3x3xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_2_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Conv"([[VAR_3_]], [[VAR_1_]], [[VAR_2_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x6x6xf32>
+// CHECK:           onnx.Return [[VAR_4_]], [[VAR_3_]] : tensor<1x8x6x6xf32>, tensor<1x4x8x8xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_no_fuse_non_1x1_conv1(
+    %x: tensor<1x3x10x10xf32>) -> tensor<1x8x4x4xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x3x3xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %c1 = "onnx.Conv"(%x, %w1, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x10x10xf32>, tensor<4x3x3x3xf32>, none) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x4x4xf32>
+  onnx.Return %c2 : tensor<1x8x4x4xf32>
+
+
+// CHECK-LABEL:  func.func @test_no_fuse_non_1x1_conv1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x10x10xf32>) -> tensor<1x8x4x4xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x3x3x3xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<8x4x3x3xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_2_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x10x10xf32>, tensor<4x3x3x3xf32>, none) -> tensor<1x4x8x8xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Conv"([[VAR_3_]], [[VAR_1_]], [[VAR_2_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x4x4xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<1x8x4x4xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_no_fuse_stride2(
+    %x: tensor<1x3x8x8xf32>) -> tensor<1x8x3x3xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %c1 = "onnx.Conv"(%x, %w1, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [2, 2]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x3x3xf32>
+  onnx.Return %c2 : tensor<1x8x3x3xf32>
+
+
+// CHECK-LABEL:  func.func @test_no_fuse_stride2
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>) -> tensor<1x8x3x3xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x3x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<8x4x3x3xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_2_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Conv"([[VAR_3_]], [[VAR_1_]], [[VAR_2_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [2, 2]} : (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x3x3xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<1x8x3x3xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_no_fuse_group(
+    %x: tensor<1x4x8x8xf32>) -> tensor<1x4x8x8xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x4x1x1xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<4x1x1x1xf32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %c1 = "onnx.Conv"(%x, %w1, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<4x4x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 4 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<4x1x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+  onnx.Return %c2 : tensor<1x4x8x8xf32>
+
+
+// CHECK-LABEL:  func.func @test_no_fuse_group
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x4x8x8xf32>) -> tensor<1x4x8x8xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x4x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x1x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_2_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x4x8x8xf32>, tensor<4x4x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Conv"([[VAR_3_]], [[VAR_1_]], [[VAR_2_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 4 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x4x8x8xf32>, tensor<4x1x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<1x4x8x8xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_fuse_conv1x1_b1_none(
+    %x: tensor<1x3x8x8xf32>) -> tensor<1x8x6x6xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %b2 = onnx.Constant dense<2.0> : tensor<8xf32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %c1 = "onnx.Conv"(%x, %w1, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %b2) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
+  onnx.Return %c2 : tensor<1x8x6x6xf32>
+
+
+// CHECK-LABEL:  func.func @test_fuse_conv1x1_b1_none
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>) -> tensor<1x8x6x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<8xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<4.000000e+00> : tensor<8x3x3x3xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_1_]], [[VAR_0_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x8x6x6xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_fuse_conv1x1_b2_none(
+    %x: tensor<1x3x8x8xf32>) -> tensor<1x8x6x6xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %b1 = onnx.Constant dense<0.5> : tensor<4xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %c1 = "onnx.Conv"(%x, %w1, %b1) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x6x6xf32>
+  onnx.Return %c2 : tensor<1x8x6x6xf32>
+
+
+// CHECK-LABEL:  func.func @test_fuse_conv1x1_b2_none
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>) -> tensor<1x8x6x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<4.000000e+00> : tensor<8x3x3x3xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.800000e+01> : tensor<8xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x8x6x6xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_no_fuse_non_constant_w1(
+    %x: tensor<1x3x8x8xf32>,
+    %w1: tensor<4x3x1x1xf32>) -> tensor<1x8x6x6xf32> {
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %c1 = "onnx.Conv"(%x, %w1, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x6x6xf32>
+  onnx.Return %c2 : tensor<1x8x6x6xf32>
+
+
+// CHECK-LABEL:  func.func @test_no_fuse_non_constant_w1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>, [[PARAM_1_:%.+]]: tensor<4x3x1x1xf32>) -> tensor<1x8x6x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<8x4x3x3xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Conv"([[VAR_2_]], [[VAR_0_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x6x6xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<1x8x6x6xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_no_fuse_non_constant_w2(
+    %x: tensor<1x3x8x8xf32>,
+    %w2: tensor<8x4x3x3xf32>) -> tensor<1x8x6x6xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %c1 = "onnx.Conv"(%x, %w1, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x6x6xf32>
+  onnx.Return %c2 : tensor<1x8x6x6xf32>
+
+
+// CHECK-LABEL:  func.func @test_no_fuse_non_constant_w2
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>, [[PARAM_1_:%.+]]: tensor<8x4x3x3xf32>) -> tensor<1x8x6x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x3x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, none) -> tensor<1x4x8x8xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Conv"([[VAR_2_]], [[PARAM_1_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, none) -> tensor<1x8x6x6xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<1x8x6x6xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_no_fuse_non_constant_b1(
+    %x: tensor<1x3x8x8xf32>,
+    %b1: tensor<4xf32>) -> tensor<1x8x6x6xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %b2 = onnx.Constant dense<2.0> : tensor<8xf32>
+  %c1 = "onnx.Conv"(%x, %w1, %b1) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %b2) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
+  onnx.Return %c2 : tensor<1x8x6x6xf32>
+
+
+// CHECK-LABEL:  func.func @test_no_fuse_non_constant_b1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>, [[PARAM_1_:%.+]]: tensor<4xf32>) -> tensor<1x8x6x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x3x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<8x4x3x3xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<8xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[PARAM_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Conv"([[VAR_3_]], [[VAR_1_]], [[VAR_2_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<1x8x6x6xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_fuse_conv1x1_numerical_weight(
+    %x: tensor<1x2x6x6xf32>) -> tensor<1x2x4x4xf32> {
+  %w1 = onnx.Constant dense<[[[[2.0]], [[3.0]]], [[[4.0]], [[5.0]]]]> : tensor<2x2x1x1xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<2x2x3x3xf32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %c1 = "onnx.Conv"(%x, %w1, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x2x6x6xf32>, tensor<2x2x1x1xf32>, none) -> tensor<1x2x6x6xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x2x6x6xf32>, tensor<2x2x3x3xf32>, none) -> tensor<1x2x4x4xf32>
+  onnx.Return %c2 : tensor<1x2x4x4xf32>
+
+
+// CHECK-LABEL:  func.func @test_fuse_conv1x1_numerical_weight
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x6x6xf32>) -> tensor<1x2x4x4xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<{{.}}[{{.}}[6.000000e+00, 6.000000e+00, 6.000000e+00], [6.000000e+00, 6.000000e+00, 6.000000e+00], [6.000000e+00, 6.000000e+00, 6.000000e+00]{{.}}, {{.}}[8.000000e+00, 8.000000e+00, 8.000000e+00], [8.000000e+00, 8.000000e+00, 8.000000e+00], [8.000000e+00, 8.000000e+00, 8.000000e+00]{{.}}{{.}}, {{.}}{{.}}[6.000000e+00, 6.000000e+00, 6.000000e+00], [6.000000e+00, 6.000000e+00, 6.000000e+00], [6.000000e+00, 6.000000e+00, 6.000000e+00]{{.}}, {{.}}[8.000000e+00, 8.000000e+00, 8.000000e+00], [8.000000e+00, 8.000000e+00, 8.000000e+00], [8.000000e+00, 8.000000e+00, 8.000000e+00]{{.}}{{.}}]> : tensor<2x2x3x3xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_1_]], [[VAR_0_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x2x6x6xf32>, tensor<2x2x3x3xf32>, none) -> tensor<1x2x4x4xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x2x4x4xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_no_fuse_dynamic_same_upper_nonzero_b1(
+    %x: tensor<1x3x?x?xf32>) -> tensor<1x8x?x?xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %b1 = onnx.Constant dense<0.5> : tensor<4xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %b2 = onnx.Constant dense<2.0> : tensor<8xf32>
+  %c1 = "onnx.Conv"(%x, %w1, %b1) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], strides = [1, 1]} :
+      (tensor<1x3x?x?xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x?x?xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %b2) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [1, 1]} :
+      (tensor<1x4x?x?xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x?x?xf32>
+  onnx.Return %c2 : tensor<1x8x?x?xf32>
+
+
+// CHECK-LABEL:  func.func @test_no_fuse_dynamic_same_upper_nonzero_b1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x?x?xf32>) -> tensor<1x8x?x?xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x3x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<8x4x3x3xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<8xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], strides = [1, 1]} : (tensor<1x3x?x?xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x?x?xf32>
+// CHECK:           [[VAR_5_:%.+]] = "onnx.Conv"([[VAR_4_]], [[VAR_2_]], [[VAR_3_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], strides = [1, 1]} : (tensor<1x4x?x?xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x?x?xf32>
+// CHECK:           onnx.Return [[VAR_5_]] : tensor<1x8x?x?xf32>
+// CHECK:         }
+}

--- a/test/mlir/onnx/onnx_conv_1x1_fusion.mlir
+++ b/test/mlir/onnx/onnx_conv_1x1_fusion.mlir
@@ -543,3 +543,34 @@ func.func @test_no_fuse_dynamic_same_upper_nonzero_b1(
 // CHECK:           onnx.Return [[VAR_5_]] : tensor<1x8x?x?xf32>
 // CHECK:         }
 }
+
+// -----
+
+func.func @test_no_fuse_quantized_conv1x1(
+    %x: tensor<1x3x8x8x!quant.uniform<i8:f32, 0.1:0>>,
+    %w1: tensor<4x3x1x1x!quant.uniform<i8:f32, 0.1:0>>,
+    %w2: tensor<8x4x3x3x!quant.uniform<i8:f32, 0.1:0>>) -> tensor<1x8x6x6x!quant.uniform<i8:f32, 0.1:0>> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %c1 = "onnx.Conv"(%x, %w1, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8x!quant.uniform<i8:f32, 0.1:0>>,
+       tensor<4x3x1x1x!quant.uniform<i8:f32, 0.1:0>>, none) ->
+      tensor<1x4x8x8x!quant.uniform<i8:f32, 0.1:0>>
+  %c2 = "onnx.Conv"(%c1, %w2, %none) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8x!quant.uniform<i8:f32, 0.1:0>>,
+       tensor<8x4x3x3x!quant.uniform<i8:f32, 0.1:0>>, none) ->
+      tensor<1x8x6x6x!quant.uniform<i8:f32, 0.1:0>>
+  onnx.Return %c2 : tensor<1x8x6x6x!quant.uniform<i8:f32, 0.1:0>>
+
+
+// CHECK-LABEL:  func.func @test_no_fuse_quantized_conv1x1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8x!quant.uniform<i8:f32, 1.000000e-01>>, [[PARAM_1_:%.+]]: tensor<4x3x1x1x!quant.uniform<i8:f32, 1.000000e-01>>, [[PARAM_2_:%.+]]: tensor<8x4x3x3x!quant.uniform<i8:f32, 1.000000e-01>>) -> tensor<1x8x6x6x!quant.uniform<i8:f32, 1.000000e-01>> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8x!quant.uniform<i8:f32, 1.000000e-01>>, tensor<4x3x1x1x!quant.uniform<i8:f32, 1.000000e-01>>, none) -> tensor<1x4x8x8x!quant.uniform<i8:f32, 1.000000e-01>>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[VAR_1_]], [[PARAM_2_]], [[VAR_0_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x4x8x8x!quant.uniform<i8:f32, 1.000000e-01>>, tensor<8x4x3x3x!quant.uniform<i8:f32, 1.000000e-01>>, none) -> tensor<1x8x6x6x!quant.uniform<i8:f32, 1.000000e-01>>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x8x6x6x!quant.uniform<i8:f32, 1.000000e-01>>
+// CHECK:         }
+}

--- a/test/mlir/onnx/onnx_conv_1x1_fusion.mlir
+++ b/test/mlir/onnx/onnx_conv_1x1_fusion.mlir
@@ -30,6 +30,90 @@ func.func @test_fuse_conv1x1_basic(
 
 // -----
 
+func.func @test_fuse_conv1x1_without_explicit_dilations(
+    %x: tensor<1x3x8x8xf32>) -> tensor<1x8x6x6xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %b1 = onnx.Constant dense<0.5> : tensor<4xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %b2 = onnx.Constant dense<2.0> : tensor<8xf32>
+  %c1 = "onnx.Conv"(%x, %w1, %b1) {
+      auto_pad = "NOTSET", group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %b2) {
+      auto_pad = "NOTSET", group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
+  onnx.Return %c2 : tensor<1x8x6x6xf32>
+
+
+// CHECK-LABEL:  func.func @test_fuse_conv1x1_without_explicit_dilations
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>) -> tensor<1x8x6x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<4.000000e+00> : tensor<8x3x3x3xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<2.000000e+01> : tensor<8xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x8x6x6xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_fuse_conv1x1_1d(
+    %x: tensor<1x3x8xf32>) -> tensor<1x8x6xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1xf32>
+  %b1 = onnx.Constant dense<0.5> : tensor<4xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3xf32>
+  %b2 = onnx.Constant dense<2.0> : tensor<8xf32>
+  %c1 = "onnx.Conv"(%x, %w1, %b1) {
+      auto_pad = "NOTSET", dilations = [1], group = 1 : si64,
+      kernel_shape = [1], pads = [0, 0], strides = [1]} :
+      (tensor<1x3x8xf32>, tensor<4x3x1xf32>, tensor<4xf32>) -> tensor<1x4x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %b2) {
+      auto_pad = "NOTSET", dilations = [1], group = 1 : si64,
+      kernel_shape = [3], pads = [0, 0], strides = [1]} :
+      (tensor<1x4x8xf32>, tensor<8x4x3xf32>, tensor<8xf32>) -> tensor<1x8x6xf32>
+  onnx.Return %c2 : tensor<1x8x6xf32>
+
+
+// CHECK-LABEL:  func.func @test_fuse_conv1x1_1d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8xf32>) -> tensor<1x8x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<4.000000e+00> : tensor<8x3x3xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<8.000000e+00> : tensor<8xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1], group = 1 : si64, kernel_shape = [3], pads = [0, 0], strides = [1]} : (tensor<1x3x8xf32>, tensor<8x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x8x6xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_fuse_conv1x1_3d(
+    %x: tensor<1x3x8x8x8xf32>) -> tensor<1x8x6x6x6xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1x1xf32>
+  %b1 = onnx.Constant dense<0.5> : tensor<4xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3x3xf32>
+  %b2 = onnx.Constant dense<2.0> : tensor<8xf32>
+  %c1 = "onnx.Conv"(%x, %w1, %b1) {
+      auto_pad = "NOTSET", dilations = [1, 1, 1], group = 1 : si64,
+      kernel_shape = [1, 1, 1], pads = [0, 0, 0, 0, 0, 0], strides = [1, 1, 1]} :
+      (tensor<1x3x8x8x8xf32>, tensor<4x3x1x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %b2) {
+      auto_pad = "NOTSET", dilations = [1, 1, 1], group = 1 : si64,
+      kernel_shape = [3, 3, 3], pads = [0, 0, 0, 0, 0, 0], strides = [1, 1, 1]} :
+      (tensor<1x4x8x8x8xf32>, tensor<8x4x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6x6xf32>
+  onnx.Return %c2 : tensor<1x8x6x6x6xf32>
+
+
+// CHECK-LABEL:  func.func @test_fuse_conv1x1_3d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8x8xf32>) -> tensor<1x8x6x6x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<4.000000e+00> : tensor<8x3x3x3x3xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<5.600000e+01> : tensor<8xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1, 1], group = 1 : si64, kernel_shape = [3, 3, 3], pads = [0, 0, 0, 0, 0, 0], strides = [1, 1, 1]} : (tensor<1x3x8x8x8xf32>, tensor<8x3x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6x6xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x8x6x6x6xf32>
+// CHECK:         }
+}
+
+// -----
+
 func.func @test_fuse_conv1x1_no_bias(
     %x: tensor<1x3x8x8xf32>) -> tensor<1x8x6x6xf32> {
   %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
@@ -368,6 +452,36 @@ func.func @test_no_fuse_non_constant_b1(
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<8xf32>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[PARAM_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
 // CHECK:           [[VAR_4_:%.+]] = "onnx.Conv"([[VAR_3_]], [[VAR_1_]], [[VAR_2_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<1x8x6x6xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_no_fuse_non_constant_b2(
+    %x: tensor<1x3x8x8xf32>,
+    %b2: tensor<8xf32>) -> tensor<1x8x6x6xf32> {
+  %w1 = onnx.Constant dense<1.0> : tensor<4x3x1x1xf32>
+  %b1 = onnx.Constant dense<0.5> : tensor<4xf32>
+  %w2 = onnx.Constant dense<1.0> : tensor<8x4x3x3xf32>
+  %c1 = "onnx.Conv"(%x, %w1, %b1) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+  %c2 = "onnx.Conv"(%c1, %w2, %b2) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} :
+      (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
+  onnx.Return %c2 : tensor<1x8x6x6xf32>
+
+
+// CHECK-LABEL:  func.func @test_no_fuse_non_constant_b2
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x8x8xf32>, [[PARAM_1_:%.+]]: tensor<8xf32>) -> tensor<1x8x6x6xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<4x3x1x1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<8x4x3x3xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<4x3x1x1xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Conv"([[VAR_3_]], [[VAR_2_]], [[PARAM_1_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x4x8x8xf32>, tensor<8x4x3x3xf32>, tensor<8xf32>) -> tensor<1x8x6x6xf32>
 // CHECK:           onnx.Return [[VAR_4_]] : tensor<1x8x6x6xf32>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_conv_normalize_autopad.mlir
+++ b/test/mlir/onnx/onnx_conv_normalize_autopad.mlir
@@ -80,6 +80,67 @@ func.func @test_normalize_conv_autopad_same_upper_stride2(
 
 // -----
 
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_same_upper_1d_stride2
+func.func @test_normalize_conv_autopad_same_upper_1d_stride2(
+    %x: tensor<1x3x28xf32>, %w: tensor<8x3x3xf32>, %b: tensor<8xf32>) -> tensor<1x8x14xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_UPPER", dilations = [1], group = 1 : si64,
+      kernel_shape = [3], strides = [2]} :
+      (tensor<1x3x28xf32>, tensor<8x3x3xf32>, tensor<8xf32>) -> tensor<1x8x14xf32>
+  onnx.Return %0 : tensor<1x8x14xf32>
+  // SAME_UPPER 1D 3-wide stride-2: outputSize=ceil(28/2)=14,
+  // sumOfPad=(14-1)*2+(3-1)*1+1-28=1; extra pad goes at the end.
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [0, 1]
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_same_upper_3d
+func.func @test_normalize_conv_autopad_same_upper_3d(
+    %x: tensor<1x3x8x8x8xf32>, %w: tensor<8x3x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<1x8x8x8x8xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1, 1], group = 1 : si64,
+      kernel_shape = [3, 3, 3], strides = [1, 1, 1]} :
+      (tensor<1x3x8x8x8xf32>, tensor<8x3x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x8x8x8xf32>
+  onnx.Return %0 : tensor<1x8x8x8x8xf32>
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [1, 1, 1, 1, 1, 1]
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_same_lower_stride3
+func.func @test_normalize_conv_autopad_same_lower_stride3(
+    %x: tensor<1x3x29x29xf32>, %w: tensor<8x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<1x8x10x10xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_LOWER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [3, 3]} :
+      (tensor<1x3x29x29xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x10x10xf32>
+  onnx.Return %0 : tensor<1x8x10x10xf32>
+  // SAME_LOWER 3x3 stride-3: outputSize=ceil(29/3)=10,
+  // sumOfPad=(10-1)*3+(3-1)*1+1-29=1; SAME_LOWER adds extra at beginning
+  // -> pads=[1,1,0,0]
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [1, 1, 0, 0]
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_same_upper_batch2
+func.func @test_normalize_conv_autopad_same_upper_batch2(
+    %x: tensor<2x3x28x28xf32>, %w: tensor<8x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<2x8x28x28xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [1, 1]} :
+      (tensor<2x3x28x28xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<2x8x28x28xf32>
+  onnx.Return %0 : tensor<2x8x28x28xf32>
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [1, 1, 1, 1]
+}
+
+// -----
+
 // Dynamic spatial dims: pattern must NOT fire for SAME_UPPER.
 // CHECK-LABEL: func.func @test_normalize_conv_autopad_dynamic_no_rewrite
 func.func @test_normalize_conv_autopad_dynamic_no_rewrite(

--- a/test/mlir/onnx/onnx_conv_normalize_autopad.mlir
+++ b/test/mlir/onnx/onnx_conv_normalize_autopad.mlir
@@ -1,0 +1,173 @@
+// RUN: onnx-mlir-opt --canonicalize %s -split-input-file | FileCheck %s
+
+// -----
+
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_same_upper_3x3
+// CHECK-SAME:  ([[X:%.+]]: tensor<1x3x28x28xf32>, [[W:%.+]]: tensor<8x3x3x3xf32>, [[B:%.+]]: tensor<8xf32>)
+func.func @test_normalize_conv_autopad_same_upper_3x3(
+    %x: tensor<1x3x28x28xf32>, %w: tensor<8x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<1x8x28x28xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [1, 1]} :
+      (tensor<1x3x28x28xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x28x28xf32>
+  onnx.Return %0 : tensor<1x8x28x28xf32>
+  // SAME_UPPER 3x3 stride-1: outputSize=28, sumOfPad=(28-1)*1+3-28=2, pads=[1,1,1,1]
+  // CHECK: "onnx.Conv"([[X]], [[W]], [[B]]) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [1, 1, 1, 1]
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_same_lower_3x3
+func.func @test_normalize_conv_autopad_same_lower_3x3(
+    %x: tensor<1x3x28x28xf32>, %w: tensor<8x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<1x8x28x28xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_LOWER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [1, 1]} :
+      (tensor<1x3x28x28xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x28x28xf32>
+  onnx.Return %0 : tensor<1x8x28x28xf32>
+  // SAME_LOWER 3x3 stride-1: sumOfPad=2 (even), so split is symmetric -> pads=[1,1,1,1]
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [1, 1, 1, 1]
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_valid
+func.func @test_normalize_conv_autopad_valid(
+    %x: tensor<1x3x28x28xf32>, %w: tensor<8x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<1x8x26x26xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "VALID", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [1, 1]} :
+      (tensor<1x3x28x28xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x26x26xf32>
+  onnx.Return %0 : tensor<1x8x26x26xf32>
+  // VALID: all zeros
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [0, 0, 0, 0]
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_same_upper_1x1
+func.func @test_normalize_conv_autopad_same_upper_1x1(
+    %x: tensor<1x32x720x1280xf32>, %w: tensor<25x32x1x1xf32>, %b: tensor<25xf32>) -> tensor<1x25x720x1280xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [1, 1], strides = [1, 1]} :
+      (tensor<1x32x720x1280xf32>, tensor<25x32x1x1xf32>, tensor<25xf32>) -> tensor<1x25x720x1280xf32>
+  onnx.Return %0 : tensor<1x25x720x1280xf32>
+  // 1x1 kernel always produces zero padding regardless of auto_pad
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [0, 0, 0, 0]
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_same_upper_stride2
+func.func @test_normalize_conv_autopad_same_upper_stride2(
+    %x: tensor<1x3x28x28xf32>, %w: tensor<8x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<1x8x14x14xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [2, 2]} :
+      (tensor<1x3x28x28xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x14x14xf32>
+  onnx.Return %0 : tensor<1x8x14x14xf32>
+  // SAME_UPPER 3x3 stride-2: outputSize=ceil(28/2)=14,
+  // sumOfPad=(14-1)*2+(3-1)*1+1-28=1 (odd); SAME_UPPER adds extra at end
+  // -> pads=[0,0,1,1]
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [0, 0, 1, 1]
+}
+
+// -----
+
+// Dynamic spatial dims: pattern must NOT fire for SAME_UPPER.
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_dynamic_no_rewrite
+func.func @test_normalize_conv_autopad_dynamic_no_rewrite(
+    %x: tensor<1x3x?x?xf32>, %w: tensor<8x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<1x8x?x?xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [1, 1]} :
+      (tensor<1x3x?x?xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x?x?xf32>
+  onnx.Return %0 : tensor<1x8x?x?xf32>
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "SAME_UPPER"
+  // CHECK-NOT: pads
+}
+
+// -----
+
+// NOTSET with explicit pads already present: no rewrite.
+// CHECK-LABEL: func.func @test_normalize_conv_notset_already_normalised
+func.func @test_normalize_conv_notset_already_normalised(
+    %x: tensor<1x3x28x28xf32>, %w: tensor<8x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<1x8x28x28xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} :
+      (tensor<1x3x28x28xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x28x28xf32>
+  onnx.Return %0 : tensor<1x8x28x28xf32>
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [1, 1, 1, 1]
+}
+
+// -----
+
+// NOTSET with no pads attribute: pattern fires and fills explicit zero pads.
+// CHECK-LABEL: func.func @test_normalize_conv_notset_no_pads
+func.func @test_normalize_conv_notset_no_pads(
+    %x: tensor<1x3x28x28xf32>, %w: tensor<8x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<1x8x26x26xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [1, 1]} :
+      (tensor<1x3x28x28xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<1x8x26x26xf32>
+  onnx.Return %0 : tensor<1x8x26x26xf32>
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [0, 0, 0, 0]
+}
+
+// -----
+
+// Unranked input (tensor<*xf32>): hasShapeAndRank(X) fails, pattern must not
+// fire even though auto_pad is SAME_UPPER.
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_unranked_input_no_rewrite
+func.func @test_normalize_conv_autopad_unranked_input_no_rewrite(
+    %x: tensor<*xf32>, %w: tensor<8x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<*xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [1, 1]} :
+      (tensor<*xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "SAME_UPPER"
+  // CHECK-NOT: pads
+}
+
+// -----
+
+// Unranked weight (tensor<*xf32>): hasShapeAndRank(W) fails at the first
+// guard, before even inspecting X. Pattern must not fire.
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_unranked_weight_no_rewrite
+func.func @test_normalize_conv_autopad_unranked_weight_no_rewrite(
+    %x: tensor<1x3x28x28xf32>, %w: tensor<*xf32>, %b: tensor<8xf32>) -> tensor<*xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [1, 1]} :
+      (tensor<1x3x28x28xf32>, tensor<*xf32>, tensor<8xf32>) -> tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "SAME_UPPER"
+  // CHECK-NOT: pads
+}
+
+// -----
+
+// Dynamic non-spatial dims (batch and channel are '?', spatial dims are
+// static): the pattern only reads xShape[2+i], so it must still fire.
+// CHECK-LABEL: func.func @test_normalize_conv_autopad_dynamic_nonspatial_fires
+func.func @test_normalize_conv_autopad_dynamic_nonspatial_fires(
+    %x: tensor<?x3x28x28xf32>, %w: tensor<8x3x3x3xf32>, %b: tensor<8xf32>) -> tensor<?x8x28x28xf32> {
+  %0 = "onnx.Conv"(%x, %w, %b) {
+      auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64,
+      kernel_shape = [3, 3], strides = [1, 1]} :
+      (tensor<?x3x28x28xf32>, tensor<8x3x3x3xf32>, tensor<8xf32>) -> tensor<?x8x28x28xf32>
+  onnx.Return %0 : tensor<?x8x28x28xf32>
+  // Spatial dims are static: pads can be computed.
+  // CHECK: "onnx.Conv"({{.*}}) {auto_pad = "NOTSET"
+  // CHECK-SAME: pads = [1, 1, 1, 1]
+}

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -531,6 +531,7 @@ OpsWithCanonicalizer = [
     "Clip",
     "Concat",
     "Constant",
+    "Conv",
     "DepthToSpace",
     "DequantizeLinear",
     "Div",


### PR DESCRIPTION
Two commits:

1. The first is a canonicalization of autopad to explicit pads, to make other pattern matching easier.
2. Fusion of 1x1 convs into consumer conv. This is only done it cases where the consumer conv size or padding does not need to be changed and no additional bias/correction add is needed.  This should always be beneficial so i think its fine to have as canonicalization


Will port to nightly

