### PR TITLE
Qualify cast<ShapedType> with mlir:: in OnnxBuilder::slice

### DIFF
--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -498,7 +498,7 @@ Value OnnxBuilder::slice(
   Value endsVal = constant(b().getI64TensorAttr(ends));
   Value axesVal = constant(b().getI64TensorAttr(axes));
   Value stepsVal = constant(b().getI64TensorAttr(steps));
-  auto inputType = cast<ShapedType>(input.getType());
+  auto inputType = mlir::cast<ShapedType>(input.getType());
   Type outputType = RankedTensorType::get(sizes, inputType.getElementType());
   return slice(outputType, input, startsVal, endsVal, axesVal, stepsVal);
 }


### PR DESCRIPTION
## Summary
- Use `mlir::cast<ShapedType>` instead of an unqualified `cast<ShapedType>` in the `ArrayRef`-based `OnnxBuilder::slice` overload (`src/Dialect/ONNX/DialectBuilder.cpp`).

This avoids ADL/namespace ambiguity for the `cast<>` template, matching the qualified form already used everywhere else in this file.

## Test plan
- [ ] Builds cleanly (no functional change; single-line namespace qualification).