### PR TITLE
Add option to normalize onnx.Conv auto_pad into an explicit pads attr…

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -4831,6 +4831,98 @@ public:
   }
 };
 
+// Resolve a non-NOTSET onnx.Conv auto_pad into an explicit pads attribute
+struct NormalizeConvAutoPadPattern : public OpRewritePattern<ONNXConvOp> {
+  using OpRewritePattern<ONNXConvOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXConvOp convOp, PatternRewriter &rewriter) const final {
+    StringRef autoPad = convOp.getAutoPad();
+    if (autoPad == "NOTSET")
+      return failure();
+
+    Value X = convOp.getX();
+    Value W = convOp.getW();
+    if (!onnx_mlir::hasShapeAndRank(X) || !onnx_mlir::hasShapeAndRank(W))
+      return failure();
+
+    auto xType = mlir::cast<ShapedType>(X.getType());
+    auto wType = mlir::cast<ShapedType>(W.getType());
+    ArrayRef<int64_t> xShape = xType.getShape();
+    ArrayRef<int64_t> wShape = wType.getShape();
+    int64_t rank = xShape.size();
+    // Spatial dims are all but N and C: [N, C, D1, ..., Dn].
+    int64_t spatialRank = rank - 2;
+    if (spatialRank <= 0)
+      return failure();
+
+    // kernel_shape: explicit attribute, else inferred from W's spatial dims.
+    SmallVector<int64_t, 4> kernel(spatialRank);
+    if (auto kAttr = convOp.getKernelShape()) {
+      if ((int64_t)onnx_mlir::ArrayAttrSize(kAttr) != spatialRank)
+        return failure();
+      for (int64_t i = 0; i < spatialRank; ++i)
+        kernel[i] = onnx_mlir::ArrayAttrIntVal(kAttr, i);
+    } else {
+      for (int64_t i = 0; i < spatialRank; ++i)
+        kernel[i] = wShape[2 + i];
+    }
+
+    // strides default to 1.
+    SmallVector<int64_t, 4> strides(spatialRank, 1);
+    if (auto sAttr = convOp.getStrides())
+      for (int64_t i = 0; i < spatialRank; ++i)
+        strides[i] = onnx_mlir::ArrayAttrIntVal(sAttr, i);
+
+    // dilations default to 1.
+    SmallVector<int64_t, 4> dilations(spatialRank, 1);
+    if (auto dAttr = convOp.getDilations())
+      for (int64_t i = 0; i < spatialRank; ++i)
+        dilations[i] = onnx_mlir::ArrayAttrIntVal(dAttr, i);
+
+    // Compute [begin..., end...] pads per spatial axis.
+    SmallVector<int64_t, 8> pads(2 * spatialRank, 0);
+    if (autoPad == "VALID") {
+      // No padding; pads stay all zero.
+    } else if (autoPad == "SAME_UPPER" || autoPad == "SAME_LOWER") {
+      for (int64_t i = 0; i < spatialRank; ++i) {
+        int64_t inputSize = xShape[2 + i];
+        // SAME_* needs static spatial sizes to compute symmetric padding.
+        if (inputSize < 0)
+          return failure();
+        int64_t outputSize =
+            (int64_t)std::ceil((1.0 * inputSize) / (1.0 * strides[i]));
+        int64_t effKernel = (kernel[i] - 1) * dilations[i] + 1;
+        int64_t sumOfPad =
+            (outputSize - 1) * strides[i] + effKernel - inputSize;
+        if (sumOfPad < 0)
+          sumOfPad = 0;
+        int64_t begin = sumOfPad / 2;
+        int64_t end = sumOfPad / 2;
+        if (sumOfPad % 2 != 0) {
+          // Extra pixel goes to the end for SAME_UPPER, beginning for
+          // SAME_LOWER.
+          if (autoPad == "SAME_UPPER")
+            end += 1;
+          else
+            begin += 1;
+        }
+        pads[i] = begin;
+        pads[spatialRank + i] = end;
+      }
+    } else {
+      // Unknown auto_pad value: leave the op untouched.
+      return failure();
+    }
+
+    rewriter.modifyOpInPlace(convOp, [&] {
+      convOp.setPadsAttr(rewriter.getI64ArrayAttr(pads));
+      convOp.setAutoPadAttr(rewriter.getStringAttr("NOTSET"));
+    });
+    return success();
+  }
+};
+
 struct DecomposeONNXToONNXPass
     : public onnx_mlir::impl::DecomposeONNXToONNXPassBase<
           DecomposeONNXToONNXPass> {
@@ -4854,7 +4946,7 @@ void DecomposeONNXToONNXPass::runOnOperation() {
       enableConcatFuse, enableLstmSeqDecompose, enableReduceL2Decompose,
       /*disableGenericDecompositions=*/false, enableGatherToSlice,
       enableHardSwishDecompose, enableGroupQueryAttentionCacheSlicing,
-      enableDepthToSpaceDecompose);
+      enableDepthToSpaceDecompose, enableConvAutoPadNormalize);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
   if (this->target == "stablehlo") {
@@ -4880,7 +4972,7 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     bool enableLstmSeqDecompose, bool enableReduceL2Decompose,
     bool disableGenericDecompositions, bool enableGatherToSlice,
     bool enableHardSwishDecompose, bool enableGroupQueryAttentionCacheSlicing,
-    bool enableDepthToSpaceDecompose) {
+    bool enableDepthToSpaceDecompose, bool enableConvAutoPadNormalize) {
   MLIRContext *context = patterns.getContext();
   if (!disableGenericDecompositions)
     populateWithGenerated(patterns);
@@ -4952,6 +5044,9 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
 
   if (enableDepthToSpaceDecompose)
     populateDecomposeDepthToSpacePattern(patterns);
+
+  if (enableConvAutoPadNormalize)
+    patterns.insert<NormalizeConvAutoPadPattern>(context);
 
   patterns.insert<ReplaceCastLikeByCastPattern>(context);
 

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -54,7 +54,8 @@ void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool disableGenericDecompositions = false, bool enableGatherToSlice = true,
     bool enableHardSwishDecompose = true,
     bool enableGroupQueryAttentionCacheSlicing = true,
-    bool enableDepthToSpaceDecompose = false);
+    bool enableDepthToSpaceDecompose = false,
+    bool enableConvAutoPadNormalize = false);
 
 // Decompose onnx.DepthToSpace (DCR and CRD) into Reshape/Transpose/Reshape
 void populateDecomposeDepthToSpacePattern(mlir::RewritePatternSet &patterns,

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -130,7 +130,7 @@ struct ONNXHybridTransformPass
           enableReduceL2Decompose,
           /*disableGenericDecompositions=*/false, enableGatherToSlice,
           enableHardSwishDecompose, enableGroupQueryAttentionCacheSlicing,
-          enableDepthToSpaceDecompose);
+          enableDepthToSpaceDecompose, enableConvAutoPadNormalize);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
       if (target == "stablehlo") {

--- a/src/Dialect/ONNX/Transforms/Passes.td
+++ b/src/Dialect/ONNX/Transforms/Passes.td
@@ -107,7 +107,13 @@ def ONNXDecomposePatternOptions {
            "bool", /*default=*/"false",
            "Decompose onnx.DepthToSpace (DCR and CRD) into "
            "Reshape/Transpose/Reshape so backends without a DepthToSpace "
-           "kernel can run it.">
+           "kernel can run it.">,
+
+    Option<"enableConvAutoPadNormalize",
+           "enable-conv-autopad-normalize",
+           "bool", /*default=*/"false",
+           "Resolve a non-NOTSET onnx.Conv auto_pad into an explicit pads "
+           "attribute and reset auto_pad to NOTSET.">
   ];
 }
 

--- a/test/mlir/onnx/onnx_decompose_conv_autopad_normalize.mlir
+++ b/test/mlir/onnx/onnx_decompose_conv_autopad_normalize.mlir
@@ -1,0 +1,63 @@
+// RUN: onnx-mlir-opt --decompose-onnx=enable-conv-autopad-normalize %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --decompose-onnx %s -split-input-file | FileCheck %s --check-prefix=DISABLED
+
+// VALID auto_pad with no pads -> explicit zero pads + auto_pad NOTSET.
+func.func @test_conv_autopad_valid(%arg0: tensor<1x3x512x512xf32>, %arg1: tensor<1024x3x16x16xf32>, %arg2: tensor<1024xf32>) -> tensor<1x1024x32x32xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "VALID", group = 1 : si64, kernel_shape = [16, 16], strides = [16, 16]} : (tensor<1x3x512x512xf32>, tensor<1024x3x16x16xf32>, tensor<1024xf32>) -> tensor<1x1024x32x32xf32>
+  return %0 : tensor<1x1024x32x32xf32>
+
+// CHECK-LABEL:  func.func @test_conv_autopad_valid
+// CHECK:           "onnx.Conv"
+// CHECK-SAME:      auto_pad = "NOTSET"
+// CHECK-SAME:      pads = [0, 0, 0, 0]
+
+// DISABLED-LABEL:  func.func @test_conv_autopad_valid
+// DISABLED:           "onnx.Conv"
+// DISABLED-SAME:      auto_pad = "VALID"
+// DISABLED-NOT:       pads
+}
+
+// -----
+
+// SAME_UPPER auto_pad: stride 1, kernel 3 -> symmetric pad [1,1,1,1].
+func.func @test_conv_autopad_same_upper(%arg0: tensor<1x3x8x8xf32>, %arg1: tensor<4x3x3x3xf32>, %arg2: tensor<4xf32>) -> tensor<1x4x8x8xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "SAME_UPPER", group = 1 : si64, kernel_shape = [3, 3], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<4x3x3x3xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+  return %0 : tensor<1x4x8x8xf32>
+
+// CHECK-LABEL:  func.func @test_conv_autopad_same_upper
+// CHECK:           "onnx.Conv"
+// CHECK-SAME:      auto_pad = "NOTSET"
+// CHECK-SAME:      pads = [1, 1, 1, 1]
+}
+
+// -----
+
+// SAME_LOWER auto_pad: stride 2, kernel 3, input 8 -> odd total pad, extra at
+// the beginning. outputSize=ceil(8/2)=4, sumOfPad=(4-1)*2+3-8=1 -> begin=1,end=0.
+func.func @test_conv_autopad_same_lower(%arg0: tensor<1x3x8x8xf32>, %arg1: tensor<4x3x3x3xf32>, %arg2: tensor<4xf32>) -> tensor<1x4x4x4xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "SAME_LOWER", group = 1 : si64, kernel_shape = [3, 3], strides = [2, 2]} : (tensor<1x3x8x8xf32>, tensor<4x3x3x3xf32>, tensor<4xf32>) -> tensor<1x4x4x4xf32>
+  return %0 : tensor<1x4x4x4xf32>
+
+// CHECK-LABEL:  func.func @test_conv_autopad_same_lower
+// CHECK:           "onnx.Conv"
+// CHECK-SAME:      auto_pad = "NOTSET"
+// CHECK-SAME:      pads = [1, 1, 0, 0]
+}
+
+// -----
+
+// NOTSET with explicit pads is left untouched even when the flag is on.
+func.func @test_conv_notset_untouched(%arg0: tensor<1x3x8x8xf32>, %arg1: tensor<4x3x3x3xf32>, %arg2: tensor<4xf32>) -> tensor<1x4x8x8xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x3x8x8xf32>, tensor<4x3x3x3xf32>, tensor<4xf32>) -> tensor<1x4x8x8xf32>
+  return %0 : tensor<1x4x8x8xf32>
+
+// CHECK-LABEL:  func.func @test_conv_notset_untouched
+// CHECK:           "onnx.Conv"
+// CHECK-SAME:      auto_pad = "NOTSET"
+// CHECK-SAME:      pads = [1, 1, 1, 1]
+
+// DISABLED-LABEL:  func.func @test_conv_notset_untouched
+// DISABLED:           "onnx.Conv"
+// DISABLED-SAME:      auto_pad = "NOTSET"
+// DISABLED-SAME:      pads = [1, 1, 1, 1]
+}


### PR DESCRIPTION
Adds an enable-conv-autopad-normalize decomposition option (default off) that resolves a non-NOTSET onnx.Conv auto_pad (VALID / SAME_UPPER / SAME_LOWER) into an explicit pads attribute and resets auto_pad to NOTSET.