### PR TITLE
Adjust registerDialects to take the registry as ref, upstream deleted…

### DIFF
--- a/src/Compiler/CompilerDialects.cpp
+++ b/src/Compiler/CompilerDialects.cpp
@@ -20,9 +20,8 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-DialectRegistry registerDialects(ArrayRef<accel::Accelerator::Kind> accels) {
-  DialectRegistry registry;
-
+void registerDialects(
+    DialectRegistry &registry, ArrayRef<accel::Accelerator::Kind> accels) {
   // Note that we cannot consult command line options because they have not yet
   // been parsed when registerDialects() is called.
 
@@ -57,8 +56,6 @@ DialectRegistry registerDialects(ArrayRef<accel::Accelerator::Kind> accels) {
 
   // Register TensorName inference
   registerTensorNameInferenceExternalModels(registry);
-
-  return registry;
 }
 
 } // namespace onnx_mlir

--- a/src/Compiler/CompilerDialects.hpp
+++ b/src/Compiler/CompilerDialects.hpp
@@ -16,7 +16,7 @@ namespace onnx_mlir {
 
 // Adds the mlir and onnx-mlir dialects needed to compile end to end.
 // Initializes accelerator(s) if required.
-mlir::DialectRegistry registerDialects(
+void registerDialects(mlir::DialectRegistry &registry,
     llvm::ArrayRef<accel::Accelerator::Kind> accels);
 
 } // namespace onnx_mlir

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -685,7 +685,9 @@ static int compileModuleToJniJar(
 }
 
 void loadDialects(mlir::MLIRContext &context) {
-  context.appendDialectRegistry(registerDialects(maccel));
+  mlir::DialectRegistry registry;
+  registerDialects(registry, maccel);
+  context.appendDialectRegistry(registry);
   context.loadAllAvailableDialects();
 }
 

--- a/src/Tools/onnx-lsp-server/onnx-lsp-server.cpp
+++ b/src/Tools/onnx-lsp-server/onnx-lsp-server.cpp
@@ -33,7 +33,8 @@ static llvm::cl::list<accel::Accelerator::Kind,
 
 int main(int argc, char **argv) {
 
-  auto registry = onnx_mlir::registerDialects(maccel);
+  mlir::DialectRegistry registry;
+  onnx_mlir::registerDialects(registry, maccel);
 
   return failed(MlirLspServerMain(argc, argv, registry));
 }

--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -138,7 +138,8 @@ int main(int argc, char **argv) {
   // Remove unrelated options except common ones and the onnx-mlir-opt options
   removeUnrelatedOptions({&OnnxMlirCommonOptions, &OnnxMlirOptOptions});
 
-  DialectRegistry registry = registerDialects(maccel);
+  DialectRegistry registry;
+  registerDialects(registry, maccel);
   registry.insert<tosa::TosaDialect>();
   registry.insert<mlir::quant::QuantDialect>();
 


### PR DESCRIPTION
… the copy/move constructor from it