### PR TITLE
Add flag for cast + concat/slice canonicalizations

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -57,6 +57,7 @@ bool enableReshapeCanonicalization;                    // common for both
 bool enablePositiveAxisCanonicalization;               // common for both
 bool enableExpandCanonicalization;                     // common for both
 bool enableReduceKeepdimsCanonicalization;             // common for both
+bool enableCastDataMovementPatterns;                   // common for both
 bool enableXFEONNXOpsetVerifier;                       // common for both
 bool enableSafeCodeGen;                                // common for both
 bool disableMemRefPrefetch;                            // common for both
@@ -387,6 +388,14 @@ static llvm::cl::opt<bool, true> enableReduceKeepdimsCanonicalizationOpt(
         "keepdims=1 + Reshape (default=false, i.e. the rewrite is disabled)."),
     llvm::cl::location(enableReduceKeepdimsCanonicalization),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
+
+static llvm::cl::opt<bool, true> enableCastDataMovementPatternsOpt(
+    "enable-cast-data-movement-patterns",
+    llvm::cl::desc(
+        "Enable canonicalization that moves Cast through Concat and Slice "
+        "(default=true)."),
+    llvm::cl::location(enableCastDataMovementPatterns), llvm::cl::init(true),
+    llvm::cl::cat(OnnxMlirCommonOptions));
 
 static llvm::cl::opt<bool, true> enableXFEONNXOpsetVerifierOpt(
     "enable-xfe-onnx-opset-verifier",

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -94,6 +94,7 @@ extern bool enableReshapeCanonicalization;                    // common for both
 extern bool enablePositiveAxisCanonicalization;               // common for both
 extern bool enableExpandCanonicalization;                     // common for both
 extern bool enableReduceKeepdimsCanonicalization;             // common for both
+extern bool enableCastDataMovementPatterns;                   // common for both
 extern bool enableXFEONNXOpsetVerifier;                       // common for both
 extern uint64_t compilationNumThreads;                        // common for both
 // AMD: Decompose unconditionally

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -72,6 +72,7 @@ void configurePasses() {
   configurePositiveAxisCanonicalization(enablePositiveAxisCanonicalization);
   configureReduceKeepdimsCanonicalization(enableReduceKeepdimsCanonicalization);
   configureExpandCanonicalization(enableExpandCanonicalization);
+  configureCastDataMovementPatterns(enableCastDataMovementPatterns);
   configureQDQDataMovementCanonicalization(
       enableQDQDataMovementCanonicalization);
 #ifdef ONNX_MLIR_ENABLE_KRNL
@@ -283,6 +284,7 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
     opts.enableExpandCanonicalization = enableExpandCanonicalization;
     opts.enableReduceKeepdimsCanonicalization =
         enableReduceKeepdimsCanonicalization;
+    opts.enableCastDataMovementPatterns = enableCastDataMovementPatterns;
     opts.enableXFEONNXOpsetVerifier = enableXFEONNXOpsetVerifier;
     if (enableXMCPasses) {
       opts.hybrid.enableInstanceNormDecompose = false;

--- a/src/Compiler/OnnxToMlirPasses.cpp
+++ b/src/Compiler/OnnxToMlirPasses.cpp
@@ -56,6 +56,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   configureExpandCanonicalization(opts.enableExpandCanonicalization);
   configureReduceKeepdimsCanonicalization(
       opts.enableReduceKeepdimsCanonicalization);
+  configureCastDataMovementPatterns(opts.enableCastDataMovementPatterns);
   configureQDQDataMovementCanonicalization(
       opts.enableQDQDataMovementCanonicalization);
 

--- a/src/Compiler/OnnxToMlirPasses.hpp
+++ b/src/Compiler/OnnxToMlirPasses.hpp
@@ -38,6 +38,7 @@ struct OnnxToMlirOptions {
   bool enablePositiveAxisCanonicalization = true;
   bool enableExpandCanonicalization = false;
   bool enableReduceKeepdimsCanonicalization = false;
+  bool enableCastDataMovementPatterns = true;
   bool enableXFEONNXOpsetVerifier = true;
   bool enableUnsafeMathOptimizations = true;
   bool enableQDQDataMovementCanonicalization = false;

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -73,6 +73,9 @@ static bool enableQDQDataMovementCanonicalization = false;
 // Populated by configureExpandCanonicalization().
 static bool enableExpandCanonicalization = false;
 
+// Populated by configureCastDataMovementPatterns().
+static bool enableCastDataMovementPatterns = true;
+
 using namespace mlir;
 using namespace onnx_mlir;
 
@@ -4799,8 +4802,10 @@ void ONNXBatchNormalizationV9Op::getCanonicalizationPatterns(
 void ONNXCastOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
   result.insert<CastEliminationPattern>(context);
-  result.insert<SwapCastConcatPattern>(context);
-  result.insert<SwapCastSlicePattern>(context);
+  if (enableCastDataMovementPatterns) {
+    result.insert<SwapCastConcatPattern>(context);
+    result.insert<SwapCastSlicePattern>(context);
+  }
   result.insert<FoldConsecutiveCastPattern>(context);
 }
 
@@ -5305,4 +5310,8 @@ bool onnx_mlir::isQDQDataMovementCanonicalizationEnabled() {
 
 void onnx_mlir::configureExpandCanonicalization(bool enable) {
   enableExpandCanonicalization = enable;
+}
+
+void onnx_mlir::configureCastDataMovementPatterns(bool enable) {
+  enableCastDataMovementPatterns = enable;
 }

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -88,6 +88,9 @@ bool isQDQDataMovementCanonicalizationEnabled();
 // enabled.
 void configureExpandCanonicalization(bool enableExpandCanonicalization);
 
+// Configure whether Cast data-movement patterns are enabled.
+void configureCastDataMovementPatterns(bool enableCastDataMovementPatterns);
+
 void populateQDQDataMovementCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::PatternBenefit benefit = 1);
 

--- a/test/mlir/onnx/onnx_canonicalization_cast_concat_slice.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_cast_concat_slice.mlir
@@ -10,7 +10,7 @@
 // ENABLED:        %[[CAST0:.*]] = "onnx.Cast"(%arg0)
 // ENABLED:        %[[CAST1:.*]] = "onnx.Cast"(%arg1)
 // ENABLED:        %[[CONCAT:.*]] = "onnx.Concat"(%[[CAST0]], %[[CAST1]])
-// ENABLED-NEXT:   "onnx.Return"(%[[CONCAT]])
+// ENABLED-NEXT:   onnx.Return %[[CONCAT]]
 func.func @cast_concat(%arg0: tensor<2xf32>, %arg1: tensor<3xf32>) -> tensor<5xi64> {
   %concat = "onnx.Concat"(%arg0, %arg1) {axis = 0 : si64} :
       (tensor<2xf32>, tensor<3xf32>) -> tensor<5xf32>
@@ -27,7 +27,7 @@ func.func @cast_concat(%arg0: tensor<2xf32>, %arg1: tensor<3xf32>) -> tensor<5xi
 // ENABLED-LABEL:  func.func @cast_slice(
 // ENABLED:        %[[CAST:.*]] = "onnx.Cast"(%arg0)
 // ENABLED:        %[[SLICE:.*]] = "onnx.Slice"(%[[CAST]], %arg1, %arg2, %arg3, %arg4)
-// ENABLED-NEXT:   "onnx.Return"(%[[SLICE]])
+// ENABLED-NEXT:   onnx.Return %[[SLICE]]
 func.func @cast_slice(%arg0: tensor<4xf32>, %arg1: tensor<1xi64>,
     %arg2: tensor<1xi64>, %arg3: tensor<1xi64>, %arg4: tensor<1xi64>) ->
     tensor<2xi64> {

--- a/test/mlir/onnx/onnx_canonicalization_cast_concat_slice.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_cast_concat_slice.mlir
@@ -1,0 +1,40 @@
+// RUN: onnx-mlir-opt --canonicalize %s | FileCheck %s --check-prefix=ENABLED
+// RUN: onnx-mlir-opt --enable-cast-data-movement-patterns=false --canonicalize %s | FileCheck %s --check-prefix=DISABLED
+
+// -----
+
+// DISABLED-LABEL: func.func @cast_concat(
+// DISABLED:       %[[CONCAT:.*]] = "onnx.Concat"(%arg0, %arg1)
+// DISABLED-NEXT:  %{{.*}} = "onnx.Cast"(%[[CONCAT]])
+// ENABLED-LABEL:  func.func @cast_concat(
+// ENABLED:        %[[CAST0:.*]] = "onnx.Cast"(%arg0)
+// ENABLED:        %[[CAST1:.*]] = "onnx.Cast"(%arg1)
+// ENABLED:        %[[CONCAT:.*]] = "onnx.Concat"(%[[CAST0]], %[[CAST1]])
+// ENABLED-NEXT:   "onnx.Return"(%[[CONCAT]])
+func.func @cast_concat(%arg0: tensor<2xf32>, %arg1: tensor<3xf32>) -> tensor<5xi64> {
+  %concat = "onnx.Concat"(%arg0, %arg1) {axis = 0 : si64} :
+      (tensor<2xf32>, tensor<3xf32>) -> tensor<5xf32>
+  %result = "onnx.Cast"(%concat) {to = i64} :
+      (tensor<5xf32>) -> tensor<5xi64>
+  "onnx.Return"(%result) : (tensor<5xi64>) -> ()
+}
+
+// -----
+
+// DISABLED-LABEL: func.func @cast_slice(
+// DISABLED:       %[[SLICE:.*]] = "onnx.Slice"(%arg0, %arg1, %arg2, %arg3, %arg4)
+// DISABLED-NEXT:  %{{.*}} = "onnx.Cast"(%[[SLICE]])
+// ENABLED-LABEL:  func.func @cast_slice(
+// ENABLED:        %[[CAST:.*]] = "onnx.Cast"(%arg0)
+// ENABLED:        %[[SLICE:.*]] = "onnx.Slice"(%[[CAST]], %arg1, %arg2, %arg3, %arg4)
+// ENABLED-NEXT:   "onnx.Return"(%[[SLICE]])
+func.func @cast_slice(%arg0: tensor<4xf32>, %arg1: tensor<1xi64>,
+    %arg2: tensor<1xi64>, %arg3: tensor<1xi64>, %arg4: tensor<1xi64>) ->
+    tensor<2xi64> {
+  %slice = "onnx.Slice"(%arg0, %arg1, %arg2, %arg3, %arg4) :
+      (tensor<4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>,
+       tensor<1xi64>) -> tensor<2xf32>
+  %result = "onnx.Cast"(%slice) {to = i64} :
+      (tensor<2xf32>) -> tensor<2xi64>
+  "onnx.Return"(%result) : (tensor<2xi64>) -> ()
+}


### PR DESCRIPTION
This PR adds a flag which toggles the cast + datamovement canonicalizations. Its enabled by default to preserve current behavior. 