### PR TITLE
Isolate transpose lowering in onnx2tosa conversion

### DIFF
--- a/src/Conversion/ONNXToTOSA/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Gemm.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Gemm.cpp - Gemm Op ----------------------------------===//
 //
-// Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -30,15 +30,17 @@ public:
 
   LogicalResult matchAndRewrite(ONNXGemmOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    TosaBuilder tosaBuilder(rewriter, op->getLoc());
+    MultiDialectBuilder<TosaBuilder, OnnxBuilder> create(
+        rewriter, op->getLoc());
     // If legal, create a FullyConnected operator instead
-    if (rewriteToTosaFC(op, adaptor, rewriter, tosaBuilder))
+    if (rewriteToTosaFC(op, adaptor, rewriter, create.tosa))
       return success();
-    return rewriteToTosaMatMul(op, adaptor, rewriter, tosaBuilder);
+    return rewriteToTosaMatMul(op, adaptor, rewriter, create);
   }
 
   LogicalResult rewriteToTosaMatMul(ONNXGemmOp op, OpAdaptor adaptor,
-      ConversionPatternRewriter &rewriter, TosaBuilder &tosaBuilder) const {
+      ConversionPatternRewriter &rewriter,
+      MultiDialectBuilder<TosaBuilder, OnnxBuilder> &create) const {
     Location loc = op->getLoc();
     Value A = op.getA();
     Value B = op.getB();
@@ -82,22 +84,10 @@ public:
 
     // If transA or transB are present, create Transpose operators.
     if (transA) {
-      Value targetTensor =
-          tosaBuilder.getConst(llvm::SmallVector<int32_t>{0, 2, 1}, {3});
-      Type outputType =
-          RankedTensorType::get(dynamicTensorShape, AType.getElementType());
-      A = tosa::CreateOpAndInfer<mlir::tosa::TransposeOp>(
-          rewriter, loc, outputType, A, targetTensor)
-              .getResult();
+      A = create.onnx.transposeInt64(A, {0, 2, 1});
     }
     if (transB) {
-      Value targetTensor =
-          tosaBuilder.getConst(llvm::SmallVector<int32_t>{0, 2, 1}, {3});
-      Type outputType =
-          RankedTensorType::get(dynamicTensorShape, BType.getElementType());
-      B = tosa::CreateOpAndInfer<mlir::tosa::TransposeOp>(
-          rewriter, loc, outputType, B, targetTensor)
-              .getResult();
+      B = create.onnx.transposeInt64(B, {0, 2, 1});
     }
 
     Value alphaMulResult = A;
@@ -105,19 +95,19 @@ public:
     // If Alpha is present and not 1, we create a multiply operation for alpha *
     // A
     if (alpha && alpha.getValueAsDouble() != 1.) {
-      Value splattedConstAlpha = tosaBuilder.getSplattedConst(
+      Value splattedConstAlpha = create.tosa.getSplattedConst(
           static_cast<float>(alpha.getValueAsDouble()), AType.getElementType(),
           newShapeA.size());
-      alphaMulResult = tosaBuilder.mul(splattedConstAlpha, A, 0);
+      alphaMulResult = create.tosa.mul(splattedConstAlpha, A, 0);
     }
 
     // If C and Beta are set, and beta is different from 1, we also need to add
     // a multiplication for beta * C
     if (beta && isCPresent && beta.getValueAsDouble() != 1.) {
-      Value splattedConstBeta = tosaBuilder.getSplattedConst(
+      Value splattedConstBeta = create.tosa.getSplattedConst(
           static_cast<float>(beta.getValueAsDouble()), AType.getElementType(),
           newShapeA.size());
-      betaMulResult = tosaBuilder.mul(splattedConstBeta, C, 0);
+      betaMulResult = create.tosa.mul(splattedConstBeta, C, 0);
     }
 
     // A * B
@@ -131,13 +121,13 @@ public:
     //(A*B) + Beta * C or (A*B) + C
     if (isCPresent) {
       addRes =
-          tosaBuilder.binaryOp<mlir::tosa::AddOp>(matmulRes, betaMulResult);
+          create.tosa.binaryOp<mlir::tosa::AddOp>(matmulRes, betaMulResult);
     } else {
       addRes = matmulRes;
     }
 
     // Add reshape to go back to the original shape
-    Value reshape = tosaBuilder.reshape(addRes, resultType.getShape());
+    Value reshape = create.tosa.reshape(addRes, resultType.getShape());
     rewriter.replaceOp(op, {reshape});
     return success();
   }

--- a/src/Conversion/ONNXToTOSA/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/MatMul.cpp
@@ -5,7 +5,7 @@
 //===------------- ONNXMatMulOp.cpp - ONNXMatMulOp --------------===//
 //
 // Copyright 2020 The TensorFlow Authors. All Rights Reserved.
-// Copyright (c) 2022 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -22,6 +22,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 
 using namespace mlir;
@@ -105,7 +106,9 @@ public:
   LogicalResult matchAndRewrite(ONNXMatMulOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
 
-    TosaBuilder builder(rewriter, op->getLoc());
+    MultiDialectBuilder<TosaBuilder, OnnxBuilder> create(
+        rewriter, op->getLoc());
+    TosaBuilder &builder = create.tosa;
 
     auto lhs = adaptor.getA();
     auto rhs = adaptor.getB();
@@ -198,6 +201,10 @@ public:
       }
       return false;
     };
+    auto transpose = [&](Value value, ArrayRef<int32_t> perm) {
+      SmallVector<int64_t> permI64(perm.begin(), perm.end());
+      return create.onnx.transposeInt64(value, permI64);
+    };
 
     SmallVector<TensorShape_t> commonElems;
     SmallVector<TensorShape_t> lhsSqueezedElems;
@@ -281,7 +288,7 @@ public:
           {maxInputRank - 2, lhsBroadcastedShape[maxInputRank - 2]});
       lhsSqueezedValue *= lhsBroadcastedShape[maxInputRank - 2];
 
-      // Step: Create the tosa.transpose array. If this array has a
+      // Step: Create the transpose array. If this array has a
       // non-monotonic series of dims, perform transpose.
       // First the common_elems
       for (uint32_t i = 0; i < commonElems.size(); i++) {
@@ -299,8 +306,7 @@ public:
 
       Value lhsReshapeInput = rankBroadcastedLhs;
       if (isTransposeRequired(transposedLhsDims)) {
-        lhsReshapeInput =
-            builder.transpose(rankBroadcastedLhs, transposedLhsDims);
+        lhsReshapeInput = transpose(rankBroadcastedLhs, transposedLhsDims);
       }
 
       // LHS = {common, lhs_squeezed, matmul_dim}
@@ -341,8 +347,7 @@ public:
 
       auto transposedRhsValue = rankBroadcastedRhs;
       if (isTransposeRequired(transposedRhsDims)) {
-        transposedRhsValue =
-            builder.transpose(rankBroadcastedRhs, transposedRhsDims);
+        transposedRhsValue = transpose(rankBroadcastedRhs, transposedRhsDims);
       }
 
       // reshape
@@ -467,7 +472,7 @@ public:
       llvm::copy(transposedOpDims, std::back_inserter(transposedOpDimsI32));
       // Perform final reshape
       output = isTransposeRequired(transposedOpDimsI32)
-                   ? builder.transpose(reshapeOp, transposedOpDimsI32)
+                   ? transpose(reshapeOp, transposedOpDimsI32)
                    : reshapeOp;
     }
 

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.cpp
@@ -6,7 +6,7 @@
 //
 // Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 // Copyright (c) 2021 Arm Limited.
-// Copyright (c) 2022 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -49,7 +49,7 @@ std::optional<Value> convertGatherOp(PatternRewriter &rewriter, Location loc,
     Value resultValue, Value inputValue, Value indicesValue, int32_t batchDims,
     int32_t axis) {
 
-  TosaBuilder tosaBuilder(rewriter, loc);
+  MultiDialectBuilder<TosaBuilder, OnnxBuilder> create(rewriter, loc);
 
   auto resultType = dyn_cast<ShapedType>(resultValue.getType());
   auto inputType = dyn_cast<RankedTensorType>(inputValue.getType());
@@ -241,7 +241,10 @@ std::optional<Value> convertGatherOp(PatternRewriter &rewriter, Location loc,
 
   // Begin of rewrite.
 
-  auto inputTransposeOp = tosaBuilder.transpose(inputValue, inputTransposePerm);
+  SmallVector<int64_t> inputTransposePermI64(
+      inputTransposePerm.begin(), inputTransposePerm.end());
+  auto inputTransposeOp =
+      create.onnx.transposeInt64(inputValue, inputTransposePermI64);
 
   if (countDynamicDims(tosaValuesShape) > 1) {
     return (void)rewriter.notifyMatchFailure(loc,
@@ -251,7 +254,7 @@ std::optional<Value> convertGatherOp(PatternRewriter &rewriter, Location loc,
   }
 
   auto tosaValuesReshapeOp =
-      tosaBuilder.reshape(inputTransposeOp, tosaValuesShape);
+      create.tosa.reshape(inputTransposeOp, tosaValuesShape);
 
   if (countDynamicDims(tosaIndicesShape) > 1) {
     return (void)rewriter.notifyMatchFailure(loc,
@@ -260,7 +263,7 @@ std::optional<Value> convertGatherOp(PatternRewriter &rewriter, Location loc,
   }
 
   auto tosaIndicesReshapeOp =
-      tosaBuilder.reshape(indicesValue, tosaIndicesShape);
+      create.tosa.reshape(indicesValue, tosaIndicesShape);
 
   Value tosaGatherOp = CreateOpAndInfer<mlir::tosa::GatherOp>(rewriter, loc,
       RankedTensorType::get(llvm::SmallVector<int64_t>(3, ShapedType::kDynamic),
@@ -274,9 +277,12 @@ std::optional<Value> convertGatherOp(PatternRewriter &rewriter, Location loc,
   }
 
   Value tosaResultReshapeOp =
-      tosaBuilder.reshape(tosaGatherOp, resultReshapeShape);
+      create.tosa.reshape(tosaGatherOp, resultReshapeShape);
 
-  return tosaBuilder.transpose(tosaResultReshapeOp, resultTransposePerm);
+  SmallVector<int64_t> resultTransposePermI64(
+      resultTransposePerm.begin(), resultTransposePerm.end());
+  return create.onnx.transposeInt64(
+      tosaResultReshapeOp, resultTransposePermI64);
 }
 
 // Lowers ReduceMean to a sequence of TOSA ops.

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
@@ -5,7 +5,7 @@
 //====------ ONNXToTOSACommon.hpp - ONNX dialects to TOSA lowering --------===//
 //
 // Copyright 2020 The TensorFlow Authors. All Rights Reserved.
-// Copyright (c) 2023 Advanced Micro Devices, Inc.
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -192,7 +192,7 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
       return rewriter.notifyMatchFailure(op, "Could not infer shapes");
   }
 
-  TosaBuilder tosaBuilder(rewriter, loc);
+  MultiDialectBuilder<TosaBuilder, OnnxBuilder> create(rewriter, loc);
 
   mlir::Value input = adaptor.getX();
   auto inputType = mlir::cast<mlir::TensorType>(input.getType());
@@ -218,7 +218,7 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
 
   // ONNX Mlir uses NCHW as an input while TOSA expects NHWC. Insert a
   // transpose to change the format
-  input = tosaBuilder.transpose(input, {0, 2, 3, 1});
+  input = create.onnx.transposeInt64(input, {0, 2, 3, 1});
 
   if (!IndexExpr::isLiteral(shapeHelper.pads)) {
     (void)rewriter.notifyMatchFailure(op, "could not determine pad values");
@@ -240,7 +240,7 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
   llvm::SmallVector<int64_t, 4> reorderedPads = {
       pads[0], pads[2] + ceilConstants[0], pads[1], pads[3] + ceilConstants[1]};
 
-  mlir::FailureOr<mlir::Value> resizedInput = tosaBuilder.resizeWindowBasedOps(
+  mlir::FailureOr<mlir::Value> resizedInput = create.tosa.resizeWindowBasedOps(
       input, mlir::cast<mlir::RankedTensorType>(input.getType()).getShape(),
       {kernelShapeVec[0], kernelShapeVec[1]}, reorderedPads,
       shapeHelper.strides, shapeHelper.dilations);
@@ -280,6 +280,6 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
 
   // Revert to original shape (NCHW)
   // Construct the old result shape out of the new one
-  mlir::Value transpose = tosaBuilder.transpose(input, {0, 3, 1, 2});
+  mlir::Value transpose = create.onnx.transposeInt64(input, {0, 3, 1, 2});
   return transpose;
 }

--- a/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Resize.cpp - Resize Op-------------------------------===//
 //
-// Copyright (c) 2023 Advanced Micro Devices, Inc.
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -178,7 +178,7 @@ public:
     Location loc = op->getLoc();
     OpAdaptor adaptor(operands, op->getAttrDictionary());
 
-    TosaBuilder tosaBuilder(rewriter, loc);
+    MultiDialectBuilder<TosaBuilder, OnnxBuilder> create(rewriter, loc);
 
     Value input = adaptor.getX();
     auto inputType = mlir::dyn_cast<RankedTensorType>(input.getType());
@@ -305,7 +305,7 @@ public:
             halfPixel, isNearest, isNearestModeFloor);
 
     // Convert input [N,IC,IH,IW] -> [N,IH,IW,IC]
-    Value newInput = tosaBuilder.transpose(input, {0, 2, 3, 1});
+    Value newInput = create.onnx.transposeInt64(input, {0, 2, 3, 1});
 
     // Create resizeOp
     auto scale = rewriter.getDenseI64ArrayAttr({yDimension.numerator,
@@ -324,7 +324,7 @@ public:
         newOutputType, newInput, scale, offset, border, resizeModeAttr);
 
     // Convert output [N,OH,OW,OC] -> [N,OC,OH,OW]
-    Value newOutput = tosaBuilder.transpose(resize, {0, 3, 1, 2});
+    Value newOutput = create.onnx.transposeInt64(resize, {0, 3, 1, 2});
 
     rewriter.replaceOp(resizeOp, newOutput);
 

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/TransposeExcluded.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/TransposeExcluded.mlir
@@ -1,0 +1,116 @@
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa -cse %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa="excluded-ops=Transpose" -cse %s -split-input-file | FileCheck %s --check-prefix=EXCLUDE
+
+func.func @test_gather_transposes(%arg0 : tensor<3x3xf32>) -> tensor<3x1x2xf32> {
+  %indices = "onnx.Constant"() {value = dense<[[0, 2]]> : tensor<1x2xi64>} : () -> tensor<1x2xi64>
+  %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<3x1x2xf32>
+  return %0 : tensor<3x1x2xf32>
+
+// CHECK-LABEL:   func.func @test_gather_transposes(
+// CHECK:           tosa.transpose
+// CHECK:           tosa.gather
+// CHECK:           tosa.transpose
+
+// EXCLUDE-LABEL:   func.func @test_gather_transposes(
+// EXCLUDE-NOT:       tosa.transpose
+// EXCLUDE:           "onnx.Transpose"
+// EXCLUDE:           tosa.gather
+// EXCLUDE:           "onnx.Transpose"
+// EXCLUDE-NOT:       tosa.transpose
+}
+
+// -----
+
+func.func @test_averagepool_transposes(%arg0 : tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32> {
+  %0 = "onnx.AveragePool"(%arg0) {kernel_shape = [3, 3]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32>
+  return %0 : tensor<5x5x30x30xf32>
+
+// CHECK-LABEL:   func.func @test_averagepool_transposes(
+// CHECK:           tosa.transpose
+// CHECK:           tosa.avg_pool2d
+// CHECK:           tosa.transpose
+
+// EXCLUDE-LABEL:   func.func @test_averagepool_transposes(
+// EXCLUDE-NOT:       tosa.transpose
+// EXCLUDE:           "onnx.Transpose"
+// EXCLUDE:           tosa.avg_pool2d
+// EXCLUDE:           "onnx.Transpose"
+// EXCLUDE-NOT:       tosa.transpose
+}
+
+// -----
+
+func.func @test_maxpool_transposes(%arg0 : tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32> {
+  %0 = "onnx.MaxPoolSingleOut"(%arg0) {kernel_shape = [3, 3]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32>
+  return %0 : tensor<5x5x30x30xf32>
+
+// CHECK-LABEL:   func.func @test_maxpool_transposes(
+// CHECK:           tosa.transpose
+// CHECK:           tosa.max_pool2d
+// CHECK:           tosa.transpose
+
+// EXCLUDE-LABEL:   func.func @test_maxpool_transposes(
+// EXCLUDE-NOT:       tosa.transpose
+// EXCLUDE:           "onnx.Transpose"
+// EXCLUDE:           tosa.max_pool2d
+// EXCLUDE:           "onnx.Transpose"
+// EXCLUDE-NOT:       tosa.transpose
+}
+
+// -----
+
+func.func @test_resize_transposes(%arg0 : tensor<1x1x2x4xf32>) -> tensor<1x1x4x8xf32> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %scales = "onnx.Constant"() {value = dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>} : () -> tensor<4xf32>
+  %0 = "onnx.Resize"(%arg0, %none, %scales, %none) {coordinate_transformation_mode = "pytorch_half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x4xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x8xf32>
+  return %0 : tensor<1x1x4x8xf32>
+
+// CHECK-LABEL:   func.func @test_resize_transposes(
+// CHECK:           tosa.transpose
+// CHECK:           tosa.resize
+// CHECK:           tosa.transpose
+
+// EXCLUDE-LABEL:   func.func @test_resize_transposes(
+// EXCLUDE-NOT:       tosa.transpose
+// EXCLUDE:           "onnx.Transpose"
+// EXCLUDE:           tosa.resize
+// EXCLUDE:           "onnx.Transpose"
+// EXCLUDE-NOT:       tosa.transpose
+}
+
+// -----
+
+func.func @test_gemm_transpose_attr(%arg0 : tensor<2x3xf32>, %arg1 : tensor<2x4xf32>) -> tensor<3x4xf32> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.Gemm"(%arg0, %arg1, %none) {transA = 1 : si64} : (tensor<2x3xf32>, tensor<2x4xf32>, none) -> tensor<3x4xf32>
+  return %0 : tensor<3x4xf32>
+
+// CHECK-LABEL:   func.func @test_gemm_transpose_attr(
+// CHECK:           tosa.transpose
+// CHECK:           tosa.matmul
+
+// EXCLUDE-LABEL:   func.func @test_gemm_transpose_attr(
+// EXCLUDE-NOT:       tosa.transpose
+// EXCLUDE:           "onnx.Transpose"
+// EXCLUDE:           tosa.matmul
+// EXCLUDE-NOT:       tosa.transpose
+}
+
+// -----
+
+func.func @test_matmul_broadcast_transposes(%arg0 : tensor<3x1x5x6xf32>, %arg1 : tensor<1x4x6x7xf32>) -> tensor<3x4x5x7xf32> {
+  %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<3x1x5x6xf32>, tensor<1x4x6x7xf32>) -> tensor<3x4x5x7xf32>
+  return %0 : tensor<3x4x5x7xf32>
+
+// CHECK-LABEL:   func.func @test_matmul_broadcast_transposes(
+// CHECK:           tosa.transpose
+// CHECK:           tosa.matmul
+// CHECK:           tosa.transpose
+
+// EXCLUDE-LABEL:   func.func @test_matmul_broadcast_transposes(
+// EXCLUDE-NOT:       tosa.transpose
+// EXCLUDE:           "onnx.Transpose"
+// EXCLUDE:           tosa.matmul
+// EXCLUDE:           "onnx.Transpose"
+// EXCLUDE-NOT:       tosa.transpose
+}


### PR DESCRIPTION
Follow up to [PR 894](https://github.com/Xilinx/onnx-mlir/pull/894) where we fix the excluded-ops=Transpose argument in the onnx-to-tosa conversion. This PR creates onnx.transpose's in the lowering of other patterns (Gather, Matmul, Resize, ...) which then get picked up by the lowering pattern for transpose.

This is a NFC unless you set excluded-ops=Transpose. 