### PR TITLE
Add keepdims canonicalization for ArgMax/ArgMin

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -56,7 +56,7 @@ bool disableBatchNormDecompose;                        // common for both
 bool enableReshapeCanonicalization;                    // common for both
 bool enablePositiveAxisCanonicalization;               // common for both
 bool enableExpandCanonicalization;                     // common for both
-bool enableReduceKeepdimsCanonicalization;             // common for both
+bool enableKeepdimsCanonicalization;                   // common for both
 bool enableXFEONNXOpsetVerifier;                       // common for both
 bool enableSafeCodeGen;                                // common for both
 bool disableMemRefPrefetch;                            // common for both
@@ -380,13 +380,14 @@ static llvm::cl::opt<bool, true> enableExpandCanonicalizationOpt(
     llvm::cl::location(enableExpandCanonicalization), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirCommonOptions));
 
-static llvm::cl::opt<bool, true> enableReduceKeepdimsCanonicalizationOpt(
-    "enable-reduce-keepdims-canonicalization",
+static llvm::cl::opt<bool, true> enableKeepdimsCanonicalizationOpt(
+    "enable-keepdims-canonicalization",
     llvm::cl::desc(
-        "Enable canonicalization of reduce ops with keepdims=0 into "
-        "keepdims=1 + Reshape (default=false, i.e. the rewrite is disabled)."),
-    llvm::cl::location(enableReduceKeepdimsCanonicalization),
-    llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
+        "Enable canonicalization of reduce, ArgMin, and ArgMax ops with "
+        "keepdims=0 into keepdims=1 + Reshape (default=false, i.e. the "
+        "rewrite is disabled)."),
+    llvm::cl::location(enableKeepdimsCanonicalization), llvm::cl::init(false),
+    llvm::cl::cat(OnnxMlirCommonOptions));
 
 static llvm::cl::opt<bool, true> enableXFEONNXOpsetVerifierOpt(
     "enable-xfe-onnx-opset-verifier",

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -93,7 +93,7 @@ extern bool disableBatchNormDecompose;                        // common for both
 extern bool enableReshapeCanonicalization;                    // common for both
 extern bool enablePositiveAxisCanonicalization;               // common for both
 extern bool enableExpandCanonicalization;                     // common for both
-extern bool enableReduceKeepdimsCanonicalization;             // common for both
+extern bool enableKeepdimsCanonicalization;                   // common for both
 extern bool enableXFEONNXOpsetVerifier;                       // common for both
 extern uint64_t compilationNumThreads;                        // common for both
 // AMD: Decompose unconditionally

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -70,7 +70,7 @@ void configurePasses() {
   configureConstPropMaxTileFoldSize(onnxConstPropMaxTileFoldSize);
   configureUnsafeMathCanonicalization(enableUnsafeMathOptimizations);
   configurePositiveAxisCanonicalization(enablePositiveAxisCanonicalization);
-  configureReduceKeepdimsCanonicalization(enableReduceKeepdimsCanonicalization);
+  configureKeepdimsCanonicalization(enableKeepdimsCanonicalization);
   configureExpandCanonicalization(enableExpandCanonicalization);
   configureQDQDataMovementCanonicalization(
       enableQDQDataMovementCanonicalization);
@@ -281,8 +281,7 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
     opts.enablePositiveAxisCanonicalization =
         enablePositiveAxisCanonicalization;
     opts.enableExpandCanonicalization = enableExpandCanonicalization;
-    opts.enableReduceKeepdimsCanonicalization =
-        enableReduceKeepdimsCanonicalization;
+    opts.enableKeepdimsCanonicalization = enableKeepdimsCanonicalization;
     opts.enableXFEONNXOpsetVerifier = enableXFEONNXOpsetVerifier;
     if (enableXMCPasses) {
       opts.hybrid.enableInstanceNormDecompose = false;

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -54,8 +54,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   configurePositiveAxisCanonicalization(
       opts.enablePositiveAxisCanonicalization);
   configureExpandCanonicalization(opts.enableExpandCanonicalization);
-  configureReduceKeepdimsCanonicalization(
-      opts.enableReduceKeepdimsCanonicalization);
+  configureKeepdimsCanonicalization(opts.enableKeepdimsCanonicalization);
   configureQDQDataMovementCanonicalization(
       opts.enableQDQDataMovementCanonicalization);
 

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -37,7 +37,7 @@ struct OnnxToMlirOptions {
   // Negative axis/axes canonicalization when rank is known.
   bool enablePositiveAxisCanonicalization = true;
   bool enableExpandCanonicalization = false;
-  bool enableReduceKeepdimsCanonicalization = false;
+  bool enableKeepdimsCanonicalization = false;
   bool enableXFEONNXOpsetVerifier = true;
   bool enableUnsafeMathOptimizations = true;
   bool enableQDQDataMovementCanonicalization = false;

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -274,6 +274,7 @@ def ONNXAndOp:ONNX_Op<"And",
 
 def ONNXArgMaxOp:ONNX_Op<"ArgMax",
   [Pure, OpVersionTrait<13>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX ArgMax operation";
   let description = [{
   Computes the indices of the max elements of the input tensor's element along the
@@ -313,6 +314,7 @@ def ONNXArgMaxOp:ONNX_Op<"ArgMax",
 
 def ONNXArgMinOp:ONNX_Op<"ArgMin",
   [Pure, OpVersionTrait<13>, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX ArgMin operation";
   let description = [{
   Computes the indices of the min elements of the input tensor's element along the

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -64,8 +64,8 @@ static bool enableReshapeCanonicalization = true;
 // Populated by configurePositiveAxisCanonicalization().
 static bool enablePositiveAxisCanonicalization = true;
 
-// Populated by configureReduceKeepdimsCanonicalization().
-static bool enableReduceKeepdimsCanonicalization = true;
+// Populated by configureKeepdimsCanonicalization().
+static bool enableKeepdimsCanonicalization = true;
 
 // Populated by configureQDQDataMovementCanonicalization().
 static bool enableQDQDataMovementCanonicalization = false;
@@ -611,6 +611,16 @@ bool isConstantOpWithNoZeroElements(Value constVal) {
 
 } // namespace onnx_mlir
 
+namespace {
+
+template <typename ONNXOp>
+void inferShapes(ONNXOp op) {
+  if (failed(op.inferShapes([](Region &region) {})))
+    llvm_unreachable("unexpected inferShapes failure");
+}
+
+} // namespace
+
 // =============================================================================
 /// Include the patterns defined in the Declarative Rewrite framework.
 // =============================================================================
@@ -1089,8 +1099,11 @@ public:
 };
 
 // Rewrite keepdims=0 to keepdims=1 + Reshape to the original result shape.
+// The op's own shape inference computes the keepdims=1 result type, so this
+// applies to both reductions with an `axes` operand and ArgMin/ArgMax with an
+// `axis` attribute.
 template <typename OP_TYPE>
-class ReduceKeepdimsCanonPattern : public OpRewritePattern<OP_TYPE> {
+class KeepdimsCanonicalizationPattern : public OpRewritePattern<OP_TYPE> {
 public:
   using OpRewritePattern<OP_TYPE>::OpRewritePattern;
 
@@ -1103,19 +1116,22 @@ public:
     if (!hasStaticShape(resultType))
       return rewriter.notifyMatchFailure(op, "result must have static shape");
 
-    Type elemType = getElementTypeOrSelf(resultType);
+    auto keepdimsOp = mlir::cast<OP_TYPE>(rewriter.clone(*op.getOperation()));
+    keepdimsOp.setKeepdimsAttr(rewriter.getIntegerAttr(
+        rewriter.getIntegerType(64, /*isSigned=*/true), 1));
+    keepdimsOp.getResult().setType(
+        UnrankedTensorType::get(getElementTypeOrSelf(resultType)));
+    // The clone must not keep ResultNames: the ONNX tensor name belongs to the
+    // Reshape that takes over this op's result. Dropping it here also lets the
+    // ResultNames listener re-derive the intermediate as a reshaped view.
+    keepdimsOp->removeAttr("ResultNames");
+    inferShapes(keepdimsOp);
 
     OnnxBuilder create(rewriter, op.getLoc());
-    auto reduceOp = create.createTypedOpAndInferShapes<OP_TYPE>(
-        UnrankedTensorType::get(elemType), op.getData(), op.getAxes(),
-        int64_t{1}, op.getNoopWithEmptyAxes());
-
-    DenseElementsAttr shapeAttr =
-        createDenseElementsAttrFromShape(rewriter, op.getResult());
-    Value shapeConst = create.constant(shapeAttr);
-    Value reshaped = create.reshape(
-        resultType, reduceOp.getResult(), shapeConst, IntegerAttr());
-    rewriter.replaceOp(op, reshaped);
+    Value shape = create.constant(
+        createDenseElementsAttrFromShape(rewriter, op.getResult()));
+    rewriter.replaceOp(op, create.reshape(resultType, keepdimsOp.getResult(),
+                               shape, IntegerAttr()));
     return success();
   }
 };
@@ -1506,12 +1522,6 @@ private:
 
 namespace {
 // RNNOpRewriteLayoutPattern helper functions and classes.
-
-template <typename ONNXOp>
-void inferShapes(ONNXOp op) {
-  if (failed(op.inferShapes([](Region &region) {})))
-    llvm_unreachable("unexpected inferShapes failure");
-}
 
 // To transpose between [batch_size, seq_length/num_directions, size]
 //                  and [seq_length/num_directions, batch_size, size].
@@ -4730,6 +4740,20 @@ void ONNXAbsOp::getCanonicalizationPatterns(
   results.insert<AbsAbsPattern>(context);
 }
 
+/// on the ONNXArgMaxOp.
+void ONNXArgMaxOp::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXArgMaxOp>>(context);
+}
+
+/// on the ONNXArgMinOp.
+void ONNXArgMinOp::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXArgMinOp>>(context);
+}
+
 /// on the ONNXBatchNormalizationInferenceModeOp.
 void ONNXBatchNormalizationInferenceModeOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
@@ -4969,36 +4993,37 @@ void ONNXOrOp::getCanonicalizationPatterns(
 /// on the ONNXReduceL1Op.
 void ONNXReduceL1Op::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  if (enableReduceKeepdimsCanonicalization)
-    result.insert<ReduceKeepdimsCanonPattern<ONNXReduceL1Op>>(context);
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXReduceL1Op>>(context);
 }
 
 /// on the ONNXReduceL2Op.
 void ONNXReduceL2Op::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  if (enableReduceKeepdimsCanonicalization)
-    result.insert<ReduceKeepdimsCanonPattern<ONNXReduceL2Op>>(context);
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXReduceL2Op>>(context);
 }
 
 /// on the ONNXReduceLogSumOp.
 void ONNXReduceLogSumOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  if (enableReduceKeepdimsCanonicalization)
-    result.insert<ReduceKeepdimsCanonPattern<ONNXReduceLogSumOp>>(context);
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXReduceLogSumOp>>(context);
 }
 
 /// on the ONNXReduceLogSumExpOp.
 void ONNXReduceLogSumExpOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  if (enableReduceKeepdimsCanonicalization)
-    result.insert<ReduceKeepdimsCanonPattern<ONNXReduceLogSumExpOp>>(context);
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXReduceLogSumExpOp>>(
+        context);
 }
 
 /// on the ONNXReduceMaxOp.
 void ONNXReduceMaxOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  if (enableReduceKeepdimsCanonicalization)
-    result.insert<ReduceKeepdimsCanonPattern<ONNXReduceMaxOp>>(context);
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXReduceMaxOp>>(context);
 }
 
 /// on the ONNXReduceMeanOp.
@@ -5006,8 +5031,8 @@ void ONNXReduceMeanOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
   result.insert<MaterializeAbsentAxesReduceMeanPattern>(context);
   result.insert<DropUnitAxesFromReduceMeanPattern>(context);
-  if (enableReduceKeepdimsCanonicalization)
-    result.insert<ReduceKeepdimsCanonPattern<ONNXReduceMeanOp>>(context);
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXReduceMeanOp>>(context);
 }
 
 /// on the ONNXReduceMeanV13Op.
@@ -5019,29 +5044,30 @@ void ONNXReduceMeanV13Op::getCanonicalizationPatterns(
 /// on the ONNXReduceMinOp.
 void ONNXReduceMinOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  if (enableReduceKeepdimsCanonicalization)
-    result.insert<ReduceKeepdimsCanonPattern<ONNXReduceMinOp>>(context);
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXReduceMinOp>>(context);
 }
 
 /// on the ONNXReduceProdOp.
 void ONNXReduceProdOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  if (enableReduceKeepdimsCanonicalization)
-    result.insert<ReduceKeepdimsCanonPattern<ONNXReduceProdOp>>(context);
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXReduceProdOp>>(context);
 }
 
 /// on the ONNXReduceSumOp.
 void ONNXReduceSumOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  if (enableReduceKeepdimsCanonicalization)
-    result.insert<ReduceKeepdimsCanonPattern<ONNXReduceSumOp>>(context);
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXReduceSumOp>>(context);
 }
 
 /// on the ONNXReduceSumSquareOp.
 void ONNXReduceSumSquareOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  if (enableReduceKeepdimsCanonicalization)
-    result.insert<ReduceKeepdimsCanonPattern<ONNXReduceSumSquareOp>>(context);
+  if (enableKeepdimsCanonicalization)
+    result.insert<KeepdimsCanonicalizationPattern<ONNXReduceSumSquareOp>>(
+        context);
 }
 
 /// on the ONNXReduceSumV11Op.
@@ -5289,8 +5315,8 @@ bool onnx_mlir::isPositiveAxisCanonicalizationEnabled() {
   return enablePositiveAxisCanonicalization;
 }
 
-void onnx_mlir::configureReduceKeepdimsCanonicalization(bool enable) {
-  enableReduceKeepdimsCanonicalization = enable;
+void onnx_mlir::configureKeepdimsCanonicalization(bool enable) {
+  enableKeepdimsCanonicalization = enable;
 }
 
 void onnx_mlir::configureQDQDataMovementCanonicalization(

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -73,10 +73,9 @@ void configurePositiveAxisCanonicalization(
 
 bool isPositiveAxisCanonicalizationEnabled();
 
-// Configure whether reduce keepdims=0 -> keepdims=1 + Reshape canonicalization
-// is enabled.
-void configureReduceKeepdimsCanonicalization(
-    bool enableReduceKeepdimsCanonicalization);
+// Configure whether keepdims=0 -> keepdims=1 + Reshape canonicalization is
+// enabled.
+void configureKeepdimsCanonicalization(bool enableKeepdimsCanonicalization);
 
 // Configure QDQ canonicalizations for data-movement/view ONNX ops.
 void configureQDQDataMovementCanonicalization(

--- a/test/mlir/onnx/onnx_canonicalization_reductors.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_reductors.mlir
@@ -1,6 +1,6 @@
 // Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
-// RUN: onnx-mlir-opt --enable-reduce-keepdims-canonicalization=true --shape-inference --canonicalize="test-convergence=true" --shape-inference --cse %s -split-input-file | FileCheck %s
-// RUN: onnx-mlir-opt --enable-reduce-keepdims-canonicalization=false --shape-inference --canonicalize="test-convergence=true" --shape-inference --cse %s -split-input-file | FileCheck %s --check-prefix=DISABLED-CHECK
+// RUN: onnx-mlir-opt --enable-keepdims-canonicalization=true --shape-inference --canonicalize="test-convergence=true" --shape-inference --cse %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --enable-keepdims-canonicalization=false --shape-inference --canonicalize="test-convergence=true" --shape-inference --cse %s -split-input-file | FileCheck %s --check-prefix=DISABLED-CHECK
 
 
 func.func @test_reducesumv11_axes(%arg0: tensor<1x32x512x640xf32>) -> tensor<1x512x640xf32> {
@@ -261,4 +261,77 @@ func.func @reduce_sum_keepdims_one_unchanged(%arg0: tensor<2x3x4xf32>) -> tensor
   // DISABLED-CHECK: "onnx.ReduceSum"(%arg0, %{{.*}}) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64}
   // DISABLED-CHECK: onnx.Return %{{.*}}
   // DISABLED-CHECK-NOT: "onnx.Reshape"
+}
+
+// -----
+// CHECK-LABEL: func.func @argmax_keepdims_zero
+func.func @argmax_keepdims_zero(%arg0: tensor<2x3x4xf32>) -> tensor<2x4xi64> {
+  %0 = "onnx.ArgMax"(%arg0) {axis = 1 : si64, keepdims = 0 : si64,
+      select_last_index = 0 : si64} : (tensor<2x3x4xf32>) -> tensor<2x4xi64>
+  onnx.Return %0 : tensor<2x4xi64>
+  // CHECK-DAG: [[SHAPE:%.+]] = onnx.Constant dense<[2, 4]> : tensor<2xi64>
+  // CHECK: [[ARGMAX:%.+]] = "onnx.ArgMax"(%arg0) {axis = 1 : si64, keepdims = 1 : si64, select_last_index = 0 : si64}
+  // CHECK-SAME: (tensor<2x3x4xf32>) -> tensor<2x1x4xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"([[ARGMAX]], [[SHAPE]]) {allowzero = 0 : si64}
+  // CHECK-SAME: (tensor<2x1x4xi64>, tensor<2xi64>) -> tensor<2x4xi64>
+  // CHECK: onnx.Return [[RES]]
+  // CHECK-NOT: keepdims = 0
+  // DISABLED-CHECK-LABEL: func.func @argmax_keepdims_zero
+  // DISABLED-CHECK: "onnx.ArgMax"(%arg0) {axis = 1 : si64, keepdims = 0 : si64, select_last_index = 0 : si64}
+  // DISABLED-CHECK: onnx.Return %{{.*}}
+  // DISABLED-CHECK-NOT: "onnx.Reshape"
+}
+
+// -----
+// CHECK-LABEL: func.func @argmin_keepdims_zero
+func.func @argmin_keepdims_zero(%arg0: tensor<2x3x4xf32>) -> tensor<2x4xi64> {
+  %0 = "onnx.ArgMin"(%arg0) {axis = 1 : si64, keepdims = 0 : si64,
+      select_last_index = 0 : si64} : (tensor<2x3x4xf32>) -> tensor<2x4xi64>
+  onnx.Return %0 : tensor<2x4xi64>
+  // CHECK-DAG: [[SHAPE:%.+]] = onnx.Constant dense<[2, 4]> : tensor<2xi64>
+  // CHECK: [[ARGMIN:%.+]] = "onnx.ArgMin"(%arg0) {axis = 1 : si64, keepdims = 1 : si64, select_last_index = 0 : si64}
+  // CHECK-SAME: (tensor<2x3x4xf32>) -> tensor<2x1x4xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"([[ARGMIN]], [[SHAPE]]) {allowzero = 0 : si64}
+  // CHECK-SAME: (tensor<2x1x4xi64>, tensor<2xi64>) -> tensor<2x4xi64>
+  // CHECK: onnx.Return [[RES]]
+  // CHECK-NOT: keepdims = 0
+  // DISABLED-CHECK-LABEL: func.func @argmin_keepdims_zero
+  // DISABLED-CHECK: "onnx.ArgMin"(%arg0) {axis = 1 : si64, keepdims = 0 : si64, select_last_index = 0 : si64}
+  // DISABLED-CHECK: onnx.Return %{{.*}}
+  // DISABLED-CHECK-NOT: "onnx.Reshape"
+}
+
+// -----
+// CHECK-LABEL: func.func @argmax_negative_axis_keepdims_zero
+func.func @argmax_negative_axis_keepdims_zero(%arg0: tensor<2x3x4xf32>) -> tensor<2x3xi64> {
+  %0 = "onnx.ArgMax"(%arg0) {axis = -1 : si64, keepdims = 0 : si64,
+      select_last_index = 0 : si64} : (tensor<2x3x4xf32>) -> tensor<2x3xi64>
+  onnx.Return %0 : tensor<2x3xi64>
+  // CHECK-DAG: [[SHAPE:%.+]] = onnx.Constant dense<[2, 3]> : tensor<2xi64>
+  // CHECK: [[ARGMAX:%.+]] = "onnx.ArgMax"(%arg0) {axis = 2 : si64, keepdims = 1 : si64, select_last_index = 0 : si64}
+  // CHECK-SAME: (tensor<2x3x4xf32>) -> tensor<2x3x1xi64>
+  // CHECK: [[RES:%.+]] = "onnx.Reshape"([[ARGMAX]], [[SHAPE]]) {allowzero = 0 : si64}
+  // CHECK-SAME: (tensor<2x3x1xi64>, tensor<2xi64>) -> tensor<2x3xi64>
+  // CHECK: onnx.Return [[RES]]
+  // CHECK-NOT: keepdims = 0
+  // DISABLED-CHECK-LABEL: func.func @argmax_negative_axis_keepdims_zero
+  // DISABLED-CHECK: "onnx.ArgMax"(%arg0) {axis = 2 : si64, keepdims = 0 : si64, select_last_index = 0 : si64}
+  // DISABLED-CHECK: onnx.Return %{{.*}}
+  // DISABLED-CHECK-NOT: "onnx.Reshape"
+}
+
+// -----
+// A dynamic result shape prevents the keepdims canonicalization.
+func.func @argmax_dynamic_result_shape(%arg0: tensor<?x3x4xf32>) -> tensor<?x4xi64> {
+  %0 = "onnx.ArgMax"(%arg0) {axis = 1 : si64, keepdims = 0 : si64,
+      select_last_index = 0 : si64} : (tensor<?x3x4xf32>) -> tensor<?x4xi64>
+  onnx.Return %0 : tensor<?x4xi64>
+  // CHECK-LABEL: func.func @argmax_dynamic_result_shape
+  // CHECK: "onnx.ArgMax"(%arg0) {axis = 1 : si64, keepdims = 0 : si64, select_last_index = 0 : si64}
+  // CHECK-NOT: "onnx.Reshape"
+  // CHECK: onnx.Return %{{.*}} : tensor<?x4xi64>
+  // DISABLED-CHECK-LABEL: func.func @argmax_dynamic_result_shape
+  // DISABLED-CHECK: "onnx.ArgMax"(%arg0) {axis = 1 : si64, keepdims = 0 : si64, select_last_index = 0 : si64}
+  // DISABLED-CHECK-NOT: "onnx.Reshape"
+  // DISABLED-CHECK: onnx.Return %{{.*}} : tensor<?x4xi64>
 }

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -535,6 +535,8 @@ OpsWithCanonicalizer = [
     "Abs",
     "Add",
     "And",
+    "ArgMax",
+    "ArgMin",
     "AveragePool",
     "BatchNormalization",
     "BatchNormalizationV9",


### PR DESCRIPTION
Extend the `keepdims=0 --> keepdims=1 + Reshape` canonicalization pattern for ArgMax and ArgMin. The new pattern is using inferShapes to work for both axis and axes. The pattern is disabled by default. 