### PR TITLE
feat: canonicalize multi-axes ScatterND for DecomposeScatterNDPattern

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -417,6 +417,28 @@ bool extractSlice1DConst(mlir::ONNXSliceOp sliceOp, int64_t &axis,
          extractI64Scalar(sliceOp.getSteps(), step);
 }
 
+int64_t indexToOffset(
+    llvm::ArrayRef<int64_t> shape, llvm::ArrayRef<int64_t> index) {
+  int64_t offset = 0;
+  for (size_t i = 0; i < shape.size(); i++) {
+    offset = offset * shape[i] + index[i];
+  }
+  return offset;
+}
+
+SmallVector<int64_t> offsetToIndex(
+    llvm::ArrayRef<int64_t> shape, int64_t offset) {
+  auto rank = shape.size();
+  // The rank of the index will be equal to the rank of the shape
+  SmallVector<int64_t> resultIndex;
+  for (int32_t i = rank - 1; i >= 0; i--) {
+    resultIndex.push_back(offset % shape[i]);
+    offset /= shape[i];
+  }
+  std::reverse(resultIndex.begin(), resultIndex.end());
+  return resultIndex;
+}
+
 //===----------------------------------------------------------------------===//
 // Support for BatchNorm
 

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -219,6 +219,23 @@ bool getI64ValuesFromONNXConstantOp(
 // Note: It's ok to inline the isa<NoneType> test and not call this function.
 inline bool isNoneValue(mlir::Value value);
 
+/// Flatten a multi-dimensional index into a linear (row-major) offset.
+/// Given a tensor `shape` and a same-rank `index`, returns the position of that
+/// element in row-major (C-contiguous) memory, i.e.
+/// `((index[0] * shape[1] + index[1]) * shape[2] + ...)`.
+/// This is the inverse of `offsetToIndex`.
+/// Example: shape = [2, 3, 4], index = [1, 2, 3] -> ((1*3 + 2)*4 + 3) = 23.
+int64_t indexToOffset(
+    llvm::ArrayRef<int64_t> shape, llvm::ArrayRef<int64_t> index);
+
+/// Expand a linear (row-major) offset into a multi-dimensional index.
+/// Given a tensor `shape` and a flat `offset`, returns the coordinates of that
+/// element under row-major (C-contiguous) layout. The result has the same rank
+/// as `shape`. This is the inverse of `indexToOffset`.
+/// Example: shape = [2, 3, 4], offset = 23 -> [1, 2, 3].
+llvm::SmallVector<int64_t> offsetToIndex(
+    llvm::ArrayRef<int64_t> shape, int64_t offset);
+
 //===----------------------------------------------------------------------===//
 // Support for BatchNorm
 

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2515,6 +2515,116 @@ private:
   ArrayRef<int64_t> shapeToCheck;
 };
 
+// Shared preconditions for the ScatterND contiguous-block rewrites
+// (DecomposeScatterNDPattern and CanonicalizeScatterNDWithMultiAxis):
+// reduction must be "none", all operands must have a static shape, and
+// rank(data) == rank(updates). On success the operand tensor types are written
+// to the out-parameters.
+LogicalResult checkScatterNDPreconditions(ONNXScatterNDOp scatterNDOp,
+    PatternRewriter &rewriter, RankedTensorType &dataType,
+    RankedTensorType &updatesType, RankedTensorType &indicesType) {
+  if (scatterNDOp.getReductionAttr().strref() != "none") {
+    return rewriter.notifyMatchFailure(
+        scatterNDOp, "Scatters with reduction are not supported");
+  }
+  const auto data = scatterNDOp.getData();
+  const auto indices = scatterNDOp.getIndices();
+  const auto updates = scatterNDOp.getUpdates();
+  if (!onnx_mlir::hasStaticShape(data.getType()) ||
+      !onnx_mlir::hasStaticShape(indices.getType()) ||
+      !onnx_mlir::hasStaticShape(updates.getType())) {
+    return rewriter.notifyMatchFailure(
+        scatterNDOp, "All operands need to have a static shape");
+  }
+  dataType = cast<RankedTensorType>(data.getType());
+  updatesType = cast<RankedTensorType>(updates.getType());
+  indicesType = cast<RankedTensorType>(indices.getType());
+  if (dataType.getRank() != updatesType.getRank()) {
+    return rewriter.notifyMatchFailure(scatterNDOp,
+        "Only the case where data and update have the same rank "
+        "is supported");
+  }
+  return success();
+}
+
+// Extracts the ScatterND indices operand as a flat constant array. Fails if the
+// indices are not a constant tensor or are empty.
+LogicalResult getScatterNDConstantIndices(ONNXScatterNDOp scatterNDOp,
+    PatternRewriter &rewriter, SmallVectorImpl<int64_t> &indicesAsFlatArray) {
+  if (!onnx_mlir::getI64ValuesFromONNXConstantOp(
+          scatterNDOp.getIndices(), indicesAsFlatArray)) {
+    return rewriter.notifyMatchFailure(
+        scatterNDOp, "The indices need to be constant");
+  }
+  if (indicesAsFlatArray.empty()) {
+    return rewriter.notifyMatchFailure(
+        scatterNDOp, "Empty indices are not supported"); // Skip the edge case
+                                                         // of empty indices
+  }
+  return success();
+}
+
+// Validates the first index vector: it must be 0 on every non-split axis (the
+// block starts at the origin there) and non-negative on the split axes (ONNX
+// negative wrap-around indexing is not supported by these rewrites).
+// `isSplitAxis` returns true when the given axis is a split axis.
+LogicalResult checkScatterNDFirstIndexShift(ONNXScatterNDOp scatterNDOp,
+    PatternRewriter &rewriter, ArrayRef<int64_t> firstIndex,
+    llvm::function_ref<bool(uint64_t)> isSplitAxis) {
+  for (auto [idx, firstIndexDim] : llvm::enumerate(firstIndex)) {
+    if (!isSplitAxis(idx) && firstIndexDim != 0) {
+      return rewriter.notifyMatchFailure(
+          scatterNDOp, " Shifting is only supported on the split axis");
+    }
+    if (isSplitAxis(idx) && firstIndexDim < 0) {
+      return rewriter.notifyMatchFailure(scatterNDOp,
+          "Negative values with wrap around are not yet "
+          "supported"); // onnx allows negative values with
+                        // wrap-around, this decomposition does
+                        // not (for now)
+    }
+  }
+  return success();
+}
+
+// Checks that all indices are contiguous.
+// - The check for contiguity and covering works the following way:
+// -- Iterated over all idx in indices and compare the idx against the
+//    expected index, fail if it differs
+// -- The expected index is calculated the following way:
+// --- The expected index is initialized with the first index in indices and
+//     then always incremented by one.
+// --- The increment works like a manual addition, the least significant
+//     digit/subindex gets incremented by one. If a digit overflows, it
+//     gets reset to the first index and the addition carries to the next,
+//     more significant digit. The addition overflows, if the index for an
+//     axis is equal to the size of this axis in updates/indices. (By
+//     definition the shape for indices.shape().drop(-1) must match the
+//     first dimensions in updates). If the addition overflows , the
+//     overflowing digit is reset to its value in the first index. This is
+//     zero for all axes, except for 'a', where it can be a positive number
+//     if the split/concat is in the middle of the tensor
+// `onIndex`, when set, is invoked with the running counter for every index
+// (before its contiguity comparison), letting callers reuse the same walk to
+// perform extra per-index work such as coordinate remapping.
+LogicalResult checkScatterNDContiguousIndices(ONNXScatterNDOp scatterNDOp,
+    PatternRewriter &rewriter, ArrayRef<int64_t> firstIndex,
+    ArrayRef<int64_t> counterShape,
+    const SubArrayAccessHelper<int64_t> &indicesFlatAccessor,
+    llvm::function_ref<void(IndicesContiguousCounter &)> onIndex = {}) {
+  IndicesContiguousCounter counter(firstIndex, counterShape);
+  for (size_t i = 0; i < indicesFlatAccessor.size(); ++i) {
+    if (onIndex)
+      onIndex(counter);
+    if (counter.getCounter() != indicesFlatAccessor[i]) {
+      return rewriter.notifyMatchFailure(
+          scatterNDOp, "Indices are not contiguous");
+    }
+    counter.increment();
+  }
+  return success();
+}
+
 } // namespace
 
 // Decomposes ScatterNDs into a single Split and Concat.
@@ -2577,30 +2687,16 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
   LogicalResult matchAndRewrite(
       ONNXScatterNDOp scatterNDOp, PatternRewriter &rewriter) const final {
     // Check preconditions
-    if (scatterNDOp.getReductionAttr().strref() != "none") {
-      return rewriter.notifyMatchFailure(
-          scatterNDOp, "Scatters with reduction are not supported");
+    RankedTensorType dataType;
+    RankedTensorType updatesType;
+    RankedTensorType indicesType;
+    if (failed(checkScatterNDPreconditions(
+            scatterNDOp, rewriter, dataType, updatesType, indicesType))) {
+      return failure();
     }
-    const auto data = scatterNDOp.getData();
-    const auto indices = scatterNDOp.getIndices();
-    const auto updates = scatterNDOp.getUpdates();
-    if (!onnx_mlir::hasStaticShape(data.getType()) ||
-        !onnx_mlir::hasStaticShape(indices.getType()) ||
-        !onnx_mlir::hasStaticShape(updates.getType())) {
-      return rewriter.notifyMatchFailure(
-          scatterNDOp, "All operands need to have a static shape");
-    }
-    const auto dataType = cast<RankedTensorType>(data.getType());
     const auto dataShape = dataType.getShape();
-    const auto updatesType = cast<RankedTensorType>(updates.getType());
     const auto updateShape = updatesType.getShape();
-    const auto indicesType = cast<RankedTensorType>(indices.getType());
     const auto indicesShape = indicesType.getShape();
-    if (dataType.getRank() != updatesType.getRank()) {
-      return rewriter.notifyMatchFailure(scatterNDOp,
-          "Only the case where data and update have the same rank "
-          "is supported");
-    }
 
     const auto splitAxis = [&]() -> uint64_t {
       // Split at the dim where the update and original data have a
@@ -2624,65 +2720,27 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
     }
 
     SmallVector<int64_t> indicesAsFlatArray;
-    if (!onnx_mlir::getI64ValuesFromONNXConstantOp(
-            indices, indicesAsFlatArray)) {
-      return rewriter.notifyMatchFailure(
-          scatterNDOp, "The indices need to be constant");
-    }
-    if (indicesAsFlatArray.empty()) {
-      return rewriter.notifyMatchFailure(
-          scatterNDOp, "Empty indices are not supported"); // Skip the edge case
-                                                           // of empty indices
+    if (failed(getScatterNDConstantIndices(
+            scatterNDOp, rewriter, indicesAsFlatArray))) {
+      return failure();
     }
     const auto indicesLastDimSize = indicesShape.back();
     SubArrayAccessHelper<int64_t> indicesFlatAccessor(
         indicesAsFlatArray, indicesLastDimSize);
     const auto firstIndex =
         indicesFlatAccessor[0]; // Safe, we have checked the length before
-    for (auto [idx, firstIndexDim] : llvm::enumerate(firstIndex)) {
-      if (idx != splitAxis && firstIndexDim != 0) {
-        return rewriter.notifyMatchFailure(
-            scatterNDOp, " Shifting is only supported on the split axis");
-      }
-      if (idx == splitAxis && firstIndexDim < 0) {
-        return rewriter.notifyMatchFailure(scatterNDOp,
-            "Negative values with wrap around are not yet "
-            "supported"); // onnx allows negative values with
-                          // wrap-around, this decomposition does
-                          // not (for now)
-      }
+    if (failed(checkScatterNDFirstIndexShift(scatterNDOp, rewriter, firstIndex,
+            [&](uint64_t idx) { return idx == splitAxis; }))) {
+      return failure();
     }
 
-    // Check that all indices are contiguous.
-    // - The check for contiguity and covering works the following way:
-    // -- Iterated over all idx in indices and compare the idx against the
-    //    expected index, fail if it differs
-    // -- The expected index is calculated the following way:
-    // --- The expected index is initialized with the first index in indices and
-    //     then always incremented by one.
-    // --- The increment works like a manual addition, the least significant
-    //     digit/subindex gets incremented by one. If a digit overflows, it
-    //     gets reset to the first index and the addition carries to the next,
-    //     more significant digit. The addition overflows, if the index for an
-    //     axis is equal to the size of this axis in updates/indices. (By
-    //     definition the shape for indices.shape().drop(-1) must match the
-    //     first dimensions in updates). If the addition overflows , the
-    //     overflowing digit is reset to its value in the first index. This is
-    //     zero for all axes, except for 'a', where it can be a positive number
-    //     if the split/concat is in the middle of the tensor
     assert(
         updateShape.drop_back(updateShape.size() - (indicesShape.size() - 1)) ==
             indicesShape.drop_back(1) &&
         "Update and indicesShape should partially match for scatterNd");
-    {
-      IndicesContiguousCounter counter(firstIndex, indicesShape.drop_back(1));
-      for (size_t i = 0; i < indicesFlatAccessor.size(); ++i) {
-        if (counter.getCounter() != indicesFlatAccessor[i]) {
-          return rewriter.notifyMatchFailure(
-              scatterNDOp, "Indices are not contiguous");
-        }
-        counter.increment();
-      }
+    if (failed(checkScatterNDContiguousIndices(scatterNDOp, rewriter,
+            firstIndex, indicesShape.drop_back(1), indicesFlatAccessor))) {
+      return failure();
     }
 
     onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(
@@ -2776,30 +2834,16 @@ struct CanonicalizeScatterNDWithMultiAxis
   LogicalResult matchAndRewrite(
       ONNXScatterNDOp scatterNDOp, PatternRewriter &rewriter) const final {
     // Check preconditions
-    if (scatterNDOp.getReductionAttr().strref() != "none") {
-      return rewriter.notifyMatchFailure(
-          scatterNDOp, "Scatters with reduction are not supported");
+    RankedTensorType dataType;
+    RankedTensorType updatesType;
+    RankedTensorType indicesType;
+    if (failed(checkScatterNDPreconditions(
+            scatterNDOp, rewriter, dataType, updatesType, indicesType))) {
+      return failure();
     }
-    const auto data = scatterNDOp.getData();
-    const auto indices = scatterNDOp.getIndices();
-    const auto updates = scatterNDOp.getUpdates();
-    if (!onnx_mlir::hasStaticShape(data.getType()) ||
-        !onnx_mlir::hasStaticShape(indices.getType()) ||
-        !onnx_mlir::hasStaticShape(updates.getType())) {
-      return rewriter.notifyMatchFailure(
-          scatterNDOp, "All operands need to have a static shape");
-    }
-    const auto dataType = cast<RankedTensorType>(data.getType());
     const auto dataShape = dataType.getShape();
-    const auto updatesType = cast<RankedTensorType>(updates.getType());
     const auto updateShape = updatesType.getShape();
-    const auto indicesType = cast<RankedTensorType>(indices.getType());
     const auto indicesShape = indicesType.getShape();
-    if (dataType.getRank() != updatesType.getRank()) {
-      return rewriter.notifyMatchFailure(scatterNDOp,
-          "Only the case where data and update have the same rank "
-          "is supported");
-    }
 
     SmallVector<uint64_t> splitAxes;
     // Split at the dim where the update and original data have a
@@ -2824,15 +2868,9 @@ struct CanonicalizeScatterNDWithMultiAxis
     }
 
     SmallVector<int64_t> indicesAsFlatArray;
-    if (!onnx_mlir::getI64ValuesFromONNXConstantOp(
-            indices, indicesAsFlatArray)) {
-      return rewriter.notifyMatchFailure(
-          scatterNDOp, "The indices need to be constant");
-    }
-    if (indicesAsFlatArray.empty()) {
-      return rewriter.notifyMatchFailure(
-          scatterNDOp, "Empty indices are not supported"); // Skip the edge case
-                                                           // of empty indices
+    if (failed(getScatterNDConstantIndices(
+            scatterNDOp, rewriter, indicesAsFlatArray))) {
+      return failure();
     }
     const auto indicesLastDimSize = indicesShape.back();
     SubArrayAccessHelper<int64_t> indicesFlatAccessor(
@@ -2852,18 +2890,11 @@ struct CanonicalizeScatterNDWithMultiAxis
 
     const auto firstIndex =
         indicesFlatAccessor[0]; // Safe, we have checked the length before
-    for (auto [idx, firstIndexDim] : llvm::enumerate(firstIndex)) {
-      if (!llvm::is_contained(splitAxes, idx) && firstIndexDim != 0) {
-        return rewriter.notifyMatchFailure(
-            scatterNDOp, " Shifting is only supported on the split axis");
-      }
-      if (llvm::is_contained(splitAxes, idx) && firstIndexDim < 0) {
-        return rewriter.notifyMatchFailure(scatterNDOp,
-            "Negative values with wrap around are not yet "
-            "supported"); // onnx allows negative values with
-                          // wrap-around, this decomposition does
-                          // not (for now)
-      }
+    if (failed(checkScatterNDFirstIndexShift(scatterNDOp, rewriter, firstIndex,
+            [&](uint64_t idx) {
+              return llvm::is_contained(splitAxes, idx);
+            }))) {
+      return failure();
     }
 
     // Collapse the two adjacent axes firstSplitAxis and firstSplitAxis+1 into a
@@ -2898,46 +2929,24 @@ struct CanonicalizeScatterNDWithMultiAxis
         indicesLastDimSize - (static_cast<int64_t>(splitAxes.size()) - 1);
     newIndicesShape.push_back(newIndexDepth);
 
-    // Check that all indices are contiguous.
-    // - The check for contiguity and covering works the following way:
-    // -- Iterated over all idx in indices and compare the idx against the
-    //    expected index, fail if it differs
-    // -- The expected index is calculated the following way:
-    // --- The expected index is initialized with the first index in indices and
-    //     then always incremented by one.
-    // --- The increment works like a manual addition, the least significant
-    //     digit/subindex gets incremented by one. If a digit overflows, it
-    //     gets reset to the first index and the addition carries to the next,
-    //     more significant digit. The addition overflows, if the index for an
-    //     axis is equal to the size of this axis in updates/indices. (By
-    //     definition the shape for indices.shape().drop(-1) must match the
-    //     first dimensions in updates). If the addition overflows , the
-    //     overflowing digit is reset to its value in the first index. This is
-    //     zero for all axes, except for 'a', where it can be a positive number
-    //     if the split/concat is in the middle of the tensor
-
     SmallVector<int64_t> newIndicesAsFlatArray;
 
     assert(
         updateShape.drop_back(updateShape.size() - (indicesShape.size() - 1)) ==
             indicesShape.drop_back(1) &&
         "Update and indicesShape should partially match for scatterNd");
-    {
-      IndicesContiguousCounter counter(firstIndex, indicesShape.drop_back(1));
-      for (size_t i = 0; i < indicesFlatAccessor.size(); ++i) {
-        // Remap each length-k index coordinate through the axis merge, working
-        // only over the indexed prefix (the first k axes). Using the full data
-        // shape here would read past the end of the k-length coordinate when
-        // k < rank(data).
-        newIndicesAsFlatArray.append(
-            counter.reshapedCounter(dataShape.take_front(indicesLastDimSize),
-                ArrayRef<int64_t>(newDataShape).take_front(newIndexDepth)));
-        if (counter.getCounter() != indicesFlatAccessor[i]) {
-          return rewriter.notifyMatchFailure(
-              scatterNDOp, "Indices are not contiguous");
-        }
-        counter.increment();
-      }
+    if (failed(checkScatterNDContiguousIndices(scatterNDOp, rewriter,
+            firstIndex, indicesShape.drop_back(1), indicesFlatAccessor,
+            [&](IndicesContiguousCounter &counter) {
+              // Remap each length-k index coordinate through the axis merge,
+              // working only over the indexed prefix (the first k axes). Using
+              // the full data shape here would read past the end of the
+              // k-length coordinate when k < rank(data).
+              newIndicesAsFlatArray.append(counter.reshapedCounter(
+                  dataShape.take_front(indicesLastDimSize),
+                  ArrayRef<int64_t>(newDataShape).take_front(newIndexDepth)));
+            }))) {
+      return failure();
     }
 
     onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2443,31 +2443,6 @@ private:
   size_t iterArraySize;
 };
 
-int64_t indexToOffset(
-    llvm::ArrayRef<int64_t> shape, llvm::ArrayRef<int64_t> index) {
-  int64_t offset = 0;
-  for (size_t i = 0; i < shape.size(); i++) {
-    offset = offset * shape[i] + index[i];
-  }
-  return offset;
-}
-
-SmallVector<int64_t> offsetToIndex(
-    llvm::ArrayRef<int64_t> shape, int64_t offset) {
-  auto rank = shape.size();
-  // The rank of the index will be equal to the rank of the shape
-  SmallVector<int64_t> resultIndex;
-  resultIndex.reserve(rank);
-  // Compute all the index values from the last to the first one, reverse the
-  // vector afterwards as there is no convenient push_front.
-  for (int32_t i = rank - 1; i >= 0; i--) {
-    resultIndex.push_back(offset % shape[i]);
-    offset /= shape[i];
-  }
-  std::reverse(resultIndex.begin(), resultIndex.end());
-  return resultIndex;
-}
-
 class IndicesContiguousCounter {
 public:
   explicit IndicesContiguousCounter(
@@ -2505,8 +2480,8 @@ public:
   //   (since 5 * 4 + 3 == 23, the same element in the [6, 4] view).
   SmallVector<int64_t> reshapedCounter(
       ArrayRef<int64_t> currentShape, ArrayRef<int64_t> newShape) {
-    auto idxToOffsetValue = indexToOffset(currentShape, counter);
-    return offsetToIndex(newShape, idxToOffsetValue);
+    auto idxToOffsetValue = onnx_mlir::indexToOffset(currentShape, counter);
+    return onnx_mlir::offsetToIndex(newShape, idxToOffsetValue);
   }
 
 private:
@@ -2890,8 +2865,8 @@ struct CanonicalizeScatterNDWithMultiAxis
 
     const auto firstIndex =
         indicesFlatAccessor[0]; // Safe, we have checked the length before
-    if (failed(checkScatterNDFirstIndexShift(scatterNDOp, rewriter, firstIndex,
-            [&](uint64_t idx) {
+    if (failed(checkScatterNDFirstIndexShift(
+            scatterNDOp, rewriter, firstIndex, [&](uint64_t idx) {
               return llvm::is_contained(splitAxes, idx);
             }))) {
       return failure();

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2720,39 +2720,40 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
   }
 };
 
-// Canonicalizes an ONNXScatterND that writes a contiguous block spanning *two
-// consecutive* axes into an equivalent ScatterND that writes along a *single*
-// axis, by merging those two axes into one.
+// Canonicalizes an ONNXScatterND that writes a contiguous block spanning two or
+// more *consecutive* axes into an equivalent ScatterND that writes along a
+// *single* axis, by merging those axes into one.
 //
 // Motivation: the contiguous-block ScatterND decomposition (Split + Concat, see
 // DecomposeScatterNDPattern) only handles the case where data and updates
-// differ in a single dimension. When the update region spans two adjacent axes
-// (e.g. it replaces a full [H, W] plane per batch), the scatter has two
-// differing axes and that pattern cannot apply. This canonicalization folds the
-// two axes together so the simpler single-axis decomposition can take over.
+// differ in a single dimension. When the update region spans several adjacent
+// axes (e.g. it replaces a full [H, W] plane per batch), the scatter has
+// multiple differing axes and that pattern cannot apply. This canonicalization
+// folds the N differing axes together so the single-axis decomposition can take
+// over.
 //
 // It matches only when (all preconditions must hold, otherwise it bails):
 //   - reduction == "none",
 //   - data, indices and updates all have static shapes,
 //   - rank(data) == rank(updates),
-//   - exactly two axes differ in size between data and updates, and they are
-//     consecutive (splitAxes = {a, a+1}),
+//   - at least two axes differ in size between data and updates, and they are
+//     all consecutive (splitAxes = {a, a+1, ..., a+N-1}),
 //   - indices is a constant, non-empty tensor,
 //   - the first index is 0 on every non-split axis (the block starts at the
 //     origin there) and non-negative on the split axes (no ONNX wrap-around),
 //   - the indices are contiguous and cover the whole merged block.
 //
-// The rewrite reshapes data, updates and indices so axes a and a+1 become one
-// axis of size data[a]*data[a+1], rebuilds the (constant) indices as linear
+// The rewrite reshapes data, updates and indices so the N split axes become one
+// axis of size prod(data[a..a+N-1]), rebuilds the (constant) indices as linear
 // coordinates into the merged shape, emits a new ScatterND, and reshapes the
 // result back to the original data shape.
 //
 // Partial indexing (k = indices.shape[-1] < rank(data)) is supported: each
-// index then addresses a data.shape[k:] slice rather than a scalar. Merging two
-// indexed axes drops the index depth by one (k -> k-1) and the coordinate remap
-// runs over the indexed prefix (the first k axes) only; the trailing r-k slice
-// axes ride along unchanged. For full indexing (k == rank(data)) the new index
-// depth equals the new data rank, matching the original behavior.
+// index then addresses a data.shape[k:] slice rather than a scalar. Merging N
+// indexed axes drops the index depth by N-1 (k -> k-N+1) and the coordinate
+// remap runs over the indexed prefix (the first k axes) only; the trailing r-k
+// slice axes ride along unchanged. For full indexing (k == rank(data)) the new
+// index depth equals the new data rank, matching the original behavior.
 //
 // Example: data:[6,4,4], updates:[6,1,1], indices:[6,1,1,3] holding [b,0,0].
 //   splitAxes = {1, 2} (4 != 1 on both) -> merge axes 1 and 2 (4*4 = 16):
@@ -2810,9 +2811,16 @@ struct CanonicalizeScatterNDWithMultiAxes
       }
     }
 
-    if (splitAxes.size() != 2 || splitAxes[0] + 1 != splitAxes[1]) {
-      return rewriter.notifyMatchFailure(scatterNDOp,
-          "This pattern needs exactly two split axes that are consecutive");
+    if (splitAxes.size() < 2) {
+      return rewriter.notifyMatchFailure(
+          scatterNDOp, "This pattern needs at least two split axes");
+    }
+
+    for (size_t i = 0; i < splitAxes.size() - 1; ++i) {
+      if (splitAxes[i] + 1 != splitAxes[i + 1]) {
+        return rewriter.notifyMatchFailure(
+            scatterNDOp, "This pattern needs consecutive split axes");
+      }
     }
 
     SmallVector<int64_t> indicesAsFlatArray;
@@ -2837,7 +2845,7 @@ struct CanonicalizeScatterNDWithMultiAxes
     // indexed one; both merged axes must therefore lie within the first k axes.
     // Guard defensively so the coordinate remap below never reads past the end
     // of a length-k index vector.
-    if (splitAxes[1] >= static_cast<uint64_t>(indicesLastDimSize)) {
+    if (splitAxes.back() >= static_cast<uint64_t>(indicesLastDimSize)) {
       return rewriter.notifyMatchFailure(
           scatterNDOp, "Split axes must lie within the indexed prefix");
     }
@@ -2860,14 +2868,19 @@ struct CanonicalizeScatterNDWithMultiAxes
 
     // Collapse the two adjacent axes firstSplitAxis and firstSplitAxis+1 into a
     // single axis of their product, keeping the surrounding dims unchanged.
-    const auto firstSplitAxis = splitAxes[0];
+    const auto firstSplitAxis = splitAxes.front();
     auto collapseAdjacentSplitAxes =
-        [firstSplitAxis](ArrayRef<int64_t> shape) -> SmallVector<int64_t> {
+        [firstSplitAxis, splitAxes](
+            ArrayRef<int64_t> shape) -> SmallVector<int64_t> {
+      auto splitAxisSize = splitAxes.size();
       SmallVector<int64_t> newShape =
           llvm::to_vector(shape.take_front(firstSplitAxis));
-      newShape.push_back(shape[firstSplitAxis] * shape[firstSplitAxis + 1]);
-      newShape.append(
-          llvm::to_vector(shape.take_back(shape.size() - firstSplitAxis - 2)));
+      auto collapsedShape = shape.slice(firstSplitAxis, splitAxisSize);
+      auto collapsedSize = std::accumulate(collapsedShape.begin(),
+          collapsedShape.end(), 1LL, std::multiplies<int64_t>());
+      newShape.push_back(collapsedSize);
+      newShape.append(llvm::to_vector(
+          shape.take_back(shape.size() - firstSplitAxis - splitAxisSize)));
       return newShape;
     };
 
@@ -2877,11 +2890,12 @@ struct CanonicalizeScatterNDWithMultiAxes
     SmallVector<int64_t> newIndicesShape =
         collapseAdjacentSplitAxes(indicesShape.drop_back(1));
     auto newIndicesShapeDroppedLastDim = newIndicesShape;
-    // Merging two indexed axes into one reduces the index depth by one. For
-    // full indexing (k == rank(data)) this equals the new data rank
+    // Merging N consecutive indexed axes into one reduces the index depth by
+    // N-1. For full indexing (k == rank(data)) this equals the new data rank
     // (newDataShape.size()); for partial indexing (k < rank(data)) it is
     // strictly smaller and the scatter stays a slice scatter.
-    const int64_t newIndexDepth = indicesLastDimSize - 1;
+    const int64_t newIndexDepth =
+        indicesLastDimSize - (static_cast<int64_t>(splitAxes.size()) - 1);
     newIndicesShape.push_back(newIndexDepth);
 
     // Check that all indices are contiguous.
@@ -2915,9 +2929,9 @@ struct CanonicalizeScatterNDWithMultiAxes
         // only over the indexed prefix (the first k axes). Using the full data
         // shape here would read past the end of the k-length coordinate when
         // k < rank(data).
-        newIndicesAsFlatArray.append(counter.reshapedCounter(
-            dataShape.take_front(indicesLastDimSize),
-            ArrayRef<int64_t>(newDataShape).take_front(newIndexDepth)));
+        newIndicesAsFlatArray.append(
+            counter.reshapedCounter(dataShape.take_front(indicesLastDimSize),
+                ArrayRef<int64_t>(newDataShape).take_front(newIndexDepth)));
         if (counter.getCounter() != indicesFlatAccessor[i]) {
           return rewriter.notifyMatchFailure(
               scatterNDOp, "Indices are not contiguous");

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2769,7 +2769,7 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
 //   (2*6 = 12): newDataShape=[12,10,12], newUpdateShape=[1,10,12],
 //   newIndicesShape=[1,10,2] (index depth 3 -> 2). Index [1,1,l] becomes
 //   [7, l] into [12,10,12] (still a slice scatter over the last axis).
-struct CanonicalizeScatterNDWithMultiAxes
+struct CanonicalizeScatterNDWithMultiAxis
     : public OpRewritePattern<ONNXScatterNDOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -5191,7 +5191,7 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
   if (!disableGenericDecompositions) {
     patterns.insert<DecomposeSlicePadPattern>(context);
     patterns.insert<DecomposeScatterNDPattern>(context);
-    patterns.insert<CanonicalizeScatterNDWithMultiAxes>(context);
+    patterns.insert<CanonicalizeScatterNDWithMultiAxis>(context);
     patterns.insert<SoftmaxCrossEntropyPattern>(context);
     patterns.insert<SumToAddPattern>(context);
   }

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2443,6 +2443,31 @@ private:
   size_t iterArraySize;
 };
 
+int64_t indexToOffset(
+    llvm::ArrayRef<int64_t> shape, llvm::ArrayRef<int64_t> index) {
+  int64_t offset = 0;
+  for (size_t i = 0; i < shape.size(); i++) {
+    offset = offset * shape[i] + index[i];
+  }
+  return offset;
+}
+
+SmallVector<int64_t> offsetToIndex(
+    llvm::ArrayRef<int64_t> shape, int64_t offset) {
+  auto rank = shape.size();
+  // The rank of the index will be equal to the rank of the shape
+  SmallVector<int64_t> resultIndex;
+  resultIndex.reserve(rank);
+  // Compute all the index values from the last to the first one, reverse the
+  // vector afterwards as there is no convenient push_front.
+  for (int32_t i = rank - 1; i >= 0; i--) {
+    resultIndex.push_back(offset % shape[i]);
+    offset /= shape[i];
+  }
+  std::reverse(resultIndex.begin(), resultIndex.end());
+  return resultIndex;
+}
+
 class IndicesContiguousCounter {
 public:
   explicit IndicesContiguousCounter(
@@ -2463,6 +2488,25 @@ public:
         break;
       }
     }
+  }
+
+  // Re-expresses the current counter position under a different shape.
+  //
+  // The counter is a multi-dimensional index into `currentShape`. This first
+  // flattens it to a single linear (row-major) offset, then re-expands that
+  // same offset into a multi-dimensional index for `newShape`. In other words
+  // it recalculates and returns the equivalent index once the underlying tensor
+  // is viewed with `newShape` instead of `currentShape` (both must describe the
+  // same number of elements for the mapping to be meaningful).
+  //
+  // Example: currentShape = [2, 3, 4], counter = [1, 2, 3].
+  //   linear offset = ((1 * 3) + 2) * 4 + 3 = 23
+  //   reshapedCounter([2, 3, 4], [6, 4]) -> offsetToIndex([6, 4], 23) = [5, 3]
+  //   (since 5 * 4 + 3 == 23, the same element in the [6, 4] view).
+  SmallVector<int64_t> reshapedCounter(
+      ArrayRef<int64_t> currentShape, ArrayRef<int64_t> newShape) {
+    auto idxToOffsetValue = indexToOffset(currentShape, counter);
+    return offsetToIndex(newShape, idxToOffsetValue);
   }
 
 private:
@@ -2672,6 +2716,207 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
     Value concat = create.onnx.concat(
         dataType, {split[0], scatterNDOp.getUpdates(), split[2]}, splitAxis);
     rewriter.replaceOp(scatterNDOp, concat);
+    return success();
+  }
+};
+
+// Canonicalizes an ONNXScatterND that writes a contiguous block spanning *two
+// consecutive* axes into an equivalent ScatterND that writes along a *single*
+// axis, by merging those two axes into one.
+//
+// Motivation: the contiguous-block ScatterND decomposition (Split + Concat, see
+// DecomposeScatterNDPattern) only handles the case where data and updates
+// differ in a single dimension. When the update region spans two adjacent axes
+// (e.g. it replaces a full [H, W] plane per batch), the scatter has two
+// differing axes and that pattern cannot apply. This canonicalization folds the
+// two axes together so the simpler single-axis decomposition can take over.
+//
+// It matches only when (all preconditions must hold, otherwise it bails):
+//   - reduction == "none",
+//   - data, indices and updates all have static shapes,
+//   - rank(data) == rank(updates),
+//   - exactly two axes differ in size between data and updates, and they are
+//     consecutive (splitAxes = {a, a+1}),
+//   - indices is a constant, non-empty tensor,
+//   - the first index is 0 on every non-split axis (the block starts at the
+//     origin there) and non-negative on the split axes (no ONNX wrap-around),
+//   - the indices are contiguous and cover the whole merged block.
+//
+// The rewrite reshapes data, updates and indices so axes a and a+1 become one
+// axis of size data[a]*data[a+1], rebuilds the (constant) indices as linear
+// coordinates into the merged shape, emits a new ScatterND, and reshapes the
+// result back to the original data shape.
+//
+// Example: data:[6,4,4], updates:[6,1,1], indices:[6,1,1,3] holding [b,0,0].
+//   splitAxes = {1, 2} (4 != 1 on both) -> merge axes 1 and 2 (4*4 = 16):
+//     newDataShape    = [6, 16]
+//     newUpdateShape  = [6, 1]
+//     newIndicesShape = [6, 1, 2]   // last dim = rank(newData) = 2
+//   each index [b,0,0] (offset b*16 into [6,4,4]) becomes [b, 0] into [6,16].
+//   The resulting ScatterND now differs from data only on axis 1, so the
+//   Split+Concat decomposition can lower it. Reshapes wrap it back to [6,4,4].
+struct CanonicalizeScatterNDWithMultiAxes
+    : public OpRewritePattern<ONNXScatterNDOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXScatterNDOp scatterNDOp, PatternRewriter &rewriter) const final {
+    // Check preconditions
+    if (scatterNDOp.getReductionAttr().strref() != "none") {
+      return rewriter.notifyMatchFailure(
+          scatterNDOp, "Scatters with reduction are not supported");
+    }
+    const auto data = scatterNDOp.getData();
+    const auto indices = scatterNDOp.getIndices();
+    const auto updates = scatterNDOp.getUpdates();
+    if (!onnx_mlir::hasStaticShape(data.getType()) ||
+        !onnx_mlir::hasStaticShape(indices.getType()) ||
+        !onnx_mlir::hasStaticShape(updates.getType())) {
+      return rewriter.notifyMatchFailure(
+          scatterNDOp, "All operands need to have a static shape");
+    }
+    const auto dataType = cast<RankedTensorType>(data.getType());
+    const auto dataShape = dataType.getShape();
+    const auto updatesType = cast<RankedTensorType>(updates.getType());
+    const auto updateShape = updatesType.getShape();
+    const auto indicesType = cast<RankedTensorType>(indices.getType());
+    const auto indicesShape = indicesType.getShape();
+    if (dataType.getRank() != updatesType.getRank()) {
+      return rewriter.notifyMatchFailure(scatterNDOp,
+          "Only the case where data and update have the same rank "
+          "is supported");
+    }
+
+    SmallVector<uint64_t> splitAxes;
+    // Split at the dim where the update and original data have a
+    // different size
+    for (auto [idx, dimData, dimUpdates] :
+        llvm::enumerate(dataShape, updateShape)) {
+      if (dimData != dimUpdates) {
+        splitAxes.push_back(idx);
+      }
+    }
+
+    if (splitAxes.size() != 2 || splitAxes[0] + 1 != splitAxes[1]) {
+      return rewriter.notifyMatchFailure(scatterNDOp,
+          "This pattern needs exactly two split axes that are consecutive");
+    }
+
+    SmallVector<int64_t> indicesAsFlatArray;
+    if (!onnx_mlir::getI64ValuesFromONNXConstantOp(
+            indices, indicesAsFlatArray)) {
+      return rewriter.notifyMatchFailure(
+          scatterNDOp, "The indices need to be constant");
+    }
+    if (indicesAsFlatArray.empty()) {
+      return rewriter.notifyMatchFailure(
+          scatterNDOp, "Empty indices are not supported"); // Skip the edge case
+                                                           // of empty indices
+    }
+    const auto indicesLastDimSize = indicesShape.back();
+    SubArrayAccessHelper<int64_t> indicesFlatAccessor(
+        indicesAsFlatArray, indicesLastDimSize);
+
+    const auto firstIndex =
+        indicesFlatAccessor[0]; // Safe, we have checked the length before
+    for (auto [idx, firstIndexDim] : llvm::enumerate(firstIndex)) {
+      if (!llvm::is_contained(splitAxes, idx) && firstIndexDim != 0) {
+        return rewriter.notifyMatchFailure(
+            scatterNDOp, " Shifting is only supported on the split axis");
+      }
+      if (llvm::is_contained(splitAxes, idx) && firstIndexDim < 0) {
+        return rewriter.notifyMatchFailure(scatterNDOp,
+            "Negative values with wrap around are not yet "
+            "supported"); // onnx allows negative values with
+                          // wrap-around, this decomposition does
+                          // not (for now)
+      }
+    }
+
+    // Collapse the two adjacent axes firstSplitAxis and firstSplitAxis+1 into a
+    // single axis of their product, keeping the surrounding dims unchanged.
+    const auto firstSplitAxis = splitAxes[0];
+    auto collapseAdjacentSplitAxes =
+        [firstSplitAxis](ArrayRef<int64_t> shape) -> SmallVector<int64_t> {
+      SmallVector<int64_t> newShape =
+          llvm::to_vector(shape.take_front(firstSplitAxis));
+      newShape.push_back(shape[firstSplitAxis] * shape[firstSplitAxis + 1]);
+      newShape.append(
+          llvm::to_vector(shape.take_back(shape.size() - firstSplitAxis - 2)));
+      return newShape;
+    };
+
+    SmallVector<int64_t> newDataShape = collapseAdjacentSplitAxes(dataShape);
+    SmallVector<int64_t> newUpdateShape =
+        collapseAdjacentSplitAxes(updateShape);
+    SmallVector<int64_t> newIndicesShape =
+        collapseAdjacentSplitAxes(indicesShape.drop_back(1));
+    auto newIndicesShapeDroppedLastDim = newIndicesShape;
+    newIndicesShape.push_back(newDataShape.size());
+
+    // Check that all indices are contiguous.
+    // - The check for contiguity and covering works the following way:
+    // -- Iterated over all idx in indices and compare the idx against the
+    //    expected index, fail if it differs
+    // -- The expected index is calculated the following way:
+    // --- The expected index is initialized with the first index in indices and
+    //     then always incremented by one.
+    // --- The increment works like a manual addition, the least significant
+    //     digit/subindex gets incremented by one. If a digit overflows, it
+    //     gets reset to the first index and the addition carries to the next,
+    //     more significant digit. The addition overflows, if the index for an
+    //     axis is equal to the size of this axis in updates/indices. (By
+    //     definition the shape for indices.shape().drop(-1) must match the
+    //     first dimensions in updates). If the addition overflows , the
+    //     overflowing digit is reset to its value in the first index. This is
+    //     zero for all axes, except for 'a', where it can be a positive number
+    //     if the split/concat is in the middle of the tensor
+
+    SmallVector<int64_t> newIndicesAsFlatArray;
+
+    assert(
+        updateShape.drop_back(updateShape.size() - (indicesShape.size() - 1)) ==
+            indicesShape.drop_back(1) &&
+        "Update and indicesShape should partially match for scatterNd");
+    {
+      IndicesContiguousCounter counter(firstIndex, indicesShape.drop_back(1));
+      for (size_t i = 0; i < indicesFlatAccessor.size(); ++i) {
+        newIndicesAsFlatArray.append(
+            counter.reshapedCounter(dataShape, newDataShape));
+        if (counter.getCounter() != indicesFlatAccessor[i]) {
+          return rewriter.notifyMatchFailure(
+              scatterNDOp, "Indices are not contiguous");
+        }
+        counter.increment();
+      }
+    }
+
+    onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(
+        rewriter, scatterNDOp->getLoc());
+
+    auto newDataTy =
+        RankedTensorType::get(newDataShape, dataType.getElementType());
+
+    auto reshapedScatterNDData = create.onnx.reshape(newDataTy,
+        scatterNDOp.getData(), create.onnx.constantInt64(newDataShape));
+
+    // New Indices
+    Value newIndices = create.onnx.constant(DenseElementsAttr::get(
+        RankedTensorType::get(newIndicesShape, indicesType.getElementType()),
+        ArrayRef<int64_t>(newIndicesAsFlatArray)));
+
+    auto reshapedScatterNDUpdates = create.onnx.reshape(
+        RankedTensorType::get(newUpdateShape, updatesType.getElementType()),
+        scatterNDOp.getUpdates(), create.onnx.constantInt64(newUpdateShape));
+
+    auto newScatterNDOp =
+        rewriter.create<ONNXScatterNDOp>(scatterNDOp->getLoc(), newDataTy,
+            reshapedScatterNDData, newIndices, reshapedScatterNDUpdates);
+
+    auto reshapedNewScatterND = create.onnx.reshape(dataType,
+        newScatterNDOp.getResult(), create.onnx.constantInt64(dataShape));
+
+    rewriter.replaceOp(scatterNDOp, reshapedNewScatterND);
     return success();
   }
 };
@@ -4897,6 +5142,7 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
   if (!disableGenericDecompositions) {
     patterns.insert<DecomposeSlicePadPattern>(context);
     patterns.insert<DecomposeScatterNDPattern>(context);
+    patterns.insert<CanonicalizeScatterNDWithMultiAxes>(context);
     patterns.insert<SoftmaxCrossEntropyPattern>(context);
     patterns.insert<SumToAddPattern>(context);
   }

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2747,14 +2747,27 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
 // coordinates into the merged shape, emits a new ScatterND, and reshapes the
 // result back to the original data shape.
 //
+// Partial indexing (k = indices.shape[-1] < rank(data)) is supported: each
+// index then addresses a data.shape[k:] slice rather than a scalar. Merging two
+// indexed axes drops the index depth by one (k -> k-1) and the coordinate remap
+// runs over the indexed prefix (the first k axes) only; the trailing r-k slice
+// axes ride along unchanged. For full indexing (k == rank(data)) the new index
+// depth equals the new data rank, matching the original behavior.
+//
 // Example: data:[6,4,4], updates:[6,1,1], indices:[6,1,1,3] holding [b,0,0].
 //   splitAxes = {1, 2} (4 != 1 on both) -> merge axes 1 and 2 (4*4 = 16):
 //     newDataShape    = [6, 16]
 //     newUpdateShape  = [6, 1]
-//     newIndicesShape = [6, 1, 2]   // last dim = rank(newData) = 2
+//     newIndicesShape = [6, 1, 2]   // last dim = new index depth k-1 = 2
 //   each index [b,0,0] (offset b*16 into [6,4,4]) becomes [b, 0] into [6,16].
 //   The resulting ScatterND now differs from data only on axis 1, so the
 //   Split+Concat decomposition can lower it. Reshapes wrap it back to [6,4,4].
+//
+// Partial-indexing example: data:[2,6,10,12], updates:[1,1,10,12],
+//   indices:[1,1,10,3] (k=3 < r=4). splitAxes = {0, 1} -> merge axes 0,1
+//   (2*6 = 12): newDataShape=[12,10,12], newUpdateShape=[1,10,12],
+//   newIndicesShape=[1,10,2] (index depth 3 -> 2). Index [1,1,l] becomes
+//   [7, l] into [12,10,12] (still a slice scatter over the last axis).
 struct CanonicalizeScatterNDWithMultiAxes
     : public OpRewritePattern<ONNXScatterNDOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -2817,6 +2830,18 @@ struct CanonicalizeScatterNDWithMultiAxes
     SubArrayAccessHelper<int64_t> indicesFlatAccessor(
         indicesAsFlatArray, indicesLastDimSize);
 
+    // The index depth k = indices.shape[-1] may be smaller than rank(data)
+    // (partial / slice indexing, where each index addresses a data.shape[k:]
+    // sub-tensor rather than a scalar). ScatterND guarantees data and updates
+    // agree on the trailing r-k slice axes, so any differing axis is always an
+    // indexed one; both merged axes must therefore lie within the first k axes.
+    // Guard defensively so the coordinate remap below never reads past the end
+    // of a length-k index vector.
+    if (splitAxes[1] >= static_cast<uint64_t>(indicesLastDimSize)) {
+      return rewriter.notifyMatchFailure(
+          scatterNDOp, "Split axes must lie within the indexed prefix");
+    }
+
     const auto firstIndex =
         indicesFlatAccessor[0]; // Safe, we have checked the length before
     for (auto [idx, firstIndexDim] : llvm::enumerate(firstIndex)) {
@@ -2852,7 +2877,12 @@ struct CanonicalizeScatterNDWithMultiAxes
     SmallVector<int64_t> newIndicesShape =
         collapseAdjacentSplitAxes(indicesShape.drop_back(1));
     auto newIndicesShapeDroppedLastDim = newIndicesShape;
-    newIndicesShape.push_back(newDataShape.size());
+    // Merging two indexed axes into one reduces the index depth by one. For
+    // full indexing (k == rank(data)) this equals the new data rank
+    // (newDataShape.size()); for partial indexing (k < rank(data)) it is
+    // strictly smaller and the scatter stays a slice scatter.
+    const int64_t newIndexDepth = indicesLastDimSize - 1;
+    newIndicesShape.push_back(newIndexDepth);
 
     // Check that all indices are contiguous.
     // - The check for contiguity and covering works the following way:
@@ -2881,8 +2911,13 @@ struct CanonicalizeScatterNDWithMultiAxes
     {
       IndicesContiguousCounter counter(firstIndex, indicesShape.drop_back(1));
       for (size_t i = 0; i < indicesFlatAccessor.size(); ++i) {
-        newIndicesAsFlatArray.append(
-            counter.reshapedCounter(dataShape, newDataShape));
+        // Remap each length-k index coordinate through the axis merge, working
+        // only over the indexed prefix (the first k axes). Using the full data
+        // shape here would read past the end of the k-length coordinate when
+        // k < rank(data).
+        newIndicesAsFlatArray.append(counter.reshapedCounter(
+            dataShape.take_front(indicesLastDimSize),
+            ArrayRef<int64_t>(newDataShape).take_front(newIndexDepth)));
         if (counter.getCounter() != indicesFlatAccessor[i]) {
           return rewriter.notifyMatchFailure(
               scatterNDOp, "Indices are not contiguous");

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -928,6 +928,58 @@ func.func @test_scatter_nd_negative_shift(%data : tensor<1x6x10x12xf32>, %update
 // CHECK:        onnx.ScatterND
 
 // -----
+
+func.func @test_scatter_nd_three_split_axes_full_indexing(%data : tensor<2x3x4x5xf32>, %updates : tensor<1x1x1x5xf32> ) -> tensor<2x3x4x5xf32> {
+  %indices = onnx.Constant dense<[[[[[1, 1, 1, 0], [1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 1, 3], [1, 1, 1, 4]]]]]> : tensor<1x1x1x5x4xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<2x3x4x5xf32>, tensor<1x1x1x5x4xi64>, tensor<1x1x1x5xf32>) -> tensor<2x3x4x5xf32>
+  onnx.Return %0 : tensor<2x3x4x5xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_three_split_axes_full_indexing
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5xf32>, [[PARAM_1_:%.+]]: tensor<1x1x1x5xf32>) -> tensor<2x3x4x5xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[2, 3, 4, 5]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[17, 1, 6]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 5]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[24, 5]> : tensor<2xi64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<2x3x4x5xf32>, tensor<2xi64>) -> tensor<24x5xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x1x5xf32>, tensor<2xi64>) -> tensor<1x5xf32>
+// CHECK:           [[VAR_6_:%.+]]:3 = "onnx.Split"([[VAR_4_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<24x5xf32>, tensor<3xi64>) -> (tensor<17x5xf32>, tensor<1x5xf32>, tensor<6x5xf32>)
+// CHECK:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_6_]]#0, [[VAR_5_]], [[VAR_6_]]#2) {axis = 0 : si64} : (tensor<17x5xf32>, tensor<1x5xf32>, tensor<6x5xf32>) -> tensor<24x5xf32>
+// CHECK:           [[VAR_8_:%.+]] = "onnx.Reshape"([[VAR_7_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<24x5xf32>, tensor<4xi64>) -> tensor<2x3x4x5xf32>
+// CHECK:           onnx.Return [[VAR_8_]] : tensor<2x3x4x5xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_three_split_axes_partial_indexing(%data : tensor<2x2x3x5xf32>, %updates : tensor<1x1x2x5xf32> ) -> tensor<2x2x3x5xf32> {
+  %indices = onnx.Constant dense<[[[[0, 1, 0], [0, 1, 1]]]]> : tensor<1x1x2x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<2x2x3x5xf32>, tensor<1x1x2x3xi64>, tensor<1x1x2x5xf32>) -> tensor<2x2x3x5xf32>
+  onnx.Return %0 : tensor<2x2x3x5xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_three_split_axes_partial_indexing
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x2x3x5xf32>, [[PARAM_1_:%.+]]: tensor<1x1x2x5xf32>) -> tensor<2x2x3x5xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[2, 2, 3, 5]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[3, 2, 7]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[2, 5]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[12, 5]> : tensor<2xi64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<2x2x3x5xf32>, tensor<2xi64>) -> tensor<12x5xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x2x5xf32>, tensor<2xi64>) -> tensor<2x5xf32>
+// CHECK:           [[VAR_6_:%.+]]:3 = "onnx.Split"([[VAR_4_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<12x5xf32>, tensor<3xi64>) -> (tensor<3x5xf32>, tensor<2x5xf32>, tensor<7x5xf32>)
+// CHECK:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_6_]]#0, [[VAR_5_]], [[VAR_6_]]#2) {axis = 0 : si64} : (tensor<3x5xf32>, tensor<2x5xf32>, tensor<7x5xf32>) -> tensor<12x5xf32>
+// CHECK:           [[VAR_8_:%.+]] = "onnx.Reshape"([[VAR_7_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<12x5xf32>, tensor<4xi64>) -> tensor<2x2x3x5xf32>
+// CHECK:           onnx.Return [[VAR_8_]] : tensor<2x2x3x5xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_non_consecutive_split_axes(%data : tensor<2x3x4x12xf32>, %updates : tensor<1x3x1x12xf32> ) -> tensor<2x3x4x12xf32> {
+  %indices = onnx.Constant dense<0> : tensor<1x3x1x3xi64>
+  %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<2x3x4x12xf32>, tensor<1x3x1x3xi64>, tensor<1x3x1x12xf32>) -> tensor<2x3x4x12xf32>
+  onnx.Return %0 : tensor<2x3x4x12xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_non_consecutive_split_axes
+// CHECK:        onnx.ScatterND
+
+// -----
 func.func @test_scatter_nd_full_overwrite(%data : tensor<1x6x10x12xf32>, %updates : tensor<1x6x10x12xf32> ) -> tensor<1x6x10x12xf32> {
   %indices = onnx.Constant dense<[[[[0, 0, 0], [0, 0, 1], [0, 0, 2], [0, 0, 3], [0, 0, 4], [0, 0, 5], [0, 0, 6], [0, 0, 7], [0, 0, 8], [0, 0, 9]], [[0, 1, 0], [0, 1, 1], [0, 1, 2], [0, 1, 3], [0, 1, 4], [0, 1, 5], [0, 1, 6], [0, 1, 7], [0, 1, 8], [0, 1, 9]], [[0, 2, 0], [0, 2, 1], [0, 2, 2], [0, 2, 3], [0, 2, 4], [0, 2, 5], [0, 2, 6], [0, 2, 7], [0, 2, 8], [0, 2, 9]], [[0, 3, 0], [0, 3, 1], [0, 3, 2], [0, 3, 3], [0, 3, 4], [0, 3, 5], [0, 3, 6], [0, 3, 7], [0, 3, 8], [0, 3, 9]], [[0, 4, 0], [0, 4, 1], [0, 4, 2], [0, 4, 3], [0, 4, 4], [0, 4, 5], [0, 4, 6], [0, 4, 7], [0, 4, 8], [0, 4, 9]], [[0, 5, 0], [0, 5, 1], [0, 5, 2], [0, 5, 3], [0, 5, 4], [0, 5, 5], [0, 5, 6], [0, 5, 7], [0, 5, 8], [0, 5, 9]]]]> : tensor<1x6x10x3xi64>
   %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x6x10x12xf32>, tensor<1x6x10x3xi64>, tensor<1x6x10x12xf32>) -> tensor<1x6x10x12xf32>
@@ -1003,14 +1055,6 @@ func.func @scatter_block_rows0to2_cols0to2_partial_slicing(%data: tensor<6x4x4xf
 // CHECK-LABEL:  func.func @scatter_block_rows0to2_cols0to2_partial_slicing
 // CHECK:        onnx.ScatterND
 
-// -----
-func.func @scatter_block_rows0to2_col3_partial_slicing(%data: tensor<6x4x4xf32>, %updates: tensor<6x3x1xf32>) -> tensor<6x4x4xf32> {
-  %indices = onnx.Constant dense<[[[[0, 0, 3]], [[0, 1, 3]], [[0, 2, 3]]], [[[1, 0, 3]], [[1, 1, 3]], [[1, 2, 3]]], [[[2, 0, 3]], [[2, 1, 3]], [[2, 2, 3]]], [[[3, 0, 3]], [[3, 1, 3]], [[3, 2, 3]]], [[[4, 0, 3]], [[4, 1, 3]], [[4, 2, 3]]], [[[5, 0, 3]], [[5, 1, 3]], [[5, 2, 3]]]]> : tensor<6x3x1x3xi64>
-  %out = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<6x4x4xf32>, tensor<6x3x1x3xi64>, tensor<6x3x1xf32>) -> tensor<6x4x4xf32>
-  onnx.Return %out : tensor<6x4x4xf32>
-}
-// CHECK-LABEL:  func.func @scatter_block_rows0to2_col3_partial_slicing
-// CHECK:        onnx.ScatterND
 
 // -----
 

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -793,22 +793,130 @@ func.func @test_scatter_nd_dynamic(%data : tensor<*xf32>, %updates : tensor<1x1x
 // CHECK:        onnx.ScatterND
 
 // -----
-func.func @test_scatter_nd_multi_dim_differ(%data : tensor<2x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<2x6x10x12xf32> {
+func.func @test_scatter_nd_multi_dim_differ_partial_indexing(%data : tensor<2x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<2x6x10x12xf32> {
   %indices = onnx.Constant dense<[[[[0, 1, 0], [0, 1, 1], [0, 1, 2], [0, 1, 3], [0, 1, 4], [0, 1, 5], [0, 1, 6], [0, 1, 7], [0, 1, 8], [0, 1, 9]]]]> : tensor<1x1x10x3xi64>
   %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<2x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<2x6x10x12xf32>
   onnx.Return %0 : tensor<2x6x10x12xf32>
 }
-// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_differ
-// CHECK:        onnx.ScatterND
+// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_differ_partial_indexing
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x6x10x12xf32>, [[PARAM_1_:%.+]]: tensor<1x1x10x12xf32>) -> tensor<2x6x10x12xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[2, 6, 10, 12]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 1, 10]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 10, 12]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[12, 10, 12]> : tensor<3xi64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<2x6x10x12xf32>, tensor<3xi64>) -> tensor<12x10x12xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x10x12xf32>, tensor<3xi64>) -> tensor<1x10x12xf32>
+// CHECK:           [[VAR_6_:%.+]]:3 = "onnx.Split"([[VAR_4_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<12x10x12xf32>, tensor<3xi64>) -> (tensor<1x10x12xf32>, tensor<1x10x12xf32>, tensor<10x10x12xf32>)
+// CHECK:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_6_]]#0, [[VAR_5_]], [[VAR_6_]]#2) {axis = 0 : si64} : (tensor<1x10x12xf32>, tensor<1x10x12xf32>, tensor<10x10x12xf32>) -> tensor<12x10x12xf32>
+// CHECK:           [[VAR_8_:%.+]] = "onnx.Reshape"([[VAR_7_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<12x10x12xf32>, tensor<4xi64>) -> tensor<2x6x10x12xf32>
+// CHECK:           onnx.Return [[VAR_8_]] : tensor<2x6x10x12xf32>
+// CHECK:         }
 
 // -----
-func.func @test_scatter_nd_multi_dim_differ_multi_shift(%data : tensor<2x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<2x6x10x12xf32> {
+func.func @test_scatter_nd_multi_dim_differ_multi_shift_partial_indexing(%data : tensor<2x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<2x6x10x12xf32> {
   %indices = onnx.Constant dense<[[[[1, 1, 0], [1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 1, 4], [1, 1, 5], [1, 1, 6], [1, 1, 7], [1, 1, 8], [1, 1, 9]]]]> : tensor<1x1x10x3xi64>
   %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<2x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<2x6x10x12xf32>
   onnx.Return %0 : tensor<2x6x10x12xf32>
 }
-// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_differ_multi_shift
-// CHECK:        onnx.ScatterND
+// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_differ_multi_shift_partial_indexing
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x6x10x12xf32>, [[PARAM_1_:%.+]]: tensor<1x1x10x12xf32>) -> tensor<2x6x10x12xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[2, 6, 10, 12]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[7, 1, 4]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 10, 12]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[12, 10, 12]> : tensor<3xi64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<2x6x10x12xf32>, tensor<3xi64>) -> tensor<12x10x12xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1x1x10x12xf32>, tensor<3xi64>) -> tensor<1x10x12xf32>
+// CHECK:           [[VAR_6_:%.+]]:3 = "onnx.Split"([[VAR_4_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<12x10x12xf32>, tensor<3xi64>) -> (tensor<7x10x12xf32>, tensor<1x10x12xf32>, tensor<4x10x12xf32>)
+// CHECK:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_6_]]#0, [[VAR_5_]], [[VAR_6_]]#2) {axis = 0 : si64} : (tensor<7x10x12xf32>, tensor<1x10x12xf32>, tensor<4x10x12xf32>) -> tensor<12x10x12xf32>
+// CHECK:           [[VAR_8_:%.+]] = "onnx.Reshape"([[VAR_7_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<12x10x12xf32>, tensor<4xi64>) -> tensor<2x6x10x12xf32>
+// CHECK:           onnx.Return [[VAR_8_]] : tensor<2x6x10x12xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_multi_dim_differ_full_indexing(%arg0: tensor<6x4x4xf32>, %arg1: tensor<6x1x1xf32>) -> (tensor<6x4x4xf32>) {
+  %159 = onnx.Constant dense<[[[[0, 1, 1]]], [[[1, 1, 1]]], [[[2, 1, 1]]], [[[3, 1, 1]]], [[[4, 1, 1]]], [[[5, 1, 1]]]]> : tensor<6x1x1x3xi64>
+  %243 = "onnx.ScatterND"(%arg0, %159, %arg1) {reduction = "none"} : (tensor<6x4x4xf32>, tensor<6x1x1x3xi64>, tensor<6x1x1xf32>) -> tensor<6x4x4xf32>
+  onnx.Return %243: tensor<6x4x4xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_differ_full_indexing
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<6x4x4xf32>, [[PARAM_1_:%.+]]: tensor<6x1x1xf32>) -> tensor<6x4x4xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[6, 4, 4]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[5, 1, 10]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[6, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[6, 16]> : tensor<2xi64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<6x4x4xf32>, tensor<2xi64>) -> tensor<6x16xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<6x1x1xf32>, tensor<2xi64>) -> tensor<6x1xf32>
+// CHECK:           [[VAR_6_:%.+]]:3 = "onnx.Split"([[VAR_4_]], [[VAR_1_]]) {axis = 1 : si64} : (tensor<6x16xf32>, tensor<3xi64>) -> (tensor<6x5xf32>, tensor<6x1xf32>, tensor<6x10xf32>)
+// CHECK:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_6_]]#0, [[VAR_5_]], [[VAR_6_]]#2) {axis = 1 : si64} : (tensor<6x5xf32>, tensor<6x1xf32>, tensor<6x10xf32>) -> tensor<6x16xf32>
+// CHECK:           [[VAR_8_:%.+]] = "onnx.Reshape"([[VAR_7_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<6x16xf32>, tensor<3xi64>) -> tensor<6x4x4xf32>
+// CHECK:           onnx.Return [[VAR_8_]] : tensor<6x4x4xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_multi_dim_differ_full_indexing_start_zeros(%data: tensor<6x4x4xf32>, %updates: tensor<6x1x1xf32>) -> tensor<6x4x4xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 0]]], [[[1, 0, 0]]], [[[2, 0, 0]]], [[[3, 0, 0]]], [[[4, 0, 0]]], [[[5, 0, 0]]]]> : tensor<6x1x1x3xi64>
+  %out = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<6x4x4xf32>, tensor<6x1x1x3xi64>, tensor<6x1x1xf32>) -> tensor<6x4x4xf32>
+  onnx.Return %out : tensor<6x4x4xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_differ_full_indexing_start_zeros
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<6x4x4xf32>, [[PARAM_1_:%.+]]: tensor<6x1x1xf32>) -> tensor<6x4x4xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[6, 4, 4]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[0, 1, 15]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[6, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[6, 16]> : tensor<2xi64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<6x4x4xf32>, tensor<2xi64>) -> tensor<6x16xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<6x1x1xf32>, tensor<2xi64>) -> tensor<6x1xf32>
+// CHECK:           [[VAR_6_:%.+]]:3 = "onnx.Split"([[VAR_4_]], [[VAR_1_]]) {axis = 1 : si64} : (tensor<6x16xf32>, tensor<3xi64>) -> (tensor<6x0xf32>, tensor<6x1xf32>, tensor<6x15xf32>)
+// CHECK:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_6_]]#0, [[VAR_5_]], [[VAR_6_]]#2) {axis = 1 : si64} : (tensor<6x0xf32>, tensor<6x1xf32>, tensor<6x15xf32>) -> tensor<6x16xf32>
+// CHECK:           [[VAR_8_:%.+]] = "onnx.Reshape"([[VAR_7_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<6x16xf32>, tensor<3xi64>) -> tensor<6x4x4xf32>
+// CHECK:           onnx.Return [[VAR_8_]] : tensor<6x4x4xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_multi_dim_differ_full_indexing_start_non_zeros(%data: tensor<6x4x4xf32>, %updates: tensor<6x1x1xf32>) -> tensor<6x4x4xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 2]]], [[[1, 0, 2]]], [[[2, 0, 2]]], [[[3, 0, 2]]], [[[4, 0, 2]]], [[[5, 0, 2]]]]> : tensor<6x1x1x3xi64>
+  %out = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<6x4x4xf32>, tensor<6x1x1x3xi64>, tensor<6x1x1xf32>) -> tensor<6x4x4xf32>
+  onnx.Return %out : tensor<6x4x4xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_differ_full_indexing_start_non_zeros
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<6x4x4xf32>, [[PARAM_1_:%.+]]: tensor<6x1x1xf32>) -> tensor<6x4x4xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[6, 4, 4]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[2, 1, 13]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[6, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[6, 16]> : tensor<2xi64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<6x4x4xf32>, tensor<2xi64>) -> tensor<6x16xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<6x1x1xf32>, tensor<2xi64>) -> tensor<6x1xf32>
+// CHECK:           [[VAR_6_:%.+]]:3 = "onnx.Split"([[VAR_4_]], [[VAR_1_]]) {axis = 1 : si64} : (tensor<6x16xf32>, tensor<3xi64>) -> (tensor<6x2xf32>, tensor<6x1xf32>, tensor<6x13xf32>)
+// CHECK:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_6_]]#0, [[VAR_5_]], [[VAR_6_]]#2) {axis = 1 : si64} : (tensor<6x2xf32>, tensor<6x1xf32>, tensor<6x13xf32>) -> tensor<6x16xf32>
+// CHECK:           [[VAR_8_:%.+]] = "onnx.Reshape"([[VAR_7_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<6x16xf32>, tensor<3xi64>) -> tensor<6x4x4xf32>
+// CHECK:           onnx.Return [[VAR_8_]] : tensor<6x4x4xf32>
+// CHECK:         }
+
+// -----
+func.func @test_scatter_nd_multi_dim_differ_full_indexing_start_non_zeros2(%arg0: tensor<6x4x4xf32>, %arg1: tensor<6x1x1xf32>) -> (tensor<6x4x4xf32>) {
+    %159 = onnx.Constant dense<[[[[0, 1, 1]]], [[[1, 1, 1]]], [[[2, 1, 1]]], [[[3, 1, 1]]], [[[4, 1, 1]]], [[[5, 1, 1]]]]> : tensor<6x1x1x3xi64>
+    %243 = "onnx.ScatterND"(%arg0, %159, %arg1) {reduction = "none"} : (tensor<6x4x4xf32>, tensor<6x1x1x3xi64>, tensor<6x1x1xf32>) -> tensor<6x4x4xf32>
+    onnx.Return %243: tensor<6x4x4xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_multi_dim_differ_full_indexing_start_non_zeros2
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<6x4x4xf32>, [[PARAM_1_:%.+]]: tensor<6x1x1xf32>) -> tensor<6x4x4xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[6, 4, 4]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[5, 1, 10]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[6, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[6, 16]> : tensor<2xi64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<6x4x4xf32>, tensor<2xi64>) -> tensor<6x16xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<6x1x1xf32>, tensor<2xi64>) -> tensor<6x1xf32>
+// CHECK:           [[VAR_6_:%.+]]:3 = "onnx.Split"([[VAR_4_]], [[VAR_1_]]) {axis = 1 : si64} : (tensor<6x16xf32>, tensor<3xi64>) -> (tensor<6x5xf32>, tensor<6x1xf32>, tensor<6x10xf32>)
+// CHECK:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_6_]]#0, [[VAR_5_]], [[VAR_6_]]#2) {axis = 1 : si64} : (tensor<6x5xf32>, tensor<6x1xf32>, tensor<6x10xf32>) -> tensor<6x16xf32>
+// CHECK:           [[VAR_8_:%.+]] = "onnx.Reshape"([[VAR_7_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<6x16xf32>, tensor<3xi64>) -> tensor<6x4x4xf32>
+// CHECK:           onnx.Return [[VAR_8_]] : tensor<6x4x4xf32>
+// CHECK:         }
 
 // -----
 func.func @test_scatter_nd_negative_shift(%data : tensor<1x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<1x6x10x12xf32> {
@@ -878,6 +986,32 @@ func.func @test_scatter_nd_single_not_in_order(%data : tensor<1x6x10x12xf32>, %u
 }
 // CHECK-LABEL:  func.func @test_scatter_nd_single_not_in_order
 // CHECK:        onnx.ScatterND
+
+// -----
+func.func @scatter_block_rows0to2_cols0to2_partial_slicing(%data: tensor<6x4x4xf32>, %updates: tensor<6x3x3xf32>) -> tensor<6x4x4xf32> {
+  %indices = onnx.Constant dense<
+    [[[[0, 0, 0], [0, 0, 1], [0, 0, 2]], [[0, 1, 0], [0, 1, 1], [0, 1, 2]], [[0, 2, 0], [0, 2, 1], [0, 2, 2]]],
+      [[[1, 0, 0], [1, 0, 1], [1, 0, 2]], [[1, 1, 0], [1, 1, 1], [1, 1, 2]], [[1, 2, 0], [1, 2, 1], [1, 2, 2]]],
+      [[[2, 0, 0], [2, 0, 1], [2, 0, 2]], [[2, 1, 0], [2, 1, 1], [2, 1, 2]], [[2, 2, 0], [2, 2, 1], [2, 2, 2]]],
+      [[[3, 0, 0], [3, 0, 1], [3, 0, 2]], [[3, 1, 0], [3, 1, 1], [3, 1, 2]], [[3, 2, 0], [3, 2, 1], [3, 2, 2]]],
+      [[[4, 0, 0], [4, 0, 1], [4, 0, 2]], [[4, 1, 0], [4, 1, 1], [4, 1, 2]], [[4, 2, 0], [4, 2, 1], [4, 2, 2]]],
+      [[[5, 0, 0], [5, 0, 1], [5, 0, 2]], [[5, 1, 0], [5, 1, 1], [5, 1, 2]], [[5, 2, 0], [5, 2, 1], [5, 2, 2]]]]
+  > : tensor<6x3x3x3xi64>
+  %out = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<6x4x4xf32>, tensor<6x3x3x3xi64>, tensor<6x3x3xf32>) -> tensor<6x4x4xf32>
+  onnx.Return %out : tensor<6x4x4xf32>
+}
+// CHECK-LABEL:  func.func @scatter_block_rows0to2_cols0to2_partial_slicing
+// CHECK:        onnx.ScatterND
+
+// -----
+func.func @scatter_block_rows0to2_col3_partial_slicing(%data: tensor<6x4x4xf32>, %updates: tensor<6x3x1xf32>) -> tensor<6x4x4xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 3]], [[0, 1, 3]], [[0, 2, 3]]], [[[1, 0, 3]], [[1, 1, 3]], [[1, 2, 3]]], [[[2, 0, 3]], [[2, 1, 3]], [[2, 2, 3]]], [[[3, 0, 3]], [[3, 1, 3]], [[3, 2, 3]]], [[[4, 0, 3]], [[4, 1, 3]], [[4, 2, 3]]], [[[5, 0, 3]], [[5, 1, 3]], [[5, 2, 3]]]]> : tensor<6x3x1x3xi64>
+  %out = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<6x4x4xf32>, tensor<6x3x1x3xi64>, tensor<6x3x1xf32>) -> tensor<6x4x4xf32>
+  onnx.Return %out : tensor<6x4x4xf32>
+}
+// CHECK-LABEL:  func.func @scatter_block_rows0to2_col3_partial_slicing
+// CHECK:        onnx.ScatterND
+
 // -----
 
 func.func @sce_mean(%arg0: tensor<64x10xf32>, %arg1: tensor<64xi64>) -> tensor<f32> {


### PR DESCRIPTION
# Canonicalize `ScatterND` with multiple consecutive split axes

To be clear, this isn't AI-generated code. Only the description is and two or three LIT tests. Others tests come
from real-case scenarios.

## Summary

Adds a new `CanonicalizeScatterNDWithMultiAxis` canonicalization that lowers an
`onnx.ScatterND` whose update region differs from `data` on **two or more
consecutive axes**. The pattern merges those axes into a single axis, which lets
the existing single-axis contiguous-block decomposition
(`DecomposeScatterNDPattern`, Split + Concat) take over.

The work is split into several commits: the initial two-axis canonicalization,
support for partial indexing, generalization to an arbitrary number of
consecutive axes, a rename, and LIT tests along the way.

## Motivation

`DecomposeScatterNDPattern` only lowers a `ScatterND` when `data` and `updates`
differ in a **single** dimension. When the update region spans several adjacent
axes — e.g. it replaces a full `[H, W]` plane per batch, or a full `[C, H, W]`
block — the scatter has multiple differing axes and that pattern cannot apply,
leaving an `onnx.ScatterND` that later stages cannot handle.

`CanonicalizeScatterNDWithMultiAxis` bridges that gap: it folds the `N` differing
consecutive axes into one axis of size `prod(data[a .. a+N-1])`, rewrites the
(constant) indices as linear coordinates into the merged shape, and reshapes the
result back to the original data shape. After the merge only a single axis
differs, so the simpler decomposition can lower it.

## Commits

1. `5b60e8b` — **feat: canonicalize multi-axes ScatterND for
   DecomposeScatterNDPattern.** Introduces the pattern, handling the case where
   exactly two consecutive axes differ: reshape/merge the two axes, rebuild the
   constant indices as linear coordinates, emit a new `ScatterND`, and reshape
   back.
2. `cbb4566` — **feat: support indices with partial indexing.** Handles
   `k = indices.shape[-1] < rank(data)`, where each index addresses a
   `data.shape[k:]` slice rather than a scalar. The coordinate remap runs over
   the indexed prefix only; the trailing slice axes ride along unchanged.
3. `d96c529` — **test: add LIT tests for new ScatterND canonicalization.**
   Covers the two-axis and partial-indexing paths, plus negative cases.
4. `3046603` — **feat: support number of axes greater than 2.** Generalizes the
   merge from exactly two to any `N >= 2` consecutive split axes, including the
   `k -> k - N + 1` index-depth reduction and the collapse of `N` axes into one.
5. `3123908` — **chore: rename rewriter** from
   `CanonicalizeScatterNDWithMultiAxes` to `CanonicalizeScatterNDWithMultiAxis`.
6. `bb3cc08` — **test: add tests to check support for number of axes greater
   than 2.** Adds LIT coverage for the `N > 2` full-indexing and
   partial-indexing paths and a non-consecutive negative case.
7. `3c8ba71` — **chore: create functions for common functionality between
ScatterND rewriters** some parts of the ScatterND rewriters are common to
one another, so avoid duplicating code by using one function that is called
by each rewriter
8 `c4a5bc` — **chore: move indexToOffset and offsetToIndex to OpHelper
and address PR comments**

## Preconditions (pattern bails otherwise)

- `reduction == "none"`.
- `data`, `indices`, and `updates` all have static shapes.
- `rank(data) == rank(updates)`.
- At least two axes differ between `data` and `updates`, and they are all
  consecutive (`splitAxes = {a, a+1, ..., a+N-1}`).
- All split axes lie within the indexed prefix (`splitAxes.back() < k`), where
  `k = indices.shape[-1]`.
- `indices` is a constant, non-empty tensor.
- The first index is `0` on every non-split axis and non-negative on the split
  axes (no ONNX negative wrap-around).
- The indices are contiguous and cover the whole merged block.

## How it works

For split axes `{a, ..., a+N-1}`:

1. Reshape `data`, `updates`, and the index batch dims so the `N` axes collapse
   into one of size `prod(data[a .. a+N-1])`, keeping surrounding dims unchanged.
2. Rebuild the constant `indices` by remapping each length-`k` coordinate through
   the axis merge, over the indexed prefix (the first `k` axes) only. The new
   index depth is `k - N + 1`.
3. Emit a new `ScatterND` on the merged shapes, then reshape the result back to
   the original `data` shape.

### Partial indexing

Partial indexing (`k = indices.shape[-1] < rank(data)`) is supported: each index
addresses a `data.shape[k:]` slice rather than a scalar. Merging `N` indexed axes
drops the index depth by `N - 1` (`k -> k - N + 1`); the trailing `r - k` slice
axes ride along unchanged. For full indexing (`k == rank(data)`) the new index
depth equals the new data rank.
**This wasn't really part of what I wanted to do but I saw that some existing**
**were also worth improving (I changed their names and the CHECKs).**

## Examples

Full indexing, three consecutive axes:

```
data:    [2, 3, 4, 5]   updates: [1, 1, 1, 5]   indices: [1, 1, 1, 5, 4]
splitAxes = {0, 1, 2}  ->  merge axes 0..2 (2*3*4 = 24)
  newDataShape    = [24, 5]
  newUpdateShape  = [1, 5]
  newIndexDepth   = 4 - (3 - 1) = 2
```

Partial indexing, three consecutive axes:

```
data:    [2, 2, 3, 5]   updates: [1, 1, 2, 5]   indices: [1, 1, 2, 3]  (k = 3 < r = 4)
splitAxes = {0, 1, 2}  ->  merge axes 0..2 (2*2*3 = 12)
  newDataShape    = [12, 5]
  newUpdateShape  = [2, 5]
  newIndexDepth   = 3 - (3 - 1) = 1
```

## Tests

Added to `third-party/onnx-mlir/test/mlir/onnx/onnx_decompose.mlir`:

- Two-axis and partial-indexing canonicalization paths, with negative cases
  (reduction, non-constant indices, negative shift, full overwrite).
- `test_scatter_nd_three_split_axes_full_indexing` — three consecutive axes
  merged, full indexing, with a trailing indexed-but-not-split axis.
- `test_scatter_nd_three_split_axes_partial_indexing` — three consecutive axes
  merged with partial indexing; the update spans two merged positions, producing
  a non-trivial `Split [3, 2, 7]`.
- `test_scatter_nd_non_consecutive_split_axes` — negative case where the
  differing axes are not adjacent, so the op is left as `onnx.ScatterND`.
- See other tests.

