### PR TITLE
Add CLI flags for XMC matmul fusion options.

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -107,6 +107,8 @@ std::vector<std::string> reportHeapAfter;  // onnx-mlir only
 std::string modelTag;                      // onnx-mlir only
 bool enableConvOptPass;                    // onnx-mlir only
 bool enableXMCPasses;                      // onnx-mlir only
+bool enableMatmulAddFusion;                // onnx-mlir only
+bool enableMatmulToConv;                   // onnx-mlir only
 bool disableConstantProp;                  // onnx-mlir only
 std::vector<std::string> extraLibPaths;    // onnx-mlir only
 std::vector<std::string> extraLibs;        // onnx-mlir only
@@ -850,6 +852,22 @@ static llvm::cl::opt<bool, true> enableConvOptPassOpt("enable-conv-opt-pass",
 static llvm::cl::opt<bool, true> enableXMCPassesOpt("enable-xmc-passes",
     llvm::cl::desc("Enable XMC xcompiler passes. Default is false."),
     llvm::cl::location(enableXMCPasses), llvm::cl::init(false),
+    llvm::cl::cat(OnnxMlirOptions));
+
+static llvm::cl::opt<bool, true> enableMatmulAddFusionOpt(
+    "enable-matmul-add-fusion",
+    llvm::cl::desc(
+        "Enable fusing MatMul+Add into XFE MatMul bias (XMC passes only). "
+        "Default is true."),
+    llvm::cl::location(enableMatmulAddFusion), llvm::cl::init(true),
+    llvm::cl::cat(OnnxMlirOptions));
+
+static llvm::cl::opt<bool, true> enableMatmulToConvOpt(
+    "enable-matmul-to-conv",
+    llvm::cl::desc(
+        "Enable converting MatMul to XFE Conv (XMC passes only). "
+        "Default is false."),
+    llvm::cl::location(enableMatmulToConv), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<bool, true> disableConstantPropOpt("disable-constant-prop",

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -862,11 +862,9 @@ static llvm::cl::opt<bool, true> enableMatmulAddFusionOpt(
     llvm::cl::location(enableMatmulAddFusion), llvm::cl::init(true),
     llvm::cl::cat(OnnxMlirOptions));
 
-static llvm::cl::opt<bool, true> enableMatmulToConvOpt(
-    "enable-matmul-to-conv",
-    llvm::cl::desc(
-        "Enable converting MatMul to XFE Conv (XMC passes only). "
-        "Default is false."),
+static llvm::cl::opt<bool, true> enableMatmulToConvOpt("enable-matmul-to-conv",
+    llvm::cl::desc("Enable converting MatMul to XFE Conv (XMC passes only). "
+                   "Default is false."),
     llvm::cl::location(enableMatmulToConv), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -142,6 +142,8 @@ extern std::vector<std::string> reportHeapAfter;  // onnx-mlir only
 extern std::string modelTag;                      // onnx-mlir only
 extern bool enableConvOptPass;                    // onnx-mlir only
 extern bool enableXMCPasses;                      // onnx-mlir only
+extern bool enableMatmulAddFusion;                // onnx-mlir only
+extern bool enableMatmulToConv;                   // onnx-mlir only
 extern bool disableConstantProp;                  // onnx-mlir only
 extern std::vector<std::string> extraLibPaths;    // onnx-mlir only
 extern std::vector<std::string> extraLibs;        // onnx-mlir only

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -284,10 +284,13 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
     opts.enableReduceKeepdimsCanonicalization =
         enableReduceKeepdimsCanonicalization;
     opts.enableXFEONNXOpsetVerifier = enableXFEONNXOpsetVerifier;
+    opts.enableMatmulAddFusion = enableMatmulAddFusion;
+    opts.enableMatmulToConv = enableMatmulToConv;
     if (enableXMCPasses) {
       opts.hybrid.enableInstanceNormDecompose = false;
       opts.hybrid.enableGroupNormDecompose = false;
       opts.hybrid.enableConvTransposeDecomposeToPhasedConv = false;
+      opts.hybrid.enableSplitToSliceDecompose = true;
     }
 
     addONNXToMLIRPasses(pm, /*target CPU*/ false,

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -47,7 +47,7 @@ struct OnnxToMlirOptions {
   bool disableSimdOption = false;
 
   bool enableMatmulAddFusion = true;
-  bool enableMatmulToConv = true;
+  bool enableMatmulToConv = false;
   bool enableRemovePairsReshape = false;
 
   int onnxOpTransformThreshold = 3;


### PR DESCRIPTION
Expose --enable-matmul-add-fusion and --enable-matmul-to-conv on the onnx-mlir driver so standalone compiles match xcompiler frontend knobs, and enable split-to-slice decomposition when XMC passes are active.