### PR TITLE
enableDepthToSpaceDecompose: prevent recomposition when set

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -61,7 +61,9 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
       getDecomposeOnlyOptions(opts.hybrid)));
   if (opts.hybrid.recomposition)
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createRecomposeONNXToONNXPass(
-        /*target=*/"", opts.hybrid.enableRotaryEmbeddingRecompose));
+        /*target=*/"", opts.hybrid.enableRotaryEmbeddingRecompose,
+        /*enableReduceL2Recompositions=*/false,
+        opts.hybrid.enableDepthToSpaceDecompose));
 
   if (opts.enableONNXHybridPass) {
     pm.addNestedPass<func::FuncOp>(

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -175,8 +175,9 @@ struct ONNXHybridTransformPass
     }
 
     if (recomposition) {
-      getRecomposeONNXToONNXPatterns(
-          cumulativePatterns, enableRotaryEmbeddingRecompose);
+      getRecomposeONNXToONNXPatterns(cumulativePatterns,
+          enableRotaryEmbeddingRecompose,
+          /*enableReduceL2Recompositions=*/false, enableDepthToSpaceDecompose);
     }
 
     patterns = FrozenRewritePatternSet(std::move(cumulativePatterns));

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -2005,10 +2005,12 @@ struct RecomposeONNXToONNXPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RecomposeONNXToONNXPass)
 
   RecomposeONNXToONNXPass(const std::string &target,
-      bool enableRotaryEmbeddingRecompose, bool enableReduceL2Recompositions) {
+      bool enableRotaryEmbeddingRecompose, bool enableReduceL2Recompositions,
+      bool enableDepthToSpaceDecompose) {
     this->target = target;
     this->enableRotaryEmbeddingRecompose = enableRotaryEmbeddingRecompose;
     this->enableReduceL2Recompositions = enableReduceL2Recompositions;
+    this->enableDepthToSpaceDecompose = enableDepthToSpaceDecompose;
   }
   RecomposeONNXToONNXPass(const RecomposeONNXToONNXPass &pass)
       : mlir::PassWrapper<RecomposeONNXToONNXPass,
@@ -2016,6 +2018,8 @@ struct RecomposeONNXToONNXPass
     this->target = pass.target.getValue();
     this->enableRotaryEmbeddingRecompose =
         pass.enableRotaryEmbeddingRecompose.getValue();
+    this->enableDepthToSpaceDecompose =
+        pass.enableDepthToSpaceDecompose.getValue();
   }
 
   StringRef getArgument() const override { return "recompose-onnx"; }
@@ -2041,6 +2045,12 @@ struct RecomposeONNXToONNXPass
                      "ReduceSumSquare from ReduceSum(Mul(x, x))"),
       ::llvm::cl::init(false)};
 
+  Option<bool> enableDepthToSpaceDecompose{*this,
+      "enable-depth-to-space-decompose",
+      llvm::cl::desc("Disable the DepthToSpace recompose patterns so they do "
+                     "not undo an active DepthToSpace decomposition"),
+      ::llvm::cl::init(false)};
+
   void runOnOperation() final;
 
   typedef PassWrapper<RecomposeONNXToONNXPass, OperationPass<func::FuncOp>>
@@ -2052,8 +2062,9 @@ void RecomposeONNXToONNXPass::runOnOperation() {
   MLIRContext *context = &getContext();
 
   RewritePatternSet patterns(context);
-  onnx_mlir::getRecomposeONNXToONNXPatterns(
-      patterns, enableRotaryEmbeddingRecompose, enableReduceL2Recompositions);
+  onnx_mlir::getRecomposeONNXToONNXPatterns(patterns,
+      enableRotaryEmbeddingRecompose, enableReduceL2Recompositions,
+      enableDepthToSpaceDecompose);
 
   onnx_mlir::ResultNamesUpdater rnUpdater;
   if (failed(applyPatternsGreedily(function, std::move(patterns),
@@ -2065,7 +2076,7 @@ void RecomposeONNXToONNXPass::runOnOperation() {
 
 void onnx_mlir::getRecomposeONNXToONNXPatterns(
     mlir::RewritePatternSet &patterns, bool enableRotaryEmbeddingRecompose,
-    bool enableReduceL2Recompositions) {
+    bool enableReduceL2Recompositions, bool enableDepthToSpaceDecompose) {
   MLIRContext *context = patterns.getContext();
   patterns.insert<RecomposeHardSwishFromMulPattern>(context);
   patterns.insert<RecomposeHardSigmoidFromMulClipPattern>(context);
@@ -2076,8 +2087,12 @@ void onnx_mlir::getRecomposeONNXToONNXPatterns(
   patterns.insert<RecomposeLayerNormFromDivPattern<ONNXDivOp, true>>(context);
   patterns.insert<RecomposeLayerNormFromDivPattern<ONNXMulOp, true>>(context);
   patterns.insert<RecomposeLayerNormFromDivPattern<ONNXPowOp, true>>(context);
-  patterns.insert<RecomposeDepthToSpaceCRD>(context);
-  patterns.insert<RecomposeDepthToSpaceDCR>(context);
+  // Skip when DepthToSpace decomposition is active, otherwise the recompose
+  // patterns would immediately undo the decompose.
+  if (!enableDepthToSpaceDecompose) {
+    patterns.insert<RecomposeDepthToSpaceCRD>(context);
+    patterns.insert<RecomposeDepthToSpaceDCR>(context);
+  }
   if (enableRotaryEmbeddingRecompose)
     patterns.insert<RecomposeRotaryEmbeddingPattern>(context);
   if (enableReduceL2Recompositions) {
@@ -2095,7 +2110,8 @@ void onnx_mlir::getRecomposeONNXToONNXPatterns(
  */
 std::unique_ptr<mlir::Pass> onnx_mlir::createRecomposeONNXToONNXPass(
     const std::string &target, bool enableRotaryEmbeddingRecompose,
-    bool enableReduceL2Recompositions) {
-  return std::make_unique<RecomposeONNXToONNXPass>(
-      target, enableRotaryEmbeddingRecompose, enableReduceL2Recompositions);
+    bool enableReduceL2Recompositions, bool enableDepthToSpaceDecompose) {
+  return std::make_unique<RecomposeONNXToONNXPass>(target,
+      enableRotaryEmbeddingRecompose, enableReduceL2Recompositions,
+      enableDepthToSpaceDecompose);
 }

--- a/src/Dialect/ONNX/Transforms/Recompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.hpp
@@ -15,6 +15,9 @@
 // implement shape inference for the recomposed operation. Hence, it is expected
 // that there is no knowledge about tensor shape at this point.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef ONNX_MLIR_RECOMPOSE_H
@@ -35,9 +38,14 @@ namespace onnx_mlir {
 // `enableReduceL2Recompositions` enables a recomposition of a decomposed
 // ReduceL2 from Sqrt(ReduceSumSquare(x)) into an onnx.ReduceL2 op and
 // ReduceSumSquare from ReduceSum(Mul(x, x)).
+// `enableDepthToSpaceDecompose` mirrors the decompose flag: when the
+// DepthToSpace decomposition is enabled, the DepthToSpace recompose patterns
+// must be disabled so they do not immediately fold the decomposed
+// reshape/transpose/reshape chain back into an onnx.DepthToSpace.
 void getRecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableRotaryEmbeddingRecompose = false,
-    bool enableReduceL2Recompositions = false);
+    bool enableReduceL2Recompositions = false,
+    bool enableDepthToSpaceDecompose = false);
 
 } // namespace onnx_mlir
 #endif

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -49,7 +49,8 @@ std::unique_ptr<mlir::Pass> createONNXOpTransformPass(int threshold,
 
 std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
     const std::string &target = "", bool enableRotaryEmbeddingRecompose = false,
-    bool enableReduceL2Recompositions = false);
+    bool enableReduceL2Recompositions = false,
+    bool enableDepthToSpaceDecompose = false);
 
 std::unique_ptr<mlir::Pass> createConvOptONNXToONNXPass(
     bool enableSimdDataLayoutOpt = false);

--- a/test/mlir/onnx/onnx_depthtospace_decompose_recompose_roundtrip.mlir
+++ b/test/mlir/onnx/onnx_depthtospace_decompose_recompose_roundtrip.mlir
@@ -1,0 +1,43 @@
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+// RUN: onnx-mlir-opt --shape-inference --decompose-onnx --recompose-onnx --canonicalize %s -split-input-file | FileCheck %s --check-prefix=OFF
+// RUN: onnx-mlir-opt --shape-inference --decompose-onnx=enable-depthtospace-decompose --recompose-onnx=enable-depth-to-space-decompose --canonicalize %s -split-input-file | FileCheck %s --check-prefix=ON
+
+// -----
+
+// Reshape/Transpose/Reshape (CRD) as input.
+func.func @test_rtr_to_dts(%arg0: tensor<1x128x540x960xf32>) -> tensor<1x32x1080x1920xf32> {
+  %0 = onnx.Constant dense<[-1, 32, 2, 2, 540, 960]> : tensor<6xi64>
+  %1 = onnx.Constant dense<[-1, 32, 1080, 1920]> : tensor<4xi64>
+  %2 = "onnx.Reshape"(%arg0, %0) {allowzero = 0 : si64} : (tensor<1x128x540x960xf32>, tensor<6xi64>) -> tensor<1x32x2x2x540x960xf32>
+  %3 = "onnx.Transpose"(%2) {perm = [0, 1, 4, 2, 5, 3]} : (tensor<1x32x2x2x540x960xf32>) -> tensor<1x32x540x2x960x2xf32>
+  %4 = "onnx.Reshape"(%3, %1) {allowzero = 0 : si64} : (tensor<1x32x540x2x960x2xf32>, tensor<4xi64>) -> tensor<1x32x1080x1920xf32>
+  return %4 : tensor<1x32x1080x1920xf32>
+}
+// OFF-LABEL:  func.func @test_rtr_to_dts
+// OFF:          "onnx.DepthToSpace"(%{{.*}}) {blocksize = 2 : si64, mode = "CRD"}
+// OFF:          return
+
+// ON-LABEL:   func.func @test_rtr_to_dts
+// ON-NOT:       onnx.DepthToSpace
+// ON:           "onnx.Reshape"
+// ON:           "onnx.Transpose"
+// ON:           "onnx.Reshape"
+// ON:           return
+
+// -----
+
+// onnx.DepthToSpace (DCR) as input.
+func.func @test_dts_to_rtr(%arg0: tensor<1x12x4x5xf32>) -> tensor<1x3x8x10xf32> {
+  %0 = "onnx.DepthToSpace"(%arg0) {blocksize = 2 : si64, mode = "DCR"} : (tensor<1x12x4x5xf32>) -> tensor<1x3x8x10xf32>
+  onnx.Return %0 : tensor<1x3x8x10xf32>
+}
+// OFF-LABEL:  func.func @test_dts_to_rtr
+// OFF:          "onnx.DepthToSpace"(%{{.*}}) {blocksize = 2 : si64, mode = "DCR"}
+// OFF:          onnx.Return
+
+// ON-LABEL:   func.func @test_dts_to_rtr
+// ON-NOT:       onnx.DepthToSpace
+// ON:           "onnx.Reshape"
+// ON:           "onnx.Transpose"
+// ON:           "onnx.Reshape"
+// ON:           onnx.Return


### PR DESCRIPTION
This deactivates the recomposition, when enableDepthToSpaceDecompose is set since the patterns revert each other.

I'm not completely sure about the design. We can also name the pass option `enableDepthToSpaceRecomposition` and set it to false if `opts.hybrid.enableDepthToSpaceDecomposition` is set.