### PR TITLE
Make verifier of onnx.Expand more strict

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -397,6 +397,17 @@ bool getI64ValuesFromONNXConstantOp(
   return true;
 }
 
+SmallVector<int64_t> valToVector(Value val) {
+  ElementsAttr elements = getDenseOrDisposableConstLikeElements(val);
+  if (!elements || !getElementType(elements.getType()).isIntOrIndex())
+    return {};
+
+  SmallVector<int64_t> vector;
+  for (APInt v : elements.getValues<APInt>())
+    vector.push_back(v.getSExtValue());
+  return vector;
+}
+
 static bool hasLegacyBroadcastAxis(Operation *op) {
   return op->hasAttr("broadcast") && op->hasAttr("axis");
 }

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -205,6 +205,10 @@ mlir::ONNXConstantOp getONNXConstantOp(mlir::Value value);
 bool getI64ValuesFromONNXConstantOp(
     mlir::Value val, mlir::SmallVectorImpl<int64_t> &iRes);
 
+// Reads the integer values of any ConstantLike producer as int64_t, returning
+// an empty vector when the value is not a constant integer tensor.
+mlir::SmallVector<int64_t> valToVector(mlir::Value val);
+
 // Classifies operands that carry scalar axis or axes values. UnsqueezeAxes is
 // distinct because negative insertion axes are normalized against output rank.
 enum class ONNXAxisOperandKind { None, Scalar, Axes, UnsqueezeAxes };

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Expand.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Expand.cpp
@@ -10,9 +10,11 @@
 //
 // This file provides definition of ONNX dialect Expand operation.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
-#include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 
 using namespace mlir;
@@ -83,14 +85,43 @@ LogicalResult ONNXExpandOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXExpandOp::verify() {
-  ONNXExpandOpAdaptor operandAdaptor = ONNXExpandOpAdaptor(*this);
+  auto operandAdaptor = ONNXExpandOpAdaptor(*this);
   // Get operands.
+  auto input = operandAdaptor.getInput();
   auto shape = operandAdaptor.getShape();
   // Check input.
   auto shapeType = mlir::dyn_cast_or_null<ShapedType>(shape.getType());
   if (shapeType && shapeType.hasRank()) {
     if (shapeType.getRank() != 1)
       return emitOpError("Shape has a rank of 1");
+  }
+
+  auto inputType = mlir::dyn_cast_or_null<ShapedType>(input.getType());
+  if (!inputType || !inputType.hasRank())
+    return success();
+
+  SmallVector<int64_t> shapeVals = valToVector(shape);
+  if (shapeVals.empty())
+    return success();
+
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+  int64_t inputIdx = inputShape.size() - 1;
+  int64_t shapeIdx = shapeVals.size() - 1;
+  for (; inputIdx >= 0 && shapeIdx >= 0; --inputIdx, --shapeIdx) {
+    int64_t inputDim = inputShape[inputIdx];
+    int64_t shapeDim = shapeVals[shapeIdx];
+
+    // Stay conservative: only flag a pair that is provably incompatible, i.e.
+    // both sides are static, positive, unequal, and neither one is 1.
+    if (ShapedType::isDynamic(inputDim) || shapeDim <= 0)
+      continue;
+    if (inputDim != shapeDim && inputDim != 1 && shapeDim != 1)
+      return mlir::emitError(getLoc(), getOperationName())
+             << ": input dimension " << inputDim << " at index " << inputIdx
+             << " is incompatible with target shape dimension " << shapeDim
+             << " at index " << shapeIdx
+             << ": two corresponding dimensions must have the same value, or "
+                "one of them is equal to 1";
   }
   return success();
 }

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Expand.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Expand.cpp
@@ -113,8 +113,12 @@ LogicalResult ONNXExpandOp::verify() {
 
     // Stay conservative: only flag a pair that is provably incompatible, i.e.
     // both sides are static, positive, unequal, and neither one is 1.
-    if (ShapedType::isDynamic(inputDim) || shapeDim <= 0)
+    if (ShapedType::isDynamic(inputDim))
       continue;
+    if (shapeDim < 0)
+      return mlir::emitError(getLoc(), getOperationName())
+             << ": shape dimension " << shapeDim << " at index " << shapeIdx
+             << " is negative";
     if (inputDim != shapeDim && inputDim != 1 && shapeDim != 1)
       return mlir::emitError(getLoc(), getOperationName())
              << ": input dimension " << inputDim << " at index " << inputIdx

--- a/src/Dialect/ONNX/TensorName.cpp
+++ b/src/Dialect/ONNX/TensorName.cpp
@@ -63,17 +63,6 @@ SmallVector<int64_t> denseToVector(DenseIntElementsAttr denseAttr) {
   return SmallVector<int64_t>(denseAttr.getValues<int64_t>());
 }
 
-SmallVector<int64_t> valToVector(Value val) {
-  ElementsAttr elements = getDenseOrDisposableConstLikeElements(val);
-  if (!elements || !getElementType(elements.getType()).isIntOrIndex())
-    return {};
-
-  SmallVector<int64_t> vector;
-  for (APInt v : elements.getValues<APInt>())
-    vector.push_back(v.getSExtValue());
-  return vector;
-}
-
 SmallVector<int64_t> axesToVector(Value val, size_t rank) {
   if (isa<NoneType>(val.getType())) {
     SmallVector<int64_t> axes(rank);

--- a/src/Dialect/ONNX/TensorName.hpp
+++ b/src/Dialect/ONNX/TensorName.hpp
@@ -36,7 +36,6 @@ std::unique_ptr<Transform> fromOp(mlir::Operation *op);
 /// Utility methods to be used by sub-classes or OpInterface implementations
 mlir::SmallVector<int64_t> arrayToVector(mlir::ArrayAttr arrayAttr);
 mlir::SmallVector<int64_t> denseToVector(mlir::DenseIntElementsAttr denseAttr);
-mlir::SmallVector<int64_t> valToVector(mlir::Value val);
 mlir::SmallVector<int64_t> axesToVector(mlir::Value val, size_t rank);
 mlir::ArrayAttr vecToAttr(
     mlir::MLIRContext *context, mlir::ArrayRef<int64_t> vector);

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Expand.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Expand.mlir
@@ -46,38 +46,6 @@ func.func @test_expand_new_dims_out(%arg0: tensor<1x64x1xf32>) -> tensor<64x64x6
 
 // -----
 
-func.func @test_expand_new_dims_start(%arg0: tensor<256x256x16xf32>) -> tensor<1x512x256x16xf32> {
-  %0 = "onnx.Constant"() {value = dense<[1, 512, 256, 16]> : tensor<4xi64>} : () -> tensor<4xi64>
-  %1 = "onnx.Expand"(%arg0, %0) : (tensor<256x256x16xf32>, tensor<4xi64>) -> tensor<1x512x256x16xf32>
-  return %1 : tensor<1x512x256x16xf32>
-}
-
-// CHECK-LABEL:  func.func @test_expand_new_dims_start
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<256x256x16xf32>) -> tensor<1x512x256x16xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1, 512, 256, 16]> : tensor<4xi64>}> : () -> tensor<4xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 256, 256, 16>} : (tensor<256x256x16xf32>) -> tensor<1x256x256x16xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 2, 1, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
-// CHECK:           [[VAR_3_:%.+]] = tosa.tile [[VAR_1_]], [[VAR_2_]] : (tensor<1x256x256x16xf32>, !tosa.shape<4>) -> tensor<1x512x256x16xf32>
-// CHECK:           return [[VAR_3_]] : tensor<1x512x256x16xf32>
-
-// -----
-
-func.func @test_expand_new_dims_mix(%arg0: tensor<128x64xf32>) -> tensor<1x128x16x128x16xf32> {
-  %0 = "onnx.Constant"() {value = dense<[1, 128, 16, 128, 16]> : tensor<5xi64>} : () -> tensor<5xi64>
-  %1 = "onnx.Expand"(%arg0, %0) : (tensor<128x64xf32>, tensor<5xi64>) -> tensor<1x128x16x128x16xf32>
-  return %1 : tensor<1x128x16x128x16xf32>
-}
-
-// CHECK-LABEL:  func.func @test_expand_new_dims_mix
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x64xf32>) -> tensor<1x128x16x128x16xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[1, 128, 16, 128, 16]> : tensor<5xi64>}> : () -> tensor<5xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 1, 128, 1, 64, 1>} : (tensor<128x64xf32>) -> tensor<1x128x1x64x1xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.const_shape  {value = dense<[1, 1, 16, 2, 16]> : tensor<5xindex>} : () -> !tosa.shape<5>
-// CHECK:           [[VAR_3_:%.+]] = tosa.tile [[VAR_1_]], [[VAR_2_]] : (tensor<1x128x1x64x1xf32>, !tosa.shape<5>) -> tensor<1x128x16x128x16xf32>
-// CHECK:           return [[VAR_3_]] : tensor<1x128x16x128x16xf32>
-
-// -----
-
 func.func @test_expand_no_tile(%arg0: tensor<128x16xf32>) -> tensor<1x1x128x16xf32> {
   %0 = "onnx.Constant"() {value = dense<[1, 1, 128, 16]> : tensor<4xi64>} : () -> tensor<4xi64>
   %1 = "onnx.Expand"(%arg0, %0) : (tensor<128x16xf32>, tensor<4xi64>) -> tensor<1x1x128x16xf32>

--- a/test/mlir/onnx/invalid.mlir
+++ b/test/mlir/onnx/invalid.mlir
@@ -92,6 +92,14 @@ func.func @test_expand_verifier_static_mismatch(%arg0 : tensor<8xf32>) -> tensor
 
 // -----
 
+func.func @test_expand_verifier_target_one_is_legal(%arg0 : tensor<2x1x6x5xf32>) -> tensor<2x3x6x5xf32> {
+  %shape = onnx.Constant dense<[1, 3, 6, 1]> : tensor<4xi64>
+  %0 = "onnx.Expand"(%arg0, %shape) : (tensor<2x1x6x5xf32>, tensor<4xi64>) -> tensor<2x3x6x5xf32>
+  "onnx.Return"(%0) : (tensor<2x3x6x5xf32>) -> ()
+}
+
+// -----
+
 func.func @test_dim_verifier_1(%arg0 : tensor<*xf32>) -> tensor<i64> {
   // expected-error @+1 {{input must have shape and rank}}
   %1 = "onnx.Dim"(%arg0) {axis = 0 : si64} : (tensor<*xf32>)  -> tensor<i64>

--- a/test/mlir/onnx/invalid.mlir
+++ b/test/mlir/onnx/invalid.mlir
@@ -92,6 +92,24 @@ func.func @test_expand_verifier_static_mismatch(%arg0 : tensor<8xf32>) -> tensor
 
 // -----
 
+func.func @test_expand_verifier_negative_shape(%arg0 : tensor<8xf32>) -> tensor<*xf32> {
+  %shape = onnx.Constant dense<[-1]> : tensor<1xi64>
+  // expected-error @+1 {{onnx.Expand: shape dimension -1 at index 0 is negative}}
+  %0 = "onnx.Expand"(%arg0, %shape) : (tensor<8xf32>, tensor<1xi64>) -> tensor<*xf32>
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
+}
+
+// -----
+
+func.func @test_expand_verifier_negative_shape_multidim(%arg0 : tensor<2x8xf32>) -> tensor<*xf32> {
+  %shape = onnx.Constant dense<[3, -2]> : tensor<2xi64>
+  // expected-error @+1 {{onnx.Expand: shape dimension -2 at index 1 is negative}}
+  %0 = "onnx.Expand"(%arg0, %shape) : (tensor<2x8xf32>, tensor<2xi64>) -> tensor<*xf32>
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
+}
+
+// -----
+
 func.func @test_expand_verifier_target_one_is_legal(%arg0 : tensor<2x1x6x5xf32>) -> tensor<2x3x6x5xf32> {
   %shape = onnx.Constant dense<[1, 3, 6, 1]> : tensor<4xi64>
   %0 = "onnx.Expand"(%arg0, %shape) : (tensor<2x1x6x5xf32>, tensor<4xi64>) -> tensor<2x3x6x5xf32>

--- a/test/mlir/onnx/invalid.mlir
+++ b/test/mlir/onnx/invalid.mlir
@@ -83,6 +83,15 @@ func.func @test_concat_from_sequence_verifier_2(%arg0 : !onnx.Seq<tensor<5x5x1x3
 
 // -----
 
+func.func @test_expand_verifier_static_mismatch(%arg0 : tensor<8xf32>) -> tensor<*xf32> {
+  %shape = onnx.Constant dense<[16]> : tensor<1xi64>
+  // expected-error @+1 {{onnx.Expand: input dimension 8 at index 0 is incompatible with target shape dimension 16 at index 0: two corresponding dimensions must have the same value, or one of them is equal to 1}}
+  %0 = "onnx.Expand"(%arg0, %shape) : (tensor<8xf32>, tensor<1xi64>) -> tensor<*xf32>
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
+}
+
+// -----
+
 func.func @test_dim_verifier_1(%arg0 : tensor<*xf32>) -> tensor<i64> {
   // expected-error @+1 {{input must have shape and rank}}
   %1 = "onnx.Dim"(%arg0) {axis = 0 : si64} : (tensor<*xf32>)  -> tensor<i64>

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -2533,6 +2533,18 @@ func.func @test_expand_with_constant(%arg0 : tensor<2x1x6x1xf32>) -> tensor<*xf3
 
 // -----
 
+func.func @test_expand_with_constant_legal_broadcast(%arg0 : tensor<?x1x8x1xf32>) -> tensor<*xf32> {
+  %0 = onnx.Constant dense<[1, 5, 8, 3]> : tensor<4xi64>
+  %1 = "onnx.Expand"(%arg0, %0) : (tensor<?x1x8x1xf32>, tensor<4xi64>) -> tensor<*xf32>
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: test_expand_with_constant_legal_broadcast
+  // CHECK: [[RES:%.+]] = "onnx.Expand"(%arg0, %0) : (tensor<?x1x8x1xf32>, tensor<4xi64>) -> tensor<?x5x8x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<?x5x8x3xf32>
+}
+
+// -----
+
 func.func @test_expand_with_shape(%arg0 : tensor<2x1x6x1xf32>, %arg1: tensor<6x2xf32>) -> tensor<*xf32> {
   %0 = "onnx.Shape"(%arg1) : (tensor<6x2xf32>) -> tensor<*xi64>
   %1 = "onnx.Expand"(%arg0, %0) : (tensor<2x1x6x1xf32>, tensor<*xi64>) -> tensor<*xf32>


### PR DESCRIPTION
I came across a few cases in which the onnx.Expand op has invalid parameters. The docs state that "two corresponding dimensions must have the same value, or one of them is equal to 1". which is not currently enforced.
This PR improves the verifier to detect and crash when given an invalid Expand op.

For example `1x8x1x1 --> 1x16x70x70` are not valid expand shapes because the `8 --> 16` dimension violates the above property.