### PR TITLE
Add ReduceSumV11 to ReduceSum pattern

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -7540,6 +7540,7 @@ def ONNXReduceSumOp:ONNX_Op<"ReduceSum",
 
 def ONNXReduceSumV11Op:ONNX_Op<"ReduceSumV11",
   [Pure, OpVersionTrait<11>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX ReduceSum operation";
   let description = [{
   Computes the sum of the input tensor's element along the provided axes. The resulting

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4142,6 +4142,13 @@ void ONNXReduceMeanOp::getCanonicalizationPatterns(
   result.insert<DropUnitAxesFromReduceMeanPattern>(context);
 }
 
+/// on the ONNXReduceSumV11Op.
+void ONNXReduceSumV11Op::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  result.insert<ReduceSumV11ToLatestPattern1>(context);
+  result.insert<ReduceSumV11ToLatestPattern2>(context);
+}
+
 /// on the ONNXReshapeOp.
 void ONNXReshapeOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -105,8 +105,19 @@ def buildBroadcastBiasViaReshapeExpand : NativeCodeCall<
 def createArrayAttrOfTwoToRankOf : NativeCodeCall<
   "onnx_mlir::createArrayAttrOfNToM($_builder, 2, mlir::cast<ShapedType>($0.getType()).getRank() - 1)">;
 
+def AttributeIsNull :
+  Constraint<CPred<"!($_self)">, "Attribute is null">;
+
 def AttributeIsNotNull :
   Constraint<CPred<"($_self)">, "Attribute is not null">;
+
+// Create a DenseElementsAttr from an ArrayAttr.
+def createDenseArrayAttr
+    : NativeCodeCall<"::onnx_mlir::createDenseArrayAttr($_builder, $0)">;
+
+def noop_with_empty_axes
+    : NativeCodeCall<"IntegerAttr::get($_builder.getIntegerType(64, "
+                     "/*isSigned=*/true), APInt(64, 0, /*isSigned=*/true))">;
 
 // Intended to check whether there is at least one not-Null the attributes
 // However, the current table gen can only support max 4 parameters
@@ -1257,5 +1268,22 @@ def AlwaysFalseWherePattern : Pat<
  (replaceWithValue $false_val),
  [(IsNegativeSplatConstant:$negative_constant), (AreAllDimSizes:$dims)]
 >;
+
+//===----------------------------------------------------------------------===//
+// Canonicalization for ONNXReduceSumV11Op
+//===----------------------------------------------------------------------===//
+
+def ReduceSumV11ToLatestPattern1
+    : Pat<(ONNXReduceSumV11Op $oprd, $axes, $keepdims),
+          (ONNXReduceSumOp $oprd,
+              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
+          [(AttributeIsNull:$axes)]>;
+
+def ReduceSumV11ToLatestPattern2
+    : Pat<(ONNXReduceSumV11Op $oprd, $axes, $keepdims),
+          (ONNXReduceSumOp $oprd,
+              (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $axes)),
+              $keepdims, (noop_with_empty_axes)),
+          [(AttributeIsNotNull:$axes)]>;
 
 #endif // ONNX_REWRITE

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -576,6 +576,39 @@ DenseElementsAttr createDenseElementsAttrFromFloatAttr(
   return DenseElementsAttr::get(tensorType, {f});
 }
 
+// Create a rank-1 DenseElementsAttr from an existing ArrayAttr.
+DenseElementsAttr createDenseArrayAttr(
+    PatternRewriter &rewriter, ArrayAttr origAttrs) {
+  assert(origAttrs && "handle EXISTING ArrayAttr only");
+
+  if (mlir::dyn_cast<FloatAttr>(origAttrs.getValue()[0])) {
+    Type elementType = rewriter.getF32Type();
+    int nElements = origAttrs.getValue().size();
+    SmallVector<float, 4> wrapper(nElements, 0);
+    for (int i = 0; i < nElements; ++i)
+      wrapper[i] =
+          mlir::cast<FloatAttr>(origAttrs.getValue()[i]).getValueAsDouble();
+
+    return DenseElementsAttr::get(
+        RankedTensorType::get(wrapper.size(), elementType),
+        llvm::ArrayRef(wrapper));
+  }
+
+  if (mlir::dyn_cast<IntegerAttr>(origAttrs.getValue()[0])) {
+    Type elementType = rewriter.getIntegerType(64);
+    int nElements = origAttrs.getValue().size();
+    SmallVector<int64_t, 4> wrapper(nElements, 0);
+    for (int i = 0; i < nElements; ++i)
+      wrapper[i] = mlir::cast<IntegerAttr>(origAttrs.getValue()[i]).getInt();
+
+    return DenseElementsAttr::get(
+        RankedTensorType::get(wrapper.size(), elementType),
+        llvm::ArrayRef(wrapper));
+  }
+
+  llvm_unreachable("unexpected attribute type");
+}
+
 ONNXCastOp castTo(
     PatternRewriter &rewriter, Value val, Type newElementTy, int64_t saturate) {
   return rewriter.create<ONNXCastOp>(val.getLoc(),

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -283,6 +283,10 @@ mlir::DenseElementsAttr createDenseElementsAttrFromShapeAtIndex(
 mlir::DenseElementsAttr createDenseElementsAttrFromSize(
     mlir::PatternRewriter &rewriter, mlir::Value value);
 
+// Create a rank-1 DenseElementsAttr from an existing ArrayAttr.
+mlir::DenseElementsAttr createDenseArrayAttr(
+    mlir::PatternRewriter &rewriter, mlir::ArrayAttr origAttrs);
+
 // Create an ArrayAttr from a dense ConstantOp
 mlir::ArrayAttr createArrayAttrFromConstantOp(mlir::ONNXConstantOp constOp);
 

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -71,41 +71,6 @@ bool separatePhasedConvsForConvTransposeActive = false;
 // (DCR) as its final interleave instead of Reshape/Transpose/Reshape.
 bool convTransposeDepthToSpaceActive = false;
 
-// Create an DenseElementsAttr of ArrayAttr.
-// This function is used to get Value Type of an EXISTING ArrayAttr for Scaler
-// function.
-DenseElementsAttr createDenseArrayAttr(
-    PatternRewriter &rewriter, ArrayAttr origAttrs) {
-  assert(origAttrs && "handle EXISTING ArrayAttr only");
-
-  if (mlir::dyn_cast<FloatAttr>(origAttrs.getValue()[0])) {
-    Type elementType = rewriter.getF32Type();
-    int nElements = origAttrs.getValue().size();
-    SmallVector<float, 4> wrapper(nElements, 0);
-    for (int i = 0; i < nElements; ++i)
-      wrapper[i] =
-          mlir::cast<FloatAttr>(origAttrs.getValue()[i]).getValueAsDouble();
-
-    return DenseElementsAttr::get(
-        RankedTensorType::get(wrapper.size(), elementType),
-        llvm::ArrayRef(wrapper));
-  }
-
-  if (mlir::dyn_cast<IntegerAttr>(origAttrs.getValue()[0])) {
-    Type elementType = rewriter.getIntegerType(64);
-    int nElements = origAttrs.getValue().size();
-    SmallVector<int64_t, 4> wrapper(nElements, 0);
-    for (int i = 0; i < nElements; ++i)
-      wrapper[i] = mlir::cast<IntegerAttr>(origAttrs.getValue()[i]).getInt();
-
-    return DenseElementsAttr::get(
-        RankedTensorType::get(wrapper.size(), elementType),
-        llvm::ArrayRef(wrapper));
-  }
-
-  llvm_unreachable("unexpected attribute type");
-}
-
 /// Create an Scalar DenseElementsAttr from FloatAttr or IntegerAttr.
 /// This is used to create an ONNXConstant of rank 0, e.g. tensor<f32>.
 DenseElementsAttr createScalarDenseAttr(

--- a/test/mlir/onnx/onnx_canonicalization_reductors.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_reductors.mlir
@@ -1,0 +1,27 @@
+// RUN: onnx-mlir-opt --canonicalize %s -split-input-file | FileCheck %s
+
+// -----
+
+func.func @test_reducesumv11_axes(%arg0: tensor<1x32x512x640xf32>) -> tensor<1x512x640xf32> {
+  %0 = "onnx.ReduceSumV11"(%arg0) {axes = [1], keepdims = 0 : si64} : (tensor<1x32x512x640xf32>) -> tensor<1x512x640xf32>
+  onnx.Return %0 : tensor<1x512x640xf32>
+// CHECK-LABEL:  func.func @test_reducesumv11_axes
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x32x512x640xf32>) -> tensor<1x512x640xf32> {
+// CHECK-DAG:       [[AXES_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           [[REDUCED_:%.+]] = "onnx.ReduceSum"([[PARAM_0_]], [[AXES_]]) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x32x512x640xf32>, tensor<1xi64>) -> tensor<1x512x640xf32>
+// CHECK:           onnx.Return [[REDUCED_]] : tensor<1x512x640xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_reducesumv11_noaxes(%arg0: tensor<2x3x4xf32>) -> tensor<1x1x1xf32> {
+  %0 = "onnx.ReduceSumV11"(%arg0) {keepdims = 1 : si64} : (tensor<2x3x4xf32>) -> tensor<1x1x1xf32>
+  onnx.Return %0 : tensor<1x1x1xf32>
+// CHECK-LABEL:  func.func @test_reducesumv11_noaxes
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>) -> tensor<1x1x1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_1_:%.+]] = "onnx.ReduceSum"([[PARAM_0_]], [[VAR_0_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, none) -> tensor<1x1x1xf32>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<1x1x1xf32>
+// CHECK:         }
+}

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -550,6 +550,7 @@ OpsWithCanonicalizer = [
     "Or",
     "Pow",
     "ReduceMean",
+    "ReduceSumV11",
     "Reshape",
     "Resize",
     "RNN",


### PR DESCRIPTION
Small PR for rewriting ReduceSumV11 to the latest version (version 13) similar to the ReduceL2 and Softmax patterns.
Its split into two patterns:

1. when axis attribute is not given: v11 default behaviour is to reduce over all axes --> v13's default behaviour with noop=0 is also to reduce over all axes.

2. Create a constant for the axis. Copy all other values/attributes.

Unlike [PR 856](https://github.com/Xilinx/onnx-mlir/pull/856), this does not contain the keepdims=1 & reshape canonicalization.