### PR TITLE
Fix bug in const-prop of cast of i8 constants

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -6,6 +6,9 @@
 //
 // Builds DisposableElementsAttr instances.
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp"
@@ -411,11 +414,13 @@ ElementsAttr ElementsAttrBuilder::castToIntElementType(
     //
     // TODO: Add configuration options to support other behaviors.
     //       See https://github.com/onnx/onnx-mlir/issues/2209
-    if (newElementType.isUnsigned() != oldElementType.isUnsignedInteger()) {
+    BType oldBType = btypeOfMlirType(oldElementType);
+    BType newBType = btypeOfMlirType(newElementType);
+    if (wideBTypeOfBType(oldBType) != wideBTypeOfBType(newBType)) {
       // DisposableElementsAttr requires transformation between integers with
       // different signs.
       // TODO: Consider relaxing the requirement and omit this transformation.
-      transformer = newElementType.isUnsigned()
+      transformer = wideBTypeOfBType(newBType) == BType::UINT64
                         ? functionTransformer(wideCast<uint64_t, int64_t>)
                         : functionTransformer(wideCast<int64_t, uint64_t>);
     } else {

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4649,6 +4649,83 @@ struct FuseConv1x1IntoConvPattern : public OpRewritePattern<ONNXConvOp> {
   }
 };
 
+/// `src <= mid`: casting `src` to `mid` is lossless.
+///
+///   int   -> int    same signedness, no truncation
+///   int   -> float  significand covers the integer range
+///   float -> float  `mid`'s format represents all of `src`
+///   anything else   never (float -> int, quant types)
+bool castPreservesAllValues(Type src, Type mid) {
+  auto srcIntTy = dyn_cast<IntegerType>(src);
+  auto midIntTy = dyn_cast<IntegerType>(mid);
+  auto srcFloatTy = dyn_cast<FloatType>(src);
+  auto midFloatTy = dyn_cast<FloatType>(mid);
+
+  if (srcIntTy && midIntTy)
+    return srcIntTy.getSignedness() == midIntTy.getSignedness() &&
+           srcIntTy.getWidth() <= midIntTy.getWidth();
+
+  // Signless counts as signed; the mantissa width includes the integer bit.
+  if (srcIntTy && midFloatTy) {
+    unsigned intBits = srcIntTy.getWidth();
+    unsigned neededBits = srcIntTy.isUnsigned() ? intBits : intBits - 1;
+    return neededBits <= midFloatTy.getFPMantissaWidth();
+  }
+
+  // Not a width comparison: bf16 and f16 are both 16-bit but neither
+  // represents the other.
+  if (srcFloatTy && midFloatTy)
+    return llvm::APFloatBase::isRepresentableBy(
+        srcFloatTy.getFloatSemantics(), midFloatTy.getFloatSemantics());
+
+  return false;
+}
+
+/// `mid >= dst`: casting to `dst` discards at least as much as casting to
+/// `mid` did, hiding the intermediate loss. Integer-only and one signedness
+/// throughout: int narrowing drops high bits while float rounding drops low
+/// ones, and two float casts round twice, which is not bit-accurate.
+bool finalCastSubsumesIntermediate(Type src, Type mid, Type dst) {
+  auto srcIntTy = dyn_cast<IntegerType>(src);
+  auto midIntTy = dyn_cast<IntegerType>(mid);
+  auto dstIntTy = dyn_cast<IntegerType>(dst);
+  if (!srcIntTy || !midIntTy || !dstIntTy)
+    return false;
+
+  return srcIntTy.getSignedness() == midIntTy.getSignedness() &&
+         midIntTy.getSignedness() == dstIntTy.getSignedness() &&
+         dstIntTy.getWidth() <= midIntTy.getWidth();
+}
+
+/// Replaces a chain of two onnx.Casts `src -> mid -> dst` with a single cast
+/// `src -> dst`, whenever `mid` is unobservable: either `src -> mid` loses
+/// nothing, or `mid -> dst` loses everything `src -> mid` did.
+struct FoldConsecutiveCastPattern : public OpRewritePattern<ONNXCastOp> {
+  using OpRewritePattern<ONNXCastOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXCastOp outerCast, PatternRewriter &rewriter) const override {
+    auto innerCast = outerCast.getInput().getDefiningOp<ONNXCastOp>();
+    if (!innerCast)
+      return failure();
+
+    if (!innerCast.getResult().hasOneUse())
+      return failure();
+
+    Type src = getElementType(innerCast.getInput().getType());
+    Type mid = getElementType(innerCast.getResult().getType());
+    Type dst = getElementType(outerCast.getResult().getType());
+
+    if (!castPreservesAllValues(src, mid) &&
+        !finalCastSubsumesIntermediate(src, mid, dst))
+      return failure();
+
+    rewriter.modifyOpInPlace(outerCast,
+        [&]() { outerCast.getInputMutable().assign(innerCast.getInput()); });
+    return success();
+  }
+};
+
 } // namespace
 
 // =============================================================================
@@ -4727,83 +4804,6 @@ void ONNXBatchNormalizationV9Op::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<RemoveBatchNormV9Pattern>(context);
 }
-
-/// `src <= mid`: casting `src` to `mid` is lossless.
-///
-///   int   -> int    same signedness, no truncation
-///   int   -> float  significand covers the integer range
-///   float -> float  `mid`'s format represents all of `src`
-///   anything else   never (float -> int, quant types)
-static bool castPreservesAllValues(Type src, Type mid) {
-  auto srcIntTy = dyn_cast<IntegerType>(src);
-  auto midIntTy = dyn_cast<IntegerType>(mid);
-  auto srcFloatTy = dyn_cast<FloatType>(src);
-  auto midFloatTy = dyn_cast<FloatType>(mid);
-
-  if (srcIntTy && midIntTy)
-    return srcIntTy.getSignedness() == midIntTy.getSignedness() &&
-           srcIntTy.getWidth() <= midIntTy.getWidth();
-
-  // Signless counts as signed; the mantissa width includes the integer bit.
-  if (srcIntTy && midFloatTy) {
-    unsigned intBits = srcIntTy.getWidth();
-    unsigned neededBits = srcIntTy.isUnsigned() ? intBits : intBits - 1;
-    return neededBits <= midFloatTy.getFPMantissaWidth();
-  }
-
-  // Not a width comparison: bf16 and f16 are both 16-bit but neither
-  // represents the other.
-  if (srcFloatTy && midFloatTy)
-    return llvm::APFloatBase::isRepresentableBy(
-        srcFloatTy.getFloatSemantics(), midFloatTy.getFloatSemantics());
-
-  return false;
-}
-
-/// `mid >= dst`: casting to `dst` discards at least as much as casting to
-/// `mid` did, hiding the intermediate loss. Integer-only and one signedness
-/// throughout: int narrowing drops high bits while float rounding drops low
-/// ones, and two float casts round twice, which is not bit-accurate.
-static bool finalCastSubsumesIntermediate(Type src, Type mid, Type dst) {
-  auto srcIntTy = dyn_cast<IntegerType>(src);
-  auto midIntTy = dyn_cast<IntegerType>(mid);
-  auto dstIntTy = dyn_cast<IntegerType>(dst);
-  if (!srcIntTy || !midIntTy || !dstIntTy)
-    return false;
-
-  return srcIntTy.getSignedness() == midIntTy.getSignedness() &&
-         midIntTy.getSignedness() == dstIntTy.getSignedness() &&
-         dstIntTy.getWidth() <= midIntTy.getWidth();
-}
-
-/// Replaces a chain of two onnx.Casts `src -> mid -> dst` with a single cast
-/// `src -> dst`, whenever `mid` is unobservable: either `src -> mid` loses
-/// nothing, or `mid -> dst` loses everything `src -> mid` did.
-struct FoldConsecutiveCastPattern : public OpRewritePattern<ONNXCastOp> {
-  using OpRewritePattern<ONNXCastOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(
-      ONNXCastOp outerCast, PatternRewriter &rewriter) const override {
-    auto innerCast = outerCast.getInput().getDefiningOp<ONNXCastOp>();
-    if (!innerCast)
-      return failure();
-
-    if (!innerCast.getResult().hasOneUse())
-      return failure();
-
-    Type src = getElementType(innerCast.getInput().getType());
-    Type mid = getElementType(innerCast.getResult().getType());
-    Type dst = getElementType(outerCast.getResult().getType());
-
-    if (!castPreservesAllValues(src, mid) &&
-        !finalCastSubsumesIntermediate(src, mid, dst))
-      return failure();
-
-    rewriter.modifyOpInPlace(outerCast,
-        [&]() { outerCast.getInputMutable().assign(innerCast.getInput()); });
-    return success();
-  }
-};
 
 /// on the ONNXCastOp.
 void ONNXCastOp::getCanonicalizationPatterns(

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -1927,6 +1927,20 @@ func.func @test_cast_i32_i1_i32() -> tensor<4xi32> {
 
 // -----
 
+func.func @test_cast_i1_i32() -> tensor<4xi32> {
+  %0 = onnx.Constant dense<[false, true, false, true]> : tensor<4xi1>
+  %1 = "onnx.Cast"(%0) {to = i32} : (tensor<4xi1>) -> tensor<4xi32>
+  "onnx.Return"(%1) : (tensor<4xi32>) -> ()
+
+  // CHECK-LABEL:  func @test_cast_i1_i32
+  // CHECK-SAME:   () -> tensor<4xi32> {
+  // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[0, 1, 0, 1]> : tensor<4xi32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<4xi32>
+  // CHECK:         }
+}
+
+// -----
+
 func.func @test_cast_i32_i64() -> tensor<3x2xi64> {
   %0 = onnx.Constant dense<[[2, 3], [4, 5], [6, 7]]> : tensor<3x2xi32>
   %1 = "onnx.Cast"(%0) {to = i64} : (tensor<3x2xi32>) -> tensor<3x2xi64>


### PR DESCRIPTION
ONNX constant propagation crashed when folding an onnx.Cast from i1 to a signed integer over a DisposableElementsAttr. The code compared only MLIR signedness and reused a boolean buffer even though its wide representation (uint64) differed from the destination (int64), triggering DisposableElementsAttr’s assertion. The fix compares the actual wide BTypes and installs the required transformer.