### PR TITLE
Add canonicalization patterns for redundant Concats

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2033,6 +2033,60 @@ struct RecomposeConcatPattern : public OpRewritePattern<ONNXConcatOp> {
   }
 };
 
+// A concat operand whose type has a statically zero-sized dimension is an
+// empty tensor and contributes nothing to the concatenation, so it can be
+// dropped. The result shape is unchanged, so the original result type is
+// reused. Only a single empty operand is removed per rewrite; when several
+// are present the greedy driver re-matches this pattern until none remain.
+// Restricted to arity > 1 so the rewrite never produces an operand-less
+// concat; a resulting single operand is folded by `ConcatSingleOperandPattern`.
+struct RemoveEmptyConcatOperandsPattern
+    : public OpRewritePattern<ONNXConcatOp> {
+  using OpRewritePattern<ONNXConcatOp>::OpRewritePattern;
+
+  static bool isEmptyTensor(Value v) {
+    auto type = mlir::dyn_cast<ShapedType>(v.getType());
+    return type && type.hasRank() && llvm::is_contained(type.getShape(), 0);
+  }
+
+  LogicalResult matchAndRewrite(
+      ONNXConcatOp concatOp, PatternRewriter &rewriter) const final {
+    if (concatOp.getNumOperands() <= 1)
+      return failure();
+
+    SmallVector<Value> keptOperands;
+    bool dropped = false;
+    for (Value operand : concatOp.getOperands()) {
+      // Drop the first 0-sized operand
+      if (!dropped && isEmptyTensor(operand)) {
+        dropped = true;
+        continue;
+      }
+      keptOperands.push_back(operand);
+    }
+
+    if (!dropped)
+      return failure();
+
+    rewriter.replaceOpWithNewOp<ONNXConcatOp>(concatOp,
+        concatOp.getResult().getType(), keptOperands, concatOp.getAxis());
+    return success();
+  }
+};
+
+// A concat with a single operand is an identity.
+struct ConcatSingleOperandPattern : public OpRewritePattern<ONNXConcatOp> {
+  using OpRewritePattern<ONNXConcatOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXConcatOp concatOp, PatternRewriter &rewriter) const final {
+    if (concatOp.getNumOperands() != 1)
+      return failure();
+    rewriter.replaceOp(concatOp, concatOp.getOperand(0));
+    return success();
+  }
+};
+
 namespace {
 
 [[nodiscard]] bool isPlainFloatType(Type t) {
@@ -3927,6 +3981,8 @@ void ONNXCastOp::getCanonicalizationPatterns(
 void ONNXConcatOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<RecomposeConcatPattern>(context);
+  results.insert<RemoveEmptyConcatOperandsPattern>(context);
+  results.insert<ConcatSingleOperandPattern>(context);
   results.insert<EliminateCarveOutAroundRotaryEmbeddingPattern>(context);
 }
 

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -27,6 +27,7 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
@@ -2036,20 +2037,24 @@ struct RecomposeConcatPattern : public OpRewritePattern<ONNXConcatOp> {
   }
 };
 
-// A concat operand whose type has a statically zero-sized dimension is an
-// empty tensor and contributes nothing to the concatenation, so it can be
-// dropped. The result shape is unchanged, so the original result type is
-// reused. Only a single empty operand is removed per rewrite; when several
-// are present the greedy driver re-matches this pattern until none remain.
-// Restricted to arity > 1 so the rewrite never produces an operand-less
-// concat; a resulting single operand is folded by `ConcatSingleOperandPattern`.
+// A concat operand whose concat-axis dimension is statically zero contributes
+// nothing along that axis and can be dropped. The result shape is unchanged,
+// so the original result type is reused. Only a single such operand is
+// removed per rewrite; when several are present the greedy driver re-matches.
+// Restricted to arity > 1 so the rewrite never produces an operand-less concat;
+// a resulting single operand is folded by `ConcatSingleOperandPattern`.
 struct RemoveEmptyConcatOperandsPattern
     : public OpRewritePattern<ONNXConcatOp> {
   using OpRewritePattern<ONNXConcatOp>::OpRewritePattern;
 
-  static bool isEmptyTensor(Value v) {
+  static bool isEmptyAlongConcatAxis(Value v, int64_t axis) {
     auto type = mlir::dyn_cast<ShapedType>(v.getType());
-    return type && type.hasRank() && llvm::is_contained(type.getShape(), 0);
+    if (!type || !type.hasRank())
+      return false;
+    int64_t rank = type.getRank();
+    if (axis < 0)
+      axis += rank;
+    return type.getDimSize(axis) == 0;
   }
 
   LogicalResult matchAndRewrite(
@@ -2057,23 +2062,16 @@ struct RemoveEmptyConcatOperandsPattern
     if (concatOp.getNumOperands() <= 1)
       return failure();
 
-    SmallVector<Value> keptOperands;
-    bool dropped = false;
-    for (Value operand : concatOp.getOperands()) {
-      // Drop the first 0-sized operand
-      if (!dropped && isEmptyTensor(operand)) {
-        dropped = true;
-        continue;
+    int64_t axis = concatOp.getAxis();
+    for (auto [idx, operand] : llvm::enumerate(concatOp.getOperands())) {
+      if (isEmptyAlongConcatAxis(operand, axis)) {
+        rewriter.modifyOpInPlace(
+            concatOp, [&] { concatOp->eraseOperand(idx); });
+        return success();
       }
-      keptOperands.push_back(operand);
     }
 
-    if (!dropped)
-      return failure();
-
-    rewriter.replaceOpWithNewOp<ONNXConcatOp>(concatOp,
-        concatOp.getResult().getType(), keptOperands, concatOp.getAxis());
-    return success();
+    return failure();
   }
 };
 

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -3785,3 +3785,74 @@ func.func @reduce_mean_keepdims_zero_unchanged(%arg0: tensor<1x3x1x5xf32>) -> te
   onnx.Return %0 : tensor<3x5xf32>
   // CHECK: "onnx.ReduceMean"(%arg0, %{{.*}}) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64}
 }
+
+// -----
+
+// CHECK-LABEL: func.func @test_concat_single_operand
+// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<3x4xf32>)
+func.func @test_concat_single_operand(%arg0: tensor<3x4xf32>) -> tensor<3x4xf32> {
+  %0 = "onnx.Concat"(%arg0) {axis = 0 : si64} : (tensor<3x4xf32>) -> tensor<3x4xf32>
+  onnx.Return %0 : tensor<3x4xf32>
+  // CHECK-NOT: onnx.Concat
+  // CHECK: onnx.Return [[PARAM_0_]] : tensor<3x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_concat_drop_empty_operand
+// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<60xf32>, [[PARAM_1_:%.+]]: tensor<0xf32>)
+func.func @test_concat_drop_empty_operand(%arg0: tensor<60xf32>, %arg1: tensor<0xf32>) -> tensor<60xf32> {
+  %0 = "onnx.Concat"(%arg0, %arg1) {axis = 0 : si64} : (tensor<60xf32>, tensor<0xf32>) -> tensor<60xf32>
+  onnx.Return %0 : tensor<60xf32>
+  // CHECK-NOT: onnx.Concat
+  // CHECK: onnx.Return [[PARAM_0_]] : tensor<60xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_concat_drop_empty_keep_rest
+// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<2x3xf32>, [[PARAM_1_:%.+]]: tensor<2x0xf32>, [[PARAM_2_:%.+]]: tensor<2x4xf32>)
+func.func @test_concat_drop_empty_keep_rest(%arg0: tensor<2x3xf32>, %arg1: tensor<2x0xf32>, %arg2: tensor<2x4xf32>) -> tensor<2x7xf32> {
+  %0 = "onnx.Concat"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<2x3xf32>, tensor<2x0xf32>, tensor<2x4xf32>) -> tensor<2x7xf32>
+  onnx.Return %0 : tensor<2x7xf32>
+  // CHECK: [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_2_]]) {axis = 1 : si64} : (tensor<2x3xf32>, tensor<2x4xf32>) -> tensor<2x7xf32>
+  // CHECK: onnx.Return [[VAR_0_]] : tensor<2x7xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_concat_no_empty_unchanged
+// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<2x3xf32>, [[PARAM_1_:%.+]]: tensor<2x4xf32>)
+func.func @test_concat_no_empty_unchanged(%arg0: tensor<2x3xf32>, %arg1: tensor<2x4xf32>) -> tensor<2x7xf32> {
+  %0 = "onnx.Concat"(%arg0, %arg1) {axis = 1 : si64} : (tensor<2x3xf32>, tensor<2x4xf32>) -> tensor<2x7xf32>
+  onnx.Return %0 : tensor<2x7xf32>
+  // CHECK: [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64} : (tensor<2x3xf32>, tensor<2x4xf32>) -> tensor<2x7xf32>
+  // CHECK: onnx.Return [[VAR_0_]] : tensor<2x7xf32>
+}
+
+// -----
+
+// Multiple empty operands are removed one-per-rewrite; the greedy driver
+// re-matches until only the non-empty operands remain.
+// CHECK-LABEL: func.func @test_concat_drop_multiple_empty
+// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<2x3xf32>, [[PARAM_1_:%.+]]: tensor<2x0xf32>, [[PARAM_2_:%.+]]: tensor<2x0xf32>, [[PARAM_3_:%.+]]: tensor<2x4xf32>)
+func.func @test_concat_drop_multiple_empty(%arg0: tensor<2x3xf32>, %arg1: tensor<2x0xf32>, %arg2: tensor<2x0xf32>, %arg3: tensor<2x4xf32>) -> tensor<2x7xf32> {
+  %0 = "onnx.Concat"(%arg0, %arg1, %arg2, %arg3) {axis = 1 : si64} : (tensor<2x3xf32>, tensor<2x0xf32>, tensor<2x0xf32>, tensor<2x4xf32>) -> tensor<2x7xf32>
+  onnx.Return %0 : tensor<2x7xf32>
+  // CHECK: [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_3_]]) {axis = 1 : si64} : (tensor<2x3xf32>, tensor<2x4xf32>) -> tensor<2x7xf32>
+  // CHECK: onnx.Return [[VAR_0_]] : tensor<2x7xf32>
+}
+
+// -----
+
+// When every operand is empty, operands are removed one-per-rewrite down to a
+// single survivor that then folds to identity. Arity stays > 1 on each
+// rewrite, so the concat never becomes operand-less.
+// CHECK-LABEL: func.func @test_concat_all_empty_collapses
+// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<0x4xf32>, [[PARAM_1_:%.+]]: tensor<0x4xf32>)
+func.func @test_concat_all_empty_collapses(%arg0: tensor<0x4xf32>, %arg1: tensor<0x4xf32>) -> tensor<0x4xf32> {
+  %0 = "onnx.Concat"(%arg0, %arg1) {axis = 0 : si64} : (tensor<0x4xf32>, tensor<0x4xf32>) -> tensor<0x4xf32>
+  onnx.Return %0 : tensor<0x4xf32>
+  // CHECK-NOT: onnx.Concat
+  // CHECK: onnx.Return [[PARAM_1_]] : tensor<0x4xf32>
+}

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -3845,9 +3845,22 @@ func.func @test_concat_drop_multiple_empty(%arg0: tensor<2x3xf32>, %arg1: tensor
 
 // -----
 
-// When every operand is empty, operands are removed one-per-rewrite down to a
-// single survivor that then folds to identity. Arity stays > 1 on each
-// rewrite, so the concat never becomes operand-less.
+// A zero on a non-concat axis does not make an operand removable: it may still
+// contribute along the concat axis.
+// CHECK-LABEL: func.func @test_concat_keep_zero_on_non_concat_axis
+// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<2x3x0xf32>, [[PARAM_1_:%.+]]: tensor<2x5x0xf32>)
+func.func @test_concat_keep_zero_on_non_concat_axis(%arg0: tensor<2x3x0xf32>, %arg1: tensor<2x5x0xf32>) -> tensor<2x8x0xf32> {
+  %0 = "onnx.Concat"(%arg0, %arg1) {axis = 1 : si64} : (tensor<2x3x0xf32>, tensor<2x5x0xf32>) -> tensor<2x8x0xf32>
+  onnx.Return %0 : tensor<2x8x0xf32>
+  // CHECK: [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64} : (tensor<2x3x0xf32>, tensor<2x5x0xf32>) -> tensor<2x8x0xf32>
+  // CHECK: onnx.Return [[VAR_0_]] : tensor<2x8x0xf32>
+}
+
+// -----
+
+// When every operand is empty along the concat axis, operands are removed
+// one-per-rewrite down to a single survivor that then folds to identity.
+// Arity stays > 1 on each rewrite, so the concat never becomes operand-less.
 // CHECK-LABEL: func.func @test_concat_all_empty_collapses
 // CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<0x4xf32>, [[PARAM_1_:%.+]]: tensor<0x4xf32>)
 func.func @test_concat_all_empty_collapses(%arg0: tensor<0x4xf32>, %arg1: tensor<0x4xf32>) -> tensor<0x4xf32> {


### PR DESCRIPTION
Adds two patterns that simplify Concats in case they have meaningless inputs.
1. removes a 0-sized input because it doesn't contribute to the result when concatening.
2. replaces a concat with its input if it only has a single operand.

Both patterns are registered by default in the --canonicalize pass. Our LSTM decomposition might create such degenerate concats.