### PR TITLE
Register AMDQuark ops for negative axis canonicalization

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -426,7 +426,10 @@ static std::optional<ONNXAxisFieldConfig> getAxisAttrConfig(Operation *op) {
     return ONNXAxisFieldConfig{
         ONNXAxisOperandKind::Scalar, ONNXAxisRankKind::FirstOperandMinusOne};
 
-  if (name == "onnx.ArgMax" || name == "onnx.ArgMin" ||
+  if (name == "onnx.AMDQuarkBFPQuantizeDequantizeOp" ||
+      name == "onnx.AMDQuarkExtendedDequantizeLinearOp" ||
+      name == "onnx.AMDQuarkExtendedQuantizeLinearOp" ||
+      name == "onnx.ArgMax" || name == "onnx.ArgMin" ||
       name == "onnx.Compress" || name == "onnx.Concat" ||
       name == "onnx.DequantizeLinear" || name == "onnx.Gather" ||
       name == "onnx.GatherElements" || name == "onnx.Hardmax" ||

--- a/test/mlir/onnx/onnx_positive_axis_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_positive_axis_canonicalization.mlir
@@ -176,6 +176,33 @@ func.func @positive_axis_layer_normalization(%arg0: tensor<2x3x4xf32>, %scale: t
 
 // -----
 
+func.func @positive_axis_amdquark_bfp_quantize_dequantize(%arg0: tensor<16x32xf32>) -> tensor<16x32xf32> {
+  %0 = "onnx.AMDQuarkBFPQuantizeDequantizeOp"(%arg0) {axis = -1 : si64} : (tensor<16x32xf32>) -> tensor<16x32xf32>
+  return %0 : tensor<16x32xf32>
+// CHECK-LABEL: func.func @positive_axis_amdquark_bfp_quantize_dequantize
+// CHECK: "onnx.AMDQuarkBFPQuantizeDequantizeOp"{{.*}}axis = 1 : si64
+}
+
+// -----
+
+func.func @positive_axis_amdquark_extended_quantize_linear(%arg0: tensor<5x2x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<5x2x3x4xi8> {
+  %0 = "onnx.AMDQuarkExtendedQuantizeLinearOp"(%arg0, %arg1, %arg2) {axis = -1 : si64} : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xi8>
+  return %0 : tensor<5x2x3x4xi8>
+// CHECK-LABEL: func.func @positive_axis_amdquark_extended_quantize_linear
+// CHECK: "onnx.AMDQuarkExtendedQuantizeLinearOp"{{.*}}axis = 3 : si64
+}
+
+// -----
+
+func.func @positive_axis_amdquark_extended_dequantize_linear(%arg0: tensor<5x2x3x4xi8>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<5x2x3x4xf32> {
+  %0 = "onnx.AMDQuarkExtendedDequantizeLinearOp"(%arg0, %arg1, %arg2) {axis = -1 : si64} : (tensor<5x2x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xf32>
+  return %0 : tensor<5x2x3x4xf32>
+// CHECK-LABEL: func.func @positive_axis_amdquark_extended_dequantize_linear
+// CHECK: "onnx.AMDQuarkExtendedDequantizeLinearOp"{{.*}}axis = 3 : si64
+}
+
+// -----
+
 func.func @positive_axis_rms_layer_normalization(%arg0: tensor<2x3x4xf32>, %scale: tensor<4xf32>) -> tensor<2x3x4xf32> {
   %none = "onnx.NoValue"() {value} : () -> none
   %0, %1 = "onnx.RMSLayerNormalization"(%arg0, %scale, %none) {axis = -1 : si64, epsilon = 9.99999974E-6 : f32, stash_type = 1 : si64} : (tensor<2x3x4xf32>, tensor<4xf32>, none) -> (tensor<2x3x4xf32>, none)


### PR DESCRIPTION
## Summary

Fix for [AIESW-40130](https://jira.xilinx.com/browse/AIESW-40130)

The XFE ONNX opset verifier rejects negative axis values, but the canonicalizer only normalizes axes for ops registered in `getAxisAttrConfig()`. The three AMDQuark ops were missing from this list:

- `AMDQuarkBFPQuantizeDequantizeOp`
- `AMDQuarkExtendedQuantizeLinearOp`
- `AMDQuarkExtendedDequantizeLinearOp`

This causes models with negative axis values (e.g. `axis=-1` from Quark BFP quantization) to fail at compile time:

```
ERROR: [VAIML-COMPILE 1000] 'onnx.AMDQuarkBFPQuantizeDequantizeOp' op negative axis value is disallowed in XFE ONNX opset
ERROR: [VAIML-COMPILE 1006] Failed to convert ONNX to MLIR: lowerONNXToONNXMLIR
```

## Root Cause

`getAxisAttrConfig()` in `OpHelper.cpp` maps ops to their axis normalization config, enabling the canonicalization pass to convert negative axes (e.g. `-1` to `rank-1`) before the XFE verifier runs. The AMDQuark ops have an `axis` attribute and a working `getNormalizedAxis()` method, but were not registered in this map — so the canonicalizer skipped them, and the verifier rejected the negative values.

This is the same class of issue fixed for `RMSLayerNormalization` in PR #935.

## Fix

Add all three AMDQuark ops to the `getAxisAttrConfig()` map with `ONNXAxisRankKind::FirstOperand` (same as other scalar-axis ops like `DequantizeLinear`, `QuantizeLinear`, etc.).

## Tests

Added LIT tests in `onnx_positive_axis_canonicalization.mlir` verifying negative axis canonicalization for each of the three AMDQuark ops.

## Test Case

- **Model**: `yolov7-non-nms_mx6` (YOLOv7 without NMS, MX6 BFP quantized)
- **Failure**: 2 of 480 `AMDQuarkBFPQuantizeDequantizeOp` nodes had `axis=-1` (on Slice and MatMul output dequantization). The other 478 nodes with `axis=0` or `axis=1` worked fine.
- **Suite**: `VAI_6_3_GEN2_REGRESSION` / `VE2_QOR_P0_MX6_HW`
