### PR TITLE
fix: default ONNX_MLIR_INCLUDE_TESTS and BUILD_TESTS to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ cmake_minimum_required(VERSION 3.20.0)
 
 project(onnx-mlir)
 
-option(ONNX_MLIR_INCLUDE_TESTS "Include the test subdirectory." ON)
-option(ONNX_MLIR_BUILD_TESTS "Build ONNX-MLIR test executables. If OFF, just generate build targets." ON)
+option(ONNX_MLIR_INCLUDE_TESTS "Include the test subdirectory." OFF)
+option(ONNX_MLIR_BUILD_TESTS "Build ONNX-MLIR test executables. If OFF, just generate build targets." OFF)
 option(ONNX_MLIR_CCACHE_BUILD "Set to ON for a ccache enabled build." OFF)
 option(ONNX_MLIR_ENABLE_KRNL "Enable Krnl dialect, ONNX-to-Krnl conversions, and related passes." OFF)
 option(ONNX_MLIR_ENABLE_STABLEHLO "Enable StableHLO support." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 project(onnx-mlir)
 
-option(ONNX_MLIR_INCLUDE_TESTS "Include the test subdirectory." OFF)
+option(ONNX_MLIR_INCLUDE_TESTS "Include the test subdirectory." ON)
 option(ONNX_MLIR_BUILD_TESTS "Build ONNX-MLIR test executables. If OFF, just generate build targets." OFF)
 option(ONNX_MLIR_CCACHE_BUILD "Set to ON for a ccache enabled build." OFF)
 option(ONNX_MLIR_ENABLE_KRNL "Enable Krnl dialect, ONNX-to-Krnl conversions, and related passes." OFF)


### PR DESCRIPTION
## Summary

Default `ONNX_MLIR_INCLUDE_TESTS` and `ONNX_MLIR_BUILD_TESTS` to `OFF` in root `CMakeLists.txt`.

### Problem

XMC builds onnx-mlir through multiple cmake paths (ExternalProject, FetchContent, LLVM external project). With tests defaulting to `ON`, every cmake config that builds onnx-mlir must explicitly pass `-DONNX_MLIR_INCLUDE_TESTS=OFF` to avoid cmake configure errors like:

```
CMake Error at AddLLVM.cmake:2125 (add_dependencies):
  The dependency target "split-file" of target
  "check-onnx_mlir-conversion-onnx_to_stablehlo" does not exist.
```

This was previously handled by `onnx_mlir_xmc_build.patch` in XMC, but patching is fragile and hard to maintain across multiple build paths.

### Fix

Default both options to `OFF` at the source. Consumers who actually want to build tests can still explicitly enable them with `-DONNX_MLIR_INCLUDE_TESTS=ON -DONNX_MLIR_BUILD_TESTS=ON`.

## Test plan

- [ ] XMC Integration build on `release_rai_1_8` passes without `onnx_mlir_xmc_build.patch`
- [ ] No impact on existing builds (tests were already disabled via cmake args or patch)
