### PR TITLE
Add canonicalization patterns for cast

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4734,9 +4734,57 @@ void ONNXBatchNormalizationV9Op::getCanonicalizationPatterns(
   results.insert<RemoveBatchNormV9Pattern>(context);
 }
 
-/// Matches an onnx.Cast whose input is produced by another onnx.Cast with a
-/// single use, and replaces the chain with a single onnx.Cast from the original
-/// source type to the final destination type.
+/// `src <= mid`: casting `src` to `mid` is lossless.
+///
+///   int   -> int    same signedness, no truncation
+///   int   -> float  significand covers the integer range
+///   float -> float  `mid`'s format represents all of `src`
+///   anything else   never (float -> int, quant types)
+static bool castPreservesAllValues(Type src, Type mid) {
+  auto srcIntTy = dyn_cast<IntegerType>(src);
+  auto midIntTy = dyn_cast<IntegerType>(mid);
+  auto srcFloatTy = dyn_cast<FloatType>(src);
+  auto midFloatTy = dyn_cast<FloatType>(mid);
+
+  if (srcIntTy && midIntTy)
+    return srcIntTy.getSignedness() == midIntTy.getSignedness() &&
+           srcIntTy.getWidth() <= midIntTy.getWidth();
+
+  // Signless counts as signed; the mantissa width includes the integer bit.
+  if (srcIntTy && midFloatTy) {
+    unsigned intBits = srcIntTy.getWidth();
+    unsigned neededBits = srcIntTy.isUnsigned() ? intBits : intBits - 1;
+    return neededBits <= midFloatTy.getFPMantissaWidth();
+  }
+
+  // Not a width comparison: bf16 and f16 are both 16-bit but neither
+  // represents the other.
+  if (srcFloatTy && midFloatTy)
+    return llvm::APFloatBase::isRepresentableBy(
+        srcFloatTy.getFloatSemantics(), midFloatTy.getFloatSemantics());
+
+  return false;
+}
+
+/// `mid >= dst`: casting to `dst` discards at least as much as casting to
+/// `mid` did, hiding the intermediate loss. Integer-only and one signedness
+/// throughout: int narrowing drops high bits while float rounding drops low
+/// ones, and two float casts round twice, which is not bit-accurate.
+static bool finalCastSubsumesIntermediate(Type src, Type mid, Type dst) {
+  auto srcIntTy = dyn_cast<IntegerType>(src);
+  auto midIntTy = dyn_cast<IntegerType>(mid);
+  auto dstIntTy = dyn_cast<IntegerType>(dst);
+  if (!srcIntTy || !midIntTy || !dstIntTy)
+    return false;
+
+  return srcIntTy.getSignedness() == midIntTy.getSignedness() &&
+         midIntTy.getSignedness() == dstIntTy.getSignedness() &&
+         dstIntTy.getWidth() <= midIntTy.getWidth();
+}
+
+/// Replaces a chain of two onnx.Casts `src -> mid -> dst` with a single cast
+/// `src -> dst`, whenever `mid` is unobservable: either `src -> mid` loses
+/// nothing, or `mid -> dst` loses everything `src -> mid` did.
 struct FoldConsecutiveCastPattern : public OpRewritePattern<ONNXCastOp> {
   using OpRewritePattern<ONNXCastOp>::OpRewritePattern;
 
@@ -4746,102 +4794,15 @@ struct FoldConsecutiveCastPattern : public OpRewritePattern<ONNXCastOp> {
     if (!innerCast)
       return failure();
 
-    // Only fold when the intermediate result has exactly one user.
     if (!innerCast.getResult().hasOneUse())
       return failure();
 
-    auto srcElemTy =
-        cast<ShapedType>(innerCast.getInput().getType()).getElementType();
-    auto midElemTy =
-        cast<ShapedType>(innerCast.getResult().getType()).getElementType();
+    Type src = getElementType(innerCast.getInput().getType());
+    Type mid = getElementType(innerCast.getResult().getType());
+    Type dst = getElementType(outerCast.getResult().getType());
 
-    // Bail out on quant types which are neither IntegerType nor FloatType.
-    auto srcIntTy = dyn_cast<IntegerType>(srcElemTy);
-    auto midIntTy = dyn_cast<IntegerType>(midElemTy);
-    auto srcFloatTy = dyn_cast<FloatType>(srcElemTy);
-    auto midFloatTy = dyn_cast<FloatType>(midElemTy);
-
-    if (!srcIntTy && !srcFloatTy)
-      return failure();
-    if (!midIntTy && !midFloatTy)
-      return failure();
-
-    // Check that the inner cast (src -> mid) is information-preserving.
-    bool bothInt = srcIntTy && midIntTy;
-    bool bothFloat = srcFloatTy && midFloatTy;
-    bool intToFloat = srcIntTy && midFloatTy;
-
-    if (bothInt) {
-      // int -> int: require same signedness and strict widening.
-      if (srcIntTy.getSignedness() != midIntTy.getSignedness())
-        return failure();
-      if (midIntTy.getWidth() <= srcIntTy.getWidth())
-        return failure();
-    } else if (bothFloat) {
-      // float -> float: the intermediate type must be able to represent every
-      // value of the source type. Examples: bf16 and f16 are both 16-bit but
-      // neither can represent the other; tf32 is 19-bit yet covers all of bf16.
-      const auto &srcSem = srcFloatTy.getFloatSemantics();
-      const auto &midSem = midFloatTy.getFloatSemantics();
-      if (!llvm::APFloatBase::isRepresentableBy(srcSem, midSem))
-        return failure();
-    } else if (intToFloat) {
-      // int -> float: safe when the float precision (significand bits including
-      // the integer bit) can represent all integer values.
-      // For unsigned: intBitWidth <= precision
-      // For signed:   intBitWidth - 1 <= precision
-      unsigned intBits = srcIntTy.getWidth();
-      unsigned floatPrec = midFloatTy.getFPMantissaWidth();
-      // Signless integers are treated as signed (conservative).
-      bool isUnsigned = srcIntTy.isUnsigned();
-      if (isUnsigned) {
-        if (intBits > floatPrec)
-          return failure();
-      } else {
-        // Signed or signless: need intBits - 1 <= precision.
-        if (intBits <= 1 ? false : (intBits - 1) > floatPrec)
-          return failure();
-      }
-    } else {
-      // float -> int or any other cross-category: not safe.
-      return failure();
-    }
-
-    rewriter.modifyOpInPlace(outerCast,
-        [&]() { outerCast.getInputMutable().assign(innerCast.getInput()); });
-    return success();
-  }
-};
-
-/// Fold an integer cast chain when the final type is strictly narrower than
-/// the intermediate type and all three types have identical signedness.
-struct FoldNarrowingIntegerCastChainPattern
-    : public OpRewritePattern<ONNXCastOp> {
-  using OpRewritePattern<ONNXCastOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(
-      ONNXCastOp outerCast, PatternRewriter &rewriter) const override {
-    auto innerCast = outerCast.getInput().getDefiningOp<ONNXCastOp>();
-    if (!innerCast || !innerCast.getResult().hasOneUse())
-      return failure();
-
-    auto srcElemTy =
-        cast<ShapedType>(innerCast.getInput().getType()).getElementType();
-    auto midElemTy =
-        cast<ShapedType>(innerCast.getResult().getType()).getElementType();
-    auto dstElemTy =
-        cast<ShapedType>(outerCast.getResult().getType()).getElementType();
-
-    auto srcIntTy = dyn_cast<IntegerType>(srcElemTy);
-    auto midIntTy = dyn_cast<IntegerType>(midElemTy);
-    auto dstIntTy = dyn_cast<IntegerType>(dstElemTy);
-    if (!srcIntTy || !midIntTy || !dstIntTy)
-      return failure();
-
-    if (srcIntTy.getSignedness() != midIntTy.getSignedness() ||
-        midIntTy.getSignedness() != dstIntTy.getSignedness())
-      return failure();
-    if (midIntTy.getWidth() <= dstIntTy.getWidth())
+    if (!castPreservesAllValues(src, mid) &&
+        !finalCastSubsumesIntermediate(src, mid, dst))
       return failure();
 
     rewriter.modifyOpInPlace(outerCast,
@@ -4857,7 +4818,6 @@ void ONNXCastOp::getCanonicalizationPatterns(
   result.insert<SwapCastConcatPattern>(context);
   result.insert<SwapCastSlicePattern>(context);
   result.insert<FoldConsecutiveCastPattern>(context);
-  result.insert<FoldNarrowingIntegerCastChainPattern>(context);
 }
 
 /// on the ONNXConcatOp.

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4813,6 +4813,43 @@ struct FoldConsecutiveCastPattern : public OpRewritePattern<ONNXCastOp> {
   }
 };
 
+/// Fold an integer cast chain when the final type is strictly narrower than
+/// the intermediate type and all three types have identical signedness.
+struct FoldNarrowingIntegerCastChainPattern
+    : public OpRewritePattern<ONNXCastOp> {
+  using OpRewritePattern<ONNXCastOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXCastOp outerCast, PatternRewriter &rewriter) const override {
+    auto innerCast = outerCast.getInput().getDefiningOp<ONNXCastOp>();
+    if (!innerCast || !innerCast.getResult().hasOneUse())
+      return failure();
+
+    auto srcElemTy =
+        cast<ShapedType>(innerCast.getInput().getType()).getElementType();
+    auto midElemTy =
+        cast<ShapedType>(innerCast.getResult().getType()).getElementType();
+    auto dstElemTy =
+        cast<ShapedType>(outerCast.getResult().getType()).getElementType();
+
+    auto srcIntTy = dyn_cast<IntegerType>(srcElemTy);
+    auto midIntTy = dyn_cast<IntegerType>(midElemTy);
+    auto dstIntTy = dyn_cast<IntegerType>(dstElemTy);
+    if (!srcIntTy || !midIntTy || !dstIntTy)
+      return failure();
+
+    if (srcIntTy.getSignedness() != midIntTy.getSignedness() ||
+        midIntTy.getSignedness() != dstIntTy.getSignedness())
+      return failure();
+    if (midIntTy.getWidth() <= dstIntTy.getWidth())
+      return failure();
+
+    rewriter.modifyOpInPlace(outerCast,
+        [&]() { outerCast.getInputMutable().assign(innerCast.getInput()); });
+    return success();
+  }
+};
+
 /// on the ONNXCastOp.
 void ONNXCastOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
@@ -4820,6 +4857,7 @@ void ONNXCastOp::getCanonicalizationPatterns(
   result.insert<SwapCastConcatPattern>(context);
   result.insert<SwapCastSlicePattern>(context);
   result.insert<FoldConsecutiveCastPattern>(context);
+  result.insert<FoldNarrowingIntegerCastChainPattern>(context);
 }
 
 /// on the ONNXConcatOp.

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4734,14 +4734,78 @@ void ONNXBatchNormalizationV9Op::getCanonicalizationPatterns(
   results.insert<RemoveBatchNormV9Pattern>(context);
 }
 
+/// Fold Cast_final(Cast_intermediate(x)) when both casts are integer casts with
+/// identical signedness and intermediateWidth > finalWidth.
+struct FoldIntegerCastChainPattern : public OpRewritePattern<ONNXCastOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXCastOp outerCast, PatternRewriter &rewriter) const override {
+    auto innerCast = outerCast.getInput().getDefiningOp<ONNXCastOp>();
+    if (!innerCast)
+      return failure();
+
+    auto outerElemTy =
+        mlir::cast<ShapedType>(outerCast.getType()).getElementType();
+    auto innerResultElemTy =
+        mlir::cast<ShapedType>(innerCast.getType()).getElementType();
+
+    auto innerIntTy = dyn_cast<IntegerType>(innerResultElemTy);
+    auto outerIntTy = dyn_cast<IntegerType>(outerElemTy);
+    if (!innerIntTy || !outerIntTy)
+      return failure();
+    if (innerIntTy.isUnsigned() != outerIntTy.isUnsigned())
+      return failure();
+    if (innerIntTy.getWidth() < outerIntTy.getWidth())
+      return failure();
+
+    rewriter.modifyOpInPlace(outerCast,
+        [&]() { outerCast.getInputMutable().assign(innerCast.getInput()); });
+    return success();
+  }
+};
+
+/// Fold lossless narrow-float round trips: f16/bf16 -> f32 -> f16/bf16.
+struct FoldLosslessFloatCastRoundTripPattern
+    : public OpRewritePattern<ONNXCastOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXCastOp outerCast, PatternRewriter &rewriter) const override {
+    auto innerCast = outerCast.getInput().getDefiningOp<ONNXCastOp>();
+    if (!innerCast)
+      return failure();
+
+    auto sourceElemTy =
+        mlir::cast<ShapedType>(innerCast.getInput().getType()).getElementType();
+    auto intermediateElemTy =
+        mlir::cast<ShapedType>(innerCast.getType()).getElementType();
+    auto finalElemTy =
+        mlir::cast<ShapedType>(outerCast.getType()).getElementType();
+
+    auto isLosslessRoundTrip = [&](auto narrowTyTag) {
+      using NarrowTy = decltype(narrowTyTag);
+      return isa<NarrowTy>(sourceElemTy) &&
+             isa<Float32Type>(intermediateElemTy) && isa<NarrowTy>(finalElemTy);
+    };
+
+    if (!(isLosslessRoundTrip(BFloat16Type{}) ||
+            isLosslessRoundTrip(Float16Type{})))
+      return failure();
+
+    rewriter.replaceOp(outerCast, innerCast.getInput());
+    return success();
+  }
+};
+
 /// on the ONNXCastOp.
 void ONNXCastOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
   result.insert<CastEliminationPattern>(context);
   result.insert<SwapCastConcatPattern>(context);
   result.insert<SwapCastSlicePattern>(context);
-  // TODO: Reintroduce pattern for sound type combinations, see issue #2210.
-  // result.insert<FuseCastCastPattern>(context);
+  result.insert<FoldIntegerCastChainPattern>(context);
+  result.insert<FoldLosslessFloatCastRoundTripPattern>(context);
 }
 
 /// on the ONNXConcatOp.

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4734,10 +4734,11 @@ void ONNXBatchNormalizationV9Op::getCanonicalizationPatterns(
   results.insert<RemoveBatchNormV9Pattern>(context);
 }
 
-/// Fold Cast_final(Cast_intermediate(x)) when both casts are integer casts with
-/// identical signedness and intermediateWidth > finalWidth.
-struct FoldIntegerCastChainPattern : public OpRewritePattern<ONNXCastOp> {
-  using OpRewritePattern::OpRewritePattern;
+/// Matches an onnx.Cast whose input is produced by another onnx.Cast with a
+/// single use, and replaces the chain with a single onnx.Cast from the original
+/// source type to the final destination type.
+struct FoldConsecutiveCastPattern : public OpRewritePattern<ONNXCastOp> {
+  using OpRewritePattern<ONNXCastOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(
       ONNXCastOp outerCast, PatternRewriter &rewriter) const override {
@@ -4745,55 +4746,69 @@ struct FoldIntegerCastChainPattern : public OpRewritePattern<ONNXCastOp> {
     if (!innerCast)
       return failure();
 
-    auto outerElemTy =
-        mlir::cast<ShapedType>(outerCast.getType()).getElementType();
-    auto innerResultElemTy =
-        mlir::cast<ShapedType>(innerCast.getType()).getElementType();
+    // Only fold when the intermediate result has exactly one user.
+    if (!innerCast.getResult().hasOneUse())
+      return failure();
 
-    auto innerIntTy = dyn_cast<IntegerType>(innerResultElemTy);
-    auto outerIntTy = dyn_cast<IntegerType>(outerElemTy);
-    if (!innerIntTy || !outerIntTy)
+    auto srcElemTy =
+        cast<ShapedType>(innerCast.getInput().getType()).getElementType();
+    auto midElemTy =
+        cast<ShapedType>(innerCast.getResult().getType()).getElementType();
+
+    // Bail out on quant types which are neither IntegerType nor FloatType.
+    auto srcIntTy = dyn_cast<IntegerType>(srcElemTy);
+    auto midIntTy = dyn_cast<IntegerType>(midElemTy);
+    auto srcFloatTy = dyn_cast<FloatType>(srcElemTy);
+    auto midFloatTy = dyn_cast<FloatType>(midElemTy);
+
+    if (!srcIntTy && !srcFloatTy)
       return failure();
-    if (innerIntTy.isUnsigned() != outerIntTy.isUnsigned())
+    if (!midIntTy && !midFloatTy)
       return failure();
-    if (innerIntTy.getWidth() < outerIntTy.getWidth())
+
+    // Check that the inner cast (src -> mid) is information-preserving.
+    bool bothInt = srcIntTy && midIntTy;
+    bool bothFloat = srcFloatTy && midFloatTy;
+    bool intToFloat = srcIntTy && midFloatTy;
+
+    if (bothInt) {
+      // int -> int: require same signedness and strict widening.
+      if (srcIntTy.getSignedness() != midIntTy.getSignedness())
+        return failure();
+      if (midIntTy.getWidth() <= srcIntTy.getWidth())
+        return failure();
+    } else if (bothFloat) {
+      // float -> float: the intermediate type must be able to represent every
+      // value of the source type. Examples: bf16 and f16 are both 16-bit but
+      // neither can represent the other; tf32 is 19-bit yet covers all of bf16.
+      const auto &srcSem = srcFloatTy.getFloatSemantics();
+      const auto &midSem = midFloatTy.getFloatSemantics();
+      if (!llvm::APFloatBase::isRepresentableBy(srcSem, midSem))
+        return failure();
+    } else if (intToFloat) {
+      // int -> float: safe when the float precision (significand bits including
+      // the integer bit) can represent all integer values.
+      // For unsigned: intBitWidth <= precision
+      // For signed:   intBitWidth - 1 <= precision
+      unsigned intBits = srcIntTy.getWidth();
+      unsigned floatPrec = midFloatTy.getFPMantissaWidth();
+      // Signless integers are treated as signed (conservative).
+      bool isUnsigned = srcIntTy.isUnsigned();
+      if (isUnsigned) {
+        if (intBits > floatPrec)
+          return failure();
+      } else {
+        // Signed or signless: need intBits - 1 <= precision.
+        if (intBits <= 1 ? false : (intBits - 1) > floatPrec)
+          return failure();
+      }
+    } else {
+      // float -> int or any other cross-category: not safe.
       return failure();
+    }
 
     rewriter.modifyOpInPlace(outerCast,
         [&]() { outerCast.getInputMutable().assign(innerCast.getInput()); });
-    return success();
-  }
-};
-
-/// Fold lossless narrow-float round trips: f16/bf16 -> f32 -> f16/bf16.
-struct FoldLosslessFloatCastRoundTripPattern
-    : public OpRewritePattern<ONNXCastOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(
-      ONNXCastOp outerCast, PatternRewriter &rewriter) const override {
-    auto innerCast = outerCast.getInput().getDefiningOp<ONNXCastOp>();
-    if (!innerCast)
-      return failure();
-
-    auto sourceElemTy =
-        mlir::cast<ShapedType>(innerCast.getInput().getType()).getElementType();
-    auto intermediateElemTy =
-        mlir::cast<ShapedType>(innerCast.getType()).getElementType();
-    auto finalElemTy =
-        mlir::cast<ShapedType>(outerCast.getType()).getElementType();
-
-    auto isLosslessRoundTrip = [&](auto narrowTyTag) {
-      using NarrowTy = decltype(narrowTyTag);
-      return isa<NarrowTy>(sourceElemTy) &&
-             isa<Float32Type>(intermediateElemTy) && isa<NarrowTy>(finalElemTy);
-    };
-
-    if (!(isLosslessRoundTrip(BFloat16Type{}) ||
-            isLosslessRoundTrip(Float16Type{})))
-      return failure();
-
-    rewriter.replaceOp(outerCast, innerCast.getInput());
     return success();
   }
 };
@@ -4804,8 +4819,7 @@ void ONNXCastOp::getCanonicalizationPatterns(
   result.insert<CastEliminationPattern>(context);
   result.insert<SwapCastConcatPattern>(context);
   result.insert<SwapCastSlicePattern>(context);
-  result.insert<FoldIntegerCastChainPattern>(context);
-  result.insert<FoldLosslessFloatCastRoundTripPattern>(context);
+  result.insert<FoldConsecutiveCastPattern>(context);
 }
 
 /// on the ONNXConcatOp.

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -586,12 +586,6 @@ def CastEliminationPattern : Pat<
 	(replaceWithValue $arg),
   [(HasSameElementType $arg, $type)]>;
 
-// TODO: Reintroduce pattern for sound type combinations, see issue #2210.
-//// onnx.Cast (onnx.Cast (%X, $type1)), $type2 = onnx.Cast (%X, $type2)
-//def FuseCastCastPattern : Pat<
-//  (ONNXCastOp (ONNXCastOp $arg, $_), $type),
-//  (ONNXCastOp $arg, $type)>;
-
 // Do cast on concat's inputs instead of output in order to propagate
 // cast operations together, which brings concat close to reshape
 // because concat is used for shape in reshape.

--- a/test/mlir/onnx/onnx_canonicalization_cast.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_cast.mlir
@@ -17,6 +17,28 @@ func.func @cast_identity_elimination(%arg0: tensor<2xf32>) -> tensor<2xf32> {
 /// Integer cast-chain folding.
 //===----------------------------------------------------------------------===//
 
+// CHECK-LABEL: @integer_cast_chain_narrowing
+func.func @integer_cast_chain_narrowing(%arg0: tensor<3xi32>) -> tensor<3xi8> {
+  %0 = "onnx.Cast"(%arg0) {to = i16} : (tensor<3xi32>) -> tensor<3xi16>
+  %1 = "onnx.Cast"(%0) {to = i8} : (tensor<3xi16>) -> tensor<3xi8>
+  return %1 : tensor<3xi8>
+  // CHECK: "onnx.Cast"(%arg0) {saturate = 1 : si64, to = i8}
+  // CHECK-NOT: {to = i16}
+}
+
+// -----
+
+// CHECK-LABEL: @unsigned_integer_cast_chain_narrowing
+func.func @unsigned_integer_cast_chain_narrowing(%arg0: tensor<3xui32>) -> tensor<3xui8> {
+  %0 = "onnx.Cast"(%arg0) {to = ui16} : (tensor<3xui32>) -> tensor<3xui16>
+  %1 = "onnx.Cast"(%0) {to = ui8} : (tensor<3xui16>) -> tensor<3xui8>
+  return %1 : tensor<3xui8>
+  // CHECK: "onnx.Cast"(%arg0) {saturate = 1 : si64, to = ui8}
+  // CHECK-NOT: {to = ui16}
+}
+
+// -----
+
 // CHECK-LABEL: @integer_cast_chain_full_elimination
 func.func @integer_cast_chain_full_elimination(%arg0: tensor<3xi8>) -> tensor<3xi8> {
   %0 = "onnx.Cast"(%arg0) {to = i16} : (tensor<3xi8>) -> tensor<3xi16>

--- a/test/mlir/onnx/onnx_canonicalization_cast.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_cast.mlir
@@ -1,0 +1,116 @@
+// RUN: onnx-mlir-opt --canonicalize="test-convergence=true" %s -split-input-file | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+/// Identity elimination.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @cast_identity_elimination
+func.func @cast_identity_elimination(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+  %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<2xf32>) -> tensor<2xf32>
+  return %0 : tensor<2xf32>
+  // CHECK: return %arg0
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Integer cast-chain folding.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @integer_cast_chain_narrowing
+func.func @integer_cast_chain_narrowing(%arg0: tensor<3xi32>) -> tensor<3xi8> {
+  %0 = "onnx.Cast"(%arg0) {to = i16} : (tensor<3xi32>) -> tensor<3xi16>
+  %1 = "onnx.Cast"(%0) {to = i8} : (tensor<3xi16>) -> tensor<3xi8>
+  return %1 : tensor<3xi8>
+  // CHECK: "onnx.Cast"(%arg0) {saturate = 1 : si64, to = i8}
+  // CHECK-NOT: {to = i16}
+}
+
+// -----
+
+// CHECK-LABEL: @integer_cast_chain_full_elimination
+func.func @integer_cast_chain_full_elimination(%arg0: tensor<3xi8>) -> tensor<3xi8> {
+  %0 = "onnx.Cast"(%arg0) {to = i16} : (tensor<3xi8>) -> tensor<3xi16>
+  %1 = "onnx.Cast"(%0) {to = i8} : (tensor<3xi16>) -> tensor<3xi8>
+  return %1 : tensor<3xi8>
+  // CHECK: return %arg0
+  // CHECK-NOT: "onnx.Cast"
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Lossless f16/bf16 round-trip elimination.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @bf16_roundtrip
+func.func @bf16_roundtrip(%arg0: tensor<1x3x3xf32>) -> tensor<1x3x3xbf16> {
+  %0 = "onnx.Cast"(%arg0) {to = bf16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xbf16>
+  %1 = "onnx.Cast"(%0) {to = f32} : (tensor<1x3x3xbf16>) -> tensor<1x3x3xf32>
+  %2 = "onnx.Cast"(%1) {to = bf16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xbf16>
+  return %2 : tensor<1x3x3xbf16>
+  // CHECK: "onnx.Cast"(%arg0) {saturate = 1 : si64, to = bf16}
+  // CHECK-NOT: {to = f32}
+}
+
+// -----
+
+// CHECK-LABEL: @f16_roundtrip
+func.func @f16_roundtrip(%arg0: tensor<1x3x3xf32>) -> tensor<1x3x3xf16> {
+  %0 = "onnx.Cast"(%arg0) {to = f16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xf16>
+  %1 = "onnx.Cast"(%0) {to = f32} : (tensor<1x3x3xf16>) -> tensor<1x3x3xf32>
+  %2 = "onnx.Cast"(%1) {to = f16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xf16>
+  return %2 : tensor<1x3x3xf16>
+  // CHECK: "onnx.Cast"(%arg0) {saturate = 1 : si64, to = f16}
+  // CHECK-NOT: {to = f32}
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Negative cases: patterns must not apply.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @integer_cast_chain_widening
+func.func @integer_cast_chain_widening(%arg0: tensor<3xi8>) -> tensor<3xi32> {
+  %0 = "onnx.Cast"(%arg0) {to = i16} : (tensor<3xi8>) -> tensor<3xi16>
+  %1 = "onnx.Cast"(%0) {to = i32} : (tensor<3xi16>) -> tensor<3xi32>
+  return %1 : tensor<3xi32>
+  // CHECK: "onnx.Cast"
+  // CHECK: "onnx.Cast"
+}
+
+// -----
+
+// CHECK-LABEL: @integer_cast_chain_signedness_mismatch
+func.func @integer_cast_chain_signedness_mismatch(%arg0: tensor<3xui8>) -> tensor<3xi8> {
+  %0 = "onnx.Cast"(%arg0) {to = ui16} : (tensor<3xui8>) -> tensor<3xui16>
+  %1 = "onnx.Cast"(%0) {to = i8} : (tensor<3xui16>) -> tensor<3xi8>
+  return %1 : tensor<3xi8>
+  // CHECK: "onnx.Cast"
+  // CHECK: "onnx.Cast"
+}
+
+// -----
+
+// CHECK-LABEL: @fp_lossy_roundtrip
+func.func @fp_lossy_roundtrip(%arg0: tensor<1x3x3xf32>) -> tensor<1x3x3xf32> {
+  %0 = "onnx.Cast"(%arg0) {to = f16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xf16>
+  %1 = "onnx.Cast"(%0) {to = f32} : (tensor<1x3x3xf16>) -> tensor<1x3x3xf32>
+  return %1 : tensor<1x3x3xf32>
+  // CHECK: "onnx.Cast"
+  // CHECK: "onnx.Cast"
+}
+
+// -----
+
+// CHECK-LABEL: @fp_mixed_narrow_types
+func.func @fp_mixed_narrow_types(%arg0: tensor<1x3x3xf32>) -> tensor<1x3x3xbf16> {
+  %0 = "onnx.Cast"(%arg0) {to = f16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xf16>
+  %1 = "onnx.Cast"(%0) {to = f32} : (tensor<1x3x3xf16>) -> tensor<1x3x3xf32>
+  %2 = "onnx.Cast"(%1) {to = bf16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xbf16>
+  return %2 : tensor<1x3x3xbf16>
+  // CHECK: "onnx.Cast"
+  // CHECK: "onnx.Cast"
+  // CHECK: "onnx.Cast"
+}

--- a/test/mlir/onnx/onnx_canonicalization_cast.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_cast.mlir
@@ -17,17 +17,6 @@ func.func @cast_identity_elimination(%arg0: tensor<2xf32>) -> tensor<2xf32> {
 /// Integer cast-chain folding.
 //===----------------------------------------------------------------------===//
 
-// CHECK-LABEL: @integer_cast_chain_narrowing
-func.func @integer_cast_chain_narrowing(%arg0: tensor<3xi32>) -> tensor<3xi8> {
-  %0 = "onnx.Cast"(%arg0) {to = i16} : (tensor<3xi32>) -> tensor<3xi16>
-  %1 = "onnx.Cast"(%0) {to = i8} : (tensor<3xi16>) -> tensor<3xi8>
-  return %1 : tensor<3xi8>
-  // CHECK: "onnx.Cast"(%arg0) {saturate = 1 : si64, to = i8}
-  // CHECK-NOT: {to = i16}
-}
-
-// -----
-
 // CHECK-LABEL: @integer_cast_chain_full_elimination
 func.func @integer_cast_chain_full_elimination(%arg0: tensor<3xi8>) -> tensor<3xi8> {
   %0 = "onnx.Cast"(%arg0) {to = i16} : (tensor<3xi8>) -> tensor<3xi16>
@@ -35,6 +24,75 @@ func.func @integer_cast_chain_full_elimination(%arg0: tensor<3xi8>) -> tensor<3x
   return %1 : tensor<3xi8>
   // CHECK: return %arg0
   // CHECK-NOT: "onnx.Cast"
+}
+
+// -----
+
+// CHECK-LABEL: @integer_cast_chain_widening
+func.func @integer_cast_chain_widening(%arg0: tensor<3xi8>) -> tensor<3xi32> {
+  %0 = "onnx.Cast"(%arg0) {to = i16} : (tensor<3xi8>) -> tensor<3xi16>
+  %1 = "onnx.Cast"(%0) {to = i32} : (tensor<3xi16>) -> tensor<3xi32>
+  return %1 : tensor<3xi32>
+  // CHECK: "onnx.Cast"(%arg0) {saturate = 1 : si64, to = i32}
+  // CHECK-NOT: {to = i16}
+}
+
+// -----
+
+// CHECK-LABEL: @unsigned_integer_cast_chain_widening
+func.func @unsigned_integer_cast_chain_widening(%arg0: tensor<3xui8>) -> tensor<3xui32> {
+  %0 = "onnx.Cast"(%arg0) {to = ui16} : (tensor<3xui8>) -> tensor<3xui16>
+  %1 = "onnx.Cast"(%0) {to = ui32} : (tensor<3xui16>) -> tensor<3xui32>
+  return %1 : tensor<3xui32>
+  // CHECK: "onnx.Cast"(%arg0) {saturate = 1 : si64, to = ui32}
+  // CHECK-NOT: {to = ui16}
+}
+
+// -----
+
+// CHECK-LABEL: @integer_cast_chain_final_signedness_change
+func.func @integer_cast_chain_final_signedness_change(%arg0: tensor<3xui8>) -> tensor<3xi8> {
+  %0 = "onnx.Cast"(%arg0) {to = ui16} : (tensor<3xui8>) -> tensor<3xui16>
+  %1 = "onnx.Cast"(%0) {to = i8} : (tensor<3xui16>) -> tensor<3xi8>
+  return %1 : tensor<3xi8>
+  // CHECK: "onnx.Cast"(%arg0) {saturate = 1 : si64, to = i8}
+  // CHECK-NOT: {to = ui16}
+}
+
+// -----
+
+// CHECK-LABEL: @float_cast_chain_widening
+func.func @float_cast_chain_widening(%arg0: tensor<3xf16>) -> tensor<3xf64> {
+  %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<3xf16>) -> tensor<3xf32>
+  %1 = "onnx.Cast"(%0) {to = f64} : (tensor<3xf32>) -> tensor<3xf64>
+  return %1 : tensor<3xf64>
+  // CHECK: "onnx.Cast"(%arg0) {saturate = 1 : si64, to = f64}
+  // CHECK-NOT: {to = f32}
+}
+
+// -----
+
+// CHECK-LABEL: @fp_mixed_narrow_types
+func.func @fp_mixed_narrow_types(%arg0: tensor<1x3x3xf32>) -> tensor<1x3x3xbf16> {
+  %0 = "onnx.Cast"(%arg0) {to = f16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xf16>
+  %1 = "onnx.Cast"(%0) {to = f32} : (tensor<1x3x3xf16>) -> tensor<1x3x3xf32>
+  %2 = "onnx.Cast"(%1) {to = bf16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xbf16>
+  return %2 : tensor<1x3x3xbf16>
+  // CHECK: %[[NARROW:.*]] = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = f16}
+  // CHECK: %[[FINAL:.*]] = "onnx.Cast"(%[[NARROW]]) {saturate = 1 : si64, to = bf16}
+  // CHECK-NOT: {to = f32}
+  // CHECK: return %[[FINAL]]
+}
+
+// -----
+
+// CHECK-LABEL: @integer_to_float_cast_chain
+func.func @integer_to_float_cast_chain(%arg0: tensor<3xi8>) -> tensor<3xi32> {
+  %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<3xi8>) -> tensor<3xf32>
+  %1 = "onnx.Cast"(%0) {to = i32} : (tensor<3xf32>) -> tensor<3xi32>
+  return %1 : tensor<3xi32>
+  // CHECK: "onnx.Cast"(%arg0) {saturate = 1 : si64, to = i32}
+  // CHECK-NOT: {to = f32}
 }
 
 // -----
@@ -71,11 +129,11 @@ func.func @f16_roundtrip(%arg0: tensor<1x3x3xf32>) -> tensor<1x3x3xf16> {
 /// Negative cases: patterns must not apply.
 //===----------------------------------------------------------------------===//
 
-// CHECK-LABEL: @integer_cast_chain_widening
-func.func @integer_cast_chain_widening(%arg0: tensor<3xi8>) -> tensor<3xi32> {
-  %0 = "onnx.Cast"(%arg0) {to = i16} : (tensor<3xi8>) -> tensor<3xi16>
-  %1 = "onnx.Cast"(%0) {to = i32} : (tensor<3xi16>) -> tensor<3xi32>
-  return %1 : tensor<3xi32>
+// CHECK-LABEL: @integer_cast_chain_information_losing
+func.func @integer_cast_chain_information_losing(%arg0: tensor<3xi32>) -> tensor<3xi16> {
+  %0 = "onnx.Cast"(%arg0) {to = i8} : (tensor<3xi32>) -> tensor<3xi8>
+  %1 = "onnx.Cast"(%0) {to = i16} : (tensor<3xi8>) -> tensor<3xi16>
+  return %1 : tensor<3xi16>
   // CHECK: "onnx.Cast"
   // CHECK: "onnx.Cast"
 }
@@ -83,12 +141,24 @@ func.func @integer_cast_chain_widening(%arg0: tensor<3xi8>) -> tensor<3xi32> {
 // -----
 
 // CHECK-LABEL: @integer_cast_chain_signedness_mismatch
-func.func @integer_cast_chain_signedness_mismatch(%arg0: tensor<3xui8>) -> tensor<3xi8> {
-  %0 = "onnx.Cast"(%arg0) {to = ui16} : (tensor<3xui8>) -> tensor<3xui16>
+func.func @integer_cast_chain_signedness_mismatch(%arg0: tensor<3xi8>) -> tensor<3xi8> {
+  %0 = "onnx.Cast"(%arg0) {to = ui16} : (tensor<3xi8>) -> tensor<3xui16>
   %1 = "onnx.Cast"(%0) {to = i8} : (tensor<3xui16>) -> tensor<3xi8>
   return %1 : tensor<3xi8>
   // CHECK: "onnx.Cast"
   // CHECK: "onnx.Cast"
+}
+
+// -----
+
+// CHECK-LABEL: @cast_chain_intermediate_multiple_uses
+func.func @cast_chain_intermediate_multiple_uses(%arg0: tensor<3xi8>) -> (tensor<3xi32>, tensor<3xf32>) {
+  %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<3xi8>) -> tensor<3xf32>
+  %1 = "onnx.Cast"(%0) {to = i32} : (tensor<3xf32>) -> tensor<3xi32>
+  return %1, %0 : tensor<3xi32>, tensor<3xf32>
+  // CHECK: %[[MID:.*]] = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = f32}
+  // CHECK: %[[FINAL:.*]] = "onnx.Cast"(%[[MID]]) {saturate = 1 : si64, to = i32}
+  // CHECK: return %[[FINAL]], %[[MID]]
 }
 
 // -----
@@ -98,19 +168,6 @@ func.func @fp_lossy_roundtrip(%arg0: tensor<1x3x3xf32>) -> tensor<1x3x3xf32> {
   %0 = "onnx.Cast"(%arg0) {to = f16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xf16>
   %1 = "onnx.Cast"(%0) {to = f32} : (tensor<1x3x3xf16>) -> tensor<1x3x3xf32>
   return %1 : tensor<1x3x3xf32>
-  // CHECK: "onnx.Cast"
-  // CHECK: "onnx.Cast"
-}
-
-// -----
-
-// CHECK-LABEL: @fp_mixed_narrow_types
-func.func @fp_mixed_narrow_types(%arg0: tensor<1x3x3xf32>) -> tensor<1x3x3xbf16> {
-  %0 = "onnx.Cast"(%arg0) {to = f16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xf16>
-  %1 = "onnx.Cast"(%0) {to = f32} : (tensor<1x3x3xf16>) -> tensor<1x3x3xf32>
-  %2 = "onnx.Cast"(%1) {to = bf16} : (tensor<1x3x3xf32>) -> tensor<1x3x3xbf16>
-  return %2 : tensor<1x3x3xbf16>
-  // CHECK: "onnx.Cast"
   // CHECK: "onnx.Cast"
   // CHECK: "onnx.Cast"
 }


### PR DESCRIPTION
Adds a pattern which removes redundant casts and is bit-accurate. Removed an old commented out invalid pattern.

- `i8 --> i64 --> i32` is replaced by `i8 --> i32` when both casts have integer type and there is no intermediate truncation.
- `f16 --> f32 --> f16` is replaced by `f16` without any cast. Same for bf16.

The new pattern is enabled by default and should always be beneficial and unopinionated.
Btw, there is already a pattern that removes same input/ouput casts.