### PR TITLE
Add convenient builder.concat overload

### DIFF
--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -101,6 +101,11 @@ Value OnnxBuilder::clip(
         toTensor(input), toTensor(min), toTensor(max));
 }
 
+Value OnnxBuilder::concat(ValueRange inputs, int64_t axis) const {
+  assert(inputs.size() >= 1 && "Expect at least one input");
+  return createOpAndInferShapes<ONNXConcatOp>(inputs, getSignedInt64Attr(axis));
+}
+
 Value OnnxBuilder::concat(
     Type outputType, ValueRange inputs, int64_t axis) const {
   IntegerAttr concatAxisAttr = getSignedInt64Attr(axis);

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -67,6 +67,7 @@ struct OnnxBuilder : DialectBuilder {
       bool scalarType = false) const;
 
   // ONNXConcatOp
+  mlir::Value concat(mlir::ValueRange inputs, int64_t axis) const;
   mlir::Value concat(
       mlir::Type outputType, mlir::ValueRange inputs, int64_t axis) const;
 

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -1482,6 +1482,13 @@ def ONNXConcatOp:ONNX_Op<"Concat",
       return sh;
     }
   }];
+  let builders = [
+  OpBuilder<(ins "ValueRange":$inputs, "IntegerAttr":$axis), [{
+   auto elementType = mlir::cast<ShapedType>(inputs[0].getType()).getElementType();
+   auto resultType = UnrankedTensorType::get(elementType);
+   build($_builder, $_state, resultType, inputs, axis);
+  }]>
+  ];
   let hasVerifier = 1;
 }
 

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -841,6 +841,16 @@ custom_definition_misc = dict(
   }] >
   ];""",
         ),
+        (
+            "Concat",
+            """  let builders = [
+  OpBuilder<(ins "ValueRange":$inputs, "IntegerAttr":$axis), [{
+   auto elementType = mlir::cast<ShapedType>(inputs[0].getType()).getElementType();
+   auto resultType = UnrankedTensorType::get(elementType);
+   build($_builder, $_state, resultType, inputs, axis);
+  }]>
+  ];""",
+        ),
     ]
 )
 


### PR DESCRIPTION
Add an overloaded builder function for concat. The new version doesn't take an output type and lets type inference infer it automatically.