### PR TITLE
Improve ReduceL2 recomposition patterns

### DIFF
--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -66,7 +66,9 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   if (opts.hybrid.recomposition) {
     onnx_mlir::RecomposeONNXToONNXPassOptions recomposeOpts{
         .enableRotaryEmbeddingRecompose =
-            opts.hybrid.enableRotaryEmbeddingRecompose};
+            opts.hybrid.enableRotaryEmbeddingRecompose,
+        .enableReduceL2Recompositions =
+            opts.hybrid.enableReduceL2Recompositions};
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::createRecomposeONNXToONNXPass(recomposeOpts));
   }

--- a/src/Dialect/ONNX/Transforms/Passes.td
+++ b/src/Dialect/ONNX/Transforms/Passes.td
@@ -148,7 +148,8 @@ def ONNXRecomposePatternOptions {
            "enable-reducel2-recompositions",
            "bool", /*default=*/"false",
            "Recompose ReduceL2 from Sqrt(ReduceSumSquare(x)) and "
-           "ReduceSumSquare from ReduceSum(Mul(x, x))">
+           "Pow(ReduceSumSquare(x), 0.5), and ReduceSumSquare from "
+           "ReduceSum(Mul(x, x)) or ReduceSum(Pow(x, 2))">
   ];
 }
 

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -1404,6 +1404,71 @@ struct RecomposeReduceL2FromSqrtReduceSumSquarePattern
   }
 };
 
+// Recompose `ReduceSum(Pow(x, 2))` into `ReduceSumSquare(x)`. This is the
+// Pow-based variant of `RecomposeReduceSumSquareFromMulReduceSumPattern`.
+struct RecomposeReduceSumSquareFromPowReduceSumPattern
+    : public OpRewritePattern<ONNXReduceSumOp> {
+  using OpRewritePattern<ONNXReduceSumOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXReduceSumOp reduceSumOp, PatternRewriter &rewriter) const final {
+    auto powOp = reduceSumOp.getData().getDefiningOp<ONNXPowOp>();
+    if (!powOp || !powOp->hasOneUse())
+      return failure();
+
+    if (!onnx_mlir::isDenseONNXConstant(powOp.getY()) ||
+        !onnx_mlir::isConstOf(powOp.getY(), 2.0))
+      return failure();
+
+    // pessimistic: bail out if any involved value carries a quantized
+    if (onnx_mlir::hasQuantizedElementType(powOp.getX()) ||
+        onnx_mlir::hasQuantizedElementType(powOp.getZ()) ||
+        onnx_mlir::hasQuantizedElementType(reduceSumOp.getReduced()))
+      return failure();
+
+    const auto loc = mlir::FusedLoc::get(
+        rewriter.getContext(), {reduceSumOp.getLoc(), powOp.getLoc()});
+    const Value reduceSumSquare = rewriter.create<ONNXReduceSumSquareOp>(loc,
+        reduceSumOp.getType(), powOp.getX(), reduceSumOp.getAxes(),
+        reduceSumOp.getKeepdimsAttr(), reduceSumOp.getNoopWithEmptyAxesAttr());
+    rewriter.replaceOp(reduceSumOp, reduceSumSquare);
+    return success();
+  }
+};
+
+// Recompose `Pow(ReduceSumSquare(x), 0.5)` into `ReduceL2(x)`.
+struct RecomposeReduceL2FromPowReduceSumSquarePattern
+    : public OpRewritePattern<ONNXPowOp> {
+  using OpRewritePattern<ONNXPowOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXPowOp powOp, PatternRewriter &rewriter) const final {
+    if (!onnx_mlir::isDenseONNXConstant(powOp.getY()) ||
+        !onnx_mlir::isConstOf(powOp.getY(), 0.5))
+      return failure();
+
+    auto reduceSumSquareOp =
+        powOp.getX().getDefiningOp<ONNXReduceSumSquareOp>();
+    if (!reduceSumSquareOp || !reduceSumSquareOp->hasOneUse())
+      return failure();
+
+    // pessimistic: bail out if any involved value carries a quantized
+    if (onnx_mlir::hasQuantizedElementType(reduceSumSquareOp.getData()) ||
+        onnx_mlir::hasQuantizedElementType(reduceSumSquareOp.getReduced()) ||
+        onnx_mlir::hasQuantizedElementType(powOp.getZ()))
+      return failure();
+
+    const auto loc = mlir::FusedLoc::get(
+        rewriter.getContext(), {powOp.getLoc(), reduceSumSquareOp.getLoc()});
+    const Value reduceL2 = rewriter.create<ONNXReduceL2Op>(loc, powOp.getType(),
+        reduceSumSquareOp.getData(), reduceSumSquareOp.getAxes(),
+        reduceSumSquareOp.getKeepdimsAttr(),
+        reduceSumSquareOp.getNoopWithEmptyAxesAttr());
+    rewriter.replaceOp(powOp, reduceL2);
+    return success();
+  }
+};
+
 struct RecomposeQLinearMatMulFromQuantizeLinearPattern
     : public OpRewritePattern<ONNXQuantizeLinearOp> {
   using OpRewritePattern<ONNXQuantizeLinearOp>::OpRewritePattern;
@@ -2092,7 +2157,9 @@ void onnx_mlir::getRecomposeONNXToONNXPatterns(
     patterns.insert<RecomposeRotaryEmbeddingPattern>(context);
   if (enableReduceL2Recompositions) {
     patterns.insert<RecomposeReduceSumSquareFromMulReduceSumPattern>(context);
+    patterns.insert<RecomposeReduceSumSquareFromPowReduceSumPattern>(context);
     patterns.insert<RecomposeReduceL2FromSqrtReduceSumSquarePattern>(context);
+    patterns.insert<RecomposeReduceL2FromPowReduceSumSquarePattern>(context);
   }
   // AMD Disabled as downstream has no special support for it
   // patterns.insert<RecomposeQLinearMatMulFromQuantizeLinearPattern>(context);

--- a/src/Dialect/ONNX/Transforms/Recompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.hpp
@@ -15,6 +15,9 @@
 // implement shape inference for the recomposed operation. Hence, it is expected
 // that there is no knowledge about tensor shape at this point.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef ONNX_MLIR_RECOMPOSE_H
@@ -34,7 +37,8 @@ namespace onnx_mlir {
 // matches the RoPE in HuggingFaces LlamaRotaryEmbedding
 // `enableReduceL2Recompositions` enables a recomposition of a decomposed
 // ReduceL2 from Sqrt(ReduceSumSquare(x)) into an onnx.ReduceL2 op and
-// ReduceSumSquare from ReduceSum(Mul(x, x)).
+// Pow(ReduceSumSquare(x), 0.5) into an onnx.ReduceL2 op, and ReduceSumSquare
+// from ReduceSum(Mul(x, x)) or ReduceSum(Pow(x, 2)).
 void getRecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableRotaryEmbeddingRecompose = false,
     bool enableReduceL2Recompositions = false);

--- a/test/mlir/onnx/onnx_recompose_reducel2.mlir
+++ b/test/mlir/onnx/onnx_recompose_reducel2.mlir
@@ -93,6 +93,42 @@ func.func @test_recompose_reducesumsquare(%arg0: tensor<2x3x4xf32>, %arg1: tenso
 
 // -----
 
+func.func @test_recompose_reducesumsquare_from_pow(%arg0: tensor<1x512x10xf32>, %arg1: tensor<1xi64>) -> tensor<1x1x10xf32> {
+  %0 = onnx.Constant dense<2.000000e+00> : tensor<f32>
+  %1 = "onnx.Pow"(%arg0, %0) : (tensor<1x512x10xf32>, tensor<f32>) -> tensor<1x512x10xf32>
+  %2 = "onnx.ReduceSum"(%1, %arg1) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x512x10xf32>, tensor<1xi64>) -> tensor<1x1x10xf32>
+  onnx.Return %2 : tensor<1x1x10xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducesumsquare_from_pow
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x10xf32>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<1x1x10xf32> {
+// CHECK-NEXT:      [[VAR_0_:%.+]] = "onnx.ReduceSumSquare"([[PARAM_0_]], [[PARAM_1_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x512x10xf32>, tensor<1xi64>) -> tensor<1x1x10xf32>
+// CHECK-NEXT:      onnx.Return [[VAR_0_]] : tensor<1x1x10xf32>
+// CHECK-NEXT:    }
+}
+
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducesumsquare_from_pow
+// DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
+
+// -----
+
+func.func @test_recompose_reducel2_from_pow_reduce_sum_pow(%arg0: tensor<1x512x10xf32>, %arg1: tensor<1xi64>) -> tensor<1x1x10xf32> {
+  %0 = onnx.Constant dense<2.000000e+00> : tensor<f32>
+  %1 = "onnx.Pow"(%arg0, %0) : (tensor<1x512x10xf32>, tensor<f32>) -> tensor<1x512x10xf32>
+  %2 = "onnx.ReduceSum"(%1, %arg1) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x512x10xf32>, tensor<1xi64>) -> tensor<1x1x10xf32>
+  %3 = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %4 = "onnx.Pow"(%2, %3) : (tensor<1x1x10xf32>, tensor<f32>) -> tensor<1x1x10xf32>
+  onnx.Return %4 : tensor<1x1x10xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_from_pow_reduce_sum_pow
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x10xf32>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<1x1x10xf32> {
+// CHECK-NEXT:      [[VAR_0_:%.+]] = "onnx.ReduceL2"([[PARAM_0_]], [[PARAM_1_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x512x10xf32>, tensor<1xi64>) -> tensor<1x1x10xf32>
+// CHECK-NEXT:      onnx.Return [[VAR_0_]] : tensor<1x1x10xf32>
+// CHECK-NEXT:    }
+}
+
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_from_pow_reduce_sum_pow
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+
+// -----
+
 // Mul(x,y) should break the pattern
 func.func @test_recompose_reducel2_not_square(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x4xf32>, %arg2: tensor<1xi64>) -> tensor<?x?xf32> {
   %0 = "onnx.Mul"(%arg0, %arg1) : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>


### PR DESCRIPTION

## TLDR

This PR extends ONNX-MLIR recomposition so L2-norm subgraphs expressed as `Pow(ReduceSum(Pow(x, 2)), 0.5)` can be recovered as `onnx.ReduceL2`. The implementation is split into two smaller staged rewrites: first recover `onnx.ReduceSumSquare`, then recover `onnx.ReduceL2`.

## Summary

This change extends the existing ONNX-to-ONNX recomposition support around `ReduceL2`.

ONNX models may represent L2 norm in several equivalent ways. Existing recomposition already handled forms such as:

```text
Sqrt(ReduceSumSquare(x)) -> ReduceL2(x)
ReduceSum(Mul(x, x))    -> ReduceSumSquare(x)
```

This PR adds support for the `Pow`-based form commonly produced by exporters:

```text
Pow(ReduceSum(Pow(x, 2)), 0.5)
```

Rather than matching the whole expression as one large pattern, the rewrite is staged:

```text
ReduceSum(Pow(x, 2))        -> ReduceSumSquare(x)
Pow(ReduceSumSquare(x), .5) -> ReduceL2(x)
```

This keeps each pattern focused, makes the intermediate `ReduceSumSquare` recomposition useful independently, and lets greedy pattern application naturally recover the full `ReduceL2`.

## Motivation

Some ONNX producers encode “square” as `Pow(x, 2)` and “square root” as `Pow(x, 0.5)` instead of using `Mul(x, x)` or `Sqrt(x)`. Without recomposition, semantically equivalent L2-norm graphs remain in a decomposed form and downstream passes only see the lower-level elementwise and reduction operations.

Recovering `onnx.ReduceL2` improves canonical IR quality and aligns the `Pow`-based representation with the existing `Sqrt(ReduceSumSquare(x))` recomposition path.

## Implementation Details

This PR adds two recomposition patterns under the existing `enable-reducel2-recompositions` option.

The first pattern matches:

```text
ReduceSum(Pow(x, 2))
```

and rewrites it to:

```text
ReduceSumSquare(x)
```

It preserves the reduction metadata from the original `ReduceSum`, including:

```text
axes
keepdims
noop_with_empty_axes
```

The second pattern matches:

```text
Pow(ReduceSumSquare(x), 0.5)
```

and rewrites it to:

```text
ReduceL2(x)
```

It preserves the reduction metadata from the `ReduceSumSquare`.

Both patterns follow the existing conservative behavior for recomposition and bail out for quantized element types.

## Pass Options

The new patterns are controlled by the existing `enable-reducel2-recompositions` option.

The option description has been updated to describe the full set of supported staged recompositions:

```text
Sqrt(ReduceSumSquare(x))       -> ReduceL2(x)
Pow(ReduceSumSquare(x), 0.5)   -> ReduceL2(x)
ReduceSum(Mul(x, x))           -> ReduceSumSquare(x)
ReduceSum(Pow(x, 2))           -> ReduceSumSquare(x)
```

The standalone recomposition pass wiring now forwards `enableReduceL2Recompositions`, so the option is consistently honored when constructing `recompose-onnx`.

## Tests

The lit coverage was extended with focused cases for:

```text
ReduceSum(Pow(x, 2)) -> ReduceSumSquare(x)
Pow(ReduceSum(Pow(x, 2)), 0.5) -> ReduceL2(x)
```

The tests also include disabled-mode checks to ensure these recompositions only fire when `enable-reducel2-recompositions` is enabled.

## Risk

The risk is limited because the new rewrites are gated behind the existing ReduceL2 recomposition option. The staged approach also keeps the matchers small and separately testable, instead of introducing a single broad whole-expression matcher.
