### PR TITLE
Isolate Tile from Expand lowering pattern

### DIFF
--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -4,7 +4,7 @@
 
 //====------ DialectBuilder.hpp - TOSA dialect builder --------------------===//
 //
-// Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -134,6 +134,16 @@ protected:
 
 private:
   mlir::PatternRewriter *patternRewriter;
+};
+
+// Recursive class specialized for TosaBuilder refereed to as tosa.
+template <class... Ts>
+struct MultiDialectBuilder<TosaBuilder, Ts...> : MultiDialectBuilder<Ts...> {
+  MultiDialectBuilder(mlir::PatternRewriter &b, mlir::Location loc)
+      : MultiDialectBuilder<Ts...>(b, loc), tosa(b, loc) {}
+  MultiDialectBuilder(const DialectBuilder &db)
+      : MultiDialectBuilder<Ts...>(db), tosa(db) {}
+  TosaBuilder tosa;
 };
 
 // =============================================================================

--- a/src/Conversion/ONNXToTOSA/Tensor/Expand.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Expand.cpp
@@ -4,7 +4,7 @@
 
 //===------------------------ Expand.cpp - Expand Op ---------------------===//
 //
-// Copyright (c) 2024 Advanced Micro Devices, Inc.
+// Copyright (c) 2024-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -15,6 +15,7 @@
 #include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 
 #include "src/Dialect/ONNX/ElementsAttr/ElementsAttrHelper.hpp"
@@ -74,6 +75,8 @@ public:
     // If inputRank is inferior to shapeRank we need to introduce a
     // reshape before the tile
     auto newInput = adaptor.getInput();
+    MultiDialectBuilder<TosaBuilder, OnnxBuilder> create(
+        rewriter, op->getLoc());
     if (inputRank != shapeArray.size()) {
       llvm::SmallVector<int64_t> newShape =
           getNewShape(inputType.getShape(), outputType.getShape());
@@ -83,8 +86,7 @@ public:
         return rewriter.notifyMatchFailure(
             op, "Could not find a shape that satisfies the expand constraints");
       }
-      TosaBuilder tosaBuilder(rewriter, op->getLoc());
-      newInput = tosaBuilder.reshape(adaptor.getInput(), newShape);
+      newInput = create.tosa.reshape(adaptor.getInput(), newShape);
     }
 
     const auto multiplies =
@@ -102,9 +104,10 @@ public:
         llvm::SmallVector<int64_t>(
             outputType.getShape().size(), ShapedType::kDynamic),
         newResultElementType);
-    onnx_mlir::tosa::CreateReplaceOpAndInfer<mlir::tosa::TileOp>(rewriter, op,
-        newTileOutputType, newInput,
-        mlir::tosa::getTosaConstShape(rewriter, op->getLoc(), multiplies));
+    Value repeats = create.onnx.constantInt64(multiplies);
+    Value tile = create.onnx.createTypedOpAndInferShapes<ONNXTileOp>(
+        newTileOutputType, newInput, repeats);
+    rewriter.replaceOp(op, tile);
     return success();
   }
 

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Expand.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Expand.mlir
@@ -1,4 +1,5 @@
 // RUN: onnx-mlir-opt --convert-onnx-to-tosa %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --convert-onnx-to-tosa="excluded-ops=Tile" %s -split-input-file | FileCheck %s --check-prefix=EXCLUDE-TILE
 
 func.func @test_expand(%arg0: tensor<1x64x1x1xf32>) -> tensor<1x64x64x64xf32> {
   %0 = "onnx.Constant"() {value = dense<[1, 64, 64, 64]> : tensor<4xi64>} : () -> tensor<4xi64>
@@ -12,6 +13,13 @@ func.func @test_expand(%arg0: tensor<1x64x1x1xf32>) -> tensor<1x64x64x64xf32> {
 // CHECK-DAG:       [[VAR_1_:%.+]] = tosa.const_shape  {value = dense<[1, 1, 64, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
 // CHECK:           [[VAR_2_:%.+]] = tosa.tile [[PARAM_0_]], [[VAR_1_]] : (tensor<1x64x1x1xf32>, !tosa.shape<4>) -> tensor<1x64x64x64xf32>
 // CHECK:           return [[VAR_2_]] : tensor<1x64x64x64xf32>
+
+// EXCLUDE-TILE-LABEL:  func.func @test_expand
+// EXCLUDE-TILE-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x1x1xf32>) -> tensor<1x64x64x64xf32> {
+// EXCLUDE-TILE-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1, 64, 64, 64]> : tensor<4xi64>}> : () -> tensor<4xi64>
+// EXCLUDE-TILE-DAG:       [[VAR_1_:%.+]] = "tosa.const"() <{value = dense<[1, 1, 64, 64]> : tensor<4xi64>}> : () -> tensor<4xi64>
+// EXCLUDE-TILE:           [[VAR_2_:%.+]] = "onnx.Tile"([[PARAM_0_]], [[VAR_1_]]) : (tensor<1x64x1x1xf32>, tensor<4xi64>) -> tensor<1x64x64x64xf32>
+// EXCLUDE-TILE:           return [[VAR_2_]] : tensor<1x64x64x64xf32>
 
 // -----
 


### PR DESCRIPTION
NFC that splits apart the Expand and Tile lowering patterns in onnx-to-tosa conversion. The point of this is the excluded-ops parameter is otherwise only partially excluding the lowering of onnx.Tile.