### PR TITLE
Make TensorNameInference use ConstantLike

### DIFF
--- a/src/Dialect/ONNX/TensorName.cpp
+++ b/src/Dialect/ONNX/TensorName.cpp
@@ -10,6 +10,7 @@
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 
 #include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 #include "src/Dialect/ONNX/TensorName.hpp"
 #include "src/Interface/TensorNameInference.hpp"
 
@@ -63,14 +64,14 @@ SmallVector<int64_t> denseToVector(DenseIntElementsAttr denseAttr) {
 }
 
 SmallVector<int64_t> valToVector(Value val) {
-  if (auto constOp = val.getDefiningOp<ONNXConstantOp>()) {
-    if (auto arrayAttr = dyn_cast<ArrayAttr>(constOp.getValueAttr()))
-      return arrayToVector(arrayAttr);
-    else if (auto denseAttr =
-                 dyn_cast<DenseIntElementsAttr>(constOp.getValueAttr()))
-      return denseToVector(denseAttr);
-  }
-  return {};
+  ElementsAttr elements = getDenseOrDisposableConstLikeElements(val);
+  if (!elements || !getElementType(elements.getType()).isIntOrIndex())
+    return {};
+
+  SmallVector<int64_t> vector;
+  for (APInt v : elements.getValues<APInt>())
+    vector.push_back(v.getSExtValue());
+  return vector;
 }
 
 SmallVector<int64_t> axesToVector(Value val, size_t rank) {

--- a/test/mlir/onnx/onnx_tensornames_inference.mlir
+++ b/test/mlir/onnx/onnx_tensornames_inference.mlir
@@ -168,6 +168,19 @@ func.func @tile_block_arg(%arg0: tensor<1x3xf32> {onnx.name = "input"}) -> tenso
 // CHECK-SAME: ResultNames = [
 // CHECK-SAME: ["input", ["Tile", [1, 3], [2, 2], [2, 6]]]]
 
+// Check tensor name inference reads Tile repeats from ConstantLike ops beyond
+// onnx.Constant.
+func.func @tile_tosa_const_repeats(%arg0: tensor<1x3xf32> {onnx.name = "input"}) -> tensor<2x6xf32> {
+  %0 = "tosa.const"() {value = dense<[2, 2]> : tensor<2xi64>} : () -> tensor<2xi64>
+  %1 = "onnx.Tile"(%arg0, %0) : (tensor<1x3xf32>, tensor<2xi64>) -> tensor<2x6xf32>
+  return %1 : tensor<2x6xf32>
+}
+
+// CHECK-LABEL: @tile_tosa_const_repeats
+// CHECK: onnx.Tile
+// CHECK-SAME: ResultNames = [
+// CHECK-SAME: ["input", ["Tile", [1, 3], [2, 2], [2, 6]]]]
+
 // Check tensor name of virtual reg with tile applied to it
 func.func @tile_operand(%arg0: tensor<1x4xf32> {onnx.name = "input"}) -> tensor<3x4xf32> {
   %0 = "onnx.Identity"(%arg0) : (tensor<1x4xf32>) -> tensor<1x4xf32>


### PR DESCRIPTION
Small PR to make TensorNameInference work with any kind of constant that implements the ConstantLike trait by reusing the `getDenseOrDisposableConstLikeElements()` helper. Works the same as before for any existing code :)