### PR TITLE
Move new lstm flag to end

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -4853,10 +4853,9 @@ void DecomposeONNXToONNXPass::runOnOperation() {
       enableGroupNormDecompose, enableMatmulNBitsDecompose,
       enableGroupQueryAttentionDecompose, enableSplitToSliceDecompose,
       enableConcatFuse, enableLstmSeqDecompose, enableReduceL2Decompose,
-      enableLstmDecompose,
       /*disableGenericDecompositions=*/false, enableGatherToSlice,
       enableHardSwishDecompose, enableGroupQueryAttentionCacheSlicing,
-      enableDepthToSpaceDecompose);
+      enableDepthToSpaceDecompose, enableLstmDecompose);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
   if (this->target == "stablehlo") {
@@ -4880,10 +4879,9 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
     bool enableSplitToSliceDecompose, bool enableConcatFuse,
     bool enableLstmSeqDecompose, bool enableReduceL2Decompose,
-    bool enableLstmDecompose, bool disableGenericDecompositions,
-    bool enableGatherToSlice, bool enableHardSwishDecompose,
-    bool enableGroupQueryAttentionCacheSlicing,
-    bool enableDepthToSpaceDecompose,
+    bool disableGenericDecompositions, bool enableGatherToSlice,
+    bool enableHardSwishDecompose, bool enableGroupQueryAttentionCacheSlicing,
+    bool enableDepthToSpaceDecompose, bool enableLstmDecompose,
     LSTMDecompositionPredicate lstmDecompositionPredicate) {
   MLIRContext *context = patterns.getContext();
   if (!disableGenericDecompositions)

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -52,10 +52,10 @@ void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableMatmulNBitsDecompose, bool enableGroupQueryAttentionDecompose,
     bool enableSplitToSliceDecompose, bool enableConcatFuse,
     bool enableLstmSeqDecompose = false, bool enableReduceL2Decompose = true,
-    bool enableLstmDecompose = false, bool disableGenericDecompositions = false,
-    bool enableGatherToSlice = true, bool enableHardSwishDecompose = true,
+    bool disableGenericDecompositions = false, bool enableGatherToSlice = true,
+    bool enableHardSwishDecompose = true,
     bool enableGroupQueryAttentionCacheSlicing = true,
-    bool enableDepthToSpaceDecompose = false,
+    bool enableDepthToSpaceDecompose = false, bool enableLstmDecompose = false,
     LSTMDecompositionPredicate lstmDecompositionPredicate = {});
 
 // Decompose onnx.DepthToSpace (DCR and CRD) into Reshape/Transpose/Reshape

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -163,10 +163,10 @@ struct ONNXHybridTransformPass
           enableInstanceNormDecompose, enableGroupNormDecompose,
           enableMatmulNBitsDecompose, enableGroupQueryAttentionDecompose,
           enableSplitToSliceDecompose, enableConcatFuse, enableLstmSeqDecompose,
-          enableReduceL2Decompose, enableLstmDecompose,
+          enableReduceL2Decompose,
           /*disableGenericDecompositions=*/false, enableGatherToSlice,
           enableHardSwishDecompose, enableGroupQueryAttentionCacheSlicing,
-          enableDepthToSpaceDecompose);
+          enableDepthToSpaceDecompose, enableLstmDecompose);
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
       if (target == "stablehlo") {


### PR DESCRIPTION
The previous order could easily break existing callers by adding the new arg in the middle