### PR TITLE
Fix: Isolate slice lowering

### DIFF
--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -4,7 +4,7 @@
 
 //====------ DialectBuilder.hpp - TOSA dialect builder --------------------===//
 //
-// Copyright (c) 2022-2024 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -18,6 +18,7 @@
 #include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 
 using namespace mlir;
@@ -370,7 +371,7 @@ static bool containsNonZero(llvm::SmallVectorImpl<int64_t> &values) {
 FailureOr<Value> TosaBuilder::resizeWindowBasedOps(mlir::Value &value,
     const llvm::ArrayRef<int64_t> inputShape,
     const llvm::ArrayRef<int64_t> weightSpatialShape,
-    llvm::SmallVectorImpl<int64_t> &padding,
+    llvm::SmallVectorImpl<int64_t> &padding, OnnxBuilder &onnxBuilder,
     const llvm::ArrayRef<int64_t> strides,
     const llvm::ArrayRef<int64_t> dilation) {
 
@@ -426,10 +427,11 @@ FailureOr<Value> TosaBuilder::resizeWindowBasedOps(mlir::Value &value,
 
   // Only slice if we actually need it
   if (containsNonZero(cellsToCut)) {
-    value = this->slice(value,
-        {inputShape[0], inputShape[1] - cellsToCut[0],
-            inputShape[2] - cellsToCut[1], inputShape[3]},
-        {0, 0, 0, 0});
+    llvm::SmallVector<int64_t, 4> sliceSizes = {inputShape[0],
+        inputShape[1] - cellsToCut[0], inputShape[2] - cellsToCut[1],
+        inputShape[3]};
+    llvm::SmallVector<int64_t, 4> sliceStarts(4, 0);
+    value = onnxBuilder.slice(value, sliceStarts, sliceSizes);
   }
   padding[1] = cellsToPad[0];
   padding[3] = cellsToPad[1];

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -368,10 +368,10 @@ static bool containsNonZero(llvm::SmallVectorImpl<int64_t> &values) {
   return llvm::any_of(values, [](int64_t value) { return value != 0; });
 }
 
-FailureOr<Value> TosaBuilder::resizeWindowBasedOps(mlir::Value &value,
-    const llvm::ArrayRef<int64_t> inputShape,
+FailureOr<Value> TosaBuilder::resizeWindowBasedOps(OnnxBuilder &onnxBuilder,
+    mlir::Value &value, const llvm::ArrayRef<int64_t> inputShape,
     const llvm::ArrayRef<int64_t> weightSpatialShape,
-    llvm::SmallVectorImpl<int64_t> &padding, OnnxBuilder &onnxBuilder,
+    llvm::SmallVectorImpl<int64_t> &padding,
     const llvm::ArrayRef<int64_t> strides,
     const llvm::ArrayRef<int64_t> dilation) {
 

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -27,6 +27,8 @@
 
 namespace onnx_mlir {
 
+struct OnnxBuilder;
+
 // =============================================================================
 // TOSA Builder
 // =============================================================================
@@ -48,6 +50,7 @@ struct TosaBuilder : DialectBuilder {
   mlir::Value intdiv(mlir::Value &lhs, mlir::Value &rhs);
 
   mlir::Value transpose(mlir::Value &value, llvm::ArrayRef<int32_t> perm);
+  // Internal helper for ONNXSliceLoweringToTOSA only.
   mlir::Value slice(mlir::Value &inputConst, llvm::ArrayRef<int64_t> size,
       llvm::ArrayRef<int64_t> start);
   mlir::Value reshape(mlir::Value value, llvm::ArrayRef<int64_t> shape);
@@ -76,7 +79,7 @@ struct TosaBuilder : DialectBuilder {
   mlir::FailureOr<mlir::Value> resizeWindowBasedOps(mlir::Value &value,
       llvm::ArrayRef<int64_t> inputShape,
       llvm::ArrayRef<int64_t> weightSpatialShape,
-      llvm::SmallVectorImpl<int64_t> &padding,
+      llvm::SmallVectorImpl<int64_t> &padding, OnnxBuilder &onnxBuilder,
       llvm::ArrayRef<int64_t> strides = {1, 1},
       llvm::ArrayRef<int64_t> dilation = {0, 0});
 

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -50,7 +50,6 @@ struct TosaBuilder : DialectBuilder {
   mlir::Value intdiv(mlir::Value &lhs, mlir::Value &rhs);
 
   mlir::Value transpose(mlir::Value &value, llvm::ArrayRef<int32_t> perm);
-  // Internal helper for ONNXSliceLoweringToTOSA only.
   mlir::Value slice(mlir::Value &inputConst, llvm::ArrayRef<int64_t> size,
       llvm::ArrayRef<int64_t> start);
   mlir::Value reshape(mlir::Value value, llvm::ArrayRef<int64_t> shape);
@@ -76,10 +75,10 @@ struct TosaBuilder : DialectBuilder {
   /// the input can only have values that are actually used. To achieve this we
   /// have to reduce padding and if this is not enough, we even have to insert a
   /// slice op.
-  mlir::FailureOr<mlir::Value> resizeWindowBasedOps(mlir::Value &value,
-      llvm::ArrayRef<int64_t> inputShape,
+  mlir::FailureOr<mlir::Value> resizeWindowBasedOps(OnnxBuilder &onnxBuilder,
+      mlir::Value &value, llvm::ArrayRef<int64_t> inputShape,
       llvm::ArrayRef<int64_t> weightSpatialShape,
-      llvm::SmallVectorImpl<int64_t> &padding, OnnxBuilder &onnxBuilder,
+      llvm::SmallVectorImpl<int64_t> &padding,
       llvm::ArrayRef<int64_t> strides = {1, 1},
       llvm::ArrayRef<int64_t> dilation = {0, 0});
 

--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -186,10 +186,11 @@ public:
     // reorder padding values
     llvm::SmallVector<int64_t, 4> reorderedPads = {
         pads[0], pads[2], pads[1], pads[3]};
-    FailureOr<Value> resizedInput = create.tosa.resizeWindowBasedOps(newInput,
-        cast<RankedTensorType>(newInput.getType()).getShape(),
-        {weightShape[2], weightShape[3]}, reorderedPads, create.onnx,
-        shapeHelper.strides, shapeHelper.dilations);
+    FailureOr<Value> resizedInput =
+        create.tosa.resizeWindowBasedOps(create.onnx, newInput,
+            cast<RankedTensorType>(newInput.getType()).getShape(),
+            {weightShape[2], weightShape[3]}, reorderedPads,
+            shapeHelper.strides, shapeHelper.dilations);
 
     if (failed(resizedInput))
       return rewriter.notifyMatchFailure(

--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -51,15 +51,15 @@ Value createConvInGroups(PatternRewriter &rewriter, Operation *op,
   for (int64_t i = 0; i < groups; i++) {
     // Slice input
     Value newSliceInput =
-        create.tosa.slice(newInput, inputSize, {0, 0, 0, i * sizeOfSliceInput});
+        create.onnx.slice(newInput, {0, 0, 0, i * sizeOfSliceInput}, inputSize);
 
     // Slice kernel
-    Value newSliceWeight = create.tosa.slice(
-        newWeight, kernelSize, {i * sizeOfSliceKernel, 0, 0, 0});
+    Value newSliceWeight = create.onnx.slice(
+        newWeight, {i * sizeOfSliceKernel, 0, 0, 0}, kernelSize);
 
     // Slice bias
     Value newSliceBias =
-        create.tosa.slice(bias, {sizeOfSliceKernel}, {i * sizeOfSliceKernel});
+        create.onnx.slice(bias, {i * sizeOfSliceKernel}, {sizeOfSliceKernel});
 
     // Create conv
     Type newConvOutputType = RankedTensorType::get(
@@ -188,8 +188,8 @@ public:
         pads[0], pads[2], pads[1], pads[3]};
     FailureOr<Value> resizedInput = create.tosa.resizeWindowBasedOps(newInput,
         cast<RankedTensorType>(newInput.getType()).getShape(),
-        {weightShape[2], weightShape[3]}, reorderedPads, shapeHelper.strides,
-        shapeHelper.dilations);
+        {weightShape[2], weightShape[3]}, reorderedPads, create.onnx,
+        shapeHelper.strides, shapeHelper.dilations);
 
     if (failed(resizedInput))
       return rewriter.notifyMatchFailure(

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
@@ -240,10 +240,11 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
   llvm::SmallVector<int64_t, 4> reorderedPads = {
       pads[0], pads[2] + ceilConstants[0], pads[1], pads[3] + ceilConstants[1]};
 
-  mlir::FailureOr<mlir::Value> resizedInput = create.tosa.resizeWindowBasedOps(
-      input, mlir::cast<mlir::RankedTensorType>(input.getType()).getShape(),
-      {kernelShapeVec[0], kernelShapeVec[1]}, reorderedPads, create.onnx,
-      shapeHelper.strides, shapeHelper.dilations);
+  mlir::FailureOr<mlir::Value> resizedInput =
+      create.tosa.resizeWindowBasedOps(create.onnx, input,
+          mlir::cast<mlir::RankedTensorType>(input.getType()).getShape(),
+          {kernelShapeVec[0], kernelShapeVec[1]}, reorderedPads,
+          shapeHelper.strides, shapeHelper.dilations);
 
   if (failed(resizedInput)) {
     return rewriter.notifyMatchFailure(

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp.inc
@@ -242,7 +242,7 @@ mlir::FailureOr<mlir::Value> convertPoolOp(
 
   mlir::FailureOr<mlir::Value> resizedInput = create.tosa.resizeWindowBasedOps(
       input, mlir::cast<mlir::RankedTensorType>(input.getType()).getShape(),
-      {kernelShapeVec[0], kernelShapeVec[1]}, reorderedPads,
+      {kernelShapeVec[0], kernelShapeVec[1]}, reorderedPads, create.onnx,
       shapeHelper.strides, shapeHelper.dilations);
 
   if (failed(resizedInput)) {

--- a/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Gather.cpp - Gather Op ------------------------------===//
 //
-// Copyright (c) 2022 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -16,6 +16,7 @@
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Support/TypeUtilities.hpp"
 #include "llvm/ADT/SmallVector.h"
@@ -35,7 +36,7 @@ public:
 
     auto loc = op.getLoc();
 
-    TosaBuilder tosaBuilder(rewriter, loc);
+    MultiDialectBuilder<TosaBuilder, OnnxBuilder> create(rewriter, loc);
 
     Value input = adaptor.getData();
     Value indices = adaptor.getIndices();
@@ -73,8 +74,8 @@ public:
                                             : indicesValInteger + size[axis];
 
       size[axis] = 1;
-      Value sliceOp = tosaBuilder.slice(input, size, starts);
-      auto reshape = tosaBuilder.reshape(sliceOp, resultTy.getShape());
+      Value sliceOp = create.onnx.slice(input, starts, size);
+      auto reshape = create.tosa.reshape(sliceOp, resultTy.getShape());
       rewriter.replaceOp(op, reshape);
       return success();
     }
@@ -90,20 +91,20 @@ public:
     // element-wise.
 
     // Create an 1x..x1 constant containing the size of the gathered dimension.
-    auto dimSize = tosaBuilder.getSplattedConst(
+    auto dimSize = create.tosa.getSplattedConst(
         inputShape[axis], indicesType.getElementType(), indicesType.getRank());
     auto indicesPlusDimSize =
-        tosaBuilder.binaryOp<mlir::tosa::AddOp>(indices, dimSize);
+        create.tosa.binaryOp<mlir::tosa::AddOp>(indices, dimSize);
 
-    auto zero = tosaBuilder.getSplattedConst(
+    auto zero = create.tosa.getSplattedConst(
         (int64_t)0, indicesType.getElementType(), indicesType.getRank());
-    auto indicesPositive = tosaBuilder.greaterEqual(indices, zero);
+    auto indicesPositive = create.tosa.greaterEqual(indices, zero);
 
     auto newIndices =
-        tosaBuilder.select(indicesPositive, indices, indicesPlusDimSize);
+        create.tosa.select(indicesPositive, indices, indicesPlusDimSize);
 
     auto newGather =
-        tosaBuilder.gather(result, input, newIndices, 0, (int32_t)axis);
+        create.tosa.gather(result, input, newIndices, 0, (int32_t)axis);
 
     if (!newGather.has_value()) {
       return failure();

--- a/src/Conversion/ONNXToTOSA/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Slice.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Slice.cpp - Slice Op --------------------===//
 //
-// Copyright (c) 2022 Advanced Micro Devices, Inc.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -17,6 +17,7 @@
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 #include "llvm/ADT/SmallVector.h"
 
 using namespace mlir;
@@ -24,6 +25,10 @@ using namespace mlir;
 namespace onnx_mlir {
 
 namespace {
+
+bool isStaticSliceAttribute(Value val) {
+  return val.getDefiningOp<mlir::tosa::ConstOp>() || isConstLikeValue(val);
+}
 
 class ONNXSliceLoweringToTOSA : public OpConversionPattern<ONNXSliceOp> {
 public:
@@ -39,12 +44,10 @@ public:
       ConversionPatternRewriter &rewriter) const override {
 
     Location loc = op->getLoc();
-    if (!adaptor.getStarts().getDefiningOp<mlir::tosa::ConstOp>()) {
+    if (!isStaticSliceAttribute(adaptor.getStarts()))
       return rewriter.notifyMatchFailure(op, "starts must be constant");
-    }
-    if (!adaptor.getEnds().getDefiningOp<mlir::tosa::ConstOp>()) {
+    if (!isStaticSliceAttribute(adaptor.getEnds()))
       return rewriter.notifyMatchFailure(op, "ends must be constant");
-    }
 
     // Get shape.
     IndexExprBuilderForTosa createTosaIE(rewriter, loc);

--- a/src/Conversion/ONNXToTOSA/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Slice.cpp
@@ -26,10 +26,6 @@ namespace onnx_mlir {
 
 namespace {
 
-bool isStaticSliceAttribute(Value val) {
-  return val.getDefiningOp<mlir::tosa::ConstOp>() || isConstLikeValue(val);
-}
-
 class ONNXSliceLoweringToTOSA : public OpConversionPattern<ONNXSliceOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
@@ -44,9 +40,9 @@ public:
       ConversionPatternRewriter &rewriter) const override {
 
     Location loc = op->getLoc();
-    if (!isStaticSliceAttribute(adaptor.getStarts()))
+    if (!isConstLikeValue(adaptor.getStarts()))
       return rewriter.notifyMatchFailure(op, "starts must be constant");
-    if (!isStaticSliceAttribute(adaptor.getEnds()))
+    if (!isConstLikeValue(adaptor.getEnds()))
       return rewriter.notifyMatchFailure(op, "ends must be constant");
 
     // Get shape.

--- a/src/Conversion/ONNXToTOSA/Tensor/Split.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Split.cpp
@@ -4,7 +4,7 @@
 
 //===------------- Split.cpp - Split Op---------===//
 //
-// Copyright (c) 2023 Advanced Micro Devices, Inc.
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
@@ -15,6 +15,7 @@
 #include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 
 using namespace mlir;
@@ -47,7 +48,7 @@ public:
     if (failed(shapeHelper.computeShape()))
       return rewriter.notifyMatchFailure(op, "could not compute shape.");
 
-    TosaBuilder tosaBuilder(rewriter, op->getLoc());
+    OnnxBuilder onnxBuilder(rewriter, op->getLoc());
     uint64_t outputNum = op.getNumResults();
     SmallVector<Value, 4> slices;
     slices.reserve(outputNum);
@@ -60,7 +61,7 @@ public:
       DimsExpr outputDim = shapeHelper.getOutputDims(i);
       IndexExpr::getShape(outputDim, size);
       starts[splitAxis] = start;
-      slices.push_back(tosaBuilder.slice(input, size, starts));
+      slices.push_back(onnxBuilder.slice(input, starts, size));
       start += size[splitAxis];
     }
     rewriter.replaceOp(op, slices);

--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -483,6 +483,26 @@ Value OnnxBuilder::slice(Type outputType, Value input, Value starts, Value ends,
       toTensor(steps));
 }
 
+Value OnnxBuilder::slice(
+    Value input, ArrayRef<int64_t> starts, ArrayRef<int64_t> sizes) const {
+  assert(starts.size() == sizes.size() && "starts/sizes rank mismatch");
+  const int64_t rank = static_cast<int64_t>(starts.size());
+  SmallVector<int64_t> ends(rank);
+  SmallVector<int64_t> axes(rank);
+  SmallVector<int64_t> steps(rank, 1);
+  for (int64_t i = 0; i < rank; ++i) {
+    ends[i] = starts[i] + sizes[i];
+    axes[i] = i;
+  }
+  Value startsVal = constant(b().getI64TensorAttr(starts));
+  Value endsVal = constant(b().getI64TensorAttr(ends));
+  Value axesVal = constant(b().getI64TensorAttr(axes));
+  Value stepsVal = constant(b().getI64TensorAttr(steps));
+  auto inputType = cast<ShapedType>(input.getType());
+  Type outputType = RankedTensorType::get(sizes, inputType.getElementType());
+  return slice(outputType, input, startsVal, endsVal, axesVal, stepsVal);
+}
+
 // 1D slice: take ints instead of values, and axis is by default 0 since we deal
 // here with 1D vectors.
 Value OnnxBuilder::slice(Type outputType, Value input, int64_t start,

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -210,6 +210,8 @@ struct OnnxBuilder : DialectBuilder {
   mlir::Value slice(mlir::Type outputType, mlir::Value input,
       mlir::Value starts, mlir::Value ends, mlir::Value axes,
       mlir::Value steps) const;
+  mlir::Value slice(mlir::Value input, llvm::ArrayRef<int64_t> starts,
+      llvm::ArrayRef<int64_t> sizes) const;
   mlir::Value slice(mlir::Type outputType, mlir::Value input, int64_t start,
       int64_t end, int64_t step = 1) const; // 1D slice
 

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Slice.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Slice.mlir
@@ -1,5 +1,6 @@
 // RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa -cse %s -split-input-file | FileCheck %s
 // RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa="convert-slice-only-when-step-one=true" -cse %s -split-input-file | FileCheck %s --check-prefix=ONLY-STEP1
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa="excluded-ops=Slice" -cse %s -split-input-file | FileCheck %s --check-prefix=EXCLUDE-SLICE
 
 
 func.func @test_slice_constant_default_steps(%arg0 : tensor<2x4xf32>) -> tensor<1x3xf32> {
@@ -11,6 +12,10 @@ func.func @test_slice_constant_default_steps(%arg0 : tensor<2x4xf32>) -> tensor<
   "func.return"(%1) : (tensor<1x3xf32>) -> ()
 // CHECK-LABEL: func @test_slice_constant_default_steps
 // CHECK: %0 = tosa.slice %arg0 {size = array<i64: 1, 3>, start = array<i64: 1, 0>} : (tensor<2x4xf32>) -> tensor<1x3xf32>
+// EXCLUDE-SLICE-LABEL: func @test_slice_constant_default_steps
+// EXCLUDE-SLICE-NOT: tosa.slice
+// EXCLUDE-SLICE: "onnx.Slice"
+// EXCLUDE-SLICE: return
 }
 
 func.func @test_slice_all_constant_negative(%arg0 : tensor<2x4xf32>) -> tensor<1x3xf32> {
@@ -74,6 +79,10 @@ func.func @slice_just_steps(%arg0: tensor<100x200xf32>) -> tensor<20x20xf32> {
 // CHECK: %1 = tosa.slice %0 {size = array<i64: 20, 1, 20, 1>, start = array<i64: 0, 0, 0, 0>} : (tensor<20x5x20x10xf32>) -> tensor<20x1x20x1xf32>
 // CHECK: %2 = tosa.reshape %1 {new_shape = array<i64: 20, 20>} : (tensor<20x1x20x1xf32>) -> tensor<20x20xf32>
 // CHECK: return %2 : tensor<20x20xf32>
+// EXCLUDE-SLICE-LABEL: func @slice_just_steps
+// EXCLUDE-SLICE-NOT: tosa.slice
+// EXCLUDE-SLICE: "onnx.Slice"
+// EXCLUDE-SLICE: return
 
 // ONLY-STEP1-LABEL: func @slice_just_steps
 // ONLY-STEP1: tosa.slice


### PR DESCRIPTION
For excluded-ops=Slice to work properly we need other ops to not create it as a byproduct. This PR isolates slice lowering from GroupConv, Gather, and Split. All existing tests still pass and the lowering is unaffected unless slice is excluded.