### PR TITLE
Fix type erasing bug in cast elimination

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -232,11 +232,6 @@ def IsSingleElementONNXConstant : Constraint<
 
 def HasShapeAndRank : Constraint<CPred<"onnx_mlir::hasShapeAndRank($_self)">>;
 
-def HasSameElementType : Constraint<
-    CPred<"(mlir::dyn_cast<ShapedType>($0.getType()).getElementType() == "
-          "mlir::cast<::mlir::TypeAttr>($1).getValue())">,
-    "has same element type">;
-
 def HaveSameElementType : Constraint<
     CPred<"(mlir::dyn_cast<ShapedType>($0.getType()).getElementType() == "
           "mlir::dyn_cast<ShapedType>($1.getType()).getElementType())">,
@@ -585,11 +580,10 @@ def DropoutEliminationPattern : Pattern<(ONNXDropoutOp $data, $ratio, $training_
 // Canonicalization for ONNXCastOp
 //===----------------------------------------------------------------------===//
 
-// ONNX_Op (onnx.Cast (%X, $type)) = ONNX_Op (%X)
 def CastEliminationPattern : Pat<
-	(ONNXCastOp $arg, $saturate, $type),
+	(ONNXCastOp:$result $arg, $saturate, $type),
 	(replaceWithValue $arg),
-  [(HasSameElementType $arg, $type)]>;
+  [(HaveSameShapedType $arg, $result)]>;
 
 // Do cast on concat's inputs instead of output in order to propagate
 // cast operations together, which brings concat close to reshape

--- a/test/mlir/onnx/onnx_canonicalization_cast.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_cast.mlir
@@ -14,6 +14,20 @@ func.func @cast_identity_elimination(%arg0: tensor<2xf32>) -> tensor<2xf32> {
 // -----
 
 //===----------------------------------------------------------------------===//
+/// Identity casts that refine shape information must not be eliminated.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @cast_shape_refinement_preserved
+func.func @cast_shape_refinement_preserved(%arg0: tensor<*xi64>) -> tensor<64x32xi64> {
+  %0 = "onnx.Cast"(%arg0) {to = i64} : (tensor<*xi64>) -> tensor<64x32xi64>
+  onnx.Return %0 : tensor<64x32xi64>
+  // CHECK: %[[CAST:.*]] = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = i64} : (tensor<*xi64>) -> tensor<64x32xi64>
+  // CHECK: onnx.Return %[[CAST]] : tensor<64x32xi64>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 /// Integer cast-chain folding.
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Unlikely bug where we have `cast(%x) : (tensor<*xf32>) -> tensor<1x2x3xf32>` so the cast is trivial and can be removed, but that would also erase type information and caused issues in some model.
Instead we now require input and output type to also have the same shape. After shape inference runs this pattern will trigger again and still remove the trivial cast.