### PR TITLE
feat: generalize ScatterND to Split+Concat

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2606,9 +2606,62 @@ LogicalResult checkScatterNDContiguousIndices(ONNXScatterNDOp scatterNDOp,
   return success();
 }
 
+// Collects, in ascending order, the axes where data and updates differ in
+// size. These are the axes along which a contiguous-block ScatterND writes a
+// sub-range (and where the Split/Concat decomposition peels/rebuilds).
+SmallVector<uint64_t> getScatterNDSplitAxes(
+    ArrayRef<int64_t> dataShape, ArrayRef<int64_t> updateShape) {
+  SmallVector<uint64_t> splitAxes;
+  for (auto [idx, dimData, dimUpdates] :
+      llvm::enumerate(dataShape, updateShape)) {
+    if (dimData != dimUpdates)
+      splitAxes.push_back(idx);
+  }
+  return splitAxes;
+}
+
+// Returns true iff the axes are consecutive (a, a+1, ..., a+N-1).
+bool areAxesConsecutive(ArrayRef<uint64_t> axes) {
+  for (size_t i = 0; i + 1 < axes.size(); ++i)
+    if (axes[i] + 1 != axes[i + 1])
+      return false;
+  return true;
+}
+
+// The written block maps to a single contiguous run once the (consecutive)
+// split axes are merged (row-major flattened) iff, scanning them from outer to
+// inner, after the first axis that writes a partial range (updateSize > 1)
+// every more-inner split axis is full-width (updateSize == dataSize). Trailing
+// non-split (slice) axes are always full-width, so they never break
+// contiguity. When this holds, CanonicalizeScatterNDWithMultiAxis (reshape +
+// merge) is the cheaper lowering; otherwise the block is multi-interval and is
+// lowered by the nested Split+Concat in DecomposeScatterNDPattern.
+//
+// Example (single interval): data [6,4,4], updates [6,2,4], splitAxes {1,2}.
+//   axis 1 is partial (2 < 4) but axis 2 (the inner one) is full-width (4 ==
+//   4). Flattening axes 1,2 into 16, rows [0,1] cover merged offsets [0..7] --
+//   one contiguous run per batch -> returns true (reshape/merge path).
+//
+// Counter-example (multi-interval): data [6,4,4], updates [6,2,3], splitAxes
+//   {1,2}. axis 1 is partial (2 < 4) and the inner axis 2 is also partial
+//   (3 < 4). Flattening into 16, row 0 covers offsets [0..2] and row 1 covers
+//   [4..6] -- two separate runs with a gap at offset 3 -> returns false (nested
+//   Split+Concat path).
+bool isSingleMergedInterval(ArrayRef<int64_t> dataShape,
+    ArrayRef<int64_t> updateShape, ArrayRef<uint64_t> splitAxes) {
+  bool seenPartial = false;
+  for (uint64_t ax : splitAxes) {
+    if (seenPartial && updateShape[ax] != dataShape[ax])
+      return false;
+    if (updateShape[ax] > 1)
+      seenPartial = true;
+  }
+  return true;
+}
+
 } // namespace
 
-// Decomposes ScatterNDs into a single Split and Concat.
+// Decomposes contiguous-block ScatterNDs into Split and Concat operations.
 // We can always split ScatterNDs by splitting the input tensor together with
 // the indices and their updates belonging to that part of the input tensor,
 // performing the ScatterNDs on each split, and the concatenating the result.
@@ -2617,6 +2670,17 @@ LogicalResult checkScatterNDContiguousIndices(ONNXScatterNDOp scatterNDOp,
 // affect their parts of the input tensor), and the middle ScatterND overwrites
 // the full input with sequential indices (i.e. can be replaced by a copy of its
 // update).
+//
+// The write region must be a hyper-rectangular block over one or more
+// *consecutive* differing axes. A single differing axis lowers to one
+// Split + Concat. When several consecutive axes differ, the block is peeled one
+// axis at a time (innermost to outermost) with a Split and re-stitched with a
+// Concat per axis, so a rank-r ScatterND spanning N differing axes lowers to N
+// Split/Concat pairs. The special case where merging the differing axes yields
+// a single contiguous run is left to CanonicalizeScatterNDWithMultiAxis, which
+// produces a cheaper reshape-based single-axis Split + Concat; this pattern
+// therefore only handles the multi-interval multi-axis case (and all
+// single-axis cases).
 //
 // Example:
 // ` %indices = onnx.Constant dense<[[[[0, 1, 0], [0, 1, 1], [0, 1, 2],
@@ -2651,8 +2715,8 @@ LogicalResult checkScatterNDContiguousIndices(ONNXScatterNDOp scatterNDOp,
 // To ensure that this decomposition to split and concat is
 // valid, the following constraints need to hold:
 // - r == rank(updates)
-// - The shape of data and updates differs only in one dimension 'a'
-// -- 'a' is the dimension where the split and concat will happen
+// - The shape of data and updates differs only in consecutive dimensions
+// -- Those are the dimensions where the (nested) split and concat will happen
 // - The update indices need to be contiguous
 // -- The update indices are the last dim in indices
 // -- We call them contiguous, if each idx in indices is indexing the element
@@ -2679,25 +2743,19 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
     const auto updateShape = updatesType.getShape();
     const auto indicesShape = indicesType.getShape();
 
-    const auto splitAxis = [&]() -> uint64_t {
-      // Split at the dim where the update and original data have a
-      // different size
-      for (auto [idx, dimData, dimUpdates] :
-          llvm::enumerate(dataShape, updateShape)) {
-        if (dimData != dimUpdates) {
-          return idx;
-        }
-      }
-      return dataType.getRank() -
-             1; // Edge case, all elements get updated, split on the last dim
-    }();
+    // Collect the axes where data and updates differ. These are the axes along
+    // which the scatter writes a sub-range and where we peel/rebuild.
+    SmallVector<uint64_t> splitAxes =
+        getScatterNDSplitAxes(dataShape, updateShape);
+    if (splitAxes.empty()) {
+      // Edge case: data and updates have the same shape (the whole tensor is
+      // overwritten); split on the last dim.
+      splitAxes.push_back(dataType.getRank() - 1);
+    }
 
-    for (auto [idx, dimData, dimUpdates] :
-        llvm::enumerate(dataShape, updateShape)) {
-      if (idx != splitAxis && dimData != dimUpdates) {
-        return rewriter.notifyMatchFailure(
-            scatterNDOp, "Only a single differing dimension is supported");
-      }
+    if (!areAxesConsecutive(splitAxes)) {
+      return rewriter.notifyMatchFailure(
+          scatterNDOp, "Only consecutive differing axes are supported");
     }
 
     SmallVector<int64_t> indicesAsFlatArray;
@@ -2708,10 +2766,29 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
     const auto indicesLastDimSize = indicesShape.back();
     SubArrayAccessHelper<int64_t> indicesFlatAccessor(
         indicesAsFlatArray, indicesLastDimSize);
+
+    // Real differing axes always lie within the indexed prefix (the trailing
+    // r-k slice axes agree between data and updates), so no explicit prefix
+    // guard is needed here; the empty-splitAxes fallback deliberately splits
+    // the full slice axis (whole-tensor overwrite) and must be allowed through.
+
+    // For two or more differing axes that collapse to a single contiguous run,
+    // the reshape-based merge (CanonicalizeScatterNDWithMultiAxis) is the
+    // cheaper lowering; defer to it. Single-axis scatters are always handled
+    // here.
+    if (splitAxes.size() >= 2 &&
+        isSingleMergedInterval(dataShape, updateShape, splitAxes)) {
+      return rewriter.notifyMatchFailure(scatterNDOp,
+          "Single-interval multi-axis block is handled by "
+          "CanonicalizeScatterNDWithMultiAxis");
+    }
+
     const auto firstIndex =
         indicesFlatAccessor[0]; // Safe, we have checked the length before
-    if (failed(checkScatterNDFirstIndexShift(scatterNDOp, rewriter, firstIndex,
-            [&](uint64_t idx) { return idx == splitAxis; }))) {
+    if (failed(checkScatterNDFirstIndexShift(
+            scatterNDOp, rewriter, firstIndex, [&](uint64_t idx) {
+              return llvm::is_contained(splitAxes, idx);
+            }))) {
       return failure();
     }
 
@@ -2826,26 +2903,28 @@ struct CanonicalizeScatterNDWithMultiAxis
     const auto updateShape = updatesType.getShape();
     const auto indicesShape = indicesType.getShape();
 
-    SmallVector<uint64_t> splitAxes;
-    // Split at the dim where the update and original data have a
-    // different size
-    for (auto [idx, dimData, dimUpdates] :
-        llvm::enumerate(dataShape, updateShape)) {
-      if (dimData != dimUpdates) {
-        splitAxes.push_back(idx);
-      }
-    }
+    // Split at the dims where the update and original data have a
+    // different size.
+    SmallVector<uint64_t> splitAxes =
+        getScatterNDSplitAxes(dataShape, updateShape);
 
     if (splitAxes.size() < 2) {
       return rewriter.notifyMatchFailure(
           scatterNDOp, "This pattern needs at least two split axes");
     }
 
-    for (size_t i = 0; i < splitAxes.size() - 1; ++i) {
-      if (splitAxes[i] + 1 != splitAxes[i + 1]) {
-        return rewriter.notifyMatchFailure(
-            scatterNDOp, "This pattern needs consecutive split axes");
-      }
+    if (!areAxesConsecutive(splitAxes)) {
+      return rewriter.notifyMatchFailure(
+          scatterNDOp, "This pattern needs consecutive split axes");
+    }
+
+    // Merging the axes only yields a valid single-axis scatter when the block
+    // maps to one contiguous run. Multi-interval blocks are left to
+    // DecomposeScatterNDPattern's nested Split+Concat lowering.
+    if (!isSingleMergedInterval(dataShape, updateShape, splitAxes)) {
+      return rewriter.notifyMatchFailure(scatterNDOp,
+          "Merged block is multi-interval; handled by "
+          "DecomposeScatterNDPattern");
     }
 
     SmallVector<int64_t> indicesAsFlatArray;

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2801,37 +2801,65 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
       return failure();
     }
 
+    // Strategy for the decomposition (nested peel/rebuild):
+    // Isolate the hyper-rectangular block one split axis at a time with a
+    // 3-way Split into [before, band, after]; the band is carried into the next
+    // peel and the surrounding before/after slabs are kept. The innermost band
+    // is the block region and is discarded. Then stitch the updates back in
+    // with a Concat(before, result, after) per axis. For a single differing
+    // axis this reduces exactly to the classic
+    // `before, band, after = split(data, [s, b, D-s-b]); concat(before,
+    // updates, after)` (before/after may be zero-sized, matching prior
+    // behavior).
     onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(
         rewriter, scatterNDOp->getLoc());
-    // Strategy for the decomposition:
-    // Split at the split axis, concat the update and part of the split
-    // a, b = split(input)
-    // a1, a2 = split(a)
-    // concat(a1, update, b)
-    // In onnx this split can be done in one:
-    // a1, a2, b = split(input)
-    const auto firstSplitPosition =
-        (splitAxis < firstIndex.size()) ? firstIndex[splitAxis] : 0;
-    const auto secondSplitPosition =
-        updateShape[splitAxis] + firstSplitPosition;
-    SmallVector<int64_t> splitTyFirstQuarter(dataShape);
-    splitTyFirstQuarter[splitAxis] = firstSplitPosition;
-    SmallVector<int64_t> splitTySecondQuarter(dataShape);
-    splitTySecondQuarter[splitAxis] = updateShape[splitAxis];
-    SmallVector<int64_t> splitTySecondHalf(dataShape);
-    splitTySecondHalf[splitAxis] -= secondSplitPosition;
-    Value splitSize = create.onnx.constantInt64({firstSplitPosition,
-        updateShape[splitAxis], splitTySecondHalf[splitAxis]});
-    const Type dataElementType = dataType.getElementType();
-    ValueRange split = create.onnx.split(
-        {RankedTensorType::get(splitTyFirstQuarter, dataElementType),
-            RankedTensorType::get(splitTySecondQuarter, dataElementType),
-            RankedTensorType::get(splitTySecondHalf, dataElementType)},
-        scatterNDOp.getData(), splitSize, splitAxis);
+    const Type elemTy = dataType.getElementType();
 
-    Value concat = create.onnx.concat(
-        dataType, {split[0], scatterNDOp.getUpdates(), split[2]}, splitAxis);
-    rewriter.replaceOp(scatterNDOp, concat);
+    // firstIndex holds the block start on the indexed axes; 0 elsewhere.
+    auto blockStart = [&](uint64_t axis) -> int64_t {
+      return (axis < firstIndex.size()) ? firstIndex[axis] : 0;
+    };
+
+    // Peel innermost split axis to outermost. `kept` records the surrounding
+    // slabs (in inner->outer order) to be re-stitched during rebuild.
+    struct KeptPieces {
+      uint64_t axis;
+      Value before;
+      Value after;
+    };
+    SmallVector<KeptPieces> kept;
+    Value current = scatterNDOp.getData();
+    SmallVector<int64_t> currentShape(dataShape);
+    for (uint64_t axis : llvm::reverse(splitAxes)) {
+      const int64_t s = blockStart(axis);
+      const int64_t b = updateShape[axis];
+      const int64_t after = currentShape[axis] - s - b;
+
+      auto pieceTy = [&](int64_t sz) {
+        SmallVector<int64_t> shp(currentShape);
+        shp[axis] = sz;
+        return RankedTensorType::get(shp, elemTy);
+      };
+      ValueRange parts =
+          create.onnx.split({pieceTy(s), pieceTy(b), pieceTy(after)}, current,
+              create.onnx.constantInt64({s, b, after}), axis);
+
+      kept.push_back({axis, parts[0], parts[2]});
+      current = parts[1]; // descend into the block band
+      currentShape[axis] = b;
+    }
+
+    // Rebuild outermost split axis to innermost (reverse of the peel order),
+    // starting from the updates.
+    Value result = scatterNDOp.getUpdates();
+    SmallVector<int64_t> resultShape(updateShape);
+    for (const KeptPieces &kp : llvm::reverse(kept)) {
+      resultShape[kp.axis] = dataShape[kp.axis];
+      result = create.onnx.concat(RankedTensorType::get(resultShape, elemTy),
+          {kp.before, result, kp.after}, kp.axis);
+    }
+
+    rewriter.replaceOp(scatterNDOp, result);
     return success();
   }
 };

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -2811,6 +2811,20 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
     // `before, band, after = split(data, [s, b, D-s-b]); concat(before,
     // updates, after)` (before/after may be zero-sized, matching prior
     // behavior).
+    //
+    // Example: data<4x4x8>, updates<2x2x8> writing a 2x2 block at offset [1,1]
+    // (splitAxes = {0, 1}). Peel inner->outer, i.e. axis 1 then axis 0:
+    //   axis 1: split<4x4x8> -> before<4x1x8>, band<4x2x8>, after<4x1x8>
+    //           keep before/after; descend into band<4x2x8>.
+    //   axis 0: split<4x2x8> -> before<1x2x8>, band<2x2x8>, after<1x2x8>
+    //           keep before/after; band<2x2x8> is the block (discarded).
+    // Rebuild outer->inner starting from updates<2x2x8>:
+    //   axis 0: concat(before<1x2x8>, updates<2x2x8>, after<1x2x8>) -> <4x2x8>
+    //   axis 1: concat(before<4x1x8>,        <4x2x8>, after<4x1x8>) -> <4x4x8>
+    // yielding the original data with the 2x2 block replaced by the updates.
+    //
+    // The number of split axes drives the cost: N split axes produce exactly N
+    // (3-way) Splits during the peel and N Concats during the rebuild.
     onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(
         rewriter, scatterNDOp->getLoc());
     const Type elemTy = dataType.getElementType();
@@ -2831,22 +2845,29 @@ struct DecomposeScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
     Value current = scatterNDOp.getData();
     SmallVector<int64_t> currentShape(dataShape);
     for (uint64_t axis : llvm::reverse(splitAxes)) {
-      const int64_t s = blockStart(axis);
-      const int64_t b = updateShape[axis];
-      const int64_t after = currentShape[axis] - s - b;
+      // Split this axis into three contiguous slabs: the leading "before" slab
+      // [0, start), the "band" [start, start + bandSize) that holds the block
+      // region, and the trailing "after" slab [start + bandSize, dim). The
+      // before/after slabs are kept as-is; the band descends into the next
+      // peel. Either surrounding slab may be zero-sized when the block touches
+      // an axis boundary.
+      const int64_t before = blockStart(axis);    // length of the before slab
+      const int64_t bandSize = updateShape[axis]; // block extent on this axis
+      const int64_t after =
+          currentShape[axis] - before - bandSize; // after slab
 
-      auto pieceTy = [&](int64_t sz) {
-        SmallVector<int64_t> shp(currentShape);
-        shp[axis] = sz;
-        return RankedTensorType::get(shp, elemTy);
+      auto pieceTy = [&](int64_t size) {
+        SmallVector<int64_t> shape(currentShape);
+        shape[axis] = size;
+        return RankedTensorType::get(shape, elemTy);
       };
-      ValueRange parts =
-          create.onnx.split({pieceTy(s), pieceTy(b), pieceTy(after)}, current,
-              create.onnx.constantInt64({s, b, after}), axis);
+      ValueRange parts = create.onnx.split(
+          {pieceTy(before), pieceTy(bandSize), pieceTy(after)}, current,
+          create.onnx.constantInt64({before, bandSize, after}), axis);
 
       kept.push_back({axis, parts[0], parts[2]});
       current = parts[1]; // descend into the block band
-      currentShape[axis] = b;
+      currentShape[axis] = bandSize;
     }
 
     // Rebuild outermost split axis to innermost (reverse of the peel order),

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -919,6 +919,31 @@ func.func @test_scatter_nd_multi_dim_differ_full_indexing_start_non_zeros2(%arg0
 // CHECK:         }
 
 // -----
+// A single (scalar) element is scattered per index with full indexing (index
+// depth 3 == data rank), starting at [row=2, col=1]. Axes 1 and 2 form a single
+// merged interval, so it goes through the reshape/merge path: they collapse to
+// one axis of 16 and the scalar offset becomes 2*4 + 1 = 9.
+func.func @test_scatter_nd_single_element_full_indexing(%data: tensor<6x4x4xf32>, %updates: tensor<6x1x1xf32>) -> tensor<6x4x4xf32> {
+  %indices = onnx.Constant dense<[[[[0, 2, 1]]], [[[1, 2, 1]]], [[[2, 2, 1]]], [[[3, 2, 1]]], [[[4, 2, 1]]], [[[5, 2, 1]]]]> : tensor<6x1x1x3xi64>
+  %out = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<6x4x4xf32>, tensor<6x1x1x3xi64>, tensor<6x1x1xf32>) -> tensor<6x4x4xf32>
+  onnx.Return %out : tensor<6x4x4xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_single_element_full_indexing
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<6x4x4xf32>, [[PARAM_1_:%.+]]: tensor<6x1x1xf32>) -> tensor<6x4x4xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[6, 4, 4]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[9, 1, 6]> : tensor<3xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[6, 1]> : tensor<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[6, 16]> : tensor<2xi64>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<6x4x4xf32>, tensor<2xi64>) -> tensor<6x16xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<6x1x1xf32>, tensor<2xi64>) -> tensor<6x1xf32>
+// CHECK:           [[VAR_6_:%.+]]:3 = "onnx.Split"([[VAR_4_]], [[VAR_1_]]) {axis = 1 : si64} : (tensor<6x16xf32>, tensor<3xi64>) -> (tensor<6x9xf32>, tensor<6x1xf32>, tensor<6x6xf32>)
+// CHECK:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_6_]]#0, [[VAR_5_]], [[VAR_6_]]#2) {axis = 1 : si64} : (tensor<6x9xf32>, tensor<6x1xf32>, tensor<6x6xf32>) -> tensor<6x16xf32>
+// CHECK:           [[VAR_8_:%.+]] = "onnx.Reshape"([[VAR_7_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<6x16xf32>, tensor<3xi64>) -> tensor<6x4x4xf32>
+// CHECK:           onnx.Return [[VAR_8_]] : tensor<6x4x4xf32>
+// CHECK:         }
+
+// -----
 func.func @test_scatter_nd_negative_shift(%data : tensor<1x6x10x12xf32>, %updates : tensor<1x1x10x12xf32> ) -> tensor<1x6x10x12xf32> {
   %indices = onnx.Constant dense<[[[[ 0, -1, 0], [ 0, -1, 1], [ 0, -1, 2], [ 0, -1, 3], [ 0, -1, 4], [ 0, -1, 5], [ 0, -1, 6], [ 0, -1, 7], [ 0, -1, 8], [ 0, -1, 9]]]]> : tensor<1x1x10x3xi64>
   %0 = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<1x6x10x12xf32>, tensor<1x1x10x3xi64>, tensor<1x1x10x12xf32>) -> tensor<1x6x10x12xf32>
@@ -1040,7 +1065,10 @@ func.func @test_scatter_nd_single_not_in_order(%data : tensor<1x6x10x12xf32>, %u
 // CHECK:        onnx.ScatterND
 
 // -----
-func.func @scatter_block_rows0to2_cols0to2_partial_slicing(%data: tensor<6x4x4xf32>, %updates: tensor<6x3x3xf32>) -> tensor<6x4x4xf32> {
+// Multi-interval rectangular block (3x3 into 4x4) over two consecutive axes.
+// Merging axes 1 and 2 yields a non-contiguous (multi-interval) run, so this is
+// lowered by the nested Split+Concat in DecomposeScatterNDPattern (no reshape).
+func.func @scatter_block_rows0to2_cols0to2_full_indexing(%data: tensor<6x4x4xf32>, %updates: tensor<6x3x3xf32>) -> tensor<6x4x4xf32> {
   %indices = onnx.Constant dense<
     [[[[0, 0, 0], [0, 0, 1], [0, 0, 2]], [[0, 1, 0], [0, 1, 1], [0, 1, 2]], [[0, 2, 0], [0, 2, 1], [0, 2, 2]]],
       [[[1, 0, 0], [1, 0, 1], [1, 0, 2]], [[1, 1, 0], [1, 1, 1], [1, 1, 2]], [[1, 2, 0], [1, 2, 1], [1, 2, 2]]],
@@ -1052,9 +1080,108 @@ func.func @scatter_block_rows0to2_cols0to2_partial_slicing(%data: tensor<6x4x4xf
   %out = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<6x4x4xf32>, tensor<6x3x3x3xi64>, tensor<6x3x3xf32>) -> tensor<6x4x4xf32>
   onnx.Return %out : tensor<6x4x4xf32>
 }
-// CHECK-LABEL:  func.func @scatter_block_rows0to2_cols0to2_partial_slicing
-// CHECK:        onnx.ScatterND
+// CHECK-LABEL:  func.func @scatter_block_rows0to2_cols0to2_full_indexing
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<6x4x4xf32>, [[PARAM_1_:%.+]]: tensor<6x3x3xf32>) -> tensor<6x4x4xf32> {
+// CHECK:           [[SPLIT2_:%.+]]:3 = "onnx.Split"([[PARAM_0_]], {{.*}}) {axis = 2 : si64} : (tensor<6x4x4xf32>, tensor<3xi64>) -> (tensor<6x4x0xf32>, tensor<6x4x3xf32>, tensor<6x4x1xf32>)
+// CHECK:           [[SPLIT1_:%.+]]:3 = "onnx.Split"([[SPLIT2_]]#1, {{.*}}) {axis = 1 : si64} : (tensor<6x4x3xf32>, tensor<3xi64>) -> (tensor<6x0x3xf32>, tensor<6x3x3xf32>, tensor<6x1x3xf32>)
+// CHECK:           [[CONCAT1_:%.+]] = "onnx.Concat"([[SPLIT1_]]#0, [[PARAM_1_]], [[SPLIT1_]]#2) {axis = 1 : si64} : (tensor<6x0x3xf32>, tensor<6x3x3xf32>, tensor<6x1x3xf32>) -> tensor<6x4x3xf32>
+// CHECK:           [[CONCAT2_:%.+]] = "onnx.Concat"([[SPLIT2_]]#0, [[CONCAT1_]], [[SPLIT2_]]#2) {axis = 2 : si64} : (tensor<6x4x0xf32>, tensor<6x4x3xf32>, tensor<6x4x1xf32>) -> tensor<6x4x4xf32>
+// CHECK:           onnx.Return [[CONCAT2_]] : tensor<6x4x4xf32>
+// CHECK:         }
 
+// -----
+
+// Multi-interval block with partial (slice) indexing: index depth k=3 < rank 4,
+// so each index addresses a length-5 slice along the trailing axis. The nested
+// Split+Concat peels only the two indexed block axes (1 and 2).
+func.func @scatter_block_multi_interval_partial_indexing(%data: tensor<6x4x4x5xf32>, %updates: tensor<6x3x3x5xf32>) -> tensor<6x4x4x5xf32> {
+  %indices = onnx.Constant dense<
+    [[[[0, 0, 0], [0, 0, 1], [0, 0, 2]], [[0, 1, 0], [0, 1, 1], [0, 1, 2]], [[0, 2, 0], [0, 2, 1], [0, 2, 2]]],
+      [[[1, 0, 0], [1, 0, 1], [1, 0, 2]], [[1, 1, 0], [1, 1, 1], [1, 1, 2]], [[1, 2, 0], [1, 2, 1], [1, 2, 2]]],
+      [[[2, 0, 0], [2, 0, 1], [2, 0, 2]], [[2, 1, 0], [2, 1, 1], [2, 1, 2]], [[2, 2, 0], [2, 2, 1], [2, 2, 2]]],
+      [[[3, 0, 0], [3, 0, 1], [3, 0, 2]], [[3, 1, 0], [3, 1, 1], [3, 1, 2]], [[3, 2, 0], [3, 2, 1], [3, 2, 2]]],
+      [[[4, 0, 0], [4, 0, 1], [4, 0, 2]], [[4, 1, 0], [4, 1, 1], [4, 1, 2]], [[4, 2, 0], [4, 2, 1], [4, 2, 2]]],
+      [[[5, 0, 0], [5, 0, 1], [5, 0, 2]], [[5, 1, 0], [5, 1, 1], [5, 1, 2]], [[5, 2, 0], [5, 2, 1], [5, 2, 2]]]]
+  > : tensor<6x3x3x3xi64>
+  %out = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<6x4x4x5xf32>, tensor<6x3x3x3xi64>, tensor<6x3x3x5xf32>) -> tensor<6x4x4x5xf32>
+  onnx.Return %out : tensor<6x4x4x5xf32>
+}
+// CHECK-LABEL:  func.func @scatter_block_multi_interval_partial_indexing
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<6x4x4x5xf32>, [[PARAM_1_:%.+]]: tensor<6x3x3x5xf32>) -> tensor<6x4x4x5xf32> {
+// CHECK:           [[SPLIT2_:%.+]]:3 = "onnx.Split"([[PARAM_0_]], {{.*}}) {axis = 2 : si64} : (tensor<6x4x4x5xf32>, tensor<3xi64>) -> (tensor<6x4x0x5xf32>, tensor<6x4x3x5xf32>, tensor<6x4x1x5xf32>)
+// CHECK:           [[SPLIT1_:%.+]]:3 = "onnx.Split"([[SPLIT2_]]#1, {{.*}}) {axis = 1 : si64} : (tensor<6x4x3x5xf32>, tensor<3xi64>) -> (tensor<6x0x3x5xf32>, tensor<6x3x3x5xf32>, tensor<6x1x3x5xf32>)
+// CHECK:           [[CONCAT1_:%.+]] = "onnx.Concat"([[SPLIT1_]]#0, [[PARAM_1_]], [[SPLIT1_]]#2) {axis = 1 : si64} : (tensor<6x0x3x5xf32>, tensor<6x3x3x5xf32>, tensor<6x1x3x5xf32>) -> tensor<6x4x3x5xf32>
+// CHECK:           [[CONCAT2_:%.+]] = "onnx.Concat"([[SPLIT2_]]#0, [[CONCAT1_]], [[SPLIT2_]]#2) {axis = 2 : si64} : (tensor<6x4x0x5xf32>, tensor<6x4x3x5xf32>, tensor<6x4x1x5xf32>) -> tensor<6x4x4x5xf32>
+// CHECK:           onnx.Return [[CONCAT2_]] : tensor<6x4x4x5xf32>
+
+// -----
+
+// Multi-interval block with a non-zero offset on both axes (rows 1..2, cols
+// 1..2 of a 4x4). Each peel keeps both a "before" and an "after" slab, so the
+// Splits are 3-way and the Concats take three inputs.
+func.func @scatter_block_multi_interval_shift(%data: tensor<6x4x4xf32>, %updates: tensor<6x2x2xf32>) -> tensor<6x4x4xf32> {
+  %indices = onnx.Constant dense<
+    [[[[0, 1, 1], [0, 1, 2]], [[0, 2, 1], [0, 2, 2]]],
+      [[[1, 1, 1], [1, 1, 2]], [[1, 2, 1], [1, 2, 2]]],
+      [[[2, 1, 1], [2, 1, 2]], [[2, 2, 1], [2, 2, 2]]],
+      [[[3, 1, 1], [3, 1, 2]], [[3, 2, 1], [3, 2, 2]]],
+      [[[4, 1, 1], [4, 1, 2]], [[4, 2, 1], [4, 2, 2]]],
+      [[[5, 1, 1], [5, 1, 2]], [[5, 2, 1], [5, 2, 2]]]]
+  > : tensor<6x2x2x3xi64>
+  %out = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<6x4x4xf32>, tensor<6x2x2x3xi64>, tensor<6x2x2xf32>) -> tensor<6x4x4xf32>
+  onnx.Return %out : tensor<6x4x4xf32>
+}
+// CHECK-LABEL:  func.func @scatter_block_multi_interval_shift
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<6x4x4xf32>, [[PARAM_1_:%.+]]: tensor<6x2x2xf32>) -> tensor<6x4x4xf32> {
+// CHECK:           [[SPLIT2_:%.+]]:3 = "onnx.Split"([[PARAM_0_]], {{.*}}) {axis = 2 : si64} : (tensor<6x4x4xf32>, tensor<3xi64>) -> (tensor<6x4x1xf32>, tensor<6x4x2xf32>, tensor<6x4x1xf32>)
+// CHECK:           [[SPLIT1_:%.+]]:3 = "onnx.Split"([[SPLIT2_]]#1, {{.*}}) {axis = 1 : si64} : (tensor<6x4x2xf32>, tensor<3xi64>) -> (tensor<6x1x2xf32>, tensor<6x2x2xf32>, tensor<6x1x2xf32>)
+// CHECK:           [[CONCAT1_:%.+]] = "onnx.Concat"([[SPLIT1_]]#0, [[PARAM_1_]], [[SPLIT1_]]#2) {axis = 1 : si64} : (tensor<6x1x2xf32>, tensor<6x2x2xf32>, tensor<6x1x2xf32>) -> tensor<6x4x2xf32>
+// CHECK:           [[CONCAT2_:%.+]] = "onnx.Concat"([[SPLIT2_]]#0, [[CONCAT1_]], [[SPLIT2_]]#2) {axis = 2 : si64} : (tensor<6x4x1xf32>, tensor<6x4x2xf32>, tensor<6x4x1xf32>) -> tensor<6x4x4xf32>
+// CHECK:           onnx.Return [[CONCAT2_]] : tensor<6x4x4xf32>
+
+// -----
+
+// Multi-interval block over three consecutive axes (2x2x2 into 4x4x4, full
+// indexing). Merging any of the axes would leave gaps, so this uses the nested
+// Split+Concat path: three Splits (peeled inner->outer) and three Concats
+// (rebuilt outer->inner).
+func.func @test_scatter_nd_three_axes_multi_interval(%data: tensor<4x4x4xf32>, %updates: tensor<2x2x2xf32>) -> tensor<4x4x4xf32> {
+  %indices = onnx.Constant dense<[[[[0, 0, 0], [0, 0, 1]], [[0, 1, 0], [0, 1, 1]]], [[[1, 0, 0], [1, 0, 1]], [[1, 1, 0], [1, 1, 1]]]]> : tensor<2x2x2x3xi64>
+  %out = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<4x4x4xf32>, tensor<2x2x2x3xi64>, tensor<2x2x2xf32>) -> tensor<4x4x4xf32>
+  onnx.Return %out : tensor<4x4x4xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_three_axes_multi_interval
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x4x4xf32>, [[PARAM_1_:%.+]]: tensor<2x2x2xf32>) -> tensor<4x4x4xf32> {
+// CHECK:           [[SPLIT2_:%.+]]:3 = "onnx.Split"([[PARAM_0_]], {{.*}}) {axis = 2 : si64} : (tensor<4x4x4xf32>, tensor<3xi64>) -> (tensor<4x4x0xf32>, tensor<4x4x2xf32>, tensor<4x4x2xf32>)
+// CHECK:           [[SPLIT1_:%.+]]:3 = "onnx.Split"([[SPLIT2_]]#1, {{.*}}) {axis = 1 : si64} : (tensor<4x4x2xf32>, tensor<3xi64>) -> (tensor<4x0x2xf32>, tensor<4x2x2xf32>, tensor<4x2x2xf32>)
+// CHECK:           [[SPLIT0_:%.+]]:3 = "onnx.Split"([[SPLIT1_]]#1, {{.*}}) {axis = 0 : si64} : (tensor<4x2x2xf32>, tensor<3xi64>) -> (tensor<0x2x2xf32>, tensor<2x2x2xf32>, tensor<2x2x2xf32>)
+// CHECK:           [[CONCAT0_:%.+]] = "onnx.Concat"([[SPLIT0_]]#0, [[PARAM_1_]], [[SPLIT0_]]#2) {axis = 0 : si64} : (tensor<0x2x2xf32>, tensor<2x2x2xf32>, tensor<2x2x2xf32>) -> tensor<4x2x2xf32>
+// CHECK:           [[CONCAT1_:%.+]] = "onnx.Concat"([[SPLIT1_]]#0, [[CONCAT0_]], [[SPLIT1_]]#2) {axis = 1 : si64} : (tensor<4x0x2xf32>, tensor<4x2x2xf32>, tensor<4x2x2xf32>) -> tensor<4x4x2xf32>
+// CHECK:           [[CONCAT2_:%.+]] = "onnx.Concat"([[SPLIT2_]]#0, [[CONCAT1_]], [[SPLIT2_]]#2) {axis = 2 : si64} : (tensor<4x4x0xf32>, tensor<4x4x2xf32>, tensor<4x4x2xf32>) -> tensor<4x4x4xf32>
+// CHECK:           onnx.Return [[CONCAT2_]] : tensor<4x4x4xf32>
+// CHECK:         }
+
+// -----
+
+// Multi-interval block over four consecutive axes (2x2x2x2 into 4x4x4x4, full
+// indexing) -> four Splits and four Concats via the nested path.
+func.func @test_scatter_nd_four_axes_multi_interval(%data: tensor<4x4x4x4xf32>, %updates: tensor<2x2x2x2xf32>) -> tensor<4x4x4x4xf32> {
+  %indices = onnx.Constant dense<[[[[[0, 0, 0, 0], [0, 0, 0, 1]], [[0, 0, 1, 0], [0, 0, 1, 1]]], [[[0, 1, 0, 0], [0, 1, 0, 1]], [[0, 1, 1, 0], [0, 1, 1, 1]]]], [[[[1, 0, 0, 0], [1, 0, 0, 1]], [[1, 0, 1, 0], [1, 0, 1, 1]]], [[[1, 1, 0, 0], [1, 1, 0, 1]], [[1, 1, 1, 0], [1, 1, 1, 1]]]]]> : tensor<2x2x2x2x4xi64>
+  %out = "onnx.ScatterND"(%data, %indices, %updates) {reduction = "none"} : (tensor<4x4x4x4xf32>, tensor<2x2x2x2x4xi64>, tensor<2x2x2x2xf32>) -> tensor<4x4x4x4xf32>
+  onnx.Return %out : tensor<4x4x4x4xf32>
+}
+// CHECK-LABEL:  func.func @test_scatter_nd_four_axes_multi_interval
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x4x4x4xf32>, [[PARAM_1_:%.+]]: tensor<2x2x2x2xf32>) -> tensor<4x4x4x4xf32> {
+// CHECK:           [[SPLIT3_:%.+]]:3 = "onnx.Split"([[PARAM_0_]], {{.*}}) {axis = 3 : si64} : (tensor<4x4x4x4xf32>, tensor<3xi64>) -> (tensor<4x4x4x0xf32>, tensor<4x4x4x2xf32>, tensor<4x4x4x2xf32>)
+// CHECK:           [[SPLIT2_:%.+]]:3 = "onnx.Split"([[SPLIT3_]]#1, {{.*}}) {axis = 2 : si64} : (tensor<4x4x4x2xf32>, tensor<3xi64>) -> (tensor<4x4x0x2xf32>, tensor<4x4x2x2xf32>, tensor<4x4x2x2xf32>)
+// CHECK:           [[SPLIT1_:%.+]]:3 = "onnx.Split"([[SPLIT2_]]#1, {{.*}}) {axis = 1 : si64} : (tensor<4x4x2x2xf32>, tensor<3xi64>) -> (tensor<4x0x2x2xf32>, tensor<4x2x2x2xf32>, tensor<4x2x2x2xf32>)
+// CHECK:           [[SPLIT0_:%.+]]:3 = "onnx.Split"([[SPLIT1_]]#1, {{.*}}) {axis = 0 : si64} : (tensor<4x2x2x2xf32>, tensor<3xi64>) -> (tensor<0x2x2x2xf32>, tensor<2x2x2x2xf32>, tensor<2x2x2x2xf32>)
+// CHECK:           [[CONCAT0_:%.+]] = "onnx.Concat"([[SPLIT0_]]#0, [[PARAM_1_]], [[SPLIT0_]]#2) {axis = 0 : si64} : (tensor<0x2x2x2xf32>, tensor<2x2x2x2xf32>, tensor<2x2x2x2xf32>) -> tensor<4x2x2x2xf32>
+// CHECK:           [[CONCAT1_:%.+]] = "onnx.Concat"([[SPLIT1_]]#0, [[CONCAT0_]], [[SPLIT1_]]#2) {axis = 1 : si64} : (tensor<4x0x2x2xf32>, tensor<4x2x2x2xf32>, tensor<4x2x2x2xf32>) -> tensor<4x4x2x2xf32>
+// CHECK:           [[CONCAT2_:%.+]] = "onnx.Concat"([[SPLIT2_]]#0, [[CONCAT1_]], [[SPLIT2_]]#2) {axis = 2 : si64} : (tensor<4x4x0x2xf32>, tensor<4x4x2x2xf32>, tensor<4x4x2x2xf32>) -> tensor<4x4x4x2xf32>
+// CHECK:           [[CONCAT3_:%.+]] = "onnx.Concat"([[SPLIT3_]]#0, [[CONCAT2_]], [[SPLIT3_]]#2) {axis = 3 : si64} : (tensor<4x4x4x0xf32>, tensor<4x4x4x2xf32>, tensor<4x4x4x2xf32>) -> tensor<4x4x4x4xf32>
+// CHECK:           onnx.Return [[CONCAT3_]] : tensor<4x4x4x4xf32>
+// CHECK:         }
 
 // -----
 


### PR DESCRIPTION
We now support multiple Split and Concat generation by slicing and concatenating on multiple dims.
PS.: Don't think we need any flag because the number of slices and concats is the number of axes we need to Slice/Concat. It is very unlikely that we would get a huge rank and many axes to slice/concat, so I think this would be okay to keep without any flag. 🙂 