### PR TITLE
Add whitelist for onnx to xfe conversion

### DIFF
--- a/src/Dialect/ONNX/Transforms/ConvertToChannelLast.cpp
+++ b/src/Dialect/ONNX/Transforms/ConvertToChannelLast.cpp
@@ -2,6 +2,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 //
 // Pattern to convert ONNX operations to their ChannelLast variants.
@@ -34,6 +37,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Debug.h"
 
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"
@@ -1103,11 +1107,25 @@ struct ConvertToChannelLastPass : public PassWrapper<ConvertToChannelLastPass,
                                       OperationPass<func::FuncOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvertToChannelLastPass)
 
+  ConvertToChannelLastPass() = default;
+
+  // Options are not copyable; Pass::clone() transfers their values separately.
+  ConvertToChannelLastPass(const ConvertToChannelLastPass &pass)
+      : PassWrapper(pass) {}
+
+  explicit ConvertToChannelLastPass(llvm::ArrayRef<std::string> whitelist) {
+    this->whitelist = whitelist;
+  }
+
   StringRef getArgument() const override { return "convert-to-channel-last"; }
 
   StringRef getDescription() const override {
     return "Convert ONNX operations to ChannelLast variants with transposes";
   }
+
+  ListOption<std::string> whitelist{*this, "whitelist",
+      llvm::cl::desc("ONNX operation names to convert, e.g. onnx.Conv. "
+                     "Converts every supported op when empty.")};
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<ONNXDialect>();
@@ -1118,20 +1136,49 @@ struct ConvertToChannelLastPass : public PassWrapper<ConvertToChannelLastPass,
     func::FuncOp function = getOperation();
     MLIRContext *context = &getContext();
 
+    llvm::StringSet<> enabledOps;
+    enabledOps.insert(whitelist.begin(), whitelist.end());
+
+    llvm::StringSet<> supportedOps;
+    auto isEnabled = [&](StringRef opName) {
+      supportedOps.insert(opName);
+      return enabledOps.empty() || enabledOps.contains(opName);
+    };
+
     RewritePatternSet patterns(context);
-    patterns.add<ConvToChannelLastPattern>(context);
-    patterns.add<ConvTransposeToChannelLastPattern>(context);
-    patterns.add<AveragePoolToChannelLastPattern>(context);
-    patterns.add<MaxPoolToChannelLastPattern>(context);
-    patterns.add<GlobalAveragePoolToChannelLastPattern>(context);
-    patterns.add<GlobalMaxPoolToChannelLastPattern>(context);
-    patterns.add<BatchNormToChannelLastPattern>(context);
-    patterns.add<InstanceNormToChannelLastPattern>(context);
-    patterns.add<GroupNormToChannelLastPattern>(context);
-    patterns.add<DepthToSpaceToChannelLastPattern>(context);
-    patterns.add<SpaceToDepthToChannelLastPattern>(context);
-    patterns.add<ResizeToChannelLastPattern>(context);
-    patterns.add<GridSampleToChannelLastPattern>(context);
+    if (isEnabled(ONNXConvOp::getOperationName()))
+      patterns.add<ConvToChannelLastPattern>(context);
+    if (isEnabled(ONNXConvTransposeOp::getOperationName()))
+      patterns.add<ConvTransposeToChannelLastPattern>(context);
+    if (isEnabled(ONNXAveragePoolOp::getOperationName()))
+      patterns.add<AveragePoolToChannelLastPattern>(context);
+    if (isEnabled(ONNXMaxPoolSingleOutOp::getOperationName()))
+      patterns.add<MaxPoolToChannelLastPattern>(context);
+    if (isEnabled(ONNXGlobalAveragePoolOp::getOperationName()))
+      patterns.add<GlobalAveragePoolToChannelLastPattern>(context);
+    if (isEnabled(ONNXGlobalMaxPoolOp::getOperationName()))
+      patterns.add<GlobalMaxPoolToChannelLastPattern>(context);
+    if (isEnabled(ONNXBatchNormalizationInferenceModeOp::getOperationName()))
+      patterns.add<BatchNormToChannelLastPattern>(context);
+    if (isEnabled(ONNXInstanceNormalizationOp::getOperationName()))
+      patterns.add<InstanceNormToChannelLastPattern>(context);
+    if (isEnabled(ONNXGroupNormalizationOp::getOperationName()))
+      patterns.add<GroupNormToChannelLastPattern>(context);
+    if (isEnabled(ONNXDepthToSpaceOp::getOperationName()))
+      patterns.add<DepthToSpaceToChannelLastPattern>(context);
+    if (isEnabled(ONNXSpaceToDepthOp::getOperationName()))
+      patterns.add<SpaceToDepthToChannelLastPattern>(context);
+    if (isEnabled(ONNXResizeOp::getOperationName()))
+      patterns.add<ResizeToChannelLastPattern>(context);
+    if (isEnabled(ONNXGridSampleOp::getOperationName()))
+      patterns.add<GridSampleToChannelLastPattern>(context);
+
+    for (const auto &entry : enabledOps)
+      if (!supportedOps.contains(entry.getKey())) {
+        function.emitError("convert-to-channel-last: unsupported op '")
+            << entry.getKey() << "'";
+        return signalPassFailure();
+      }
 
     GreedyRewriteConfig config;
     onnx_mlir::ResultNamesUpdater rnUpdater;
@@ -1148,6 +1195,11 @@ namespace onnx_mlir {
 
 std::unique_ptr<mlir::Pass> createConvertToChannelLastPass() {
   return std::make_unique<ConvertToChannelLastPass>();
+}
+
+std::unique_ptr<mlir::Pass> createConvertToChannelLastPass(
+    llvm::ArrayRef<std::string> whitelist) {
+  return std::make_unique<ConvertToChannelLastPass>(whitelist);
 }
 
 } // namespace onnx_mlir

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -149,6 +149,10 @@ std::unique_ptr<mlir::Pass> createSetONNXNodeNamePass();
 /// Supports: Conv, AveragePool, MaxPool, GlobalAveragePool, GlobalMaxPool,
 /// InstanceNormalization, DepthToSpace, SpaceToDepth
 std::unique_ptr<mlir::Pass> createConvertToChannelLastPass();
+/// Converts only the ops named in `whitelist` (e.g. "onnx.Conv"). An empty
+/// list converts every supported op.
+std::unique_ptr<mlir::Pass> createConvertToChannelLastPass(
+    llvm::ArrayRef<std::string> whitelist);
 
 /// Pass for merging Slice->Concat patterns with downstream ops.
 std::unique_ptr<mlir::Pass> createMergeSliceConcatPass();

--- a/test/mlir/onnx/onnx_convert_to_channel_last_ops.mlir
+++ b/test/mlir/onnx/onnx_convert_to_channel_last_ops.mlir
@@ -1,0 +1,40 @@
+// RUN: onnx-mlir-opt --convert-to-channel-last --shape-inference %s | FileCheck %s
+// RUN: onnx-mlir-opt --convert-to-channel-last="whitelist=onnx.Conv" --shape-inference %s | FileCheck %s --check-prefix=CHECK-CONV
+// RUN: onnx-mlir-opt --convert-to-channel-last="whitelist=onnx.Conv,onnx.AveragePool" --shape-inference %s | FileCheck %s --check-prefix=CHECK-BOTH
+// RUN: onnx-mlir-opt --convert-to-channel-last="whitelist=onnx.NotAnOp" %s -verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+/// The `whitelist` option restricts the conversion to the named source ops. An
+/// empty list converts every supported op.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @test_ops_option
+// CHECK-CONV-LABEL: func.func @test_ops_option
+// CHECK-BOTH-LABEL: func.func @test_ops_option
+// expected-error@+1 {{convert-to-channel-last: unsupported op 'onnx.NotAnOp'}}
+func.func @test_ops_option(
+    %arg0: tensor<1x3x28x28xf32>, %arg1: tensor<64x3x3x3xf32>, %arg2: tensor<64xf32>,
+    %arg3: tensor<1x64x28x28xf32>) -> (tensor<1x64x26x26xf32>, tensor<1x64x14x14xf32>) {
+  %conv = "onnx.Conv"(%arg0, %arg1, %arg2) {
+    dilations = [1, 1],
+    group = 1 : si64,
+    pads = [0, 0, 0, 0],
+    strides = [1, 1]
+  } : (tensor<1x3x28x28xf32>, tensor<64x3x3x3xf32>, tensor<64xf32>) -> tensor<1x64x26x26xf32>
+  %pool = "onnx.AveragePool"(%arg3) {
+    kernel_shape = [2, 2],
+    strides = [2, 2],
+    pads = [0, 0, 0, 0]
+  } : (tensor<1x64x28x28xf32>) -> tensor<1x64x14x14xf32>
+  onnx.Return %conv, %pool : tensor<1x64x26x26xf32>, tensor<1x64x14x14xf32>
+
+  // CHECK: "onnx.XFEConv"
+  // CHECK: "onnx.XFEAveragePool"
+
+  // CHECK-CONV: "onnx.XFEConv"
+  // CHECK-CONV-NOT: "onnx.XFEAveragePool"
+  // CHECK-CONV: "onnx.AveragePool"
+
+  // CHECK-BOTH: "onnx.XFEConv"
+  // CHECK-BOTH: "onnx.XFEAveragePool"
+}


### PR DESCRIPTION
Adds an (optional) whitelist to --convert-to-channel-last to only convert the whitelisted ops. If the whitelist is empty or not provided then we will continue to insert all patterns. 