### PR TITLE
Infer external data length when exporter writes length=0

### DIFF
--- a/src/Builder/FrontendDialectHelper.cpp
+++ b/src/Builder/FrontendDialectHelper.cpp
@@ -292,6 +292,16 @@ ElementsAttr createElmAttr(RankedTensorType tensorType,
       return createElmAttrFromRawBytes_LE<T>(tensorType,
           llvm::ArrayRef(reinterpret_cast<char *>(loc.offset), loc.length));
     }
+    // Some exporters write length="0" instead of the correct byte count.
+    // While not officially supported in onnx, the length can also be computed
+    // from the tensor shape and element type so we add support for this "as
+    // an extension".
+    if (loc.length == 0) {
+      const uint64_t bits =
+          static_cast<uint64_t>(tensorType.getNumElements()) *
+          tensorType.getElementTypeBitWidth();
+      loc.length = (bits + 7) / 8; // round up for sub-byte types (e.g. I4)
+    }
     return createElementsAttrFromMemoryBuffer_LE<T>(
         tensorType, readExternalData_LE(externalDataDir, loc));
   }

--- a/test/unit/FrontendDialectHelper/TestFrontendDialectHelper.cpp
+++ b/test/unit/FrontendDialectHelper/TestFrontendDialectHelper.cpp
@@ -11,8 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 #include <cassert>
+#include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <vector>
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
@@ -27,19 +32,41 @@ class FrontendDialectHelperTest {
 private:
   MLIRContext ctx;
 
-public:
-  FrontendDialectHelperTest() {
-    ctx.getOrLoadDialect<ONNXDialect>();
+  // Shared test vector.
+  static constexpr float kFloatTestData[] = {
+      1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  static constexpr size_t kFloatTestNumElements = 6;
+
+  // Verify that attr contains exactly the values in kFloatTestData.
+  bool verifyFloatTestData(const char *testName, mlir::ElementsAttr attr) {
+    if (!attr) {
+      std::cerr << "[" << testName << "] attr is null\n";
+      return false;
+    }
+    int i = 0;
+    for (float v : attr.getValues<float>()) {
+      if (v != kFloatTestData[i]) {
+        std::cerr << "[" << testName << "] value[" << i << "]: expected "
+                  << kFloatTestData[i] << " got " << v << "\n";
+        return false;
+      }
+      ++i;
+    }
+    if (static_cast<size_t>(i) != kFloatTestNumElements) {
+      std::cerr << "[" << testName << "] wrong element count: " << i << "\n";
+      return false;
+    }
+    return true;
   }
 
+public:
+  FrontendDialectHelperTest() { ctx.getOrLoadDialect<ONNXDialect>(); }
+
   bool testInMemoryExternalDataFloat32() {
-    const char* testName = "testInMemoryExternalDataFloat32";
-    
-    // Create test data
-    float testData[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
-    size_t dataSize = sizeof(testData);
-    
-    // Create ONNX TensorProto with external data pointing to memory
+    const char *testName = "testInMemoryExternalDataFloat32";
+
+    // Create ONNX TensorProto with external data pointing directly to the
+    // in-process kFloatTestData array (ORT in-memory address tag).
     onnx::TensorProto tp;
     tp.set_name("test_tensor");
     tp.set_data_type(onnx::TensorProto::FLOAT);
@@ -47,32 +74,22 @@ public:
     tp.add_dims(3);
     tp.set_data_location(onnx::TensorProto::EXTERNAL);
     
-    // Add external data entries with special ORT memory address tag
     auto* location_entry = tp.add_external_data();
     location_entry->set_key("location");
     location_entry->set_value("*/_ORT_MEM_ADDR_/*");
     
     auto* offset_entry = tp.add_external_data();
     offset_entry->set_key("offset");
-    offset_entry->set_value(std::to_string(reinterpret_cast<uintptr_t>(testData)));
-    
+    offset_entry->set_value(
+        std::to_string(reinterpret_cast<uintptr_t>(kFloatTestData)));
+
     auto* length_entry = tp.add_external_data();
     length_entry->set_key("length");
-    length_entry->set_value(std::to_string(dataSize));
+    length_entry->set_value(
+        std::to_string(kFloatTestNumElements * sizeof(float)));
     
-    // Call onnxTensorProtoToElmAttr to process the in-memory external data
     ElementsAttr attr = onnx_mlir::onnxTensorProtoToElmAttr(&ctx, "", tp);
-    
-    // Verify the attribute was created successfully
-    if (!attr) {
-      std::cerr << "[" << testName << "] Failed to create attribute" << std::endl;
-      return false;
-    }
-    
-    // Note: The implementation returns DisposableElementsAttr, not DenseElementsAttr
-    // This is the expected behavior for external data in ONNX-MLIR
-    // We accept this as correct behavior and return true
-    return true;
+    return verifyFloatTestData(testName, attr);
   }
 
   bool testInMemoryExternalDataInt32() {
@@ -199,6 +216,59 @@ public:
     return true;
   }
 
+  // Tests that a TensorProto whose external_data "length" entry is "0"
+  // (non-standard but some onnx tools support it) is loaded correctly
+  // based on the length from the tensor's shape × element-type bitwidth.
+  bool testFileExternalDataWithZeroLength() {
+    const char* testName = "testFileExternalDataWithZeroLength";
+
+    // Write kFloatTestData as little-endian raw bytes to a temporary file.
+    constexpr size_t byteCount = kFloatTestNumElements * sizeof(float);
+
+    llvm::SmallString<128> tmpPath;
+    int fd = -1;
+    if (llvm::sys::fs::createTemporaryFile(
+            "onnx_ext_data_test", "bin", fd, tmpPath)) {
+      std::cerr << "[" << testName << "] Could not create temp file\n";
+      return false;
+    }
+    {
+      llvm::raw_fd_ostream os(fd, /*shouldClose=*/true);
+      os.write(reinterpret_cast<const char *>(kFloatTestData), byteCount);
+    }
+
+    // Build a TensorProto with shape [2, 3], FLOAT, backed by the temp file.
+    // The "length" entry is deliberately "0" to reproduce the exporter bug.
+    onnx::TensorProto tp;
+    tp.set_name("broken_weight");
+    tp.set_data_type(onnx::TensorProto::FLOAT);
+    tp.add_dims(2);
+    tp.add_dims(3);
+    tp.set_data_location(onnx::TensorProto::EXTERNAL);
+
+    auto* locEntry = tp.add_external_data();
+    locEntry->set_key("location");
+    // Pass only the filename; the directory is given as externalDataDir below.
+    locEntry->set_value(llvm::sys::path::filename(tmpPath).str());
+
+    auto* offEntry = tp.add_external_data();
+    offEntry->set_key("offset");
+    offEntry->set_value("0");
+
+    // THE BUG: exporter wrote "0" instead of the correct byte count "24".
+    auto* lenEntry = tp.add_external_data();
+    lenEntry->set_key("length");
+    lenEntry->set_value("0");
+
+    const std::string tmpDir = llvm::sys::path::parent_path(tmpPath).str();
+    mlir::ElementsAttr attr =
+        onnx_mlir::onnxTensorProtoToElmAttr(&ctx, tmpDir, tp);
+
+    llvm::sys::fs::remove(tmpPath);
+
+    return verifyFloatTestData(testName, attr);
+  }
+
   bool runAllTests() {
     bool allPassed = true;
     
@@ -206,7 +276,8 @@ public:
     allPassed = testInMemoryExternalDataInt32() && allPassed;
     allPassed = testInMemoryExternalDataInt8() && allPassed;
     allPassed = testEmptyTensorWithInMemoryExternalData() && allPassed;
-    
+    allPassed = testFileExternalDataWithZeroLength() && allPassed;
+
     return allPassed;
   }
 };


### PR DESCRIPTION
Some ONNX exporters (e.g. the Qwen2.5-VL vision encoder exporter) write the external_data 'length' field as '0' (the proto int64 default) instead of the correct byte count.  When onnx-mlir reads such a model it calls `llvm::MemoryBuffer::getFileSlice(path, length=0, offset)` which returns a 0-byte buffer, leading to `Assertion `isValid' failed`.

As the required external_data 'length' field can be computed from the tensor dtype and shape, this PR does so when length is zero as an extension to the ONNX requirements. The fix does not affect the standard path (length > 0).