### PR TITLE
Backport reshape canonicalization 

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -121,6 +121,7 @@ add_onnx_mlir_library(OMOnnxToMlirPasses
   ${OMOnnxToMlirPasses_EXTRA_LIBS}
   OMInstrumentONNX
   OMHybridTransform
+  OMXFEONNXOpsetVerifier
   OMOpTransform
   OMONNXStandardFuncReturnPass
   OMONNXSimplifyShapeRelatedOps

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -52,6 +52,8 @@ bool enableKrnlBufferReuse;                            // common for both
 std::string onnxTransformOptions;                      // onnx-mlir only
 bool enableQuarkQuantizerLegalization;                 // common for both
 bool disableBatchNormDecompose;                        // common for both
+bool enableReshapeCanonicalization;                    // common for both
+bool enableXFEONNXOpsetVerifier;                       // common for both
 bool enableSafeCodeGen;                                // common for both
 bool disableMemRefPrefetch;                            // common for both
 uint64_t compilationNumThreads;                        // common for both
@@ -336,6 +338,21 @@ static llvm::cl::opt<bool, true> disableBatchNormDecomposeOpt(
         "patterns (default=false). Set to 'true' to keep BatchNorm as a "
         "single op."),
     llvm::cl::location(disableBatchNormDecompose), llvm::cl::init(false),
+    llvm::cl::cat(OnnxMlirCommonOptions));
+
+static llvm::cl::opt<bool, true> enableReshapeCanonicalizationOpt(
+    "enable-reshape-canonicalization",
+    llvm::cl::desc(
+        "Enable canonicalization of Flatten/Squeeze/Unsqueeze to Reshape "
+        "(default=true, i.e. the rewrite is enabled by default)."),
+    llvm::cl::location(enableReshapeCanonicalization), llvm::cl::init(true),
+    llvm::cl::cat(OnnxMlirCommonOptions));
+
+static llvm::cl::opt<bool, true> enableXFEONNXOpsetVerifierOpt(
+    "enable-xfe-onnx-opset-verifier",
+    llvm::cl::desc(
+        "Enable the XFE ONNX opset verifier at the end of the ONNX pipeline."),
+    llvm::cl::location(enableXFEONNXOpsetVerifier), llvm::cl::init(true),
     llvm::cl::cat(OnnxMlirCommonOptions));
 
 // Options for onnx-mlir only

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -89,6 +89,8 @@ extern bool disableMemRefPrefetch;                            // common for both
 extern std::string onnxTransformOptions;                      // onnx-mlir only
 extern bool enableQuarkQuantizerLegalization;                 // common for both
 extern bool disableBatchNormDecompose;                        // common for both
+extern bool enableReshapeCanonicalization;                    // common for both
+extern bool enableXFEONNXOpsetVerifier;                       // common for both
 extern uint64_t compilationNumThreads;                        // common for both
 // AMD: Decompose unconditionally
 // extern std::vector<std::string> decomposeOpsInONNX; // common for both

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -262,6 +262,8 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
     opts.profileIR = profileIR;
     opts.instrumentStage = instrumentStage;
     opts.enableXMCPasses = enableXMCPasses;
+    opts.enableReshapeCanonicalization = enableReshapeCanonicalization;
+    opts.enableXFEONNXOpsetVerifier = enableXFEONNXOpsetVerifier;
     if (enableXMCPasses) {
       opts.hybrid.enableInstanceNormDecompose = false;
       opts.hybrid.enableGroupNormDecompose = false;

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -52,6 +52,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   configureUnsafeMathCanonicalization(opts.enableUnsafeMathOptimizations);
   configureConv1x1IntoConvCanonicalization(
       opts.enableConv1x1IntoConvCanonicalization);
+  configureReshapeCanonicalization(opts.enableReshapeCanonicalization);
 
   if (!donotScrubDisposableElementsAttr)
     pm.addInstrumentation(
@@ -152,6 +153,9 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   // Set onnx_node_name if it is missing. Keep this pass at the end of this
   // function and just before instrumentation.
   pm.addPass(createSetONNXNodeNamePass());
+
+  if (opts.enableXFEONNXOpsetVerifier)
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createXFEONNXOpsetVerifierPass());
 
 #ifdef ONNX_MLIR_ENABLE_KRNL
   // Add instrumentation for Onnx Ops (requires Krnl dialect for

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -32,6 +32,9 @@ struct OnnxToMlirOptions {
   bool enableXMCPasses = false;
 
   bool disableBatchNormDecompose = false;
+  // Reshape-family canonicalization (Flatten/Squeeze/Unsqueeze -> Reshape).
+  bool enableReshapeCanonicalization = true;
+  bool enableXFEONNXOpsetVerifier = true;
   bool enableUnsafeMathOptimizations = true;
   bool enableConv1x1IntoConvCanonicalization = false;
   bool enableONNXHybridPass = true;

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -2561,6 +2561,7 @@ def ONNXEyeLikeOp:ONNX_Op<"EyeLike",
 
 def ONNXFlattenOp:ONNX_Op<"Flatten",
   [Pure, OpVersionTrait<21>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Flatten operation";
   let description = [{
   Flattens the input tensor into a 2D matrix. If input tensor has shape

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -55,6 +55,9 @@ static bool enableUnsafeMath = true;
 // Populated by configureConv1x1IntoConvCanonicalization().
 static bool enableConv1x1IntoConvCanonicalization = false;
 
+// Populated by configureReshapeCanonicalization().
+static bool enableReshapeCanonicalization = true;
+
 using namespace mlir;
 using namespace onnx_mlir;
 
@@ -2914,6 +2917,38 @@ public:
 };
 
 // =============================================================================
+// Reshape canonicalization patterns.
+// Rewrite Flatten/Squeeze/Unsqueeze to onnx.Reshape when the output is fully
+// static. Guarded by enableReshapeCanonicalization.
+//
+/// Rewrite Flatten/Squeeze/Unsqueeze as onnx.Reshape when the result is a
+/// fully static ranked tensor.  All three ops have the data tensor as their
+/// first operand and the reshaped tensor as their first (and only) result, so
+/// no per-op accessors are needed.
+template <typename OpT>
+struct ReshapeFamilyToReshapePattern : public OpRewritePattern<OpT> {
+  using OpRewritePattern<OpT>::OpRewritePattern;
+  LogicalResult matchAndRewrite(OpT op, PatternRewriter &rewriter) const final {
+    auto resultType =
+        mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
+    if (!resultType || !resultType.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          op, "output must be a static ranked tensor");
+    SmallVector<int64_t> shape(
+        resultType.getShape().begin(), resultType.getShape().end());
+    Value shapeConst = rewriter.create<ONNXConstantOp>(
+        op.getLoc(), nullptr, rewriter.getI64TensorAttr(shape));
+    rewriter.replaceOpWithNewOp<ONNXReshapeOp>(
+        op, resultType, op->getOperand(0), shapeConst);
+    return success();
+  }
+};
+
+using FlattenToReshapePattern = ReshapeFamilyToReshapePattern<ONNXFlattenOp>;
+using SqueezeToReshapePattern = ReshapeFamilyToReshapePattern<ONNXSqueezeOp>;
+using UnsqueezeToReshapePattern =
+    ReshapeFamilyToReshapePattern<ONNXUnsqueezeOp>;
+
 // Rewrite pattern for BatchNormalization
 // =============================================================================
 /// Decompose BatchNormV9 to BatchNorm
@@ -3646,6 +3681,42 @@ public:
   }
 };
 
+/// Simplify Reshape(Cast(Reshape(x, s1)), s2) to Cast(x) when the outer
+/// Reshape's result shape equals the inner Reshape's input shape (i.e., the
+/// two Reshapes together form an identity).
+struct FuseCastBetweenReshapesPattern : public OpRewritePattern<ONNXReshapeOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(
+      ONNXReshapeOp outerReshape, PatternRewriter &rewriter) const final {
+    auto castOp = outerReshape.getData().getDefiningOp<ONNXCastOp>();
+    if (!castOp)
+      return rewriter.notifyMatchFailure(outerReshape, "input is not Cast");
+    auto innerReshape = castOp.getInput().getDefiningOp<ONNXReshapeOp>();
+    if (!innerReshape)
+      return rewriter.notifyMatchFailure(
+          outerReshape, "Cast input is not Reshape");
+    // Both result and inner input must be static ranked tensors with the
+    // same shape
+    auto outerTy =
+        mlir::dyn_cast<RankedTensorType>(outerReshape.getResult().getType());
+    auto innerInTy =
+        mlir::dyn_cast<RankedTensorType>(innerReshape.getData().getType());
+    if (!outerTy || !innerInTy)
+      return rewriter.notifyMatchFailure(outerReshape, "types not ranked");
+    if (!outerTy.hasStaticShape() || !innerInTy.hasStaticShape())
+      return rewriter.notifyMatchFailure(outerReshape, "types not static");
+    if (outerTy.getShape() != innerInTy.getShape())
+      return rewriter.notifyMatchFailure(
+          outerReshape, "outer result shape != inner input shape");
+    Location fusedLoc = rewriter.getFusedLoc(
+        {innerReshape.getLoc(), castOp.getLoc(), outerReshape.getLoc()});
+    Value newCast = rewriter.create<ONNXCastOp>(fusedLoc, outerTy,
+        innerReshape.getData(), castOp.getSaturateAttr(), castOp.getToAttr());
+    rewriter.replaceOp(outerReshape, newCast);
+    return success();
+  }
+};
+
 // =============================================================================
 /// Register optimization patterns as "canonicalization" patterns.
 /// Add op to OpsWithCanonicalizer in gen_onnx_mlir.py to activate.
@@ -3890,6 +3961,7 @@ void ONNXReshapeOp::getCanonicalizationPatterns(
   result.insert<RemoveIdentityReshapePattern2>(context);
   result.insert<SwapReshapeMatMulPattern>(context);
   result.insert<ReplaceReshapeAllowZeroByReshape>(context);
+  result.insert<FuseCastBetweenReshapesPattern>(context);
 }
 
 /// on the ONNXResizeOp.
@@ -3960,10 +4032,19 @@ void ONNXSplitOp::getCanonicalizationPatterns(
 }
 
 /// on the ONNXSqueezeOp.
+void ONNXFlattenOp::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  if (enableReshapeCanonicalization)
+    result.insert<FlattenToReshapePattern>(context);
+}
+
+/// on the ONNXSqueezeOp.
 void ONNXSqueezeOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
   result.insert<RemoveSqueezeUnsqueezePattern>(context);
   result.insert<RemoveSqueezeCastUnsqueezePattern>(context);
+  if (enableReshapeCanonicalization)
+    result.insert<SqueezeToReshapePattern>(context);
 }
 
 void ONNXSqueezeV11Op::getCanonicalizationPatterns(
@@ -4025,6 +4106,8 @@ void ONNXUnsqueezeOp::getCanonicalizationPatterns(
   result.insert<RemoveUnsqueezeSqueezePattern>(context);
   result.insert<RemoveUnsqueezeCastSqueezePattern>(context);
   result.insert<ReplaceUnsqueezeOfExpandRewritePattern>(context);
+  if (enableReshapeCanonicalization)
+    result.insert<UnsqueezeToReshapePattern>(context);
 }
 
 void ONNXUnsqueezeV11Op::getCanonicalizationPatterns(
@@ -4442,4 +4525,8 @@ void onnx_mlir::configureConv1x1IntoConvCanonicalization(
     bool enableConv1x1IntoConvCanonicalizationOption) {
   enableConv1x1IntoConvCanonicalization =
       enableConv1x1IntoConvCanonicalizationOption;
+}
+
+void onnx_mlir::configureReshapeCanonicalization(bool enable) {
+  enableReshapeCanonicalization = enable;
 }

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -187,6 +187,19 @@ if (ONNX_MLIR_ENABLE_KRNL)
     )
 endif()
 
+add_onnx_mlir_library(OMXFEONNXOpsetVerifier
+  XFEONNXOpsetVerifierPass.cpp
+
+  DEPENDS
+  OMONNXTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  OMONNXOps
+  OMMlirUtilities
+  MLIRFuncDialect
+  MLIRPass
+  )
+
 add_onnx_mlir_library(OMONNXSimplifyShapeRelatedOps
   SimplifyShapeRelatedOps.cpp
 

--- a/src/Dialect/ONNX/Transforms/Passes.td
+++ b/src/Dialect/ONNX/Transforms/Passes.td
@@ -185,3 +185,17 @@ def ONNXHybridTransformPass
   let options =
       ONNXHybridTransformOptions.options # ONNXDecomposePatternOptions.options;
 }
+
+def XFEONNXOpsetVerifierPass
+    : Pass<"xfe-onnx-opset-verifier", "::mlir::func::FuncOp"> {
+  let summary = "Verify XFE ONNX opset constraints.";
+  let description = [{
+    Verifies that the ops inside a function match the XFE ONNX opset
+    constraints. Currently implements a check for disallowed ops.
+  }];
+  let options = [
+    Option<"disallowedOps", "disallowed-ops", "std::string",
+           /*default=*/"\"Flatten,Squeeze,Unsqueeze\"",
+           "Comma-separated bare ONNX op names that must not appear. Skips ops with non-static shapes.">
+  ];
+}

--- a/src/Dialect/ONNX/Transforms/XFEONNXOpsetVerifierPass.cpp
+++ b/src/Dialect/ONNX/Transforms/XFEONNXOpsetVerifierPass.cpp
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===-- XFEONNXOpsetVerifierPass.cpp - XFE ONNX opset verifier -----------===//
+//
+// Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/StringSet.h"
+
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Pass/Passes.hpp"
+#include "src/Support/TypeUtilities.hpp"
+
+namespace onnx_mlir {
+#define GEN_PASS_DEF_XFEONNXOPSETVERIFIERPASS
+#include "src/Dialect/ONNX/Transforms/Passes.h.inc"
+} // namespace onnx_mlir
+
+using namespace mlir;
+
+namespace {
+
+struct XFEONNXOpsetVerifierPass
+    : public onnx_mlir::impl::XFEONNXOpsetVerifierPassBase<
+          XFEONNXOpsetVerifierPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    llvm::StringSet<> denySet;
+
+    llvm::StringRef list(disallowedOps);
+    while (!list.empty()) {
+      auto [token, rest] = list.split(',');
+      token = token.trim();
+      if (!token.empty())
+        denySet.insert(("onnx." + token).str());
+      list = rest;
+    }
+
+    if (denySet.empty())
+      return;
+
+    bool anyFailed = false;
+    func::FuncOp func = getOperation();
+
+    for (Operation &op : func.getBody().getOps()) {
+      // Check deny-list.
+      if (!denySet.count(op.getName().getStringRef()))
+        continue;
+
+      // Static gate: skip if any tensor-typed operand is not fully static.
+      bool allStatic = true;
+      for (Value operand : op.getOperands()) {
+        Type ty = operand.getType();
+        if (isa<NoneType>(ty))
+          continue;
+        if (!isa<RankedTensorType>(ty) || !onnx_mlir::hasStaticShape(ty)) {
+          allStatic = false;
+          break;
+        }
+      }
+      if (!allStatic)
+        continue;
+
+      op.emitOpError("disallowed in XFE ONNX opset");
+      anyFailed = true;
+    }
+
+    if (anyFailed)
+      signalPassFailure();
+  }
+};
+
+} // namespace

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -71,6 +71,10 @@ void configureUnsafeMathCanonicalization(bool enableUnsafeMathOptimizations);
 void configureConv1x1IntoConvCanonicalization(
     bool enableConv1x1IntoConvCanonicalization);
 
+// Configure whether Flatten/Squeeze/Unsqueeze-to-Reshape canonicalization is
+// enabled.
+void configureReshapeCanonicalization(bool enableReshapeCanonicalization);
+
 std::unique_ptr<mlir::Pass> createConstPropONNXToONNXPass(
     bool enableQDQ = false, bool enableQuantConstFold = false);
 

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -354,6 +354,10 @@ void registerOMPasses(int optLevel) {
     return createSetONNXNodeNamePass();
   });
 
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return createXFEONNXOpsetVerifierPass();
+  });
+
 #ifdef ONNX_MLIR_ENABLE_KRNL
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return createONNXPreKrnlVerifyPass();

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -818,9 +818,9 @@ func.func @test_should_not_remove_unsqueeze_squeeze(%arg0 : tensor<10x10xf32>) -
   %3 = "onnx.Squeeze"(%2, %1) : (tensor<1x10x1x10xf32>, tensor<1xi64>) -> tensor<10x1x10xf32>
   onnx.Return %3: tensor<10x1x10xf32>
   // CHECK-LABEL: test_should_not_remove_unsqueeze_squeeze
-  // CHECK: {{.*}} = "onnx.Unsqueeze"{{.*}}
-  // CHECK: {{.*}} = "onnx.Squeeze"{{.*}}
-  // CHECK: onnx.Return {{.*}}
+  // CHECK: [[CST:%.+]] = onnx.Constant dense<[10, 1, 10]> : tensor<3xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, [[CST]]) {allowzero = 0 : si64}
+  // CHECK: onnx.Return [[RES]]
 }
 
 // -----
@@ -886,9 +886,9 @@ func.func @test_should_not_remove_squeeze_unsqueeze(%arg0 : tensor<1x10x1x10xf32
   %3 = "onnx.Unsqueeze"(%2, %1) : (tensor<10x1x10xf32>, tensor<1xi64>) -> tensor<10x1x10x1xf32>
   onnx.Return %3: tensor<10x1x10x1xf32>
   // CHECK-LABEL: test_should_not_remove_squeeze_unsqueeze
-  // CHECK: {{.*}} = "onnx.Squeeze"{{.*}}
-  // CHECK: {{.*}} = "onnx.Unsqueeze"{{.*}}
-  // CHECK: onnx.Return {{.*}}
+  // CHECK: [[CST:%.+]] = onnx.Constant dense<[10, 1, 10, 1]> : tensor<4xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, [[CST]]) {allowzero = 0 : si64}
+  // CHECK: onnx.Return [[RES]]
 }
 
 // -----
@@ -912,9 +912,9 @@ func.func @test_should_not_remove_null_axes_squeeze_unsqueeze(%arg0 : tensor<1x1
   %2 = "onnx.Unsqueeze"(%1, %0) : (tensor<10x10xf32>, tensor<2xi64>) -> tensor<10x1x10x1xf32>
   onnx.Return %2: tensor<10x1x10x1xf32>
   // CHECK-LABEL: test_should_not_remove_null_axes_squeeze_unsqueeze
-  // CHECK: {{.*}} = "onnx.Squeeze"{{.*}}
-  // CHECK: {{.*}} = "onnx.Unsqueeze"{{.*}}
-  // CHECK: onnx.Return {{.*}}
+  // CHECK: [[CST:%.+]] = onnx.Constant dense<[10, 1, 10, 1]> : tensor<4xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, [[CST]]) {allowzero = 0 : si64}
+  // CHECK: onnx.Return [[RES]]
 }
 
 // -----
@@ -2210,8 +2210,8 @@ func.func @mul_broadcast_axis_unsqueeze(%279: tensor<1x64x112x112xf32>, %138: te
 
 // CHECK-LABEL:  func.func @mul_broadcast_axis_unsqueeze
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x112x112xf32>, [[PARAM_1_:%.+]]: tensor<64xf32>) -> tensor<1x64x112x112xf32> {
-// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-// CHECK:           [[VAR_1_:%.+]] = "onnx.Unsqueeze"([[PARAM_1_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[64, 1, 1]> : tensor<3xi64>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<1x64x112x112xf32>, tensor<64x1x1xf32>) -> tensor<1x64x112x112xf32>
 // CHECK:           onnx.Return [[VAR_2_]] : tensor<1x64x112x112xf32>
 // CHECK:         }

--- a/test/mlir/onnx/onnx_canonicalization_reshape.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_reshape.mlir
@@ -1,0 +1,128 @@
+// RUN: onnx-mlir-opt --shape-inference --canonicalize="test-convergence=true" --shape-inference --cse %s -split-input-file | FileCheck %s
+
+// -----
+// CHECK-LABEL: func @flatten_static_to_reshape
+// Static Flatten (axis=1) becomes onnx.Reshape with the same 2-D shape.
+func.func @flatten_static_to_reshape(%arg0: tensor<2x3x4xf32>) -> tensor<6x4xf32> {
+  %0 = "onnx.Flatten"(%arg0) {axis = 1 : si64} : (tensor<2x3x4xf32>) -> tensor<6x4xf32>
+  onnx.Return %0 : tensor<6x4xf32>
+  // CHECK: [[CST:%.+]] = onnx.Constant dense<[6, 4]> : tensor<2xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, [[CST]]) {allowzero = 0 : si64}
+  // CHECK-SAME: (tensor<2x3x4xf32>, tensor<2xi64>) -> tensor<6x4xf32>
+  // CHECK: onnx.Return [[RES]]
+  // CHECK-NOT: "onnx.Flatten"
+}
+
+// -----
+// CHECK-LABEL: func @flatten_axis0_static_to_reshape
+// axis=0 => first dim is 1, second is the full element count.
+func.func @flatten_axis0_static_to_reshape(%arg0: tensor<2x3x4xf32>) -> tensor<1x24xf32> {
+  %0 = "onnx.Flatten"(%arg0) {axis = 0 : si64} : (tensor<2x3x4xf32>) -> tensor<1x24xf32>
+  onnx.Return %0 : tensor<1x24xf32>
+  // CHECK: [[CST:%.+]] = onnx.Constant dense<[1, 24]> : tensor<2xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, [[CST]]) {allowzero = 0 : si64}
+  // CHECK: onnx.Return [[RES]]
+  // CHECK-NOT: "onnx.Flatten"
+}
+
+// -----
+// CHECK-LABEL: func @flatten_dynamic_no_reshape
+// Dynamic input: gate prevents the rewrite.
+func.func @flatten_dynamic_no_reshape(%arg0: tensor<?x3x4xf32>) -> tensor<?x4xf32> {
+  %0 = "onnx.Flatten"(%arg0) {axis = 1 : si64} : (tensor<?x3x4xf32>) -> tensor<?x4xf32>
+  onnx.Return %0 : tensor<?x4xf32>
+  // CHECK: "onnx.Flatten"
+  // CHECK-NOT: "onnx.Reshape"
+}
+
+// -----
+// CHECK-LABEL: func @squeeze_static_to_reshape
+// Static Squeeze on a single axis becomes onnx.Reshape.
+func.func @squeeze_static_to_reshape(%arg0: tensor<2x1x4xf32>) -> tensor<2x4xf32> {
+  %axes = onnx.Constant dense<[1]> : tensor<1xi64>
+  %0 = "onnx.Squeeze"(%arg0, %axes) : (tensor<2x1x4xf32>, tensor<1xi64>) -> tensor<2x4xf32>
+  onnx.Return %0 : tensor<2x4xf32>
+  // CHECK: [[CST:%.+]] = onnx.Constant dense<[2, 4]> : tensor<2xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, [[CST]]) {allowzero = 0 : si64}
+  // CHECK: onnx.Return [[RES]]
+  // CHECK-NOT: "onnx.Squeeze"
+}
+
+// -----
+// CHECK-LABEL: func @squeeze_dynamic_data_no_reshape
+// Dynamic primary operand: rewrite must not fire.
+func.func @squeeze_dynamic_data_no_reshape(%arg0: tensor<?x1x4xf32>) -> tensor<?x4xf32> {
+  %axes = onnx.Constant dense<[1]> : tensor<1xi64>
+  %0 = "onnx.Squeeze"(%arg0, %axes) : (tensor<?x1x4xf32>, tensor<1xi64>) -> tensor<?x4xf32>
+  onnx.Return %0 : tensor<?x4xf32>
+  // CHECK: "onnx.Squeeze"
+  // CHECK-NOT: "onnx.Reshape"
+}
+
+// -----
+// CHECK-LABEL: func @unsqueeze_static_to_reshape
+// Static Unsqueeze becomes onnx.Reshape.
+func.func @unsqueeze_static_to_reshape(%arg0: tensor<2x4xf32>) -> tensor<2x1x4xf32> {
+  %axes = onnx.Constant dense<[1]> : tensor<1xi64>
+  %0 = "onnx.Unsqueeze"(%arg0, %axes) : (tensor<2x4xf32>, tensor<1xi64>) -> tensor<2x1x4xf32>
+  onnx.Return %0 : tensor<2x1x4xf32>
+  // CHECK: [[CST:%.+]] = onnx.Constant dense<[2, 1, 4]> : tensor<3xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, [[CST]]) {allowzero = 0 : si64}
+  // CHECK: onnx.Return [[RES]]
+  // CHECK-NOT: "onnx.Unsqueeze"
+}
+
+// -----
+// CHECK-LABEL: func @unsqueeze_dynamic_data_no_reshape
+// Dynamic primary operand: rewrite must not fire.
+func.func @unsqueeze_dynamic_data_no_reshape(%arg0: tensor<?x4xf32>) -> tensor<?x1x4xf32> {
+  %axes = onnx.Constant dense<[1]> : tensor<1xi64>
+  %0 = "onnx.Unsqueeze"(%arg0, %axes) : (tensor<?x4xf32>, tensor<1xi64>) -> tensor<?x1x4xf32>
+  onnx.Return %0 : tensor<?x1x4xf32>
+  // CHECK: "onnx.Unsqueeze"
+  // CHECK-NOT: "onnx.Reshape"
+}
+
+// -----
+// CHECK-LABEL: func @squeeze_unsqueeze_different_axes_to_single_reshape
+// Squeeze + Unsqueeze with non-matching axes both become Reshape and then fuse.
+func.func @squeeze_unsqueeze_different_axes_to_single_reshape(%arg0: tensor<10x1x10xf32>) -> tensor<10x10x1xf32> {
+  %s_axes = onnx.Constant dense<[1]> : tensor<1xi64>
+  %u_axes = onnx.Constant dense<[2]> : tensor<1xi64>
+  %2 = "onnx.Squeeze"(%arg0, %s_axes) : (tensor<10x1x10xf32>, tensor<1xi64>) -> tensor<10x10xf32>
+  %3 = "onnx.Unsqueeze"(%2, %u_axes) : (tensor<10x10xf32>, tensor<1xi64>) -> tensor<10x10x1xf32>
+  onnx.Return %3 : tensor<10x10x1xf32>
+  // CHECK: [[CST:%.+]] = onnx.Constant dense<[10, 10, 1]> : tensor<3xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, [[CST]]) {allowzero = 0 : si64}
+  // CHECK: onnx.Return [[RES]]
+  // CHECK-NOT: "onnx.Squeeze"
+  // CHECK-NOT: "onnx.Unsqueeze"
+}
+
+// -----
+// CHECK-LABEL: func @unsqueeze_cast_squeeze_to_cast
+// Unsqueeze + Cast + Squeeze with the same net shape restores to plain Cast
+// via the FuseCastBetweenReshapes pattern.
+func.func @unsqueeze_cast_squeeze_to_cast(%arg0: tensor<10x10xf32>) -> tensor<10x10xi64> {
+  %u_axes = onnx.Constant dense<[0, 2]> : tensor<2xi64>
+  %s_axes = onnx.Constant dense<[0, -2]> : tensor<2xi64>
+  %2 = "onnx.Unsqueeze"(%arg0, %u_axes) : (tensor<10x10xf32>, tensor<2xi64>) -> tensor<1x10x1x10xf32>
+  %3 = "onnx.Cast"(%2) {to = i64} : (tensor<1x10x1x10xf32>) -> tensor<1x10x1x10xi64>
+  %4 = "onnx.Squeeze"(%3, %s_axes) : (tensor<1x10x1x10xi64>, tensor<2xi64>) -> tensor<10x10xi64>
+  onnx.Return %4 : tensor<10x10xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Cast"(%arg0) {{.*}} : (tensor<10x10xf32>) -> tensor<10x10xi64>
+  // CHECK: onnx.Return [[RES]]
+  // CHECK-NOT: "onnx.Unsqueeze"
+  // CHECK-NOT: "onnx.Squeeze"
+}
+
+// -----
+// CHECK-LABEL: func @v11_ops_not_touched
+func.func @v11_ops_not_touched(%arg0: tensor<10x10xf32>) -> tensor<10x1x10xf32> {
+  %0 = "onnx.UnsqueezeV11"(%arg0) {axes=[0, 2]} : (tensor<10x10xf32>) -> tensor<1x10x1x10xf32>
+  %1 = "onnx.SqueezeV11"(%0) {axes=[0]} : (tensor<1x10x1x10xf32>) -> tensor<10x1x10xf32>
+  onnx.Return %1 : tensor<10x1x10xf32>
+  // CHECK: "onnx.UnsqueezeV11"
+  // CHECK: "onnx.SqueezeV11"
+  // CHECK-NOT: "onnx.Reshape"
+}

--- a/test/mlir/onnx/onnx_decompose_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_decompose_canonicalize.mlir
@@ -14,10 +14,10 @@ func.func @sequence_at_squeezed(%arg0 : tensor<1x1x100xf32>) -> tensor<1x100xf32
   return %33: tensor<1x100xf32>
 // CHECK-LABEL:  func.func @sequence_at_squeezed
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x100xf32>) -> tensor<1x100xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 100]> : tensor<2xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Split"([[PARAM_0_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<1x1x100xf32>, tensor<1xi64>) -> tensor<1x1x100xf32>
-// CHECK:           [[VAR_3_:%.+]] = "onnx.Squeeze"([[VAR_2_]], [[VAR_0_]]) : (tensor<1x1x100xf32>, tensor<1xi64>) -> tensor<1x100xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Reshape"([[VAR_2_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1x1x100xf32>, tensor<2xi64>) -> tensor<1x100xf32>
 // CHECK:           return [[VAR_3_]] : tensor<1x100xf32>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_hybrid_transform.mlir
+++ b/test/mlir/onnx/onnx_hybrid_transform.mlir
@@ -102,196 +102,200 @@ func.func @test_inception_v2_6_snippet(%arg0: tensor<1x3x224x224xf32>, %arg1: te
 }
 // CHECK-LABEL:  func.func @test_inception_v2_6_snippet
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x224x224xf32>, [[PARAM_1_:%.+]]: tensor<64x3x7x7xf32>) -> tensor<1x64x28x28xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<9.99999974E-6> : tensor<1xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
-// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<1.000000e-01> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<2.000000e-01> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<3.000000e-01> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<4.000000e-01> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<6.000000e-01> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<0.699999988> : tensor<64x64x1x1xf32>
-// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<8.000000e-01> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<0.899999976> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<1.100000e+00> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<1.200000e+00> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<1.300000e+00> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<1.400000e+00> : tensor<192x64x3x3xf32>
-// CHECK-DAG:       [[VAR_17_:%.+]] = onnx.Constant dense<1.500000e+00> : tensor<192xf32>
-// CHECK-DAG:       [[VAR_18_:%.+]] = onnx.Constant dense<1.600000e+00> : tensor<192xf32>
-// CHECK-DAG:       [[VAR_19_:%.+]] = onnx.Constant dense<1.700000e+00> : tensor<192xf32>
-// CHECK-DAG:       [[VAR_20_:%.+]] = onnx.Constant dense<1.800000e+00> : tensor<192xf32>
-// CHECK-DAG:       [[VAR_21_:%.+]] = onnx.Constant dense<1.900000e+00> : tensor<192xf32>
-// CHECK-DAG:       [[VAR_22_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<192xf32>
-// CHECK-DAG:       [[VAR_23_:%.+]] = onnx.Constant dense<4.200000e+00> : tensor<64x192x1x1xf32>
-// CHECK-DAG:       [[VAR_24_:%.+]] = onnx.Constant dense<4.300000e+00> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_25_:%.+]] = onnx.Constant dense<4.400000e+00> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_26_:%.+]] = onnx.Constant dense<4.500000e+00> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_27_:%.+]] = onnx.Constant dense<4.600000e+00> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_28_:%.+]] = onnx.Constant dense<4.700000e+00> : tensor<64xf32>
-// CHECK-DAG:       [[VAR_29_:%.+]] = onnx.Constant dense<4.800000e+00> : tensor<64xf32>
-// CHECK:           [[VAR_30_:%.+]] = "onnx.Add"([[VAR_6_]], [[VAR_1_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_31_:%.+]] = "onnx.Sqrt"([[VAR_30_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_32_:%.+]] = "onnx.Div"([[VAR_3_]], [[VAR_31_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_33_:%.+]] = "onnx.Unsqueeze"([[VAR_32_]], [[VAR_2_]]) : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1x1xf32>
-// CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Mul"([[PARAM_1_]], [[VAR_33_]]) : (tensor<64x3x7x7xf32>, tensor<64x1x1x1xf32>) -> tensor<64x3x7x7xf32>
-// CHECK-DAG:       [[VAR_35_:%.+]] = "onnx.Neg"([[VAR_5_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_36_:%.+]] = "onnx.Mul"([[VAR_32_]], [[VAR_35_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_37_:%.+]] = "onnx.Add"([[VAR_36_]], [[VAR_4_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// CHECK-DAG:       [[VAR_38_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_34_]], [[VAR_37_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [7, 7], pads = [3, 3, 3, 3], strides = [2, 2]} : (tensor<1x3x224x224xf32>, tensor<64x3x7x7xf32>, tensor<64xf32>) -> tensor<1x64x112x112xf32>
-// CHECK-DAG:       [[VAR_39_:%.+]] = "onnx.Unsqueeze"([[VAR_7_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[192, 1, 1, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[192, 1, 1]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[64, 1, 1, 1]> : tensor<4xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[64, 1, 1]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<1.000000e-01> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<2.000000e-01> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<3.000000e-01> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<4.000000e-01> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<6.000000e-01> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<0.699999988> : tensor<64x64x1x1xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<8.000000e-01> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<0.899999976> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<1.100000e+00> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<1.200000e+00> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<1.300000e+00> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_17_:%.+]] = onnx.Constant dense<1.400000e+00> : tensor<192x64x3x3xf32>
+// CHECK-DAG:       [[VAR_18_:%.+]] = onnx.Constant dense<1.500000e+00> : tensor<192xf32>
+// CHECK-DAG:       [[VAR_19_:%.+]] = onnx.Constant dense<1.600000e+00> : tensor<192xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = onnx.Constant dense<1.700000e+00> : tensor<192xf32>
+// CHECK-DAG:       [[VAR_21_:%.+]] = onnx.Constant dense<1.800000e+00> : tensor<192xf32>
+// CHECK-DAG:       [[VAR_22_:%.+]] = onnx.Constant dense<1.900000e+00> : tensor<192xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<192xf32>
+// CHECK-DAG:       [[VAR_24_:%.+]] = onnx.Constant dense<4.200000e+00> : tensor<64x192x1x1xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = onnx.Constant dense<4.300000e+00> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_26_:%.+]] = onnx.Constant dense<4.400000e+00> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = onnx.Constant dense<4.500000e+00> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_28_:%.+]] = onnx.Constant dense<4.600000e+00> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_29_:%.+]] = onnx.Constant dense<4.700000e+00> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_30_:%.+]] = onnx.Constant dense<4.800000e+00> : tensor<64xf32>
+// CHECK-DAG:       [[VAR_31_:%.+]] = onnx.Constant dense<9.99999974E-6> : tensor<1xf32>
+// CHECK:           [[VAR_32_:%.+]] = "onnx.Add"([[VAR_7_]], [[VAR_31_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_33_:%.+]] = "onnx.Sqrt"([[VAR_32_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_34_:%.+]] = "onnx.Div"([[VAR_4_]], [[VAR_33_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_35_:%.+]] = "onnx.Reshape"([[VAR_34_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<4xi64>) -> tensor<64x1x1x1xf32>
+// CHECK-DAG:       [[VAR_36_:%.+]] = "onnx.Mul"([[PARAM_1_]], [[VAR_35_]]) : (tensor<64x3x7x7xf32>, tensor<64x1x1x1xf32>) -> tensor<64x3x7x7xf32>
+// CHECK-DAG:       [[VAR_37_:%.+]] = "onnx.Neg"([[VAR_6_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_38_:%.+]] = "onnx.Mul"([[VAR_34_]], [[VAR_37_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_39_:%.+]] = "onnx.Add"([[VAR_38_]], [[VAR_5_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// CHECK-DAG:       [[VAR_40_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_36_]], [[VAR_39_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [7, 7], pads = [3, 3, 3, 3], strides = [2, 2]} : (tensor<1x3x224x224xf32>, tensor<64x3x7x7xf32>, tensor<64xf32>) -> tensor<1x64x112x112xf32>
+// CHECK-DAG:       [[VAR_41_:%.+]] = "onnx.Reshape"([[VAR_8_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_40_:%.+]] = "onnx.Mul"([[VAR_38_]], [[VAR_39_]]) : (tensor<1x64x112x112xf32>, tensor<64x1x1xf32>) -> tensor<1x64x112x112xf32>
-// CHECK-DAG:       [[VAR_41_:%.+]] = "onnx.Unsqueeze"([[VAR_8_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
-// CHECK:           [[VAR_42_:%.+]] = "onnx.Add"([[VAR_40_]], [[VAR_41_]]) : (tensor<1x64x112x112xf32>, tensor<64x1x1xf32>) -> tensor<1x64x112x112xf32>
-// CHECK:           [[VAR_43_:%.+]] = "onnx.MaxPoolSingleOut"([[VAR_42_]]) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3, 3], pads = [0, 0, 1, 1], storage_order = 0 : si64, strides = [2, 2]} : (tensor<1x64x112x112xf32>) -> tensor<1x64x56x56xf32>
-// CHECK-DAG:       [[VAR_44_:%.+]] = "onnx.Relu"([[VAR_43_]]) : (tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
-// CHECK-DAG:       [[VAR_45_:%.+]] = "onnx.Add"([[VAR_13_]], [[VAR_1_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_46_:%.+]] = "onnx.Sqrt"([[VAR_45_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_47_:%.+]] = "onnx.Div"([[VAR_10_]], [[VAR_46_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_48_:%.+]] = "onnx.Unsqueeze"([[VAR_47_]], [[VAR_2_]]) : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1x1xf32>
-// CHECK-DAG:       [[VAR_49_:%.+]] = "onnx.Mul"([[VAR_48_]], [[VAR_9_]]) : (tensor<64x1x1x1xf32>, tensor<64x64x1x1xf32>) -> tensor<64x64x1x1xf32>
-// CHECK-DAG:       [[VAR_50_:%.+]] = "onnx.Neg"([[VAR_12_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_51_:%.+]] = "onnx.Mul"([[VAR_47_]], [[VAR_50_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_52_:%.+]] = "onnx.Add"([[VAR_51_]], [[VAR_11_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// CHECK-DAG:       [[VAR_53_:%.+]] = "onnx.Conv"([[VAR_44_]], [[VAR_49_]], [[VAR_52_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x64x56x56xf32>, tensor<64x64x1x1xf32>, tensor<64xf32>) -> tensor<1x64x56x56xf32>
-// CHECK-DAG:       [[VAR_54_:%.+]] = "onnx.Unsqueeze"([[VAR_14_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
+// CHECK-DAG:       [[VAR_42_:%.+]] = "onnx.Mul"([[VAR_40_]], [[VAR_41_]]) : (tensor<1x64x112x112xf32>, tensor<64x1x1xf32>) -> tensor<1x64x112x112xf32>
+// CHECK-DAG:       [[VAR_43_:%.+]] = "onnx.Reshape"([[VAR_9_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
+// CHECK:           [[VAR_44_:%.+]] = "onnx.Add"([[VAR_42_]], [[VAR_43_]]) : (tensor<1x64x112x112xf32>, tensor<64x1x1xf32>) -> tensor<1x64x112x112xf32>
+// CHECK:           [[VAR_45_:%.+]] = "onnx.MaxPoolSingleOut"([[VAR_44_]]) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3, 3], pads = [0, 0, 1, 1], storage_order = 0 : si64, strides = [2, 2]} : (tensor<1x64x112x112xf32>) -> tensor<1x64x56x56xf32>
+// CHECK-DAG:       [[VAR_46_:%.+]] = "onnx.Relu"([[VAR_45_]]) : (tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+// CHECK-DAG:       [[VAR_47_:%.+]] = "onnx.Add"([[VAR_14_]], [[VAR_31_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_48_:%.+]] = "onnx.Sqrt"([[VAR_47_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_49_:%.+]] = "onnx.Div"([[VAR_11_]], [[VAR_48_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_50_:%.+]] = "onnx.Reshape"([[VAR_49_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<4xi64>) -> tensor<64x1x1x1xf32>
+// CHECK-DAG:       [[VAR_51_:%.+]] = "onnx.Mul"([[VAR_50_]], [[VAR_10_]]) : (tensor<64x1x1x1xf32>, tensor<64x64x1x1xf32>) -> tensor<64x64x1x1xf32>
+// CHECK-DAG:       [[VAR_52_:%.+]] = "onnx.Neg"([[VAR_13_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_53_:%.+]] = "onnx.Mul"([[VAR_49_]], [[VAR_52_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_54_:%.+]] = "onnx.Add"([[VAR_53_]], [[VAR_12_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// CHECK-DAG:       [[VAR_55_:%.+]] = "onnx.Conv"([[VAR_46_]], [[VAR_51_]], [[VAR_54_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x64x56x56xf32>, tensor<64x64x1x1xf32>, tensor<64xf32>) -> tensor<1x64x56x56xf32>
+// CHECK-DAG:       [[VAR_56_:%.+]] = "onnx.Reshape"([[VAR_15_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_55_:%.+]] = "onnx.Mul"([[VAR_53_]], [[VAR_54_]]) : (tensor<1x64x56x56xf32>, tensor<64x1x1xf32>) -> tensor<1x64x56x56xf32>
-// CHECK-DAG:       [[VAR_56_:%.+]] = "onnx.Unsqueeze"([[VAR_15_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
-// CHECK:           [[VAR_57_:%.+]] = "onnx.Add"([[VAR_55_]], [[VAR_56_]]) : (tensor<1x64x56x56xf32>, tensor<64x1x1xf32>) -> tensor<1x64x56x56xf32>
-// CHECK-DAG:       [[VAR_58_:%.+]] = "onnx.Relu"([[VAR_57_]]) : (tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
-// CHECK-DAG:       [[VAR_59_:%.+]] = "onnx.Add"([[VAR_20_]], [[VAR_1_]]) : (tensor<192xf32>, tensor<1xf32>) -> tensor<192xf32>
-// CHECK:           [[VAR_60_:%.+]] = "onnx.Sqrt"([[VAR_59_]]) : (tensor<192xf32>) -> tensor<192xf32>
-// CHECK:           [[VAR_61_:%.+]] = "onnx.Div"([[VAR_17_]], [[VAR_60_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
-// CHECK:           [[VAR_62_:%.+]] = "onnx.Unsqueeze"([[VAR_61_]], [[VAR_2_]]) : (tensor<192xf32>, tensor<3xi64>) -> tensor<192x1x1x1xf32>
-// CHECK-DAG:       [[VAR_63_:%.+]] = "onnx.Mul"([[VAR_62_]], [[VAR_16_]]) : (tensor<192x1x1x1xf32>, tensor<192x64x3x3xf32>) -> tensor<192x64x3x3xf32>
-// CHECK-DAG:       [[VAR_64_:%.+]] = "onnx.Neg"([[VAR_19_]]) : (tensor<192xf32>) -> tensor<192xf32>
-// CHECK:           [[VAR_65_:%.+]] = "onnx.Mul"([[VAR_61_]], [[VAR_64_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
-// CHECK:           [[VAR_66_:%.+]] = "onnx.Add"([[VAR_65_]], [[VAR_18_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
-// CHECK-DAG:       [[VAR_67_:%.+]] = "onnx.Conv"([[VAR_58_]], [[VAR_63_]], [[VAR_66_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x64x56x56xf32>, tensor<192x64x3x3xf32>, tensor<192xf32>) -> tensor<1x192x56x56xf32>
-// CHECK-DAG:       [[VAR_68_:%.+]] = "onnx.Unsqueeze"([[VAR_21_]], [[VAR_0_]]) : (tensor<192xf32>, tensor<2xi64>) -> tensor<192x1x1xf32>
+// CHECK-DAG:       [[VAR_57_:%.+]] = "onnx.Mul"([[VAR_55_]], [[VAR_56_]]) : (tensor<1x64x56x56xf32>, tensor<64x1x1xf32>) -> tensor<1x64x56x56xf32>
+// CHECK-DAG:       [[VAR_58_:%.+]] = "onnx.Reshape"([[VAR_16_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
+// CHECK:           [[VAR_59_:%.+]] = "onnx.Add"([[VAR_57_]], [[VAR_58_]]) : (tensor<1x64x56x56xf32>, tensor<64x1x1xf32>) -> tensor<1x64x56x56xf32>
+// CHECK-DAG:       [[VAR_60_:%.+]] = "onnx.Relu"([[VAR_59_]]) : (tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+// CHECK-DAG:       [[VAR_61_:%.+]] = "onnx.Add"([[VAR_21_]], [[VAR_31_]]) : (tensor<192xf32>, tensor<1xf32>) -> tensor<192xf32>
+// CHECK:           [[VAR_62_:%.+]] = "onnx.Sqrt"([[VAR_61_]]) : (tensor<192xf32>) -> tensor<192xf32>
+// CHECK:           [[VAR_63_:%.+]] = "onnx.Div"([[VAR_18_]], [[VAR_62_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
+// CHECK:           [[VAR_64_:%.+]] = "onnx.Reshape"([[VAR_63_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<192xf32>, tensor<4xi64>) -> tensor<192x1x1x1xf32>
+// CHECK-DAG:       [[VAR_65_:%.+]] = "onnx.Mul"([[VAR_64_]], [[VAR_17_]]) : (tensor<192x1x1x1xf32>, tensor<192x64x3x3xf32>) -> tensor<192x64x3x3xf32>
+// CHECK-DAG:       [[VAR_66_:%.+]] = "onnx.Neg"([[VAR_20_]]) : (tensor<192xf32>) -> tensor<192xf32>
+// CHECK:           [[VAR_67_:%.+]] = "onnx.Mul"([[VAR_63_]], [[VAR_66_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
+// CHECK:           [[VAR_68_:%.+]] = "onnx.Add"([[VAR_67_]], [[VAR_19_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
+// CHECK-DAG:       [[VAR_69_:%.+]] = "onnx.Conv"([[VAR_60_]], [[VAR_65_]], [[VAR_68_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x64x56x56xf32>, tensor<192x64x3x3xf32>, tensor<192xf32>) -> tensor<1x192x56x56xf32>
+// CHECK-DAG:       [[VAR_70_:%.+]] = "onnx.Reshape"([[VAR_22_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<192xf32>, tensor<3xi64>) -> tensor<192x1x1xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_69_:%.+]] = "onnx.Mul"([[VAR_67_]], [[VAR_68_]]) : (tensor<1x192x56x56xf32>, tensor<192x1x1xf32>) -> tensor<1x192x56x56xf32>
-// CHECK-DAG:       [[VAR_70_:%.+]] = "onnx.Unsqueeze"([[VAR_22_]], [[VAR_0_]]) : (tensor<192xf32>, tensor<2xi64>) -> tensor<192x1x1xf32>
-// CHECK:           [[VAR_71_:%.+]] = "onnx.Add"([[VAR_69_]], [[VAR_70_]]) : (tensor<1x192x56x56xf32>, tensor<192x1x1xf32>) -> tensor<1x192x56x56xf32>
-// CHECK:           [[VAR_72_:%.+]] = "onnx.MaxPoolSingleOut"([[VAR_71_]]) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3, 3], pads = [0, 0, 1, 1], storage_order = 0 : si64, strides = [2, 2]} : (tensor<1x192x56x56xf32>) -> tensor<1x192x28x28xf32>
-// CHECK-DAG:       [[VAR_73_:%.+]] = "onnx.Relu"([[VAR_72_]]) : (tensor<1x192x28x28xf32>) -> tensor<1x192x28x28xf32>
-// CHECK-DAG:       [[VAR_74_:%.+]] = "onnx.Add"([[VAR_27_]], [[VAR_1_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_75_:%.+]] = "onnx.Sqrt"([[VAR_74_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_76_:%.+]] = "onnx.Div"([[VAR_24_]], [[VAR_75_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_77_:%.+]] = "onnx.Unsqueeze"([[VAR_76_]], [[VAR_2_]]) : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1x1xf32>
-// CHECK-DAG:       [[VAR_78_:%.+]] = "onnx.Mul"([[VAR_77_]], [[VAR_23_]]) : (tensor<64x1x1x1xf32>, tensor<64x192x1x1xf32>) -> tensor<64x192x1x1xf32>
-// CHECK-DAG:       [[VAR_79_:%.+]] = "onnx.Neg"([[VAR_26_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_80_:%.+]] = "onnx.Mul"([[VAR_76_]], [[VAR_79_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_81_:%.+]] = "onnx.Add"([[VAR_80_]], [[VAR_25_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// CHECK-DAG:       [[VAR_82_:%.+]] = "onnx.Conv"([[VAR_73_]], [[VAR_78_]], [[VAR_81_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x192x28x28xf32>, tensor<64x192x1x1xf32>, tensor<64xf32>) -> tensor<1x64x28x28xf32>
-// CHECK-DAG:       [[VAR_83_:%.+]] = "onnx.Unsqueeze"([[VAR_28_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
+// CHECK-DAG:       [[VAR_71_:%.+]] = "onnx.Mul"([[VAR_69_]], [[VAR_70_]]) : (tensor<1x192x56x56xf32>, tensor<192x1x1xf32>) -> tensor<1x192x56x56xf32>
+// CHECK-DAG:       [[VAR_72_:%.+]] = "onnx.Reshape"([[VAR_23_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<192xf32>, tensor<3xi64>) -> tensor<192x1x1xf32>
+// CHECK:           [[VAR_73_:%.+]] = "onnx.Add"([[VAR_71_]], [[VAR_72_]]) : (tensor<1x192x56x56xf32>, tensor<192x1x1xf32>) -> tensor<1x192x56x56xf32>
+// CHECK:           [[VAR_74_:%.+]] = "onnx.MaxPoolSingleOut"([[VAR_73_]]) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3, 3], pads = [0, 0, 1, 1], storage_order = 0 : si64, strides = [2, 2]} : (tensor<1x192x56x56xf32>) -> tensor<1x192x28x28xf32>
+// CHECK-DAG:       [[VAR_75_:%.+]] = "onnx.Relu"([[VAR_74_]]) : (tensor<1x192x28x28xf32>) -> tensor<1x192x28x28xf32>
+// CHECK-DAG:       [[VAR_76_:%.+]] = "onnx.Add"([[VAR_28_]], [[VAR_31_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_77_:%.+]] = "onnx.Sqrt"([[VAR_76_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_78_:%.+]] = "onnx.Div"([[VAR_25_]], [[VAR_77_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_79_:%.+]] = "onnx.Reshape"([[VAR_78_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<4xi64>) -> tensor<64x1x1x1xf32>
+// CHECK-DAG:       [[VAR_80_:%.+]] = "onnx.Mul"([[VAR_79_]], [[VAR_24_]]) : (tensor<64x1x1x1xf32>, tensor<64x192x1x1xf32>) -> tensor<64x192x1x1xf32>
+// CHECK-DAG:       [[VAR_81_:%.+]] = "onnx.Neg"([[VAR_27_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_82_:%.+]] = "onnx.Mul"([[VAR_78_]], [[VAR_81_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_83_:%.+]] = "onnx.Add"([[VAR_82_]], [[VAR_26_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// CHECK-DAG:       [[VAR_84_:%.+]] = "onnx.Conv"([[VAR_75_]], [[VAR_80_]], [[VAR_83_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x192x28x28xf32>, tensor<64x192x1x1xf32>, tensor<64xf32>) -> tensor<1x64x28x28xf32>
+// CHECK-DAG:       [[VAR_85_:%.+]] = "onnx.Reshape"([[VAR_29_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_84_:%.+]] = "onnx.Mul"([[VAR_82_]], [[VAR_83_]]) : (tensor<1x64x28x28xf32>, tensor<64x1x1xf32>) -> tensor<1x64x28x28xf32>
-// CHECK-DAG:       [[VAR_85_:%.+]] = "onnx.Unsqueeze"([[VAR_29_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
-// CHECK:           [[VAR_86_:%.+]] = "onnx.Add"([[VAR_84_]], [[VAR_85_]]) : (tensor<1x64x28x28xf32>, tensor<64x1x1xf32>) -> tensor<1x64x28x28xf32>
-// CHECK:           [[VAR_87_:%.+]] = "onnx.Relu"([[VAR_86_]]) : (tensor<1x64x28x28xf32>) -> tensor<1x64x28x28xf32>
-// CHECK:           return [[VAR_87_]] : tensor<1x64x28x28xf32>
+// CHECK-DAG:       [[VAR_86_:%.+]] = "onnx.Mul"([[VAR_84_]], [[VAR_85_]]) : (tensor<1x64x28x28xf32>, tensor<64x1x1xf32>) -> tensor<1x64x28x28xf32>
+// CHECK-DAG:       [[VAR_87_:%.+]] = "onnx.Reshape"([[VAR_30_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
+// CHECK:           [[VAR_88_:%.+]] = "onnx.Add"([[VAR_86_]], [[VAR_87_]]) : (tensor<1x64x28x28xf32>, tensor<64x1x1xf32>) -> tensor<1x64x28x28xf32>
+// CHECK:           [[VAR_89_:%.+]] = "onnx.Relu"([[VAR_88_]]) : (tensor<1x64x28x28xf32>) -> tensor<1x64x28x28xf32>
+// CHECK:           return [[VAR_89_]] : tensor<1x64x28x28xf32>
 // CHECK:         }
 
 // DECOMPOSE-LABEL:  func.func @test_inception_v2_6_snippet
 // DECOMPOSE-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x224x224xf32>, [[PARAM_1_:%.+]]: tensor<64x3x7x7xf32>) -> tensor<1x64x28x28xf32> {
-// DECOMPOSE-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-// DECOMPOSE-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<9.99999974E-6> : tensor<1xf32>
-// DECOMPOSE-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
-// DECOMPOSE-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<1.000000e-01> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<2.000000e-01> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<3.000000e-01> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<4.000000e-01> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<6.000000e-01> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<0.699999988> : tensor<64x64x1x1xf32>
-// DECOMPOSE-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<8.000000e-01> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<0.899999976> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<1.100000e+00> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<1.200000e+00> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<1.300000e+00> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<1.400000e+00> : tensor<192x64x3x3xf32>
-// DECOMPOSE-DAG:       [[VAR_17_:%.+]] = onnx.Constant dense<1.500000e+00> : tensor<192xf32>
-// DECOMPOSE-DAG:       [[VAR_18_:%.+]] = onnx.Constant dense<1.600000e+00> : tensor<192xf32>
-// DECOMPOSE-DAG:       [[VAR_19_:%.+]] = onnx.Constant dense<1.700000e+00> : tensor<192xf32>
-// DECOMPOSE-DAG:       [[VAR_20_:%.+]] = onnx.Constant dense<1.800000e+00> : tensor<192xf32>
-// DECOMPOSE-DAG:       [[VAR_21_:%.+]] = onnx.Constant dense<1.900000e+00> : tensor<192xf32>
-// DECOMPOSE-DAG:       [[VAR_22_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<192xf32>
-// DECOMPOSE-DAG:       [[VAR_23_:%.+]] = onnx.Constant dense<4.200000e+00> : tensor<64x192x1x1xf32>
-// DECOMPOSE-DAG:       [[VAR_24_:%.+]] = onnx.Constant dense<4.300000e+00> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_25_:%.+]] = onnx.Constant dense<4.400000e+00> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_26_:%.+]] = onnx.Constant dense<4.500000e+00> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_27_:%.+]] = onnx.Constant dense<4.600000e+00> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_28_:%.+]] = onnx.Constant dense<4.700000e+00> : tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_29_:%.+]] = onnx.Constant dense<4.800000e+00> : tensor<64xf32>
-// DECOMPOSE:           [[VAR_30_:%.+]] = "onnx.Add"([[VAR_6_]], [[VAR_1_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_31_:%.+]] = "onnx.Sqrt"([[VAR_30_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_32_:%.+]] = "onnx.Div"([[VAR_3_]], [[VAR_31_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_33_:%.+]] = "onnx.Unsqueeze"([[VAR_32_]], [[VAR_2_]]) : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1x1xf32>
-// DECOMPOSE-DAG:       [[VAR_34_:%.+]] = "onnx.Mul"([[PARAM_1_]], [[VAR_33_]]) : (tensor<64x3x7x7xf32>, tensor<64x1x1x1xf32>) -> tensor<64x3x7x7xf32>
-// DECOMPOSE-DAG:       [[VAR_35_:%.+]] = "onnx.Neg"([[VAR_5_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_36_:%.+]] = "onnx.Mul"([[VAR_32_]], [[VAR_35_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_37_:%.+]] = "onnx.Add"([[VAR_36_]], [[VAR_4_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_38_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_34_]], [[VAR_37_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [7, 7], pads = [3, 3, 3, 3], strides = [2, 2]} : (tensor<1x3x224x224xf32>, tensor<64x3x7x7xf32>, tensor<64xf32>) -> tensor<1x64x112x112xf32>
-// DECOMPOSE-DAG:       [[VAR_39_:%.+]] = "onnx.Unsqueeze"([[VAR_7_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[192, 1, 1, 1]> : tensor<4xi64>
+// DECOMPOSE-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[192, 1, 1]> : tensor<3xi64>
+// DECOMPOSE-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[64, 1, 1, 1]> : tensor<4xi64>
+// DECOMPOSE-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[64, 1, 1]> : tensor<3xi64>
+// DECOMPOSE-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<1.000000e-01> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<2.000000e-01> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_6_:%.+]] = onnx.Constant dense<3.000000e-01> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_7_:%.+]] = onnx.Constant dense<4.000000e-01> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_8_:%.+]] = onnx.Constant dense<5.000000e-01> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<6.000000e-01> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<0.699999988> : tensor<64x64x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<8.000000e-01> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_12_:%.+]] = onnx.Constant dense<0.899999976> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_13_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_14_:%.+]] = onnx.Constant dense<1.100000e+00> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_15_:%.+]] = onnx.Constant dense<1.200000e+00> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_16_:%.+]] = onnx.Constant dense<1.300000e+00> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_17_:%.+]] = onnx.Constant dense<1.400000e+00> : tensor<192x64x3x3xf32>
+// DECOMPOSE-DAG:       [[VAR_18_:%.+]] = onnx.Constant dense<1.500000e+00> : tensor<192xf32>
+// DECOMPOSE-DAG:       [[VAR_19_:%.+]] = onnx.Constant dense<1.600000e+00> : tensor<192xf32>
+// DECOMPOSE-DAG:       [[VAR_20_:%.+]] = onnx.Constant dense<1.700000e+00> : tensor<192xf32>
+// DECOMPOSE-DAG:       [[VAR_21_:%.+]] = onnx.Constant dense<1.800000e+00> : tensor<192xf32>
+// DECOMPOSE-DAG:       [[VAR_22_:%.+]] = onnx.Constant dense<1.900000e+00> : tensor<192xf32>
+// DECOMPOSE-DAG:       [[VAR_23_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<192xf32>
+// DECOMPOSE-DAG:       [[VAR_24_:%.+]] = onnx.Constant dense<4.200000e+00> : tensor<64x192x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_25_:%.+]] = onnx.Constant dense<4.300000e+00> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_26_:%.+]] = onnx.Constant dense<4.400000e+00> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_27_:%.+]] = onnx.Constant dense<4.500000e+00> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_28_:%.+]] = onnx.Constant dense<4.600000e+00> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_29_:%.+]] = onnx.Constant dense<4.700000e+00> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_30_:%.+]] = onnx.Constant dense<4.800000e+00> : tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_31_:%.+]] = onnx.Constant dense<9.99999974E-6> : tensor<1xf32>
+// DECOMPOSE:           [[VAR_32_:%.+]] = "onnx.Add"([[VAR_7_]], [[VAR_31_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_33_:%.+]] = "onnx.Sqrt"([[VAR_32_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_34_:%.+]] = "onnx.Div"([[VAR_4_]], [[VAR_33_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_35_:%.+]] = "onnx.Reshape"([[VAR_34_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<4xi64>) -> tensor<64x1x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_36_:%.+]] = "onnx.Mul"([[PARAM_1_]], [[VAR_35_]]) : (tensor<64x3x7x7xf32>, tensor<64x1x1x1xf32>) -> tensor<64x3x7x7xf32>
+// DECOMPOSE-DAG:       [[VAR_37_:%.+]] = "onnx.Neg"([[VAR_6_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_38_:%.+]] = "onnx.Mul"([[VAR_34_]], [[VAR_37_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_39_:%.+]] = "onnx.Add"([[VAR_38_]], [[VAR_5_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_40_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_36_]], [[VAR_39_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [7, 7], pads = [3, 3, 3, 3], strides = [2, 2]} : (tensor<1x3x224x224xf32>, tensor<64x3x7x7xf32>, tensor<64xf32>) -> tensor<1x64x112x112xf32>
+// DECOMPOSE-DAG:       [[VAR_41_:%.+]] = "onnx.Reshape"([[VAR_8_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
 // DECOMPOSE-NOT: separator of consecutive DAGs
-// DECOMPOSE-DAG:       [[VAR_40_:%.+]] = "onnx.Mul"([[VAR_38_]], [[VAR_39_]]) : (tensor<1x64x112x112xf32>, tensor<64x1x1xf32>) -> tensor<1x64x112x112xf32>
-// DECOMPOSE-DAG:       [[VAR_41_:%.+]] = "onnx.Unsqueeze"([[VAR_8_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
-// DECOMPOSE:           [[VAR_42_:%.+]] = "onnx.Add"([[VAR_40_]], [[VAR_41_]]) : (tensor<1x64x112x112xf32>, tensor<64x1x1xf32>) -> tensor<1x64x112x112xf32>
-// DECOMPOSE:           [[VAR_43_:%.+]] = "onnx.MaxPoolSingleOut"([[VAR_42_]]) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3, 3], pads = [0, 0, 1, 1], storage_order = 0 : si64, strides = [2, 2]} : (tensor<1x64x112x112xf32>) -> tensor<1x64x56x56xf32>
-// DECOMPOSE-DAG:       [[VAR_44_:%.+]] = "onnx.Relu"([[VAR_43_]]) : (tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
-// DECOMPOSE-DAG:       [[VAR_45_:%.+]] = "onnx.Add"([[VAR_13_]], [[VAR_1_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_46_:%.+]] = "onnx.Sqrt"([[VAR_45_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_47_:%.+]] = "onnx.Div"([[VAR_10_]], [[VAR_46_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_48_:%.+]] = "onnx.Unsqueeze"([[VAR_47_]], [[VAR_2_]]) : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1x1xf32>
-// DECOMPOSE-DAG:       [[VAR_49_:%.+]] = "onnx.Mul"([[VAR_48_]], [[VAR_9_]]) : (tensor<64x1x1x1xf32>, tensor<64x64x1x1xf32>) -> tensor<64x64x1x1xf32>
-// DECOMPOSE-DAG:       [[VAR_50_:%.+]] = "onnx.Neg"([[VAR_12_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_51_:%.+]] = "onnx.Mul"([[VAR_47_]], [[VAR_50_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_52_:%.+]] = "onnx.Add"([[VAR_51_]], [[VAR_11_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_53_:%.+]] = "onnx.Conv"([[VAR_44_]], [[VAR_49_]], [[VAR_52_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x64x56x56xf32>, tensor<64x64x1x1xf32>, tensor<64xf32>) -> tensor<1x64x56x56xf32>
-// DECOMPOSE-DAG:       [[VAR_54_:%.+]] = "onnx.Unsqueeze"([[VAR_14_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_42_:%.+]] = "onnx.Mul"([[VAR_40_]], [[VAR_41_]]) : (tensor<1x64x112x112xf32>, tensor<64x1x1xf32>) -> tensor<1x64x112x112xf32>
+// DECOMPOSE-DAG:       [[VAR_43_:%.+]] = "onnx.Reshape"([[VAR_9_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
+// DECOMPOSE:           [[VAR_44_:%.+]] = "onnx.Add"([[VAR_42_]], [[VAR_43_]]) : (tensor<1x64x112x112xf32>, tensor<64x1x1xf32>) -> tensor<1x64x112x112xf32>
+// DECOMPOSE:           [[VAR_45_:%.+]] = "onnx.MaxPoolSingleOut"([[VAR_44_]]) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3, 3], pads = [0, 0, 1, 1], storage_order = 0 : si64, strides = [2, 2]} : (tensor<1x64x112x112xf32>) -> tensor<1x64x56x56xf32>
+// DECOMPOSE-DAG:       [[VAR_46_:%.+]] = "onnx.Relu"([[VAR_45_]]) : (tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+// DECOMPOSE-DAG:       [[VAR_47_:%.+]] = "onnx.Add"([[VAR_14_]], [[VAR_31_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_48_:%.+]] = "onnx.Sqrt"([[VAR_47_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_49_:%.+]] = "onnx.Div"([[VAR_11_]], [[VAR_48_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_50_:%.+]] = "onnx.Reshape"([[VAR_49_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<4xi64>) -> tensor<64x1x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_51_:%.+]] = "onnx.Mul"([[VAR_50_]], [[VAR_10_]]) : (tensor<64x1x1x1xf32>, tensor<64x64x1x1xf32>) -> tensor<64x64x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_52_:%.+]] = "onnx.Neg"([[VAR_13_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_53_:%.+]] = "onnx.Mul"([[VAR_49_]], [[VAR_52_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_54_:%.+]] = "onnx.Add"([[VAR_53_]], [[VAR_12_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_55_:%.+]] = "onnx.Conv"([[VAR_46_]], [[VAR_51_]], [[VAR_54_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x64x56x56xf32>, tensor<64x64x1x1xf32>, tensor<64xf32>) -> tensor<1x64x56x56xf32>
+// DECOMPOSE-DAG:       [[VAR_56_:%.+]] = "onnx.Reshape"([[VAR_15_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
 // DECOMPOSE-NOT: separator of consecutive DAGs
-// DECOMPOSE-DAG:       [[VAR_55_:%.+]] = "onnx.Mul"([[VAR_53_]], [[VAR_54_]]) : (tensor<1x64x56x56xf32>, tensor<64x1x1xf32>) -> tensor<1x64x56x56xf32>
-// DECOMPOSE-DAG:       [[VAR_56_:%.+]] = "onnx.Unsqueeze"([[VAR_15_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
-// DECOMPOSE:           [[VAR_57_:%.+]] = "onnx.Add"([[VAR_55_]], [[VAR_56_]]) : (tensor<1x64x56x56xf32>, tensor<64x1x1xf32>) -> tensor<1x64x56x56xf32>
-// DECOMPOSE-DAG:       [[VAR_58_:%.+]] = "onnx.Relu"([[VAR_57_]]) : (tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
-// DECOMPOSE-DAG:       [[VAR_59_:%.+]] = "onnx.Add"([[VAR_20_]], [[VAR_1_]]) : (tensor<192xf32>, tensor<1xf32>) -> tensor<192xf32>
-// DECOMPOSE:           [[VAR_60_:%.+]] = "onnx.Sqrt"([[VAR_59_]]) : (tensor<192xf32>) -> tensor<192xf32>
-// DECOMPOSE:           [[VAR_61_:%.+]] = "onnx.Div"([[VAR_17_]], [[VAR_60_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
-// DECOMPOSE:           [[VAR_62_:%.+]] = "onnx.Unsqueeze"([[VAR_61_]], [[VAR_2_]]) : (tensor<192xf32>, tensor<3xi64>) -> tensor<192x1x1x1xf32>
-// DECOMPOSE-DAG:       [[VAR_63_:%.+]] = "onnx.Mul"([[VAR_62_]], [[VAR_16_]]) : (tensor<192x1x1x1xf32>, tensor<192x64x3x3xf32>) -> tensor<192x64x3x3xf32>
-// DECOMPOSE-DAG:       [[VAR_64_:%.+]] = "onnx.Neg"([[VAR_19_]]) : (tensor<192xf32>) -> tensor<192xf32>
-// DECOMPOSE:           [[VAR_65_:%.+]] = "onnx.Mul"([[VAR_61_]], [[VAR_64_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
-// DECOMPOSE:           [[VAR_66_:%.+]] = "onnx.Add"([[VAR_65_]], [[VAR_18_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
-// DECOMPOSE-DAG:       [[VAR_67_:%.+]] = "onnx.Conv"([[VAR_58_]], [[VAR_63_]], [[VAR_66_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x64x56x56xf32>, tensor<192x64x3x3xf32>, tensor<192xf32>) -> tensor<1x192x56x56xf32>
-// DECOMPOSE-DAG:       [[VAR_68_:%.+]] = "onnx.Unsqueeze"([[VAR_21_]], [[VAR_0_]]) : (tensor<192xf32>, tensor<2xi64>) -> tensor<192x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_57_:%.+]] = "onnx.Mul"([[VAR_55_]], [[VAR_56_]]) : (tensor<1x64x56x56xf32>, tensor<64x1x1xf32>) -> tensor<1x64x56x56xf32>
+// DECOMPOSE-DAG:       [[VAR_58_:%.+]] = "onnx.Reshape"([[VAR_16_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
+// DECOMPOSE:           [[VAR_59_:%.+]] = "onnx.Add"([[VAR_57_]], [[VAR_58_]]) : (tensor<1x64x56x56xf32>, tensor<64x1x1xf32>) -> tensor<1x64x56x56xf32>
+// DECOMPOSE-DAG:       [[VAR_60_:%.+]] = "onnx.Relu"([[VAR_59_]]) : (tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+// DECOMPOSE-DAG:       [[VAR_61_:%.+]] = "onnx.Add"([[VAR_21_]], [[VAR_31_]]) : (tensor<192xf32>, tensor<1xf32>) -> tensor<192xf32>
+// DECOMPOSE:           [[VAR_62_:%.+]] = "onnx.Sqrt"([[VAR_61_]]) : (tensor<192xf32>) -> tensor<192xf32>
+// DECOMPOSE:           [[VAR_63_:%.+]] = "onnx.Div"([[VAR_18_]], [[VAR_62_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
+// DECOMPOSE:           [[VAR_64_:%.+]] = "onnx.Reshape"([[VAR_63_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<192xf32>, tensor<4xi64>) -> tensor<192x1x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_65_:%.+]] = "onnx.Mul"([[VAR_64_]], [[VAR_17_]]) : (tensor<192x1x1x1xf32>, tensor<192x64x3x3xf32>) -> tensor<192x64x3x3xf32>
+// DECOMPOSE-DAG:       [[VAR_66_:%.+]] = "onnx.Neg"([[VAR_20_]]) : (tensor<192xf32>) -> tensor<192xf32>
+// DECOMPOSE:           [[VAR_67_:%.+]] = "onnx.Mul"([[VAR_63_]], [[VAR_66_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
+// DECOMPOSE:           [[VAR_68_:%.+]] = "onnx.Add"([[VAR_67_]], [[VAR_19_]]) : (tensor<192xf32>, tensor<192xf32>) -> tensor<192xf32>
+// DECOMPOSE-DAG:       [[VAR_69_:%.+]] = "onnx.Conv"([[VAR_60_]], [[VAR_65_]], [[VAR_68_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : (tensor<1x64x56x56xf32>, tensor<192x64x3x3xf32>, tensor<192xf32>) -> tensor<1x192x56x56xf32>
+// DECOMPOSE-DAG:       [[VAR_70_:%.+]] = "onnx.Reshape"([[VAR_22_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<192xf32>, tensor<3xi64>) -> tensor<192x1x1xf32>
 // DECOMPOSE-NOT: separator of consecutive DAGs
-// DECOMPOSE-DAG:       [[VAR_69_:%.+]] = "onnx.Mul"([[VAR_67_]], [[VAR_68_]]) : (tensor<1x192x56x56xf32>, tensor<192x1x1xf32>) -> tensor<1x192x56x56xf32>
-// DECOMPOSE-DAG:       [[VAR_70_:%.+]] = "onnx.Unsqueeze"([[VAR_22_]], [[VAR_0_]]) : (tensor<192xf32>, tensor<2xi64>) -> tensor<192x1x1xf32>
-// DECOMPOSE:           [[VAR_71_:%.+]] = "onnx.Add"([[VAR_69_]], [[VAR_70_]]) : (tensor<1x192x56x56xf32>, tensor<192x1x1xf32>) -> tensor<1x192x56x56xf32>
-// DECOMPOSE:           [[VAR_72_:%.+]] = "onnx.MaxPoolSingleOut"([[VAR_71_]]) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3, 3], pads = [0, 0, 1, 1], storage_order = 0 : si64, strides = [2, 2]} : (tensor<1x192x56x56xf32>) -> tensor<1x192x28x28xf32>
-// DECOMPOSE-DAG:       [[VAR_73_:%.+]] = "onnx.Relu"([[VAR_72_]]) : (tensor<1x192x28x28xf32>) -> tensor<1x192x28x28xf32> 
-// DECOMPOSE-DAG:       [[VAR_74_:%.+]] = "onnx.Add"([[VAR_27_]], [[VAR_1_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_75_:%.+]] = "onnx.Sqrt"([[VAR_74_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_76_:%.+]] = "onnx.Div"([[VAR_24_]], [[VAR_75_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_77_:%.+]] = "onnx.Unsqueeze"([[VAR_76_]], [[VAR_2_]]) : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1x1xf32>
-// DECOMPOSE-DAG:       [[VAR_78_:%.+]] = "onnx.Mul"([[VAR_77_]], [[VAR_23_]]) : (tensor<64x1x1x1xf32>, tensor<64x192x1x1xf32>) -> tensor<64x192x1x1xf32>
-// DECOMPOSE-DAG:       [[VAR_79_:%.+]] = "onnx.Neg"([[VAR_26_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_80_:%.+]] = "onnx.Mul"([[VAR_76_]], [[VAR_79_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_81_:%.+]] = "onnx.Add"([[VAR_80_]], [[VAR_25_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE-DAG:       [[VAR_82_:%.+]] = "onnx.Conv"([[VAR_73_]], [[VAR_78_]], [[VAR_81_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x192x28x28xf32>, tensor<64x192x1x1xf32>, tensor<64xf32>) -> tensor<1x64x28x28xf32>
-// DECOMPOSE-DAG:       [[VAR_83_:%.+]] = "onnx.Unsqueeze"([[VAR_28_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_71_:%.+]] = "onnx.Mul"([[VAR_69_]], [[VAR_70_]]) : (tensor<1x192x56x56xf32>, tensor<192x1x1xf32>) -> tensor<1x192x56x56xf32>
+// DECOMPOSE-DAG:       [[VAR_72_:%.+]] = "onnx.Reshape"([[VAR_23_]], [[VAR_1_]]) {allowzero = 0 : si64} : (tensor<192xf32>, tensor<3xi64>) -> tensor<192x1x1xf32>
+// DECOMPOSE:           [[VAR_73_:%.+]] = "onnx.Add"([[VAR_71_]], [[VAR_72_]]) : (tensor<1x192x56x56xf32>, tensor<192x1x1xf32>) -> tensor<1x192x56x56xf32>
+// DECOMPOSE:           [[VAR_74_:%.+]] = "onnx.MaxPoolSingleOut"([[VAR_73_]]) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3, 3], pads = [0, 0, 1, 1], storage_order = 0 : si64, strides = [2, 2]} : (tensor<1x192x56x56xf32>) -> tensor<1x192x28x28xf32>
+// DECOMPOSE-DAG:       [[VAR_75_:%.+]] = "onnx.Relu"([[VAR_74_]]) : (tensor<1x192x28x28xf32>) -> tensor<1x192x28x28xf32>
+// DECOMPOSE-DAG:       [[VAR_76_:%.+]] = "onnx.Add"([[VAR_28_]], [[VAR_31_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_77_:%.+]] = "onnx.Sqrt"([[VAR_76_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_78_:%.+]] = "onnx.Div"([[VAR_25_]], [[VAR_77_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_79_:%.+]] = "onnx.Reshape"([[VAR_78_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<4xi64>) -> tensor<64x1x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_80_:%.+]] = "onnx.Mul"([[VAR_79_]], [[VAR_24_]]) : (tensor<64x1x1x1xf32>, tensor<64x192x1x1xf32>) -> tensor<64x192x1x1xf32>
+// DECOMPOSE-DAG:       [[VAR_81_:%.+]] = "onnx.Neg"([[VAR_27_]]) : (tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_82_:%.+]] = "onnx.Mul"([[VAR_78_]], [[VAR_81_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_83_:%.+]] = "onnx.Add"([[VAR_82_]], [[VAR_26_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE-DAG:       [[VAR_84_:%.+]] = "onnx.Conv"([[VAR_75_]], [[VAR_80_]], [[VAR_83_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x192x28x28xf32>, tensor<64x192x1x1xf32>, tensor<64xf32>) -> tensor<1x64x28x28xf32>
+// DECOMPOSE-DAG:       [[VAR_85_:%.+]] = "onnx.Reshape"([[VAR_29_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
 // DECOMPOSE-NOT: separator of consecutive DAGs
-// DECOMPOSE-DAG:       [[VAR_84_:%.+]] = "onnx.Mul"([[VAR_82_]], [[VAR_83_]]) : (tensor<1x64x28x28xf32>, tensor<64x1x1xf32>) -> tensor<1x64x28x28xf32>
-// DECOMPOSE-DAG:       [[VAR_85_:%.+]] = "onnx.Unsqueeze"([[VAR_29_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
-// DECOMPOSE:           [[VAR_86_:%.+]] = "onnx.Add"([[VAR_84_]], [[VAR_85_]]) : (tensor<1x64x28x28xf32>, tensor<64x1x1xf32>) -> tensor<1x64x28x28xf32>
-// DECOMPOSE:           [[VAR_87_:%.+]] = "onnx.Relu"([[VAR_86_]]) : (tensor<1x64x28x28xf32>) -> tensor<1x64x28x28xf32>
-// DECOMPOSE:           return [[VAR_87_]] : tensor<1x64x28x28xf32>
+// DECOMPOSE-DAG:       [[VAR_86_:%.+]] = "onnx.Mul"([[VAR_84_]], [[VAR_85_]]) : (tensor<1x64x28x28xf32>, tensor<64x1x1xf32>) -> tensor<1x64x28x28xf32>
+// DECOMPOSE-DAG:       [[VAR_87_:%.+]] = "onnx.Reshape"([[VAR_30_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1xf32>
+// DECOMPOSE:           [[VAR_88_:%.+]] = "onnx.Add"([[VAR_86_]], [[VAR_87_]]) : (tensor<1x64x28x28xf32>, tensor<64x1x1xf32>) -> tensor<1x64x28x28xf32>
+// DECOMPOSE:           [[VAR_89_:%.+]] = "onnx.Relu"([[VAR_88_]]) : (tensor<1x64x28x28xf32>) -> tensor<1x64x28x28xf32>
+// DECOMPOSE:           return [[VAR_89_]] : tensor<1x64x28x28xf32>
 // DECOMPOSE:         }
 
 // CONSTPROP-LABEL:  func.func @test_inception_v2_6_snippet

--- a/test/mlir/onnx/onnx_simplify_shape_related_ops.mlir
+++ b/test/mlir/onnx/onnx_simplify_shape_related_ops.mlir
@@ -56,9 +56,9 @@ func.func @test_pass_dims_scalar(%arg0: tensor<?x?x200xf32>) -> tensor<i64> {
 
 // CHECK-LABEL:  func.func @test_pass_dims_scalar
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x200xf32>) -> tensor<i64> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x?x200xf32>) -> tensor<1xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Squeeze"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xi64>, tensor<1xi64>) -> tensor<i64>
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<> : tensor<0xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x?x200xf32>) -> tensor<1xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Reshape"([[VAR_1_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<1xi64>, tensor<0xi64>) -> tensor<i64>
 // CHECK:           onnx.Return [[VAR_2_]] : tensor<i64>
 // CHECK:         }
 }

--- a/test/mlir/onnx/parse/instancenorm_to_layernorm.onnxtext
+++ b/test/mlir/onnx/parse/instancenorm_to_layernorm.onnxtext
@@ -10,9 +10,9 @@ test_instancenorm_e2e (float[2,3,4,5] input, float[3] scale, float[3] bias) => (
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @main_graph
 // CHECK-SAME:   ([[INPUT:%.+]]: tensor<2x3x4x5xf32> {onnx.name = "input"}, [[SCALE:%.+]]: tensor<3xf32> {onnx.name = "scale"}, [[BIAS:%.+]]: tensor<3xf32> {onnx.name = "bias"}) -> (tensor<2x3x4x5xf32> {onnx.name = "output"}) {
-// CHECK-DAG:       [[AXES:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-// CHECK-DAG:       [[UNSQUEEZE_SCALE:%.+]] = "onnx.Unsqueeze"([[SCALE]], [[AXES]]) {{.*}} : (tensor<3xf32>, tensor<2xi64>) -> tensor<3x1x1xf32>
-// CHECK-DAG:       [[UNSQUEEZE_BIAS:%.+]] = "onnx.Unsqueeze"([[BIAS]], [[AXES]]) {{.*}} : (tensor<3xf32>, tensor<2xi64>) -> tensor<3x1x1xf32>
+// CHECK:           [[AXES:%.+]] = onnx.Constant dense<[3, 1, 1]> : tensor<3xi64>
+// CHECK-DAG:       [[UNSQUEEZE_SCALE:%.+]] = "onnx.Reshape"([[SCALE]], [[AXES]]) {{.*}} : (tensor<3xf32>, tensor<3xi64>) -> tensor<3x1x1xf32>
+// CHECK-DAG:       [[UNSQUEEZE_BIAS:%.+]] = "onnx.Reshape"([[BIAS]], [[AXES]]) {{.*}} : (tensor<3xf32>, tensor<3xi64>) -> tensor<3x1x1xf32>
 // CHECK:           [[OUTPUT:%.+]], {{.*}}, {{.*}} = "onnx.LayerNormalization"([[INPUT]], [[UNSQUEEZE_SCALE]], [[UNSQUEEZE_BIAS]]) {axis = 2 : si64, epsilon = {{.*}} : f32{{.*}}} : (tensor<2x3x4x5xf32>, tensor<3x1x1xf32>, tensor<3x1x1xf32>) -> (tensor<2x3x4x5xf32>, none, none)
 // CHECK:           return [[OUTPUT]] : tensor<2x3x4x5xf32>
 // CHECK:         }

--- a/test/mlir/onnx/xfe_onnx_opset_verifier.mlir
+++ b/test/mlir/onnx/xfe_onnx_opset_verifier.mlir
@@ -1,0 +1,40 @@
+// RUN: onnx-mlir-opt --xfe-onnx-opset-verifier %s -split-input-file -verify-diagnostics
+
+// -----
+// Static Flatten is in the default deny-list.
+// RUN 2 (empty list): no errors at all, tool exits 0.
+func.func @static_flatten_fails(%arg0: tensor<2x3x4xf32>) -> tensor<6x4xf32> {
+  // expected-error@+1 {{'onnx.Flatten' op disallowed in XFE ONNX opset}}
+  %0 = "onnx.Flatten"(%arg0) {axis = 1 : si64} : (tensor<2x3x4xf32>) -> tensor<6x4xf32>
+  onnx.Return %0 : tensor<6x4xf32>
+}
+
+// -----
+// Dynamic primary operand: static gate skips the op.
+func.func @dynamic_flatten_passes(%arg0: tensor<?x3x4xf32>) -> tensor<?x4xf32> {
+  %0 = "onnx.Flatten"(%arg0) {axis = 1 : si64} : (tensor<?x3x4xf32>) -> tensor<?x4xf32>
+  onnx.Return %0 : tensor<?x4xf32>
+}
+
+// -----
+// Dynamic axes operand (tensor<?xi64>): static gate skips Squeeze because
+// not all operands are fully-static.
+func.func @squeeze_dynamic_axes_passes(%arg0: tensor<2x1x4xf32>,
+                                        %axes: tensor<?xi64>) -> tensor<2x4xf32> {
+  %0 = "onnx.Squeeze"(%arg0, %axes) : (tensor<2x1x4xf32>, tensor<?xi64>) -> tensor<2x4xf32>
+  onnx.Return %0 : tensor<2x4xf32>
+}
+
+// -----
+// Both Flatten and Squeeze are in the default deny-list; collect-all means
+// both errors are reported before the single signalPassFailure().
+func.func @collect_all_violations(%arg0: tensor<2x3x4xf32>,
+                                   %arg1: tensor<2x1x4xf32>)
+    -> (tensor<6x4xf32>, tensor<2x4xf32>) {
+  %axes = onnx.Constant dense<[1]> : tensor<1xi64>
+  // expected-error@+1 {{'onnx.Flatten' op disallowed in XFE ONNX opset}}
+  %0 = "onnx.Flatten"(%arg0) {axis = 1 : si64} : (tensor<2x3x4xf32>) -> tensor<6x4xf32>
+  // expected-error@+1 {{'onnx.Squeeze' op disallowed in XFE ONNX opset}}
+  %1 = "onnx.Squeeze"(%arg1, %axes) : (tensor<2x1x4xf32>, tensor<1xi64>) -> tensor<2x4xf32>
+  onnx.Return %0, %1 : tensor<6x4xf32>, tensor<2x4xf32>
+}

--- a/test/mlir/onnx/xfe_onnx_opset_verifier_override.mlir
+++ b/test/mlir/onnx/xfe_onnx_opset_verifier_override.mlir
@@ -1,0 +1,17 @@
+// RUN: onnx-mlir-opt --xfe-onnx-opset-verifier="disallowed-ops=Squeeze" %s -split-input-file -verify-diagnostics
+
+// -----
+// With disallowed-ops=Squeeze, static Flatten is allowed.
+func.func @flatten_allowed_with_squeeze_override(%arg0: tensor<2x3x4xf32>) -> tensor<6x4xf32> {
+  %0 = "onnx.Flatten"(%arg0) {axis = 1 : si64} : (tensor<2x3x4xf32>) -> tensor<6x4xf32>
+  onnx.Return %0 : tensor<6x4xf32>
+}
+
+// -----
+// With disallowed-ops=Squeeze, static Squeeze is rejected.
+func.func @squeeze_rejected_with_override(%arg0: tensor<2x1x4xf32>) -> tensor<2x4xf32> {
+  %axes = onnx.Constant dense<[1]> : tensor<1xi64>
+  // expected-error@+1 {{'onnx.Squeeze' op disallowed in XFE ONNX opset}}
+  %0 = "onnx.Squeeze"(%arg0, %axes) : (tensor<2x1x4xf32>, tensor<1xi64>) -> tensor<2x4xf32>
+  onnx.Return %0 : tensor<2x4xf32>
+}

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -540,6 +540,7 @@ OpsWithCanonicalizer = [
     "Div",
     "Dropout",
     "Equal",
+    "Flatten",
     "GlobalAveragePool",
     "GlobalMaxPool",
     "Greater",


### PR DESCRIPTION
Add canonicalization of reshape like ops and verifier for ops disallowed in XFE Dialect

Backport of https://github.com/Xilinx/onnx-mlir/pull/847