### PR TITLE
Fix: Isolating transpose lowering in onnx-to-tosa conversion

### DIFF
--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -4,7 +4,7 @@
 
 //====------ DialectBuilder.hpp - TOSA dialect builder --------------------===//
 //
-// Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -134,6 +134,16 @@ protected:
 
 private:
   mlir::PatternRewriter *patternRewriter;
+};
+
+// Recursive class specialized for TosaBuilder refereed to as tosa.
+template <class... Ts>
+struct MultiDialectBuilder<TosaBuilder, Ts...> : MultiDialectBuilder<Ts...> {
+  MultiDialectBuilder(mlir::PatternRewriter &b, mlir::Location loc)
+      : MultiDialectBuilder<Ts...>(b, loc), tosa(b, loc) {}
+  MultiDialectBuilder(const DialectBuilder &db)
+      : MultiDialectBuilder<Ts...>(db), tosa(db) {}
+  TosaBuilder tosa;
 };
 
 // =============================================================================

--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Conv2D.cpp - Conv2D Op ------------------------------===//
 //
-// Copyright (c) 2022 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -16,6 +16,7 @@
 #include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
 #include <src/Dialect/Mlir/IndexExpr.hpp>
 
@@ -130,7 +131,8 @@ public:
       }
     }
 
-    TosaBuilder tosaBuilder(rewriter, loc);
+    MultiDialectBuilder<TosaBuilder, OnnxBuilder, IndexExprBuilderForTosa>
+        create(rewriter, loc);
 
     auto input = adaptor.getX();
     auto weights = adaptor.getW();
@@ -146,8 +148,7 @@ public:
     }
 
     // Get shapehelper for autopad attributes
-    IndexExprBuilderForTosa createTosaIE(rewriter, convOp->getLoc());
-    ONNXConvOpShapeHelper shapeHelper(op, operands, &createTosaIE);
+    ONNXConvOpShapeHelper shapeHelper(op, operands, &create.tosaIE);
     if (shapeHelper.computeShape().failed()) {
       return rewriter.notifyMatchFailure(convOp, "Could not infer shapes");
     }
@@ -162,13 +163,13 @@ public:
     }
 
     // Convert input [N,IC,IH,IW] -> [N,IH,IW,IC]
-    Value newInput = tosaBuilder.transpose(input, {0, 2, 3, 1});
+    Value newInput = create.onnx.transposeInt64(input, {0, 2, 3, 1});
 
     // Convert weights [OC,IC,KH,KW] -> [OC,KH,KW,IC]
-    Value newWeight = tosaBuilder.transpose(weights, {0, 2, 3, 1});
+    Value newWeight = create.onnx.transposeInt64(weights, {0, 2, 3, 1});
 
     if (mlir::isa<NoneType>(bias.getType())) {
-      bias = tosaBuilder.getSingleValueConst(
+      bias = create.tosa.getSingleValueConst(
           0.0F, inputType.getElementType(), {weightShape[0]});
     }
 
@@ -184,7 +185,7 @@ public:
     // reorder padding values
     llvm::SmallVector<int64_t, 4> reorderedPads = {
         pads[0], pads[2], pads[1], pads[3]};
-    FailureOr<Value> resizedInput = tosaBuilder.resizeWindowBasedOps(newInput,
+    FailureOr<Value> resizedInput = create.tosa.resizeWindowBasedOps(newInput,
         cast<RankedTensorType>(newInput.getType()).getShape(),
         {weightShape[2], weightShape[3]}, reorderedPads, shapeHelper.strides,
         shapeHelper.dilations);
@@ -219,10 +220,11 @@ public:
         // this grouped convolution is equal to a Depthwise convolution.
 
         // Convert weights [OC,IC,KH,KW] -> [KH, KW, OC, M(ChannelMultiplier)]
-        Value transposedWeight = tosaBuilder.transpose(weights, {2, 3, 0, 1});
+        Value transposedWeight =
+            create.onnx.transposeInt64(weights, {2, 3, 0, 1});
         // A reshape op is needed to adhere to the TOSA standard
         // https://www.mlplatform.org/tosa/tosa_spec.html#_depthwise_conv2d
-        Value newWeight = tosaBuilder.reshape(
+        Value newWeight = create.tosa.reshape(
             transposedWeight, {weightShape[2], weightShape[3], inputChannels,
                                   outputChannels / inputChannels});
 
@@ -238,10 +240,10 @@ public:
         // can be costly, so only allow it when the number of groups is less
         // than configurable threshold.
 
-        conv2D = createConvInGroups(rewriter, convOp, tosaBuilder, resultType,
+        conv2D = createConvInGroups(rewriter, convOp, create.tosa, resultType,
             weightShape, newInput, newWeight, bias, group, newPads, strides,
             dilations, accType, activation);
-        Value newOutput = tosaBuilder.transpose(conv2D, {0, 3, 1, 2});
+        Value newOutput = create.onnx.transposeInt64(conv2D, {0, 3, 1, 2});
         auto *opToReplace = activation ? activation : convOp;
         rewriter.replaceOp(opToReplace, {newOutput});
         return success();
@@ -252,7 +254,7 @@ public:
     }
 
     // Convert output [N,OH,OW,OC] -> [N,OC,OH,OW]
-    Value newOutput = tosaBuilder.transpose(conv2D, {0, 3, 1, 2});
+    Value newOutput = create.onnx.transposeInt64(conv2D, {0, 3, 1, 2});
     rewriter.replaceOp(convOp, {newOutput});
     return success();
   }

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -1,4 +1,5 @@
 // RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa=grouped-conv-threshold=4 -cse %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa="grouped-conv-threshold=4 excluded-ops=Transpose" -cse %s -split-input-file | FileCheck %s --check-prefix=EXCLUDE-TRANSPOSE
 
 
 func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x256x256xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<5x2x15x15xf32> {
@@ -16,6 +17,17 @@ func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x256x256xf32>, %arg1 : te
 // CHECK-DAG:       %[[VAL_8:.*]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
 // CHECK:           %[[VAL_9:.*]] = tosa.transpose %[[VAL_7]], %[[VAL_8]] : (tensor<5x15x15x2xf32>, tensor<4xi32>) -> tensor<5x2x15x15xf32>
 // CHECK:           return %[[VAL_9]] : tensor<5x2x15x15xf32>
+
+// EXCLUDE-TRANSPOSE-LABEL:   func.func @test_onnx_conv2d_stride_13(
+// EXCLUDE-TRANSPOSE-SAME:                                          %[[VAL_0:.*]]: tensor<5x3x256x256xf32>,
+// EXCLUDE-TRANSPOSE-SAME:                                          %[[VAL_1:.*]]: tensor<2x3x64x64xf32>,
+// EXCLUDE-TRANSPOSE-SAME:                                          %[[VAL_2:.*]]: tensor<2xf32>) -> tensor<5x2x15x15xf32> {
+// EXCLUDE-TRANSPOSE-DAG:       %[[VAL_3:.*]] = "onnx.Transpose"(%[[VAL_0]]) {perm = [0, 2, 3, 1]} : (tensor<5x3x256x256xf32>) -> tensor<5x256x256x3xf32>
+// EXCLUDE-TRANSPOSE-DAG:       %[[VAL_4:.*]] = "onnx.Transpose"(%[[VAL_1]]) {perm = [0, 2, 3, 1]} : (tensor<2x3x64x64xf32>) -> tensor<2x64x64x3xf32>
+// EXCLUDE-TRANSPOSE:           %[[VAL_5:.*]] = tosa.slice %[[VAL_3]] {size = array<i64: 5, 245, 245, 3>, start = array<i64: 0, 0, 0, 0>} : (tensor<5x256x256x3xf32>) -> tensor<5x245x245x3xf32>
+// EXCLUDE-TRANSPOSE:           %[[VAL_6:.*]] = tosa.conv2d %[[VAL_5]], %[[VAL_4]], %[[VAL_2]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 0, 1, 0>, stride = array<i64: 13, 13>} : (tensor<5x245x245x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x15x15x2xf32>
+// EXCLUDE-TRANSPOSE:           %[[VAL_7:.*]] = "onnx.Transpose"(%[[VAL_6]]) {perm = [0, 3, 1, 2]} : (tensor<5x15x15x2xf32>) -> tensor<5x2x15x15xf32>
+// EXCLUDE-TRANSPOSE:           return %[[VAL_7]] : tensor<5x2x15x15xf32>
 }
 
 // -----


### PR DESCRIPTION
In the onnx-to-tosa conversion the excluded-ops is being bypassed by e.g. Conv patterns which create transposes. The point of this PR is to still create onnx.Transpose's which then get lowered by their own pattern in the greedy rewriter. In case transpose is included in excluded-ops it will never be created, not even by Conv patterns.

There is no change in functionality, unless you set excluded-ops=Transpose.