### PR TITLE
Upgrade ReduceMeanV13 and materialize absent ReduceMean axes

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -7271,6 +7271,7 @@ def ONNXReduceMeanOp:ONNX_Op<"ReduceMean",
 
 def ONNXReduceMeanV13Op:ONNX_Op<"ReduceMeanV13",
   [Pure, OpVersionTrait<13>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX ReduceMean operation";
   let description = [{
   Computes the mean of the input tensor's elements along the provided axes. The resulting

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -1020,6 +1020,64 @@ public:
   }
 };
 
+// Materialize the implicit "reduce all axes" of a ReduceMean whose reduction
+// axes are absent. An omitted `axes` means "reduce over every dimension"
+// (unless the modern op sets `noop_with_empty_axes = 1`, which is a no-op that
+// `ONNXReduceMeanOp::fold` already forwards).
+//
+// The two op versions store `axes` differently: the legacy ReduceMeanV13 uses
+// an optional `I64ArrayAttr`, while the modern ReduceMean uses a None-able
+// operand plus the `noop_with_empty_axes` attribute.
+class MaterializeAbsentAxesReduceMeanV13Pattern
+    : public OpRewritePattern<ONNXReduceMeanV13Op> {
+public:
+  using OpRewritePattern<ONNXReduceMeanV13Op>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXReduceMeanV13Op op, PatternRewriter &rewriter) const override {
+    if (op.getAxesAttr())
+      return rewriter.notifyMatchFailure(op, "axes already present");
+
+    auto dataType = mlir::dyn_cast<RankedTensorType>(op.getData().getType());
+    if (!dataType)
+      return rewriter.notifyMatchFailure(op, "data must be ranked");
+    const int64_t rank = dataType.getRank();
+
+    SmallVector<int64_t> axes(rank);
+    std::iota(axes.begin(), axes.end(), int64_t{0});
+    rewriter.modifyOpInPlace(
+        op, [&] { op.setAxesAttr(rewriter.getI64ArrayAttr(axes)); });
+    return success();
+  }
+};
+
+class MaterializeAbsentAxesReduceMeanPattern
+    : public OpRewritePattern<ONNXReduceMeanOp> {
+public:
+  using OpRewritePattern<ONNXReduceMeanOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXReduceMeanOp op, PatternRewriter &rewriter) const override {
+    if (!isNoneValue(op.getAxes()))
+      return rewriter.notifyMatchFailure(op, "axes already present");
+
+    if (op.getNoopWithEmptyAxes() != 0)
+      return rewriter.notifyMatchFailure(op, "noop on empty axes");
+
+    auto dataType = mlir::dyn_cast<RankedTensorType>(op.getData().getType());
+    if (!dataType)
+      return rewriter.notifyMatchFailure(op, "data must be ranked");
+    const int64_t rank = dataType.getRank();
+
+    SmallVector<int64_t> axes(rank);
+    std::iota(axes.begin(), axes.end(), int64_t{0});
+    OnnxBuilder create(rewriter, op.getLoc());
+    Value newAxes = create.constantInt64(axes);
+    rewriter.modifyOpInPlace(op, [&] { op.getAxesMutable().assign(newAxes); });
+    return success();
+  }
+};
+
 // Rewrite keepdims=0 to keepdims=1 + Reshape to the original result shape.
 template <typename OP_TYPE>
 class ReduceKeepdimsCanonPattern : public OpRewritePattern<OP_TYPE> {
@@ -4611,9 +4669,16 @@ void ONNXReduceMaxOp::getCanonicalizationPatterns(
 /// on the ONNXReduceMeanOp.
 void ONNXReduceMeanOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
+  result.insert<MaterializeAbsentAxesReduceMeanPattern>(context);
   result.insert<DropUnitAxesFromReduceMeanPattern>(context);
   if (enableReduceKeepdimsCanonicalization)
     result.insert<ReduceKeepdimsCanonPattern<ONNXReduceMeanOp>>(context);
+}
+
+/// on the ONNXReduceMeanV13Op.
+void ONNXReduceMeanV13Op::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  result.insert<MaterializeAbsentAxesReduceMeanV13Pattern>(context);
 }
 
 /// on the ONNXReduceMinOp.

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -1020,37 +1020,39 @@ public:
   }
 };
 
-// Materialize the implicit "reduce all axes" of a ReduceMean whose reduction
-// axes are absent. An omitted `axes` means "reduce over every dimension"
-// (unless the modern op sets `noop_with_empty_axes = 1`, which is a no-op that
-// `ONNXReduceMeanOp::fold` already forwards).
-//
-// The two op versions store `axes` differently: the legacy ReduceMeanV13 uses
-// an optional `I64ArrayAttr`, while the modern ReduceMean uses a None-able
-// operand plus the `noop_with_empty_axes` attribute.
-class MaterializeAbsentAxesReduceMeanV13Pattern
+// Upgrade ReduceMeanV13 latest ReduceMean. A present `axes` attribute becomes a
+// constant axes operand; an absent one becomes a None operand with
+// `noop_with_empty_axes = 0`, preserving the legacy "reduce over every
+// dimension" semantics.
+class UpgradeReduceMeanV13Pattern
     : public OpRewritePattern<ONNXReduceMeanV13Op> {
 public:
   using OpRewritePattern<ONNXReduceMeanV13Op>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(
       ONNXReduceMeanV13Op op, PatternRewriter &rewriter) const override {
-    if (op.getAxesAttr())
-      return rewriter.notifyMatchFailure(op, "axes already present");
-
-    auto dataType = mlir::dyn_cast<RankedTensorType>(op.getData().getType());
-    if (!dataType)
-      return rewriter.notifyMatchFailure(op, "data must be ranked");
-    const int64_t rank = dataType.getRank();
-
-    SmallVector<int64_t> axes(rank);
-    std::iota(axes.begin(), axes.end(), int64_t{0});
-    rewriter.modifyOpInPlace(
-        op, [&] { op.setAxesAttr(rewriter.getI64ArrayAttr(axes)); });
+    OnnxBuilder create(rewriter, op.getLoc());
+    Value newAxes;
+    if (ArrayAttr axesAttr = op.getAxesAttr()) {
+      SmallVector<int64_t> axes;
+      for (size_t i = 0; i < axesAttr.size(); ++i)
+        axes.push_back(ArrayAttrIntVal(axesAttr, i));
+      newAxes = create.constantInt64(axes);
+    } else {
+      newAxes = create.none();
+    }
+    IntegerAttr noopWithEmptyAxes = IntegerAttr::get(
+        rewriter.getIntegerType(64, /*isSigned=*/true), APInt(64, 0, true));
+    rewriter.replaceOpWithNewOp<ONNXReduceMeanOp>(op, op.getResult().getType(),
+        op.getData(), newAxes, op.getKeepdimsAttr(), noopWithEmptyAxes);
     return success();
   }
 };
 
+// Materialize the implicit "reduce all axes" of a ReduceMean whose reduction
+// axes operand is absent (None). An omitted `axes` means "reduce over every
+// dimension" unless `noop_with_empty_axes = 1`, which is a no-op that
+// `ONNXReduceMeanOp::fold` already forwards.
 class MaterializeAbsentAxesReduceMeanPattern
     : public OpRewritePattern<ONNXReduceMeanOp> {
 public:
@@ -4678,7 +4680,7 @@ void ONNXReduceMeanOp::getCanonicalizationPatterns(
 /// on the ONNXReduceMeanV13Op.
 void ONNXReduceMeanV13Op::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  result.insert<MaterializeAbsentAxesReduceMeanV13Pattern>(context);
+  result.insert<UpgradeReduceMeanV13Pattern>(context);
 }
 
 /// on the ONNXReduceMinOp.

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -690,23 +690,25 @@ func.func @consecutive_clips(%arg0: tensor<3x1024x1024xf32> {onnx.name = "input"
 
 // -----
 
-// COM: Test rewriting GlobalAveragePool into ReduceMeanV13
+// COM: Test rewriting GlobalAveragePool into ReduceMean
 func.func @test_global_average_pool(%arg0: tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32> {
   %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32>
   onnx.Return %0 : tensor<1x3x1x1xf32>
   // CHECK-LABEL: test_global_average_pool
-  // CHECK: [[RES:%.+]] = "onnx.ReduceMeanV13"(%arg0) {axes = [2, 3], keepdims = 1 : si64} : (tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32>
+  // CHECK: [[AXES:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+  // CHECK: [[RES:%.+]] = "onnx.ReduceMean"(%arg0, [[AXES]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x3x5x5xf32>, tensor<2xi64>) -> tensor<1x3x1x1xf32>
   // CHECK: onnx.Return [[RES]] : tensor<1x3x1x1xf32>
 }
 
 // -----
 
-// COM: Test rewriting GlobalAveragePool into ReduceMeanV13 with dynamic dimensions
+// COM: Test rewriting GlobalAveragePool into ReduceMean with dynamic dimensions
 func.func @test_global_average_pool_dyn_dims(%arg0: tensor<1x?x?x5xf32>) -> tensor<1x?x?x1xf32> {
   %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<1x?x?x5xf32>) -> tensor<1x?x?x1xf32>
   onnx.Return %0 : tensor<1x?x?x1xf32>
   // CHECK-LABEL: test_global_average_pool_dyn_dims
-  // CHECK: [[RES:%.+]] = "onnx.ReduceMeanV13"(%arg0) {axes = [2, 3], keepdims = 1 : si64} : (tensor<1x?x?x5xf32>) -> tensor<1x?x1x1xf32>
+  // CHECK: [[AXES:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+  // CHECK: [[RES:%.+]] = "onnx.ReduceMean"(%arg0, [[AXES]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x?x?x5xf32>, tensor<2xi64>) -> tensor<1x?x1x1xf32>
   // CHECK: onnx.Return [[RES]] : tensor<1x?x1x1xf32>
 }
 

--- a/test/mlir/onnx/onnx_canonicalization_reducemean_axes.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_reducemean_axes.mlir
@@ -1,0 +1,51 @@
+// Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+// RUN: onnx-mlir-opt --shape-inference --canonicalize="test-convergence=true" --shape-inference %s -split-input-file | FileCheck %s
+
+// -----
+
+// Modern ReduceMean with an absent (None) axes operand and default semantics
+// (noop_with_empty_axes = 0) means "reduce all dims"; the materialization
+// pattern makes the axes explicit as [0, 1, ..., rank-1].
+func.func @test_reducemean_noaxes_materialize(%arg0: tensor<2x3x4xf32>) -> tensor<1x1x1xf32> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.ReduceMean"(%arg0, %none) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, none) -> tensor<1x1x1xf32>
+  onnx.Return %0 : tensor<1x1x1xf32>
+// CHECK-LABEL:  func.func @test_reducemean_noaxes_materialize
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>) -> tensor<1x1x1xf32> {
+// CHECK:           [[AXES_:%.+]] = onnx.Constant dense<[0, 1, 2]> : tensor<3xi64>
+// CHECK:           [[RES_:%.+]] = "onnx.ReduceMean"([[PARAM_0_]], [[AXES_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<3xi64>) -> tensor<1x1x1xf32>
+// CHECK:           onnx.Return [[RES_]] : tensor<1x1x1xf32>
+// CHECK-NOT:       "onnx.NoValue"
+}
+
+// -----
+
+// ReduceMeanV13 without an axes attribute is first upgraded to a modern
+// ReduceMean with a None axes operand, which is then materialized to an
+// explicit [0, 1, ..., rank-1] by the materialization pattern.
+func.func @test_reducemeanv13_noaxes_materialize(%arg0: tensor<2x3x4xf32>) -> tensor<1x1x1xf32> {
+  %0 = "onnx.ReduceMeanV13"(%arg0) {keepdims = 1 : si64} : (tensor<2x3x4xf32>) -> tensor<1x1x1xf32>
+  onnx.Return %0 : tensor<1x1x1xf32>
+// CHECK-LABEL:  func.func @test_reducemeanv13_noaxes_materialize
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>) -> tensor<1x1x1xf32> {
+// CHECK:           [[AXES_:%.+]] = onnx.Constant dense<[0, 1, 2]> : tensor<3xi64>
+// CHECK:           [[RES_:%.+]] = "onnx.ReduceMean"([[PARAM_0_]], [[AXES_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<3xi64>) -> tensor<1x1x1xf32>
+// CHECK:           onnx.Return [[RES_]] : tensor<1x1x1xf32>
+// CHECK-NOT:       "onnx.ReduceMeanV13"
+// CHECK-NOT:       "onnx.NoValue"
+}
+
+// -----
+
+// Modern ReduceMean with an absent (None) axes operand and
+// noop_with_empty_axes = 1 is a genuine no-op that forwards `data`; the
+// materialization pattern must NOT fire here.
+func.func @test_reducemean_noaxes_noop_not_materialized(%arg0: tensor<2x3x4xf32>) -> tensor<2x3x4xf32> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %0 = "onnx.ReduceMean"(%arg0, %none) {keepdims = 1 : si64, noop_with_empty_axes = 1 : si64} : (tensor<2x3x4xf32>, none) -> tensor<2x3x4xf32>
+  onnx.Return %0 : tensor<2x3x4xf32>
+// CHECK-LABEL:  func.func @test_reducemean_noaxes_noop_not_materialized
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>) -> tensor<2x3x4xf32> {
+// CHECK:           onnx.Return [[PARAM_0_]] : tensor<2x3x4xf32>
+// CHECK-NOT:       "onnx.Constant"
+}

--- a/test/mlir/onnx/onnx_canonicalization_reducemeanv13_upgrade.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_reducemeanv13_upgrade.mlir
@@ -1,0 +1,59 @@
+// Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+// RUN: onnx-mlir-opt --shape-inference --canonicalize="test-convergence=true" --shape-inference %s -split-input-file | FileCheck %s
+
+// -----
+
+// ReduceMeanV13 (attribute axes) is upgraded to the modern operand-axes
+// ReduceMean. The axes attribute becomes a constant axes operand.
+func.func @test_reducemeanv13_to_reducemean(%arg0: tensor<2x3x4xf32>) -> tensor<2x1x4xf32> {
+  %0 = "onnx.ReduceMeanV13"(%arg0) {axes = [1], keepdims = 1 : si64} : (tensor<2x3x4xf32>) -> tensor<2x1x4xf32>
+  onnx.Return %0 : tensor<2x1x4xf32>
+// CHECK-LABEL:  func.func @test_reducemeanv13_to_reducemean
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>) -> tensor<2x1x4xf32> {
+// CHECK:           [[AXES_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           [[RES_:%.+]] = "onnx.ReduceMean"([[PARAM_0_]], [[AXES_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<2x1x4xf32>
+// CHECK:           onnx.Return [[RES_]] : tensor<2x1x4xf32>
+// CHECK-NOT:       "onnx.ReduceMeanV13"
+}
+
+// -----
+
+// A multi-axis attribute is preserved as a rank-N constant operand.
+func.func @test_reducemeanv13_multi_axes(%arg0: tensor<2x3x4x5xf32>) -> tensor<2x1x1x5xf32> {
+  %0 = "onnx.ReduceMeanV13"(%arg0) {axes = [1, 2], keepdims = 1 : si64} : (tensor<2x3x4x5xf32>) -> tensor<2x1x1x5xf32>
+  onnx.Return %0 : tensor<2x1x1x5xf32>
+// CHECK-LABEL:  func.func @test_reducemeanv13_multi_axes
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5xf32>) -> tensor<2x1x1x5xf32> {
+// CHECK:           [[AXES_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+// CHECK:           [[RES_:%.+]] = "onnx.ReduceMean"([[PARAM_0_]], [[AXES_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4x5xf32>, tensor<2xi64>) -> tensor<2x1x1x5xf32>
+// CHECK:           onnx.Return [[RES_]] : tensor<2x1x1x5xf32>
+// CHECK-NOT:       "onnx.ReduceMeanV13"
+}
+
+// -----
+
+// Negative axes are carried through verbatim (not normalized to non-negative).
+func.func @test_reducemeanv13_negative_axis(%arg0: tensor<1x384x768xf32>) -> tensor<1x384x1xf32> {
+  %0 = "onnx.ReduceMeanV13"(%arg0) {axes = [-1], keepdims = 1 : si64} : (tensor<1x384x768xf32>) -> tensor<1x384x1xf32>
+  onnx.Return %0 : tensor<1x384x1xf32>
+// CHECK-LABEL:  func.func @test_reducemeanv13_negative_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x384x768xf32>) -> tensor<1x384x1xf32> {
+// CHECK:           [[AXES_:%.+]] = onnx.Constant dense<-1> : tensor<1xi64>
+// CHECK:           [[RES_:%.+]] = "onnx.ReduceMean"([[PARAM_0_]], [[AXES_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x384x768xf32>, tensor<1xi64>) -> tensor<1x384x1xf32>
+// CHECK:           onnx.Return [[RES_]] : tensor<1x384x1xf32>
+// CHECK-NOT:       "onnx.ReduceMeanV13"
+}
+
+// -----
+
+// keepdims = 0 is preserved through the upgrade.
+func.func @test_reducemeanv13_keepdims_zero(%arg0: tensor<2x3x4xf32>) -> tensor<2x4xf32> {
+  %0 = "onnx.ReduceMeanV13"(%arg0) {axes = [1], keepdims = 0 : si64} : (tensor<2x3x4xf32>) -> tensor<2x4xf32>
+  onnx.Return %0 : tensor<2x4xf32>
+// CHECK-LABEL:  func.func @test_reducemeanv13_keepdims_zero
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>) -> tensor<2x4xf32> {
+// CHECK:           [[AXES_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CHECK:           [[RES_:%.+]] = "onnx.ReduceMean"([[PARAM_0_]], [[AXES_]]) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<2x4xf32>
+// CHECK:           onnx.Return [[RES_]] : tensor<2x4xf32>
+// CHECK-NOT:       "onnx.ReduceMeanV13"
+}

--- a/test/mlir/onnx/onnx_recompose.mlir
+++ b/test/mlir/onnx/onnx_recompose.mlir
@@ -70,9 +70,10 @@ func.func @layernorm_without_bias_first_reduce_unsuitable_axis(%x: tensor<1x384x
 // CHECK-LABEL:  func.func @layernorm_without_bias_first_reduce_unsuitable_axis
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x384x768xf32>, [[PARAM_1_:%.+]]: tensor<768xf32>, [[PARAM_2_:%.+]]: tensor<768xf32>) -> tensor<1x384x768xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
-// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.ReduceMeanV13"([[PARAM_0_]]) {axes = [-2], keepdims = 1 : si64} : (tensor<1x384x768xf32>) -> tensor<1x384x1xf32>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Sub"([[PARAM_0_]], [[VAR_1_]]) : (tensor<1x384x768xf32>, tensor<1x384x1xf32>) -> tensor<1x384x768xf32>
-// CHECK:           [[Y_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.RMSLayerNormalization"([[VAR_2_]], [[PARAM_1_]], [[VAR_0_]]) {axis = 2 : si64, epsilon = 1.200000e+00 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<768xf32>, none) -> (tensor<1x384x768xf32>, none)
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<-2> : tensor<1xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.ReduceMean"([[PARAM_0_]], [[VAR_1_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x384x768xf32>, tensor<1xi64>) -> tensor<1x384x1xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Sub"([[PARAM_0_]], [[VAR_2_]]) : (tensor<1x384x768xf32>, tensor<1x384x1xf32>) -> tensor<1x384x768xf32>
+// CHECK:           [[Y_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.RMSLayerNormalization"([[VAR_3_]], [[PARAM_1_]], [[VAR_0_]]) {axis = 2 : si64, epsilon = 1.200000e+00 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<768xf32>, none) -> (tensor<1x384x768xf32>, none)
 // CHECK:           return [[Y_]] : tensor<1x384x768xf32>
 // CHECK:         }
 }
@@ -428,9 +429,10 @@ func.func @rms_layer_norm_v1(%x: tensor<1x384x768xf32>, %scale: tensor<768xf32>,
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @rms_layer_norm_v1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x384x768xf32>, [[PARAM_1_:%.+]]: tensor<768xf32>, [[PARAM_2_:%.+]]: tensor<768xf32>) -> tensor<1x384x768xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.ReduceMeanV13"([[PARAM_0_]]) {axes = [-1], keepdims = 1 : si64} : (tensor<1x384x768xf32>) -> tensor<1x384x1xf32>
-// CHECK:           [[VAR_1_:%.+]] = "onnx.Sub"([[VAR_0_]], [[PARAM_0_]]) : (tensor<1x384x1xf32>, tensor<1x384x768xf32>) -> tensor<1x384x768xf32>
-// CHECK:           [[Y_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.RMSLayerNormalization"([[VAR_1_]], [[PARAM_1_]], [[PARAM_2_]]) {axis = 2 : si64, epsilon = 1.200000e+00 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<768xf32>, tensor<768xf32>) -> (tensor<1x384x768xf32>, none)
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<-1> : tensor<1xi64>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.ReduceMean"([[PARAM_0_]], [[VAR_0_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x384x768xf32>, tensor<1xi64>) -> tensor<1x384x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Sub"([[VAR_1_]], [[PARAM_0_]]) : (tensor<1x384x1xf32>, tensor<1x384x768xf32>) -> tensor<1x384x768xf32>
+// CHECK:           [[Y_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.RMSLayerNormalization"([[VAR_2_]], [[PARAM_1_]], [[PARAM_2_]]) {axis = 2 : si64, epsilon = 1.200000e+00 : f32, stash_type = 1 : si64} : (tensor<1x384x768xf32>, tensor<768xf32>, tensor<768xf32>) -> (tensor<1x384x768xf32>, none)
 // CHECK:           return [[Y_]] : tensor<1x384x768xf32>
 // CHECK:         }
 }

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -554,6 +554,7 @@ OpsWithCanonicalizer = [
     "ReduceL2",
     "ReduceMax",
     "ReduceMean",
+    "ReduceMeanV13",
     "ReduceMin",
     "ReduceProd",
     "ReduceLogSum",


### PR DESCRIPTION
- Upgrade ReduceMeanV13 → ReduceMean (UpgradeReduceMeanV13Pattern). The legacy opset-13 op stores axes as an I64ArrayAttr; the modern (opset-18) op stores them as a None-able operand plus noop_with_empty_axes. A present attribute becomes a constant axes operand; an absent one becomes a None operand with noop_with_empty_axes = 0, preserving the legacy "reduce over every dimension" semantics.

- Materialize implicit axes (MaterializeAbsentAxesReduceMeanPattern). A modern ReduceMean with a None axes and default semantics means "reduce all dims". This makes it explicit as [0, 1, ..., rank-1]. The genuine no-op case (noop_with_empty_axes = 1) is left untouched — the folder already forwards data.