### PR TITLE
Remove transpose(concat) upwards movement pattern

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4287,7 +4287,6 @@ void ONNXTransposeOp::getCanonicalizationPatterns(
   result.insert<FuseTransposeAndTanPattern>(context);
   result.insert<FuseTransposeAndTanhPattern>(context);
   result.insert<RemoveIdentityTransposePattern>(context);
-  result.insert<SwapTransposeConcatPattern>(context);
 }
 
 /// on the ONNXUnsqueezeOp.

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -327,34 +327,6 @@ bool isNotConvProducer(mlir::Value val) {
   return true; // If no defining op, assume it's safe
 }
 
-// Get the index of the axis value in the given permutation array.
-IntegerAttr getIndexOfAxisInPerm(
-    PatternRewriter &rewriter, ArrayAttr permAttr, IntegerAttr axis) {
-  IntegerAttr result;
-  for (uint64_t i = 0; i < permAttr.getValue().size(); ++i) {
-    IntegerAttr attr = mlir::cast<IntegerAttr>(permAttr.getValue()[i]);
-    assert(attr && "Element in ArrayAttr is not IntegerAttr");
-    if (attr.getValue().getSExtValue() == axis.getValue().getSExtValue())
-      return rewriter.getIntegerAttr(rewriter.getIntegerType(64, true), i);
-  }
-  return result;
-}
-
-// Transpose a variadic input using a permutation array.
-SmallVector<Value, 4> transposeVariadicInput(PatternRewriter &rewriter,
-    Location loc, ValueRange inputs, ArrayAttr permAttr) {
-  SmallVector<Value, 4> transposedInputs;
-  for (Value inp : inputs) {
-    ShapedType inpType = mlir::cast<ShapedType>(inp.getType());
-    assert(inpType && "Type is not ShapedType");
-    ONNXTransposeOp transposeOp = rewriter.create<ONNXTransposeOp>(
-        loc, UnrankedTensorType::get(inpType.getElementType()), inp, permAttr);
-    static_cast<void>(transposeOp.inferShapes([](Region &region) {}));
-    transposedInputs.emplace_back(transposeOp.getResult());
-  }
-  return transposedInputs;
-}
-
 // Cast a variadic input using the given `saturate` and `to`.
 SmallVector<Value, 4> castVariadicInput(PatternRewriter &rewriter, Location loc,
     ValueRange inputs, IntegerAttr saturate, TypeAttr to) {
@@ -366,15 +338,6 @@ SmallVector<Value, 4> castVariadicInput(PatternRewriter &rewriter, Location loc,
     castInputs.emplace_back(castOp.getResult());
   }
   return castInputs;
-}
-
-// Check if all values are produced by ONNXTransposeOp.
-bool areProducedByTransposeOp(ValueRange values) {
-  return llvm::all_of(values, [](Value v) {
-    if (mlir::isa<BlockArgument>(v))
-      return false;
-    return isa<ONNXTransposeOp>(v.getDefiningOp());
-  });
 }
 
 Value maxOrDefault(PatternRewriter &rewriter, Location loc, Value a, Value b) {

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -307,9 +307,6 @@ class RankXMinusRankYIs<int diff>: Constraint<
           " - mlir::cast<ShapedType>($1.getType()).getRank() == " # diff # ")">,
     "X' rank is greater than Y's rank diff units">;
 
-def TransposeVariadicInput: NativeCodeCall<
-  "onnx_mlir::transposeVariadicInput($_builder, $_loc, $0, $1)">;
-
 def CastVariadicInput: NativeCodeCall<
   "onnx_mlir::castVariadicInput($_builder, $_loc, $0, $1, $2)">;
 
@@ -750,25 +747,6 @@ def RemoveIdentityTransposePattern:  Pat<
   (replaceWithValue $val),
   // Check that we have indeed a identity transpose pattern.
   [(IsIdentityPermuteAttribute:$p)]>;
-
-def GetIndexOfAxisInPerm: NativeCodeCall<
-  "onnx_mlir::getIndexOfAxisInPerm($_builder, $0, $1)"
->;
-
-def ProducedByTransposeOp: Constraint<
-  CPred<"onnx_mlir::areProducedByTransposeOp($_self)">,
-  "all values are produced by ONNXTransposeOp"
->;
-
-// Do transpose on concat's inputs instead of output in order to propagate
-// transpose operations together, which allows more chance for transpose fusion.
-// Do this only when all inputs are produced by transpose operations.
-def SwapTransposeConcatPattern: Pat<
-  (ONNXTransposeOp:$res (ONNXConcatOp $inputs, $axis), $perm),
-  (ONNXConcatOp (TransposeVariadicInput $inputs, $perm),
-                (GetIndexOfAxisInPerm $perm, $axis)),
-  [(ProducedByTransposeOp:$inputs)]
->;
 
 //===----------------------------------------------------------------------===//
 // Canonicalization for ONNXReshapeOp

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -188,22 +188,6 @@ func.func @test_transpose_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x1
 
 // -----
 
-// Check the fusion of transposes when transposes at the output side are moved
-// to the input side. This is only done when there are transposes at the input side.
-// CHECK-LABEL: func @test_transpose_concat_reversed
-func.func @test_transpose_concat_reversed(%arg0: tensor<?x5x5x1xf32>, %arg1: tensor<?x5x5x2xf32>) -> tensor<?x5x5x3xf32> {
-    %0 = "onnx.Transpose"(%arg0) {perm = [0, 3, 1, 2]} : (tensor<?x5x5x1xf32>) -> tensor<?x1x5x5xf32>
-    %1 = "onnx.Transpose"(%arg1) {perm = [0, 3, 1, 2]} : (tensor<?x5x5x2xf32>) -> tensor<?x2x5x5xf32>
-    %2 = "onnx.Concat"(%0, %1) {axis = 1 : si64} : (tensor<?x1x5x5xf32>, tensor<?x2x5x5xf32>) -> tensor<?x3x5x5xf32>
-    %3 = "onnx.Transpose"(%2) {perm = [0, 2, 3, 1]} : (tensor<?x3x5x5xf32>) -> tensor<?x5x5x3xf32>
-    onnx.Return %3 : tensor<?x5x5x3xf32>
-
-    // CHECK-NEXT: "onnx.Concat"(%arg0, %arg1) {axis = 3 : si64} : (tensor<?x5x5x1xf32>, tensor<?x5x5x2xf32>) -> tensor<?x5x5x3xf32>
-    // CHECK-NOT: "onnx.Transpose"
-}
-
-// -----
-
 // CHECK-LABEL: func @identity_tile
 func.func @identity_tile(%arg0: tensor<32x64xf32>) -> tensor<32x64xf32> {
     %0 = onnx.Constant dense<1> : tensor<2xi64>


### PR DESCRIPTION
Remove a pattern that rewrites `t(concat(t(a), t(b), ...))` to `concat(t(t(a)), t(t(b)), ...)`. In general this pattern is sensible but we get rid of transposes by pushing them down not up. So this onnx canonicalization causes a hang when combined with our downstream patterns.