### PR TITLE
Replace GatherElements+Tile by Gather+Reshape

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -57,6 +57,7 @@ bool enableReshapeCanonicalization;                    // common for both
 bool enablePositiveAxisCanonicalization;               // common for both
 bool enableExpandCanonicalization;                     // common for both
 bool enableReduceKeepdimsCanonicalization;             // common for both
+bool enableGatherElementsTileCanonicalization;         // common for both
 bool enableXFEONNXOpsetVerifier;                       // common for both
 bool enableSafeCodeGen;                                // common for both
 bool disableMemRefPrefetch;                            // common for both
@@ -387,6 +388,14 @@ static llvm::cl::opt<bool, true> enableReduceKeepdimsCanonicalizationOpt(
         "keepdims=1 + Reshape (default=false, i.e. the rewrite is disabled)."),
     llvm::cl::location(enableReduceKeepdimsCanonicalization),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
+
+static llvm::cl::opt<bool, true> enableGatherElementsTileCanonicalizationOpt(
+    "enable-gather-elements-tile-canonicalization",
+    llvm::cl::desc(
+        "Enable simplification of GatherElements with tiled indices into "
+        "Gather with reshaped indices (default=true)."),
+    llvm::cl::location(enableGatherElementsTileCanonicalization),
+    llvm::cl::init(true), llvm::cl::cat(OnnxMlirCommonOptions));
 
 static llvm::cl::opt<bool, true> enableXFEONNXOpsetVerifierOpt(
     "enable-xfe-onnx-opset-verifier",

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -94,6 +94,7 @@ extern bool enableReshapeCanonicalization;                    // common for both
 extern bool enablePositiveAxisCanonicalization;               // common for both
 extern bool enableExpandCanonicalization;                     // common for both
 extern bool enableReduceKeepdimsCanonicalization;             // common for both
+extern bool enableGatherElementsTileCanonicalization;         // common for both
 extern bool enableXFEONNXOpsetVerifier;                       // common for both
 extern uint64_t compilationNumThreads;                        // common for both
 // AMD: Decompose unconditionally

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -72,6 +72,8 @@ void configurePasses() {
   configurePositiveAxisCanonicalization(enablePositiveAxisCanonicalization);
   configureReduceKeepdimsCanonicalization(enableReduceKeepdimsCanonicalization);
   configureExpandCanonicalization(enableExpandCanonicalization);
+  configureGatherElementsTileCanonicalization(
+      enableGatherElementsTileCanonicalization);
   configureQDQDataMovementCanonicalization(
       enableQDQDataMovementCanonicalization);
 #ifdef ONNX_MLIR_ENABLE_KRNL
@@ -283,6 +285,8 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
     opts.enableExpandCanonicalization = enableExpandCanonicalization;
     opts.enableReduceKeepdimsCanonicalization =
         enableReduceKeepdimsCanonicalization;
+    opts.enableGatherElementsTileCanonicalization =
+        enableGatherElementsTileCanonicalization;
     opts.enableXFEONNXOpsetVerifier = enableXFEONNXOpsetVerifier;
     if (enableXMCPasses) {
       opts.hybrid.enableInstanceNormDecompose = false;

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -48,6 +48,10 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   // 2. Easy to compare two approaches.
   // In future, only the dynamic pass, ONNXOpTransformPass, will be used for
   // this function.
+
+  if (opts.enableXMCPasses)
+    opts.enableGatherElementsTileCanonicalization = false;
+
   configureBatchNormCanonicalization(opts.disableBatchNormDecompose);
   configureUnsafeMathCanonicalization(opts.enableUnsafeMathOptimizations);
   configureReshapeCanonicalization(opts.enableReshapeCanonicalization);
@@ -56,6 +60,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   configureExpandCanonicalization(opts.enableExpandCanonicalization);
   configureReduceKeepdimsCanonicalization(
       opts.enableReduceKeepdimsCanonicalization);
+  configureGatherElementsTileCanonicalization(
+      opts.enableGatherElementsTileCanonicalization);
   configureQDQDataMovementCanonicalization(
       opts.enableQDQDataMovementCanonicalization);
 

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -38,6 +38,7 @@ struct OnnxToMlirOptions {
   bool enablePositiveAxisCanonicalization = true;
   bool enableExpandCanonicalization = false;
   bool enableReduceKeepdimsCanonicalization = false;
+  bool enableGatherElementsTileCanonicalization = true;
   bool enableXFEONNXOpsetVerifier = true;
   bool enableUnsafeMathOptimizations = true;
   bool enableQDQDataMovementCanonicalization = false;

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -2818,6 +2818,7 @@ def ONNXGatherOp:ONNX_Op<"Gather",
 
 def ONNXGatherElementsOp:ONNX_Op<"GatherElements",
   [Pure, OpVersionTrait<13>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX GatherElements operation";
   let description = [{
   GatherElements takes two inputs `data` and `indices` of the same rank r >= 1

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -73,6 +73,9 @@ static bool enableQDQDataMovementCanonicalization = false;
 // Populated by configureExpandCanonicalization().
 static bool enableExpandCanonicalization = false;
 
+// Populated by configureGatherElementsTileCanonicalization().
+static bool enableGatherElementsTileCanonicalization = true;
+
 using namespace mlir;
 using namespace onnx_mlir;
 
@@ -4937,7 +4940,8 @@ void ONNXExpandOp::getCanonicalizationPatterns(
 /// on the ONNXGatherElementsOp.
 void ONNXGatherElementsOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  result.insert<FuseGatherElementsTilePattern>(context);
+  if (enableGatherElementsTileCanonicalization)
+    result.insert<FuseGatherElementsTilePattern>(context);
 }
 
 /// on the ONNXGlobalAveragePoolOp.
@@ -5371,4 +5375,8 @@ bool onnx_mlir::isQDQDataMovementCanonicalizationEnabled() {
 
 void onnx_mlir::configureExpandCanonicalization(bool enable) {
   enableExpandCanonicalization = enable;
+}
+
+void onnx_mlir::configureGatherElementsTileCanonicalization(bool enable) {
+  enableGatherElementsTileCanonicalization = enable;
 }

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -1882,6 +1882,66 @@ public:
   }
 };
 
+// Rewrite GatherElements(data, Tile(indices, repeats)) to
+// Gather(data, Reshape(indices)) when Tile broadcasts a one-dimensional index
+// vector across all non-axis dimensions of data.
+class FuseGatherElementsTilePattern
+    : public OpRewritePattern<ONNXGatherElementsOp> {
+public:
+  using OpRewritePattern<ONNXGatherElementsOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ONNXGatherElementsOp gatherElementsOp,
+      PatternRewriter &rewriter) const override {
+    auto tileOp = gatherElementsOp.getIndices().getDefiningOp<ONNXTileOp>();
+    if (!tileOp || !tileOp->hasOneUse())
+      return failure();
+
+    auto dataType =
+        dyn_cast<RankedTensorType>(gatherElementsOp.getData().getType());
+    auto indicesType = dyn_cast<RankedTensorType>(tileOp.getInput().getType());
+    auto tiledType = dyn_cast<RankedTensorType>(tileOp.getOutput().getType());
+    if (!dataType || !indicesType || !tiledType || !dataType.hasStaticShape() ||
+        !indicesType.hasStaticShape() || !tiledType.hasStaticShape())
+      return failure();
+
+    int64_t rank = dataType.getRank();
+    if (indicesType.getRank() != rank || tiledType.getRank() != rank)
+      return failure();
+
+    int64_t axis = gatherElementsOp.getAxis();
+    if (axis < 0)
+      axis += rank;
+
+    ArrayRef<int64_t> dataShape = dataType.getShape();
+    ArrayRef<int64_t> indicesShape = indicesType.getShape();
+    ArrayRef<int64_t> tiledShape = tiledType.getShape();
+
+    // All non-axis dimensions must be broadcastable.
+    int64_t numIndices = indicesShape[axis];
+    if (numIndices < 1 || tiledShape[axis] != numIndices)
+      return failure();
+    for (int64_t i = 0; i < rank; ++i)
+      if (i != axis && (indicesShape[i] != 1 || tiledShape[i] != dataShape[i]))
+        return failure();
+
+    SmallVector<int64_t> gatherShape(dataShape);
+    gatherShape[axis] = numIndices;
+    auto gatherType =
+        RankedTensorType::get(gatherShape, dataType.getElementType());
+    if (gatherType != gatherElementsOp.getOutput().getType())
+      return failure();
+
+    OnnxBuilder create(rewriter, gatherElementsOp.getLoc());
+    Value flattenedIndices = create.reshape(
+        RankedTensorType::get({numIndices}, indicesType.getElementType()),
+        tileOp.getInput(), create.constantInt64({numIndices}));
+    rewriter.replaceOpWithNewOp<ONNXGatherOp>(gatherElementsOp, gatherType,
+        gatherElementsOp.getData(), flattenedIndices,
+        gatherElementsOp.getAxisAttr());
+    return success();
+  }
+};
+
 /// The pattern is to replace two consecutive ReshapeOp with a single ReshapeOp.
 /// It's not successful for arbitrary ReshapeOp, so let's consider necessary
 /// condition for the replacement.
@@ -4872,6 +4932,12 @@ void ONNXExpandOp::getCanonicalizationPatterns(
     result.insert<ExpandToTilePattern>(context);
     result.insert<ExpandRankIncreaseToReshapeExpandPattern>(context);
   }
+}
+
+/// on the ONNXGatherElementsOp.
+void ONNXGatherElementsOp::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  result.insert<FuseGatherElementsTilePattern>(context);
 }
 
 /// on the ONNXGlobalAveragePoolOp.

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -88,6 +88,9 @@ bool isQDQDataMovementCanonicalizationEnabled();
 // enabled.
 void configureExpandCanonicalization(bool enableExpandCanonicalization);
 
+void configureGatherElementsTileCanonicalization(
+    bool enableGatherElementsTileCanonicalization);
+
 void populateQDQDataMovementCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::PatternBenefit benefit = 1);
 

--- a/test/mlir/onnx/onnx_canonicalization_gather_elements.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_gather_elements.mlir
@@ -1,4 +1,5 @@
 // RUN: onnx-mlir-opt --canonicalize="test-convergence=true" %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --enable-gather-elements-tile-canonicalization=false --canonicalize="test-convergence=true" %s -split-input-file | FileCheck %s --check-prefix=DISABLED
 
 func.func @fuse_gather_elements_tile(
     %data: tensor<2x5x4xf32>, %indices: tensor<1x3x1xi64>)
@@ -16,6 +17,9 @@ func.func @fuse_gather_elements_tile(
 // CHECK-NEXT: [[GATHER:%.+]] = "onnx.Gather"(%arg0, [[RESHAPED]]) {axis = 1 : si64} : (tensor<2x5x4xf32>, tensor<3xi64>) -> tensor<2x3x4xf32>
 // CHECK-NOT: "onnx.GatherElements"
 // CHECK-NEXT: onnx.Return [[GATHER]] : tensor<2x3x4xf32>
+// DISABLED-LABEL: func.func @fuse_gather_elements_tile(
+// DISABLED: "onnx.Tile"
+// DISABLED: "onnx.GatherElements"
 
 // -----
 

--- a/test/mlir/onnx/onnx_canonicalization_gather_elements.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_gather_elements.mlir
@@ -1,0 +1,73 @@
+// RUN: onnx-mlir-opt --canonicalize="test-convergence=true" %s -split-input-file | FileCheck %s
+
+func.func @fuse_gather_elements_tile(
+    %data: tensor<2x5x4xf32>, %indices: tensor<1x3x1xi64>)
+    -> tensor<2x3x4xf32> {
+  %repeats = onnx.Constant dense<[2, 1, 4]> : tensor<3xi64>
+  %tiled = "onnx.Tile"(%indices, %repeats) :
+      (tensor<1x3x1xi64>, tensor<3xi64>) -> tensor<2x3x4xi64>
+  %result = "onnx.GatherElements"(%data, %tiled) {axis = 1 : si64} :
+      (tensor<2x5x4xf32>, tensor<2x3x4xi64>) -> tensor<2x3x4xf32>
+  onnx.Return %result : tensor<2x3x4xf32>
+}
+// CHECK-LABEL: func.func @fuse_gather_elements_tile(
+// CHECK-NOT: "onnx.Tile"
+// CHECK: [[RESHAPED:%.+]] = "onnx.Reshape"(%arg1, %{{.+}}) {allowzero = 0 : si64} : (tensor<1x3x1xi64>, tensor<1xi64>) -> tensor<3xi64>
+// CHECK-NEXT: [[GATHER:%.+]] = "onnx.Gather"(%arg0, [[RESHAPED]]) {axis = 1 : si64} : (tensor<2x5x4xf32>, tensor<3xi64>) -> tensor<2x3x4xf32>
+// CHECK-NOT: "onnx.GatherElements"
+// CHECK-NEXT: onnx.Return [[GATHER]] : tensor<2x3x4xf32>
+
+// -----
+
+func.func @fuse_gather_elements_tile_negative_axis(
+    %data: tensor<2x5x4xf32>, %indices: tensor<1x3x1xi64>)
+    -> tensor<2x3x4xf32> {
+  %repeats = onnx.Constant dense<[2, 1, 4]> : tensor<3xi64>
+  %tiled = "onnx.Tile"(%indices, %repeats) :
+      (tensor<1x3x1xi64>, tensor<3xi64>) -> tensor<2x3x4xi64>
+  %result = "onnx.GatherElements"(%data, %tiled) {axis = -2 : si64} :
+      (tensor<2x5x4xf32>, tensor<2x3x4xi64>) -> tensor<2x3x4xf32>
+  onnx.Return %result : tensor<2x3x4xf32>
+}
+// CHECK-LABEL: func.func @fuse_gather_elements_tile_negative_axis(
+// CHECK-NOT: "onnx.Tile"
+// CHECK: [[RESHAPED:%.+]] = "onnx.Reshape"(%arg1, %{{.+}}) {allowzero = 0 : si64} : (tensor<1x3x1xi64>, tensor<1xi64>) -> tensor<3xi64>
+// CHECK-NEXT: [[GATHER:%.+]] = "onnx.Gather"(%arg0, [[RESHAPED]]) {axis = -2 : si64} : (tensor<2x5x4xf32>, tensor<3xi64>) -> tensor<2x3x4xf32>
+// CHECK-NOT: "onnx.GatherElements"
+// CHECK-NEXT: onnx.Return [[GATHER]] : tensor<2x3x4xf32>
+
+// -----
+
+// Repeating the GatherElements axis cannot be represented by a 1-D Gather.
+func.func @do_not_fuse_repeated_axis(
+    %data: tensor<2x5x4xf32>, %indices: tensor<1x3x1xi64>)
+    -> tensor<2x6x4xf32> {
+  %repeats = onnx.Constant dense<[2, 2, 4]> : tensor<3xi64>
+  %tiled = "onnx.Tile"(%indices, %repeats) :
+      (tensor<1x3x1xi64>, tensor<3xi64>) -> tensor<2x6x4xi64>
+  %result = "onnx.GatherElements"(%data, %tiled) {axis = 1 : si64} :
+      (tensor<2x5x4xf32>, tensor<2x6x4xi64>) -> tensor<2x6x4xf32>
+  onnx.Return %result : tensor<2x6x4xf32>
+}
+// CHECK-LABEL: func.func @do_not_fuse_repeated_axis(
+// CHECK: [[TILED:%.+]] = "onnx.Tile"
+// CHECK: [[RESULT:%.+]] = "onnx.GatherElements"(%arg0, [[TILED]]) {axis = 1 : si64}
+// CHECK: onnx.Return [[RESULT]]
+
+// -----
+
+// Gather would retain the full first data dimension, unlike GatherElements.
+func.func @do_not_fuse_partial_non_axis_dimension(
+    %data: tensor<2x5x4xf32>, %indices: tensor<1x3x1xi64>)
+    -> tensor<1x3x4xf32> {
+  %repeats = onnx.Constant dense<[1, 1, 4]> : tensor<3xi64>
+  %tiled = "onnx.Tile"(%indices, %repeats) :
+      (tensor<1x3x1xi64>, tensor<3xi64>) -> tensor<1x3x4xi64>
+  %result = "onnx.GatherElements"(%data, %tiled) {axis = 1 : si64} :
+      (tensor<2x5x4xf32>, tensor<1x3x4xi64>) -> tensor<1x3x4xf32>
+  onnx.Return %result : tensor<1x3x4xf32>
+}
+// CHECK-LABEL: func.func @do_not_fuse_partial_non_axis_dimension(
+// CHECK: [[TILED:%.+]] = "onnx.Tile"
+// CHECK: [[RESULT:%.+]] = "onnx.GatherElements"(%arg0, [[TILED]]) {axis = 1 : si64}
+// CHECK: onnx.Return [[RESULT]]

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -550,6 +550,7 @@ OpsWithCanonicalizer = [
     "Equal",
     "Expand",
     "Flatten",
+    "GatherElements",
     "GlobalAveragePool",
     "GlobalMaxPool",
     "Greater",


### PR DESCRIPTION
Adds a pattern that rewrites `GatherElements(data, Tile(indices)) --> Gather(data, Reshape(indices))` to avoid large intermediate tensors of indices. The main precondition is that all non-axis dimensions must be broadcasted by the Tile.


```mlir
// before
%repeats = onnx.Constant dense<[2, 1, 4]> : tensor<3xi64>
%tiled = "onnx.Tile"(%indices, %repeats) : (tensor<1x300x1xi64>, tensor<3xi64>) -> tensor<2x300x4xi64>
%result = "onnx.GatherElements"(%data, %tiled) {axis = 1 : si64} 
                                    : (tensor<2x300x4xf32>, tensor<2x300x4xi64>) -> tensor<2x300x4xf32>

// after
%0 = onnx.Constant dense<300> : tensor<1xi64>
%1 = "onnx.Reshape"(%indices, %0) : (tensor<1x300x1xi64>, tensor<1xi64>) -> tensor<300xi64>
%2 = "onnx.Gather"(%data, %1) {axis = 1 : si64} : (tensor<2x300x4xf32>, tensor<300xi64>) -> tensor<2x300x4xf32>
```
