### PR TITLE
Isolate Concat lowering from GroupConv

### DIFF
--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -31,9 +31,10 @@ namespace {
 /// where the input, kernel and bias is a slice of the original inputs.
 /// Afterwards we have to concat the results of these into a single tensor.
 Value createConvInGroups(PatternRewriter &rewriter, Operation *op,
-    TosaBuilder &tosaBuilder, Type &resultType,
-    const llvm::ArrayRef<int64_t> weightShape, Value &newInput,
-    Value &newWeight, Value &bias, const int64_t groups,
+    MultiDialectBuilder<TosaBuilder, OnnxBuilder, IndexExprBuilderForTosa>
+        &create,
+    Type &resultType, const llvm::ArrayRef<int64_t> weightShape,
+    Value &newInput, Value &newWeight, Value &bias, const int64_t groups,
     DenseI64ArrayAttr &pads, DenseI64ArrayAttr &strides,
     DenseI64ArrayAttr &dilations, TypeAttr &accType, Operation *activation) {
   // Set up constants outside of loop
@@ -50,15 +51,15 @@ Value createConvInGroups(PatternRewriter &rewriter, Operation *op,
   for (int64_t i = 0; i < groups; i++) {
     // Slice input
     Value newSliceInput =
-        tosaBuilder.slice(newInput, inputSize, {0, 0, 0, i * sizeOfSliceInput});
+        create.tosa.slice(newInput, inputSize, {0, 0, 0, i * sizeOfSliceInput});
 
     // Slice kernel
-    Value newSliceWeight = tosaBuilder.slice(
+    Value newSliceWeight = create.tosa.slice(
         newWeight, kernelSize, {i * sizeOfSliceKernel, 0, 0, 0});
 
     // Slice bias
     Value newSliceBias =
-        tosaBuilder.slice(bias, {sizeOfSliceKernel}, {i * sizeOfSliceKernel});
+        create.tosa.slice(bias, {sizeOfSliceKernel}, {i * sizeOfSliceKernel});
 
     // Create conv
     Type newConvOutputType = RankedTensorType::get(
@@ -91,12 +92,12 @@ Value createConvInGroups(PatternRewriter &rewriter, Operation *op,
 
   auto concatInputs = activation ? slicesWithAct : sliceValues;
 
-  // Create concat op
+  // Create concat op. Keep it in ONNX so the recursive conversion picks up the
+  // regular ONNX Concat lowering instead of leaving an excluded TOSA op behind.
   Type newConcatOutputType = RankedTensorType::get(
       llvm::SmallVector<int64_t, 4>(4, ShapedType::kDynamic),
       mlir::cast<ShapedType>(resultType).getElementType());
-  Value conv2D = tosa::CreateOpAndInfer<mlir::tosa::ConcatOp>(
-      rewriter, op->getLoc(), newConcatOutputType, concatInputs, 3);
+  Value conv2D = create.onnx.concat(newConcatOutputType, concatInputs, 3);
   return conv2D;
 }
 
@@ -240,7 +241,7 @@ public:
         // can be costly, so only allow it when the number of groups is less
         // than configurable threshold.
 
-        conv2D = createConvInGroups(rewriter, convOp, create.tosa, resultType,
+        conv2D = createConvInGroups(rewriter, convOp, create, resultType,
             weightShape, newInput, newWeight, bias, group, newPads, strides,
             dilations, accType, activation);
         Value newOutput = create.onnx.transposeInt64(conv2D, {0, 3, 1, 2});

--- a/test/mlir/conversion/onnx_to_tosa/Math/GroupConvExcludedConcat.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/GroupConvExcludedConcat.mlir
@@ -1,0 +1,36 @@
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa="grouped-conv-threshold=4" -cse %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa="grouped-conv-threshold=4 excluded-ops=Concat" -cse %s -split-input-file | FileCheck %s --check-prefix=EXCLUDE
+
+func.func @test_group_conv_preserves_excluded_concat(%arg0: tensor<5x64x256x256xf32>, %arg1 : tensor<12x16x45x45xf32>, %arg2: tensor<12xf32>) -> tensor<5x12x17x17xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {
+      group = 4 : si64,
+      pads = [1, 1, 1, 1],
+      strides = [13, 13]
+    } : (tensor<5x64x256x256xf32>, tensor<12x16x45x45xf32>, tensor<12xf32>) -> tensor<5x12x17x17xf32>
+  return %0 : tensor<5x12x17x17xf32>
+
+// CHECK-LABEL:   func.func @test_group_conv_preserves_excluded_concat(
+// CHECK-SAME:      %[[ARG0:.*]]: tensor<5x64x256x256xf32>,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<12x16x45x45xf32>,
+// CHECK-SAME:      %[[ARG2:.*]]: tensor<12xf32>) -> tensor<5x12x17x17xf32> {
+// CHECK:           %[[CONV0:.*]] = tosa.conv2d
+// CHECK:           %[[CONV1:.*]] = tosa.conv2d
+// CHECK:           %[[CONV2:.*]] = tosa.conv2d
+// CHECK:           %[[CONV3:.*]] = tosa.conv2d
+// CHECK-NOT:       "onnx.Concat"
+// CHECK:           %[[CONCAT:.*]] = tosa.concat %[[CONV0]], %[[CONV1]], %[[CONV2]], %[[CONV3]] {axis = 3 : i32}
+// CHECK:           tosa.transpose %[[CONCAT]]
+// CHECK:           return
+
+// EXCLUDE-LABEL:   func.func @test_group_conv_preserves_excluded_concat(
+// EXCLUDE-SAME:      %[[ARG0:.*]]: tensor<5x64x256x256xf32>,
+// EXCLUDE-SAME:      %[[ARG1:.*]]: tensor<12x16x45x45xf32>,
+// EXCLUDE-SAME:      %[[ARG2:.*]]: tensor<12xf32>) -> tensor<5x12x17x17xf32> {
+// EXCLUDE:           %[[CONV0:.*]] = tosa.conv2d
+// EXCLUDE:           %[[CONV1:.*]] = tosa.conv2d
+// EXCLUDE:           %[[CONV2:.*]] = tosa.conv2d
+// EXCLUDE:           %[[CONV3:.*]] = tosa.conv2d
+// EXCLUDE-NOT:       tosa.concat
+// EXCLUDE:           %[[CONCAT:.*]] = "onnx.Concat"(%[[CONV0]], %[[CONV1]], %[[CONV2]], %[[CONV3]]) {axis = 3 : si64}
+// EXCLUDE:           tosa.transpose %[[CONCAT]]
+}


### PR DESCRIPTION
The excluded-ops=Concat only partially excludes concat from being lowered to tosa because the GroupConv paths was bypassing the excluded-ops. This PR isolates concat lowering from the groupconv pattern. Everything works as previously except that excluded-ops=Concat now does what it is supposed to.