### PR TITLE
Fix hang in hybrid pass caused by ReduceL2

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -1166,6 +1166,28 @@ bool isConstOf(Value constValue, double n) {
   return ElementsAttrBuilder::allEqual(constElements, w);
 }
 
+bool isShapePreservingBroadcast(Value source, Value target) {
+  auto sourceType = mlir::dyn_cast<RankedTensorType>(source.getType());
+  if (!sourceType)
+    return false;
+  if (sourceType.getRank() == 0)
+    return true;
+
+  auto targetType = mlir::dyn_cast<RankedTensorType>(target.getType());
+  if (!targetType || sourceType.getRank() > targetType.getRank())
+    return false;
+
+  const int64_t rankOffset = targetType.getRank() - sourceType.getRank();
+  for (int64_t i = 0; i < sourceType.getRank(); ++i) {
+    const int64_t sourceDim = sourceType.getDimSize(i);
+    const int64_t targetDim = targetType.getDimSize(rankOffset + i);
+    if (sourceDim != 1 &&
+        (ShapedType::isDynamic(targetDim) || sourceDim != targetDim))
+      return false;
+  }
+  return true;
+}
+
 bool isFloatAttrApprox(mlir::FloatAttr attr, double expected, double epsilon) {
   if (!attr)
     return false;

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -400,6 +400,12 @@ WideNum asWideNum(double n, mlir::Type elemType);
 /// Checks whether a constant tensor's elements are all equal to a given scalar.
 bool isConstOf(mlir::Value constValue, double n);
 
+/// Returns true when broadcasting `source` against `target` is guaranteed not
+/// to change the target shape. This is stricter than being broadcast
+/// compatible: a source dim may only be 1 or match the target dim exactly, so
+/// e.g. 2x1 against 1x3 is compatible but not shape preserving.
+bool isShapePreservingBroadcast(mlir::Value source, mlir::Value target);
+
 /// True if \p attr is non-null and its numeric value differs from \p expected
 /// by at most \p epsilon (using \p attr's value converted to double).
 bool isFloatAttrApprox(mlir::FloatAttr attr, double expected, double epsilon);

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -145,7 +145,9 @@ struct ONNXHybridTransformPass
 
     if (recomposition) {
       getRecomposeONNXToONNXPatterns(cumulativePatterns,
-          enableRotaryEmbeddingRecompose, enableReduceL2Recompositions,
+          enableRotaryEmbeddingRecompose,
+          enableReduceL2Recompositions &&
+              !(decomposition && enableReduceL2Decompose),
           enableDepthToSpaceDecompose);
     }
 

--- a/src/Dialect/ONNX/Transforms/Passes.td
+++ b/src/Dialect/ONNX/Transforms/Passes.td
@@ -154,9 +154,8 @@ def ONNXRecomposePatternOptions {
     Option<"enableReduceL2Recompositions",
            "enable-reducel2-recompositions",
            "bool", /*default=*/"false",
-           "Recompose ReduceL2 from Sqrt(ReduceSumSquare(x)) and "
-           "Pow(ReduceSumSquare(x), 0.5), and ReduceSumSquare from "
-           "ReduceSum(Mul(x, x)) or ReduceSum(Pow(x, 2))">
+           "Recompose ReduceL2 from Sqrt/Pow(0.5) square-reduction "
+           "chains into ReduceL2. Off by default.">
   ];
 }
 

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -23,6 +23,7 @@
 
 #include <cassert>
 #include <numeric>
+#include <optional>
 
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
@@ -1338,134 +1339,116 @@ struct RecomposeDepthToSpaceCRD
   }
 };
 
-// Recompose `ReduceSum(Mul(x, x))` into `ReduceSumSquare(x)`. This inverts
-// `ReduceSumSquareOpPattern` from Decompose.td and is the first stage of the
-// staged recomposition that ultimately rebuilds `ReduceL2`.
-struct RecomposeReduceSumSquareFromMulReduceSumPattern
-    : public OpRewritePattern<ONNXReduceSumOp> {
-  using OpRewritePattern<ONNXReduceSumOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(
-      ONNXReduceSumOp reduceSumOp, PatternRewriter &rewriter) const final {
-    auto mulOp = reduceSumOp.getData().getDefiningOp<ONNXMulOp>();
-    if (!mulOp)
-      return failure();
-    if (!mulOp->hasOneUse())
-      return failure();
-    if (mulOp.getA() != mulOp.getB())
-      return failure();
-
-    // pessimistic: bail out if any involved value carries a quantized
-    if (onnx_mlir::hasQuantizedElementType(mulOp.getA()) ||
-        onnx_mlir::hasQuantizedElementType(mulOp.getC()) ||
-        onnx_mlir::hasQuantizedElementType(reduceSumOp.getReduced()))
-      return failure();
-
-    const Value x = mulOp.getA();
-    const auto loc = mlir::FusedLoc::get(
-        rewriter.getContext(), {reduceSumOp.getLoc(), mulOp.getLoc()});
-    const Value reduceSumSquare = rewriter.create<ONNXReduceSumSquareOp>(loc,
-        reduceSumOp.getType(), x, reduceSumOp.getAxes(),
-        reduceSumOp.getKeepdimsAttr(), reduceSumOp.getNoopWithEmptyAxesAttr());
-    rewriter.replaceOp(reduceSumOp, reduceSumSquare);
-    return success();
-  }
+struct SquaredInputMatch {
+  Value input;
+  Location producerLoc;
 };
 
-// Recompose `Sqrt(ReduceSumSquare(x))` into `ReduceL2(x)`. This inverts
-// `DecomposeReduceL2Pattern` from Decompose.cpp.
-struct RecomposeReduceL2FromSqrtReduceSumSquarePattern
-    : public OpRewritePattern<ONNXSqrtOp> {
+// Match an explicitly squared value without introducing ReduceSumSquare.
+// Requiring one use avoids duplicating the square when the full L2 chain is
+// replaced.
+std::optional<SquaredInputMatch> matchSquaredInput(Value value) {
+  // Mul needs no broadcast check: both operands are the same value, so the
+  // result always has the shape of the value being squared.
+  if (auto mulOp = value.getDefiningOp<ONNXMulOp>()) {
+    if (!mulOp->hasOneUse() || mulOp.getA() != mulOp.getB())
+      return std::nullopt;
+    return SquaredInputMatch{mulOp.getA(), mulOp.getLoc()};
+  }
+
+  // A Pow exponent that broadcasts would expand the squared value, so dropping
+  // it in favor of ReduceL2 would change the reduced shape.
+  if (auto powOp = value.getDefiningOp<ONNXPowOp>()) {
+    if (!powOp->hasOneUse() || !onnx_mlir::isDenseONNXConstant(powOp.getY()) ||
+        !onnx_mlir::isConstOf(powOp.getY(), 2.0) ||
+        !onnx_mlir::isShapePreservingBroadcast(powOp.getY(), powOp.getX()))
+      return std::nullopt;
+    return SquaredInputMatch{powOp.getX(), powOp.getLoc()};
+  }
+
+  return std::nullopt;
+}
+
+struct ReduceL2ReductionMatch {
+  Value input;
+  Value axes;
+  IntegerAttr keepdims;
+  IntegerAttr noopWithEmptyAxes;
+  SmallVector<Location, 2> innerLocs;
+};
+
+// Match either an imported ReduceSumSquare or its supported decomposed forms.
+// The reduction must have one use so replacing the outer root does not
+// duplicate a potentially expensive reduction.
+std::optional<ReduceL2ReductionMatch> matchReduceL2Reduction(Value value) {
+  if (auto reduceSumSquareOp = value.getDefiningOp<ONNXReduceSumSquareOp>()) {
+    if (!reduceSumSquareOp->hasOneUse() ||
+        onnx_mlir::hasQuantizedElementType(reduceSumSquareOp.getData()) ||
+        onnx_mlir::hasQuantizedElementType(reduceSumSquareOp.getReduced()))
+      return std::nullopt;
+
+    return ReduceL2ReductionMatch{reduceSumSquareOp.getData(),
+        reduceSumSquareOp.getAxes(), reduceSumSquareOp.getKeepdimsAttr(),
+        reduceSumSquareOp.getNoopWithEmptyAxesAttr(),
+        {reduceSumSquareOp.getLoc()}};
+  }
+
+  auto reduceSumOp = value.getDefiningOp<ONNXReduceSumOp>();
+  if (!reduceSumOp || !reduceSumOp->hasOneUse())
+    return std::nullopt;
+
+  const std::optional<SquaredInputMatch> square =
+      matchSquaredInput(reduceSumOp.getData());
+  if (!square || onnx_mlir::hasQuantizedElementType(square->input) ||
+      onnx_mlir::hasQuantizedElementType(reduceSumOp.getData()) ||
+      onnx_mlir::hasQuantizedElementType(reduceSumOp.getReduced()))
+    return std::nullopt;
+
+  return ReduceL2ReductionMatch{square->input, reduceSumOp.getAxes(),
+      reduceSumOp.getKeepdimsAttr(), reduceSumOp.getNoopWithEmptyAxesAttr(),
+      {reduceSumOp.getLoc(), square->producerLoc}};
+}
+
+LogicalResult replaceWithReduceL2(
+    Operation *rootOp, Value reduction, PatternRewriter &rewriter) {
+  const std::optional<ReduceL2ReductionMatch> match =
+      matchReduceL2Reduction(reduction);
+  if (!match || onnx_mlir::hasQuantizedElementType(rootOp->getResult(0)))
+    return failure();
+
+  SmallVector<Location, 3> locations{rootOp->getLoc()};
+  locations.append(match->innerLocs);
+  const auto loc = mlir::FusedLoc::get(rewriter.getContext(), locations);
+  const Value reduceL2 =
+      rewriter.create<ONNXReduceL2Op>(loc, rootOp->getResult(0).getType(),
+          match->input, match->axes, match->keepdims, match->noopWithEmptyAxes);
+  rewriter.replaceOp(rootOp, reduceL2);
+  return success();
+}
+
+// Recompose Sqrt(ReduceSum(square(x))) or Sqrt(ReduceSumSquare(x)) directly
+// into ReduceL2 without exposing a ReduceSumSquare intermediate.
+struct RecomposeReduceL2FromSqrtPattern : public OpRewritePattern<ONNXSqrtOp> {
   using OpRewritePattern<ONNXSqrtOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(
       ONNXSqrtOp sqrtOp, PatternRewriter &rewriter) const final {
-    auto reduceSumSquareOp =
-        sqrtOp.getX().getDefiningOp<ONNXReduceSumSquareOp>();
-    if (!reduceSumSquareOp)
-      return failure();
-    if (!reduceSumSquareOp->hasOneUse())
-      return failure();
-
-    // pessimistic: bail out if any involved value carries a quantized
-    if (onnx_mlir::hasQuantizedElementType(reduceSumSquareOp.getData()) ||
-        onnx_mlir::hasQuantizedElementType(sqrtOp.getX()) ||
-        onnx_mlir::hasQuantizedElementType(sqrtOp.getY()))
-      return failure();
-
-    const auto loc = mlir::FusedLoc::get(
-        rewriter.getContext(), {sqrtOp.getLoc(), reduceSumSquareOp.getLoc()});
-    const Value reduceL2 = rewriter.create<ONNXReduceL2Op>(loc,
-        sqrtOp.getType(), reduceSumSquareOp.getData(),
-        reduceSumSquareOp.getAxes(), reduceSumSquareOp.getKeepdimsAttr(),
-        reduceSumSquareOp.getNoopWithEmptyAxesAttr());
-    rewriter.replaceOp(sqrtOp, reduceL2);
-    return success();
+    return replaceWithReduceL2(sqrtOp.getOperation(), sqrtOp.getX(), rewriter);
   }
 };
 
-// Recompose `ReduceSum(Pow(x, 2))` into `ReduceSumSquare(x)`. This is the
-// Pow-based variant of `RecomposeReduceSumSquareFromMulReduceSumPattern`.
-struct RecomposeReduceSumSquareFromPowReduceSumPattern
-    : public OpRewritePattern<ONNXReduceSumOp> {
-  using OpRewritePattern<ONNXReduceSumOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(
-      ONNXReduceSumOp reduceSumOp, PatternRewriter &rewriter) const final {
-    auto powOp = reduceSumOp.getData().getDefiningOp<ONNXPowOp>();
-    if (!powOp || !powOp->hasOneUse())
-      return failure();
-
-    if (!onnx_mlir::isDenseONNXConstant(powOp.getY()) ||
-        !onnx_mlir::isConstOf(powOp.getY(), 2.0))
-      return failure();
-
-    // pessimistic: bail out if any involved value carries a quantized
-    if (onnx_mlir::hasQuantizedElementType(powOp.getX()) ||
-        onnx_mlir::hasQuantizedElementType(powOp.getZ()) ||
-        onnx_mlir::hasQuantizedElementType(reduceSumOp.getReduced()))
-      return failure();
-
-    const auto loc = mlir::FusedLoc::get(
-        rewriter.getContext(), {reduceSumOp.getLoc(), powOp.getLoc()});
-    const Value reduceSumSquare = rewriter.create<ONNXReduceSumSquareOp>(loc,
-        reduceSumOp.getType(), powOp.getX(), reduceSumOp.getAxes(),
-        reduceSumOp.getKeepdimsAttr(), reduceSumOp.getNoopWithEmptyAxesAttr());
-    rewriter.replaceOp(reduceSumOp, reduceSumSquare);
-    return success();
-  }
-};
-
-// Recompose `Pow(ReduceSumSquare(x), 0.5)` into `ReduceL2(x)`.
-struct RecomposeReduceL2FromPowReduceSumSquarePattern
-    : public OpRewritePattern<ONNXPowOp> {
+// Recompose Pow(ReduceSum(square(x)), 0.5) or
+// Pow(ReduceSumSquare(x), 0.5) directly into ReduceL2.
+struct RecomposeReduceL2FromPowPattern : public OpRewritePattern<ONNXPowOp> {
   using OpRewritePattern<ONNXPowOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(
       ONNXPowOp powOp, PatternRewriter &rewriter) const final {
     if (!onnx_mlir::isDenseONNXConstant(powOp.getY()) ||
-        !onnx_mlir::isConstOf(powOp.getY(), 0.5))
+        !onnx_mlir::isConstOf(powOp.getY(), 0.5) ||
+        !onnx_mlir::isShapePreservingBroadcast(powOp.getY(), powOp.getX()))
       return failure();
-
-    auto reduceSumSquareOp =
-        powOp.getX().getDefiningOp<ONNXReduceSumSquareOp>();
-    if (!reduceSumSquareOp || !reduceSumSquareOp->hasOneUse())
-      return failure();
-
-    // pessimistic: bail out if any involved value carries a quantized
-    if (onnx_mlir::hasQuantizedElementType(reduceSumSquareOp.getData()) ||
-        onnx_mlir::hasQuantizedElementType(reduceSumSquareOp.getReduced()) ||
-        onnx_mlir::hasQuantizedElementType(powOp.getZ()))
-      return failure();
-
-    const auto loc = mlir::FusedLoc::get(
-        rewriter.getContext(), {powOp.getLoc(), reduceSumSquareOp.getLoc()});
-    const Value reduceL2 = rewriter.create<ONNXReduceL2Op>(loc, powOp.getType(),
-        reduceSumSquareOp.getData(), reduceSumSquareOp.getAxes(),
-        reduceSumSquareOp.getKeepdimsAttr(),
-        reduceSumSquareOp.getNoopWithEmptyAxesAttr());
-    rewriter.replaceOp(powOp, reduceL2);
-    return success();
+    return replaceWithReduceL2(powOp.getOperation(), powOp.getX(), rewriter);
   }
 };
 
@@ -2161,10 +2144,8 @@ void onnx_mlir::getRecomposeONNXToONNXPatterns(
   if (enableRotaryEmbeddingRecompose)
     patterns.insert<RecomposeRotaryEmbeddingPattern>(context);
   if (enableReduceL2Recompositions) {
-    patterns.insert<RecomposeReduceSumSquareFromMulReduceSumPattern>(context);
-    patterns.insert<RecomposeReduceSumSquareFromPowReduceSumPattern>(context);
-    patterns.insert<RecomposeReduceL2FromSqrtReduceSumSquarePattern>(context);
-    patterns.insert<RecomposeReduceL2FromPowReduceSumSquarePattern>(context);
+    patterns.insert<RecomposeReduceL2FromSqrtPattern>(context);
+    patterns.insert<RecomposeReduceL2FromPowPattern>(context);
   }
   // AMD Disabled as downstream has no special support for it
   // patterns.insert<RecomposeQLinearMatMulFromQuantizeLinearPattern>(context);

--- a/src/Dialect/ONNX/Transforms/Recompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.hpp
@@ -35,10 +35,10 @@ namespace onnx_mlir {
 // `enableRotaryEmbeddingRecompose` enables a recomposition of a decomposed
 // RotaryEmbedding into an onnx.RotaryEmbedding op. The targeted decomposition
 // matches the RoPE in HuggingFaces LlamaRotaryEmbedding
-// `enableReduceL2Recompositions` enables a recomposition of a decomposed
-// ReduceL2 from Sqrt(ReduceSumSquare(x)) into an onnx.ReduceL2 op and
-// Pow(ReduceSumSquare(x), 0.5) into an onnx.ReduceL2 op, and ReduceSumSquare
-// from ReduceSum(Mul(x, x)) or ReduceSum(Pow(x, 2)).
+// `enableReduceL2Recompositions` enables direct recomposition of complete
+// Sqrt/Pow-based L2 reduction chains into an onnx.ReduceL2 op. Callers that
+// also run the ReduceL2 decomposition in the same rewrite driver must clear
+// this flag, otherwise the two patterns invert each other and never converge.
 // `enableDepthToSpaceDecompose` mirrors the decompose flag: when the
 // DepthToSpace decomposition is enabled, the DepthToSpace recompose patterns
 // must be disabled so they do not immediately fold the decomposed

--- a/test/mlir/onnx/onnx_hybrid_transform_reducel2.mlir
+++ b/test/mlir/onnx/onnx_hybrid_transform_reducel2.mlir
@@ -1,0 +1,55 @@
+// RUN: onnx-mlir-opt --onnx-hybrid-transform="shape-inference=false canonicalization=false constant-propagation=false enable-reducel2-decompose=false enable-reducel2-recompositions=true" %s -split-input-file | FileCheck %s --check-prefix=RECOMPOSE
+// RUN: onnx-mlir-opt --onnx-hybrid-transform="shape-inference=false canonicalization=false constant-propagation=false enable-reducel2-decompose=true enable-reducel2-recompositions=true" %s -split-input-file | FileCheck %s --check-prefix=DECOMPOSE
+
+func.func @test_full_reducel2_chain(%arg0: tensor<2x3x4xf32>, %arg1: tensor<1xi64>) -> tensor<?x?xf32> {
+  %square = "onnx.Mul"(%arg0, %arg0) : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
+  %sum = "onnx.ReduceSum"(%square, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
+  %result = "onnx.Sqrt"(%sum) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  onnx.Return %result : tensor<?x?xf32>
+// RECOMPOSE-LABEL:  func.func @test_full_reducel2_chain
+// RECOMPOSE-NOT:       "onnx.ReduceSumSquare"
+// RECOMPOSE:           [[L2_:%.+]] = "onnx.ReduceL2"(%arg0, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64}
+// RECOMPOSE:           onnx.Return [[L2_]] : tensor<?x?xf32>
+// DECOMPOSE-LABEL:  func.func @test_full_reducel2_chain
+// DECOMPOSE-NOT:       "onnx.ReduceL2"
+// DECOMPOSE-NOT:       "onnx.ReduceSumSquare"
+// DECOMPOSE:           [[SQUARE_:%.+]] = "onnx.Mul"(%arg0, %arg0)
+// DECOMPOSE:           [[SUM_:%.+]] = "onnx.ReduceSum"([[SQUARE_]], %arg1)
+// DECOMPOSE:           [[RESULT_:%.+]] = "onnx.Sqrt"([[SUM_]])
+// DECOMPOSE:           onnx.Return [[RESULT_]] : tensor<?x?xf32>
+}
+
+// -----
+
+func.func @test_standalone_reducesumsquare(%arg0: tensor<2x3x4xf32>, %arg1: tensor<1xi64>) -> tensor<?x?xf32> {
+  %result = "onnx.ReduceSumSquare"(%arg0, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
+  onnx.Return %result : tensor<?x?xf32>
+// RECOMPOSE-LABEL:  func.func @test_standalone_reducesumsquare
+// RECOMPOSE-NOT:       "onnx.ReduceSumSquare"
+// RECOMPOSE:           [[SQUARE_:%.+]] = "onnx.Mul"(%arg0, %arg0)
+// RECOMPOSE:           [[SUM_:%.+]] = "onnx.ReduceSum"([[SQUARE_]], %arg1)
+// RECOMPOSE:           onnx.Return [[SUM_]] : tensor<?x?xf32>
+// DECOMPOSE-LABEL:  func.func @test_standalone_reducesumsquare
+// DECOMPOSE-NOT:       "onnx.ReduceSumSquare"
+// DECOMPOSE:           [[SQUARE_:%.+]] = "onnx.Mul"(%arg0, %arg0)
+// DECOMPOSE:           [[SUM_:%.+]] = "onnx.ReduceSum"([[SQUARE_]], %arg1)
+// DECOMPOSE:           onnx.Return [[SUM_]] : tensor<?x?xf32>
+}
+
+// -----
+
+func.func @test_reducel2_decomposition_precedence(%arg0: tensor<2x3x4xf32>, %arg1: tensor<1xi64>) -> tensor<?x?xf32> {
+  %result = "onnx.ReduceL2"(%arg0, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
+  onnx.Return %result : tensor<?x?xf32>
+// RECOMPOSE-LABEL:  func.func @test_reducel2_decomposition_precedence
+// RECOMPOSE-NOT:       "onnx.ReduceSumSquare"
+// RECOMPOSE:           [[L2_:%.+]] = "onnx.ReduceL2"(%arg0, %arg1)
+// RECOMPOSE:           onnx.Return [[L2_]] : tensor<?x?xf32>
+// DECOMPOSE-LABEL:  func.func @test_reducel2_decomposition_precedence
+// DECOMPOSE-NOT:       "onnx.ReduceL2"
+// DECOMPOSE-NOT:       "onnx.ReduceSumSquare"
+// DECOMPOSE:           [[SQUARE_:%.+]] = "onnx.Mul"(%arg0, %arg0)
+// DECOMPOSE:           [[SUM_:%.+]] = "onnx.ReduceSum"([[SQUARE_]], %arg1)
+// DECOMPOSE:           [[RESULT_:%.+]] = "onnx.Sqrt"([[SUM_]])
+// DECOMPOSE:           onnx.Return [[RESULT_]] : tensor<?x?xf32>
+}

--- a/test/mlir/onnx/onnx_recompose_reducel2.mlir
+++ b/test/mlir/onnx/onnx_recompose_reducel2.mlir
@@ -77,35 +77,42 @@ func.func @test_recompose_reducel2_from_reducesumsquare(%arg0: tensor<2x3x4xf32>
 
 // -----
 
-func.func @test_recompose_reducesumsquare(%arg0: tensor<2x3x4xf32>, %arg1: tensor<1xi64>) -> tensor<?x?xf32> {
+// An incomplete chain (no Sqrt/Pow consumer) must stay decomposed: fusing it
+// into ReduceSumSquare would be undone by the unconditional ReduceSumSquare
+// decomposition and the two would never converge.
+func.func @test_mul_reducesum_stays_decomposed(%arg0: tensor<2x3x4xf32>, %arg1: tensor<1xi64>) -> tensor<?x?xf32> {
   %0 = "onnx.Mul"(%arg0, %arg0) : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
   %1 = "onnx.ReduceSum"(%0, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
   onnx.Return %1 : tensor<?x?xf32>
-// CHECK-LABEL:  func.func @test_recompose_reducesumsquare
+// CHECK-LABEL:  func.func @test_mul_reducesum_stays_decomposed
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<?x?xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = "onnx.ReduceSumSquare"([[PARAM_0_]], [[PARAM_1_]]) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
-// CHECK-NEXT:      onnx.Return [[VAR_0_]] : tensor<?x?xf32>
+// CHECK-NOT:       "onnx.ReduceSumSquare"
+// CHECK:           [[SQUARE_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[PARAM_0_]])
+// CHECK:           [[SUM_:%.+]] = "onnx.ReduceSum"([[SQUARE_]], [[PARAM_1_]])
+// CHECK:           onnx.Return [[SUM_]] : tensor<?x?xf32>
 // CHECK-NEXT:    }
 }
 
-// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducesumsquare
+// DISABLED-CHECK-LABEL:  func.func @test_mul_reducesum_stays_decomposed
 // DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
 
 // -----
 
-func.func @test_recompose_reducesumsquare_from_pow(%arg0: tensor<1x512x10xf32>, %arg1: tensor<1xi64>) -> tensor<1x1x10xf32> {
+func.func @test_pow_reducesum_stays_decomposed(%arg0: tensor<1x512x10xf32>, %arg1: tensor<1xi64>) -> tensor<1x1x10xf32> {
   %0 = onnx.Constant dense<2.000000e+00> : tensor<f32>
   %1 = "onnx.Pow"(%arg0, %0) : (tensor<1x512x10xf32>, tensor<f32>) -> tensor<1x512x10xf32>
   %2 = "onnx.ReduceSum"(%1, %arg1) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x512x10xf32>, tensor<1xi64>) -> tensor<1x1x10xf32>
   onnx.Return %2 : tensor<1x1x10xf32>
-// CHECK-LABEL:  func.func @test_recompose_reducesumsquare_from_pow
+// CHECK-LABEL:  func.func @test_pow_reducesum_stays_decomposed
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x512x10xf32>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<1x1x10xf32> {
-// CHECK-NEXT:      [[VAR_0_:%.+]] = "onnx.ReduceSumSquare"([[PARAM_0_]], [[PARAM_1_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x512x10xf32>, tensor<1xi64>) -> tensor<1x1x10xf32>
-// CHECK-NEXT:      onnx.Return [[VAR_0_]] : tensor<1x1x10xf32>
-// CHECK-NEXT:    }
+// CHECK-NOT:       "onnx.ReduceSumSquare"
+// CHECK:           [[SQUARE_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[PARAM_0_]])
+// CHECK:           [[SUM_:%.+]] = "onnx.ReduceSum"([[SQUARE_]], [[PARAM_1_]])
+// CHECK:           onnx.Return [[SUM_]] : tensor<1x1x10xf32>
+// CHECK:         }
 }
 
-// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducesumsquare_from_pow
+// DISABLED-CHECK-LABEL:  func.func @test_pow_reducesum_stays_decomposed
 // DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
 
 // -----
@@ -126,6 +133,69 @@ func.func @test_recompose_reducel2_from_pow_reduce_sum_pow(%arg0: tensor<1x512x1
 
 // DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_from_pow_reduce_sum_pow
 // DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+
+// -----
+
+// recompose Pow(x,2) -> ReduceSum -> Sqrt to ReduceL2
+func.func @test_recompose_reducel2_from_sqrt_reduce_sum_pow(%arg0: tensor<2x3x4xf32>, %arg1: tensor<1xi64>) -> tensor<?x?xf32> {
+  %two = onnx.Constant dense<2.000000e+00> : tensor<f32>
+  %square = "onnx.Pow"(%arg0, %two) : (tensor<2x3x4xf32>, tensor<f32>) -> tensor<2x3x4xf32>
+  %sum = "onnx.ReduceSum"(%square, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
+  %result = "onnx.Sqrt"(%sum) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  onnx.Return %result : tensor<?x?xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_from_sqrt_reduce_sum_pow
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<?x?xf32> {
+// CHECK-NOT:       "onnx.ReduceSumSquare"
+// CHECK:           [[L2_:%.+]] = "onnx.ReduceL2"([[PARAM_0_]], [[PARAM_1_]]) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64}
+// CHECK:           onnx.Return [[L2_]] : tensor<?x?xf32>
+// CHECK:         }
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_from_sqrt_reduce_sum_pow
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+// DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
+}
+
+// -----
+
+// recompose Mul(x,x) -> ReduceSum -> Pow(y,0.5) to ReduceL2
+func.func @test_recompose_reducel2_from_pow_reduce_sum_mul(%arg0: tensor<2x3x4xf32>) -> tensor<f32> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  %square = "onnx.Mul"(%arg0, %arg0) : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
+  %sum = "onnx.ReduceSum"(%square, %none) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, none) -> tensor<f32>
+  %half = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %result = "onnx.Pow"(%sum, %half) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  onnx.Return %result : tensor<f32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_from_pow_reduce_sum_mul
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>) -> tensor<f32> {
+// CHECK-NOT:       "onnx.ReduceSumSquare"
+// CHECK:           [[NONE_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[L2_:%.+]] = "onnx.ReduceL2"([[PARAM_0_]], [[NONE_]]) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64}
+// CHECK:           onnx.Return [[L2_]] : tensor<f32>
+// CHECK:         }
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_from_pow_reduce_sum_mul
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+// DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
+}
+
+// -----
+
+// recompose ReduceSumSquare -> Pow(y,0.5) to ReduceL2, including explicit
+// empty axes and noop_with_empty_axes.
+func.func @test_recompose_reducel2_from_pow_reducesumsquare_empty_axes(%arg0: tensor<2x3x4xf32>) -> tensor<2x3x4xf32> {
+  %axes = onnx.Constant dense<> : tensor<0xi64>
+  %sum_square = "onnx.ReduceSumSquare"(%arg0, %axes) {keepdims = 1 : si64, noop_with_empty_axes = 1 : si64} : (tensor<2x3x4xf32>, tensor<0xi64>) -> tensor<2x3x4xf32>
+  %half = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %result = "onnx.Pow"(%sum_square, %half) : (tensor<2x3x4xf32>, tensor<f32>) -> tensor<2x3x4xf32>
+  onnx.Return %result : tensor<2x3x4xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_from_pow_reducesumsquare_empty_axes
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>) -> tensor<2x3x4xf32> {
+// CHECK:           [[AXES_:%.+]] = onnx.Constant dense<> : tensor<0xi64>
+// CHECK-NOT:       "onnx.ReduceSumSquare"
+// CHECK:           [[L2_:%.+]] = "onnx.ReduceL2"([[PARAM_0_]], [[AXES_]]) {keepdims = 1 : si64, noop_with_empty_axes = 1 : si64}
+// CHECK:           onnx.Return [[L2_]] : tensor<2x3x4xf32>
+// CHECK:         }
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_from_pow_reducesumsquare_empty_axes
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+}
 
 // -----
 
@@ -181,18 +251,190 @@ func.func @test_recompose_reducel2_reducesumsquare_extra_use(%arg0: tensor<2x3x4
 
 // -----
 
-func.func @test_recompose_reducesumsquare_quant_types(%arg0: tensor<2x3x4x!quant.uniform<i8:f32, 0.5:0>>, %arg1: tensor<1xi64>) -> tensor<?x?x!quant.uniform<i8:f32, 2.0:2>> {
-  %0 = "onnx.Mul"(%arg0, %arg0) : (tensor<2x3x4x!quant.uniform<i8:f32, 0.5:0>>, tensor<2x3x4x!quant.uniform<i8:f32, 0.5:0>>) -> tensor<2x3x4x!quant.uniform<i8:f32, 1.0:1>>
-  %1 = "onnx.ReduceSum"(%0, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4x!quant.uniform<i8:f32, 1.0:1>>, tensor<1xi64>) -> tensor<?x?x!quant.uniform<i8:f32, 2.0:2>>
-  onnx.Return %1 : tensor<?x?x!quant.uniform<i8:f32, 2.0:2>>
-// CHECK-LABEL:  func.func @test_recompose_reducesumsquare_quant_types
+func.func @test_recompose_reducel2_reducesum_extra_use(%arg0: tensor<2x3x4xf32>, %arg1: tensor<1xi64>) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
+  %square = "onnx.Mul"(%arg0, %arg0) : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
+  %sum = "onnx.ReduceSum"(%square, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
+  %result = "onnx.Sqrt"(%sum) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  onnx.Return %result, %sum : tensor<?x?xf32>, tensor<?x?xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_reducesum_extra_use
+// CHECK-NOT:       "onnx.ReduceL2"
+// CHECK-NOT:       "onnx.ReduceSumSquare"
+// CHECK:           "onnx.Mul"
+// CHECK:           [[SUM_:%.+]] = "onnx.ReduceSum"
+// CHECK:           "onnx.Sqrt"([[SUM_]])
+// CHECK:           onnx.Return {{%.+}}, [[SUM_]]
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_reducesum_extra_use
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+// DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
+}
+
+// -----
+
+func.func @test_recompose_reducel2_pow_square_extra_use(%arg0: tensor<2x3x4xf32>, %arg1: tensor<1xi64>) -> (tensor<?x?xf32>, tensor<2x3x4xf32>) {
+  %two = onnx.Constant dense<2.000000e+00> : tensor<f32>
+  %square = "onnx.Pow"(%arg0, %two) : (tensor<2x3x4xf32>, tensor<f32>) -> tensor<2x3x4xf32>
+  %sum = "onnx.ReduceSum"(%square, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
+  %result = "onnx.Sqrt"(%sum) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  onnx.Return %result, %square : tensor<?x?xf32>, tensor<2x3x4xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_pow_square_extra_use
+// CHECK-NOT:       "onnx.ReduceL2"
+// CHECK-NOT:       "onnx.ReduceSumSquare"
+// CHECK:           [[SQUARE_:%.+]] = "onnx.Mul"
+// CHECK:           "onnx.ReduceSum"([[SQUARE_]]
+// CHECK:           "onnx.Sqrt"
+// CHECK:           onnx.Return {{%.+}}, [[SQUARE_]]
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_pow_square_extra_use
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+// DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
+}
+
+// -----
+
+func.func @test_recompose_reducel2_wrong_inner_exponent(%arg0: tensor<2x3x4xf32>, %arg1: tensor<1xi64>) -> tensor<?x?xf32> {
+  %three = onnx.Constant dense<3.000000e+00> : tensor<f32>
+  %power = "onnx.Pow"(%arg0, %three) : (tensor<2x3x4xf32>, tensor<f32>) -> tensor<2x3x4xf32>
+  %sum = "onnx.ReduceSum"(%power, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
+  %result = "onnx.Sqrt"(%sum) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  onnx.Return %result : tensor<?x?xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_wrong_inner_exponent
+// CHECK-NOT:       "onnx.ReduceL2"
+// CHECK-NOT:       "onnx.ReduceSumSquare"
+// CHECK:           "onnx.Pow"
+// CHECK:           "onnx.ReduceSum"
+// CHECK:           "onnx.Sqrt"
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_wrong_inner_exponent
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+// DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
+}
+
+// -----
+
+func.func @test_recompose_reducel2_nonconstant_inner_exponent(%arg0: tensor<2x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<1xi64>) -> tensor<?x?xf32> {
+  %power = "onnx.Pow"(%arg0, %arg1) : (tensor<2x3x4xf32>, tensor<f32>) -> tensor<2x3x4xf32>
+  %sum = "onnx.ReduceSum"(%power, %arg2) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
+  %result = "onnx.Sqrt"(%sum) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  onnx.Return %result : tensor<?x?xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_nonconstant_inner_exponent
+// CHECK-NOT:       "onnx.ReduceL2"
+// CHECK-NOT:       "onnx.ReduceSumSquare"
+// CHECK:           "onnx.Pow"
+// CHECK:           "onnx.ReduceSum"
+// CHECK:           "onnx.Sqrt"
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_nonconstant_inner_exponent
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+// DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
+}
+
+// -----
+
+func.func @test_recompose_reducel2_wrong_outer_exponent(%arg0: tensor<2x3x4xf32>, %arg1: tensor<1xi64>) -> tensor<?x?xf32> {
+  %square = "onnx.Mul"(%arg0, %arg0) : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
+  %sum = "onnx.ReduceSum"(%square, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
+  %one = onnx.Constant dense<1.000000e+00> : tensor<f32>
+  %result = "onnx.Pow"(%sum, %one) : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
+  onnx.Return %result : tensor<?x?xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_wrong_outer_exponent
+// CHECK-NOT:       "onnx.ReduceL2"
+// CHECK-NOT:       "onnx.ReduceSumSquare"
+// CHECK:           "onnx.Mul"
+// CHECK:           [[SUM_:%.+]] = "onnx.ReduceSum"
+// CHECK:           onnx.Return [[SUM_]] : tensor<?x?xf32>
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_wrong_outer_exponent
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+// DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
+}
+
+// -----
+
+func.func @test_recompose_reducel2_nonconstant_outer_exponent(%arg0: tensor<2x3x4xf32>, %arg1: tensor<1xi64>, %arg2: tensor<f32>) -> tensor<?x?xf32> {
+  %square = "onnx.Mul"(%arg0, %arg0) : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
+  %sum = "onnx.ReduceSum"(%square, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4xf32>, tensor<1xi64>) -> tensor<?x?xf32>
+  %result = "onnx.Pow"(%sum, %arg2) : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
+  onnx.Return %result : tensor<?x?xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_nonconstant_outer_exponent
+// CHECK-NOT:       "onnx.ReduceL2"
 // CHECK-NOT:       "onnx.ReduceSumSquare"
 // CHECK:           "onnx.Mul"
 // CHECK:           "onnx.ReduceSum"
+// CHECK:           "onnx.Pow"
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_nonconstant_outer_exponent
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+// DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
 }
 
-// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducesumsquare_quant_types
-// DISABLED-CHECK-NOT:       "onnx.ReduceSumSquare"
+// -----
+
+// Uniform non-scalar exponents are safe when broadcasting does not expand
+// either Pow input.
+func.func @test_recompose_reducel2_non_scalar_shape_preserving_exponents(%arg0: tensor<2x3xf32>) -> tensor<3xf32> {
+  %axes = onnx.Constant dense<[0]> : tensor<1xi64>
+  %two = onnx.Constant dense<2.000000e+00> : tensor<2x1xf32>
+  %square = "onnx.Pow"(%arg0, %two) : (tensor<2x3xf32>, tensor<2x1xf32>) -> tensor<2x3xf32>
+  %sum = "onnx.ReduceSum"(%square, %axes) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3xf32>, tensor<1xi64>) -> tensor<3xf32>
+  %half = onnx.Constant dense<5.000000e-01> : tensor<3xf32>
+  %result = "onnx.Pow"(%sum, %half) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  onnx.Return %result : tensor<3xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_non_scalar_shape_preserving_exponents
+// CHECK:           [[L2_:%.+]] = "onnx.ReduceL2"
+// CHECK:           onnx.Return [[L2_]] : tensor<3xf32>
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_non_scalar_shape_preserving_exponents
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+}
+
+// -----
+
+// A non-scalar exponent can broadcast and expand the input, so this is not
+// equivalent to ReduceL2(%arg0, %axes).
+func.func @test_recompose_reducel2_broadcast_inner_exponent(%arg0: tensor<1x3xf32>) -> tensor<3xf32> {
+  %axes = onnx.Constant dense<[0]> : tensor<1xi64>
+  %two = onnx.Constant dense<2.000000e+00> : tensor<2x1xf32>
+  %square = "onnx.Pow"(%arg0, %two) : (tensor<1x3xf32>, tensor<2x1xf32>) -> tensor<2x3xf32>
+  %sum = "onnx.ReduceSum"(%square, %axes) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3xf32>, tensor<1xi64>) -> tensor<3xf32>
+  %result = "onnx.Sqrt"(%sum) : (tensor<3xf32>) -> tensor<3xf32>
+  onnx.Return %result : tensor<3xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_broadcast_inner_exponent
+// CHECK-NOT:       "onnx.ReduceL2"
+// CHECK:           "onnx.Sqrt"
+// CHECK:           onnx.Return
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_broadcast_inner_exponent
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+}
+
+// -----
+
+// The outer exponent can also broadcast the reduced tensor and must not be
+// dropped by replacing Pow with ReduceL2.
+func.func @test_recompose_reducel2_broadcast_outer_exponent(%arg0: tensor<2x3xf32>) -> tensor<2x3xf32> {
+  %axes = onnx.Constant dense<[0]> : tensor<1xi64>
+  %square = "onnx.Mul"(%arg0, %arg0) : (tensor<2x3xf32>, tensor<2x3xf32>) -> tensor<2x3xf32>
+  %sum = "onnx.ReduceSum"(%square, %axes) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3xf32>, tensor<1xi64>) -> tensor<3xf32>
+  %half = onnx.Constant dense<5.000000e-01> : tensor<2x1xf32>
+  %result = "onnx.Pow"(%sum, %half) : (tensor<3xf32>, tensor<2x1xf32>) -> tensor<2x3xf32>
+  onnx.Return %result : tensor<2x3xf32>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_broadcast_outer_exponent
+// CHECK-NOT:       "onnx.ReduceL2"
+// CHECK:           "onnx.Pow"
+// CHECK:           onnx.Return
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_broadcast_outer_exponent
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
+}
+
+// -----
+
+func.func @test_recompose_reducel2_from_mul_reducesum_quant_types(%arg0: tensor<2x3x4x!quant.uniform<i8:f32, 0.5:0>>, %arg1: tensor<1xi64>) -> tensor<?x?x!quant.uniform<i8:f32, 4.0:3>> {
+  %0 = "onnx.Mul"(%arg0, %arg0) : (tensor<2x3x4x!quant.uniform<i8:f32, 0.5:0>>, tensor<2x3x4x!quant.uniform<i8:f32, 0.5:0>>) -> tensor<2x3x4x!quant.uniform<i8:f32, 1.0:1>>
+  %1 = "onnx.ReduceSum"(%0, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3x4x!quant.uniform<i8:f32, 1.0:1>>, tensor<1xi64>) -> tensor<?x?x!quant.uniform<i8:f32, 2.0:2>>
+  %2 = "onnx.Sqrt"(%1) : (tensor<?x?x!quant.uniform<i8:f32, 2.0:2>>) -> tensor<?x?x!quant.uniform<i8:f32, 4.0:3>>
+  onnx.Return %2 : tensor<?x?x!quant.uniform<i8:f32, 4.0:3>>
+// CHECK-LABEL:  func.func @test_recompose_reducel2_from_mul_reducesum_quant_types
+// CHECK-NOT:       "onnx.ReduceL2"
+// CHECK:           "onnx.Mul"
+// CHECK:           "onnx.ReduceSum"
+// CHECK:           "onnx.Sqrt"
+}
+
+// DISABLED-CHECK-LABEL:  func.func @test_recompose_reducel2_from_mul_reducesum_quant_types
+// DISABLED-CHECK-NOT:       "onnx.ReduceL2"
 
 // -----
 


### PR DESCRIPTION
The current ReduceL2 recomposition and decomposition patterns are direct opposites. During the hybrid pass this leads to exhausting the rewrite budget. This reworks the patterns such that we no longer produce the intermediate ReduceSumSquare during recomposition, and instead directly recompose to ReduceL2.

There is a bit of complexity because we match both Mul(x, x) and Pow(x, 2) as well as Sqrt(x) and Pow(x, 1/2). Overall the default behavior is still preserved (recompositions disabled by default) and during the hybrid pass the two directions are exclusive.

ReduceL2-related patterns now:

- **Decompose**
  - `ReduceL2(x)` → `Sqrt(ReduceSumSquare(x))`
  - `ReduceSumSquare(x)` → `ReduceSum(Mul(x, x))`

- **Recompose**
  - `Sqrt(ReduceSumSquare(x))` → `ReduceL2(x)`
  - `Sqrt(ReduceSum(square(x)))` → `ReduceL2(x)`
  - `Pow(..., 0.5)` supports the same two reduction forms.

- **Deliberately unchanged**
  - Incomplete `square → ReduceSum` chains are not recomposed.
  - Hybrid mode disables recomposition when ReduceL2 decomposition is enabled, preventing an infinite inverse cycle.