### PR TITLE
Deduplicate locations of Unsqueeze nodes generated from BatchNorm decomposition

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -90,7 +90,7 @@ Value subtractOrNeg(PatternRewriter &rewriter, Location loc, Value A, Value B) {
 }
 
 // Rename a decomposed BatchNorm branch op (the scale/bias unsqueeze) so its
-// reshape no longer inherits the BatchNorm name shared by the sibling branch.
+// unsqueeze no longer inherits the BatchNorm name shared by the sibling branch.
 // No-op when the BatchNorm has no NameLoc to derive a base from.
 Value nameBatchNormBranch(
     PatternRewriter &rewriter, Value branchVal, Value bnResult, StringRef role) {

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -101,8 +101,9 @@ Value nameBatchNormBranch(
   auto bnName = bnOp->getLoc()->findInstanceOf<NameLoc>();
   if (!bnName)
     return branchVal;
-  std::string newName =
-      (llvm::Twine(bnName.getName().getValue()) + "_" + role).str();
+  std::string newName = bnName.getName().getValue().str();
+  newName += "_";
+  newName += role.str();
   branchOp->setLoc(NameLoc::get(rewriter.getStringAttr(newName)));
   return branchVal;
 }

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -89,6 +89,24 @@ Value subtractOrNeg(PatternRewriter &rewriter, Location loc, Value A, Value B) {
   return rewriter.create<ONNXSubOp>(loc, A, B);
 }
 
+// Rename a decomposed BatchNorm branch op (the scale/bias unsqueeze) so its
+// reshape no longer inherits the BatchNorm name shared by the sibling branch.
+// No-op when the BatchNorm has no NameLoc to derive a base from.
+Value nameBatchNormBranch(
+    PatternRewriter &rewriter, Value branchVal, Value bnResult, StringRef role) {
+  Operation *branchOp = branchVal.getDefiningOp();
+  Operation *bnOp = bnResult.getDefiningOp();
+  if (!branchOp || !bnOp)
+    return branchVal;
+  auto bnName = bnOp->getLoc()->findInstanceOf<NameLoc>();
+  if (!bnName)
+    return branchVal;
+  std::string newName =
+      (llvm::Twine(bnName.getName().getValue()) + "_" + role).str();
+  branchOp->setLoc(NameLoc::get(rewriter.getStringAttr(newName)));
+  return branchVal;
+}
+
 // Create an ArrayAttr of IntegerAttr(s) of values in [N, M].
 ArrayAttr createArrayAttrOfNToM(PatternRewriter &rewriter, int N, int M) {
   SmallVector<int64_t, 4> vals;

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -92,8 +92,8 @@ Value subtractOrNeg(PatternRewriter &rewriter, Location loc, Value A, Value B) {
 // Rename a decomposed BatchNorm branch op (the scale/bias unsqueeze) so its
 // unsqueeze no longer inherits the BatchNorm name shared by the sibling branch.
 // No-op when the BatchNorm has no NameLoc to derive a base from.
-Value nameBatchNormBranch(
-    PatternRewriter &rewriter, Value branchVal, Value bnResult, StringRef role) {
+Value nameBatchNormBranch(PatternRewriter &rewriter, Value branchVal,
+    Value bnResult, StringRef role) {
   Operation *branchOp = branchVal.getDefiningOp();
   Operation *bnOp = bnResult.getDefiningOp();
   if (!branchOp || !bnOp)

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -76,6 +76,13 @@ def createDenseElementsAttrFromSize : NativeCodeCall<
 def subtractOrNeg: NativeCodeCall<
   "onnx_mlir::subtractOrNeg($_builder, $0.getDefiningOp()->getLoc(), $1, $2)">;
 
+// Rename the scale / bias branch of a decomposed BatchNorm so their reshapes
+// get distinct names instead of both inheriting the BatchNorm name.
+def NameBatchNormScaleBranch : NativeCodeCall<
+  "onnx_mlir::nameBatchNormBranch($_builder, $0, $1, \"scale\")">;
+def NameBatchNormBiasBranch : NativeCodeCall<
+  "onnx_mlir::nameBatchNormBranch($_builder, $0, $1, \"bias\")">;
+
 // Get the rank of the given value.
 def getRankOf :
 	NativeCodeCall<"mlir::cast<ShapedType>($0.getType()).getRank()">;
@@ -1033,23 +1040,27 @@ def RewriteBatchNormInferenceModeConvPattern1: Pat<
      // x * a
      (ONNXMulOp
         $x,
-        (ONNXUnsqueezeOp
-           (ONNXDivOp:$a
-              (castWithSameRankDifferentElementType $scale, $x),
-              (ONNXSqrtOp
-                 (ONNXAddOp
-                    (castWithSameRankDifferentElementType $var, $x),
-                    (ONNXConstantOpFromDenseAttr
-                       (createDenseElementsAttrFromFloatAttr $res, $epsilon))))),
-           (createConstantOpWithOneToRankOfExclusive $x))),
+        (NameBatchNormScaleBranch
+          (ONNXUnsqueezeOp
+             (ONNXDivOp:$a
+                (castWithSameRankDifferentElementType $scale, $x),
+                (ONNXSqrtOp
+                   (ONNXAddOp
+                      (castWithSameRankDifferentElementType $var, $x),
+                      (ONNXConstantOpFromDenseAttr
+                         (createDenseElementsAttrFromFloatAttr $res, $epsilon))))),
+             (createConstantOpWithOneToRankOfExclusive $x)),
+          $res)),
      // b
-     (ONNXUnsqueezeOp
-       (ONNXSubOp
-          (castWithSameRankDifferentElementType $bias, $x),
-          (ONNXMulOp
-            (castWithSameRankDifferentElementType $mean, $x),
-            $a)),
-       (createConstantOpWithOneToRankOfExclusive $x))),
+     (NameBatchNormBiasBranch
+       (ONNXUnsqueezeOp
+         (ONNXSubOp
+            (castWithSameRankDifferentElementType $bias, $x),
+            (ONNXMulOp
+              (castWithSameRankDifferentElementType $mean, $x),
+              $a)),
+         (createConstantOpWithOneToRankOfExclusive $x)),
+       $res)),
   [(HasRankGT<2> $x)], [], (addBenefit 0)
 >;
 

--- a/test/mlir/onnx/onnx_canonicalization_locations.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_locations.mlir
@@ -122,3 +122,20 @@ func.func @test_fuse_add_conv_qdq_zero_bias_loc(%arg0 : tensor<1x3x4x4xf32>, %ar
 // CHECK-DAG:   [[LOC_DQ:#.+]] = loc("DQ")
 // CHECK-DAG:   [[LOC_ADDEND_DQ:#.+]] = loc("AddendDQ")
 // CHECK-DAG:   [[LOC_FUSED]] = loc(fused[[[LOC_MY_ADD]], [[LOC_MY_CONV]], [[LOC_Q]], [[LOC_DQ]], [[LOC_ADDEND_DQ]]])
+
+// -----
+
+// BatchNorm inference-mode decomposition tags its two broadcast Unsqueeze ops
+// with distinct, role-suffixed locations derived from the BatchNorm's location.
+func.func @test_batchnorm_inference_mode_locations(%arg0: tensor<1x64x112x112xf32>, %scale: tensor<64xf32>, %bias: tensor<64xf32>, %mean: tensor<64xf32>, %var: tensor<64xf32>) -> tensor<1x64x112x112xf32> {
+  %0 = "onnx.BatchNormalizationInferenceMode"(%arg0, %scale, %bias, %mean, %var) {epsilon = 1.00000007E-5 : f32} : (tensor<1x64x112x112xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) -> tensor<1x64x112x112xf32> loc("MyBN")
+  return %0 : tensor<1x64x112x112xf32>
+
+  // CHECK-LABEL: func.func @test_batchnorm_inference_mode_locations
+  // CHECK:       "onnx.Unsqueeze"
+  // CHECK-SAME:  loc([[LOC_SCALE:#.+]])
+  // CHECK:       "onnx.Unsqueeze"
+  // CHECK-SAME:  loc([[LOC_BIAS:#.+]])
+  // CHECK-DAG:   [[LOC_SCALE]] = loc("MyBN_scale")
+  // CHECK-DAG:   [[LOC_BIAS]] = loc("MyBN_bias")
+}


### PR DESCRIPTION
**Summary**
RewriteBatchNormInferenceModeConvPattern1 rewrites BatchNormalizationInferenceMode into x * a + b, where the per-channel factors are broadcast to the input rank via two Unsqueeze ops — one for the scale term a = scale / sqrt(var + eps) and one for the bias term b = bias - mean * a. Both of these ops (and everything else the pattern creates) inherit the original BatchNorm op's location, so the scale-branch and bias-branch Unsqueezes end up with the same NameLoc.

This makes the two branches indistinguishable to any pass or tooling that identifies/labels ops by their NameLoc. This PR tags each branch with a distinct location — "<batchnorm-name>_scale" and "<batchnorm-name>_bias" — so the two decomposed branches are individually identifiable.

**Changes**
Canonicalize.cpp: new helper nameBatchNormBranch(rewriter, branchVal, bnResult, role) in namespace onnx_mlir. It derives the base name from the BatchNorm op's existing NameLoc and sets a flat NameLoc("<base>_<role>") on the branch op. It is a no-op when the BatchNorm has no NameLoc (e.g. unnamed IR), so nothing is invented.
Canonicalize.td: two NativeCodeCalls (NameBatchNormScaleBranch, NameBatchNormBiasBranch) that wrap the two Unsqueeze results in RewriteBatchNormInferenceModeConvPattern1, passing the matched BatchNorm ($res) to derive the base name.

**Behavior / scope**
Purely a location change — op structure, types, and numerics are identical; constant propagation of a/b still applies.
Only RewriteBatchNormInferenceModeConvPattern1 (rank > 2) is touched, since it's the one that inserts the Unsqueeze broadcasts. The rank‑1 Pattern2 has no Unsqueeze and is unchanged.
No effect on unnamed IR (the helper early-returns), so it's inert unless the input BatchNorm carries a NameLoc.

**Testing**
Existing onnx_canonicalization.mlir BatchNorm decomposition tests pass unchanged — they FileCheck without --mlir-print-debuginfo, so op locations aren't asserted.
Manually validated with --mlir-print-debuginfo that the two branch ops now carry ..._scale / ..._bias locations while the produced op graph is otherwise identical.