### PR TITLE
Extend cast fusion to uint-int-fp

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -4717,7 +4717,7 @@ struct FuseConv1x1IntoConvPattern : public OpRewritePattern<ONNXConvOp> {
 
 /// `src <= mid`: casting `src` to `mid` is lossless.
 ///
-///   int   -> int    same signedness, no truncation
+///   int   -> int    no truncation or unsigned-to-signed range loss
 ///   int   -> float  significand covers the integer range
 ///   float -> float  `mid`'s format represents all of `src`
 ///   anything else   never (float -> int, quant types)
@@ -4727,9 +4727,14 @@ bool castPreservesAllValues(Type src, Type mid) {
   auto srcFloatTy = dyn_cast<FloatType>(src);
   auto midFloatTy = dyn_cast<FloatType>(mid);
 
-  if (srcIntTy && midIntTy)
-    return srcIntTy.getSignedness() == midIntTy.getSignedness() &&
-           srcIntTy.getWidth() <= midIntTy.getWidth();
+  if (srcIntTy && midIntTy) {
+    if (srcIntTy.isUnsigned() == midIntTy.isUnsigned())
+      return srcIntTy.getWidth() <= midIntTy.getWidth();
+
+    // An unsigned integer can be represented by a wider signed integer.
+    return srcIntTy.isUnsigned() && !midIntTy.isUnsigned() &&
+           srcIntTy.getWidth() < midIntTy.getWidth();
+  }
 
   // Signless counts as signed; the mantissa width includes the integer bit.
   if (srcIntTy && midFloatTy) {

--- a/test/mlir/onnx/onnx_canonicalization_cast.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_cast.mlir
@@ -119,6 +119,18 @@ func.func @integer_to_float_cast_chain(%arg0: tensor<3xi8>) -> tensor<3xi32> {
 
 // -----
 
+// CHECK-LABEL: @unsigned_integer_to_float_cast_chain
+func.func @unsigned_integer_to_float_cast_chain(%arg0: tensor<3xui16>) -> tensor<3xbf16> {
+  %0 = "onnx.Cast"(%arg0) {to = i64} : (tensor<3xui16>) -> tensor<3xi64>
+  %1 = "onnx.Cast"(%0) {to = bf16} : (tensor<3xi64>) -> tensor<3xbf16>
+  return %1 : tensor<3xbf16>
+  // CHECK: %[[FINAL:.*]] = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = bf16}
+  // CHECK-NOT: {to = i64}
+  // CHECK: return %[[FINAL]]
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 /// Lossless f16/bf16 round-trip elimination.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This PR improves the existing cast-cast fusion pattern to view e.g. ui16 --> i64 as lossless. Currently it rejects integer casts that change the signedness. See the test for more details.