### PR TITLE
[AIESW-43371] Fold DequantizeLinear on constants feeding constant-only compute

### DIFF
--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -2299,12 +2299,14 @@ static bool isConstantOrDequantizeOfConstant(Value v) {
   return isNoneValue(zp) || getDenseOrDisposableConstLikeElements(zp);
 }
 
-// Pure, constant-foldable ops allowed inside a constant island (excludes
-// Conv/Gemm etc. whose quantized weights must stay integer).
+// Ops that may take part in a constant island. MatMul is included so that a
+// MatMul of two constants folds; a MatMul (or Conv/Gemm) with a real weight is
+// not dequantized because onlyFeedsConstantIsland separately requires every
+// other operand of the consumer to be constant.
 static bool isConstIslandPureOp(Operation *op) {
   return isa<ONNXMatMulOp, ONNXTransposeOp, ONNXConcatOp, ONNXReshapeOp,
-      ONNXSqueezeOp, ONNXUnsqueezeOp, ONNXExpandOp, ONNXGatherOp,
-      ONNXFlattenOp, ONNXSliceOp>(op);
+      ONNXSqueezeOp, ONNXUnsqueezeOp, ONNXExpandOp, ONNXGatherOp, ONNXFlattenOp,
+      ONNXSliceOp>(op);
 }
 
 // True if `value` flows only into constant computation that is re-quantized
@@ -2521,8 +2523,9 @@ void onnx_mlir::getConstPropONNXToONNXPatterns(RewritePatternSet &patterns,
         RemoveQDQForConst<ONNXSqueezeOp>, RemoveQDQForConst<ONNXUnsqueezeOp>,
         RemoveQDQForConst<ONNXGatherOp>>(patterns.getContext());
   if (enableQuantConstFold)
-    patterns.add<ConstFoldQuantizeLinearOnConst,
-        ConstFoldDequantizeLinearOnConst>(patterns.getContext());
+    patterns
+        .add<ConstFoldQuantizeLinearOnConst, ConstFoldDequantizeLinearOnConst>(
+            patterns.getContext());
 }
 
 void onnx_mlir::configureConstPropONNXToONNXPass(bool roundFPToInt,

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -2285,6 +2285,174 @@ public:
   }
 };
 
+// True if `v` is a constant, or a DequantizeLinear of a constant.
+static bool isConstantOrDequantizeOfConstant(Value v) {
+  if (getDenseOrDisposableConstLikeElements(v))
+    return true;
+  auto dq = v.getDefiningOp<ONNXDequantizeLinearOp>();
+  if (!dq)
+    return false;
+  if (!getDenseOrDisposableConstLikeElements(dq.getX()) ||
+      !getDenseOrDisposableConstLikeElements(dq.getXScale()))
+    return false;
+  Value zp = dq.getXZeroPoint();
+  return isNoneValue(zp) || getDenseOrDisposableConstLikeElements(zp);
+}
+
+// Pure, constant-foldable ops allowed inside a constant island (excludes
+// Conv/Gemm etc. whose quantized weights must stay integer).
+static bool isConstIslandPureOp(Operation *op) {
+  return isa<ONNXMatMulOp, ONNXTransposeOp, ONNXConcatOp, ONNXReshapeOp,
+      ONNXSqueezeOp, ONNXUnsqueezeOp, ONNXExpandOp, ONNXGatherOp,
+      ONNXFlattenOp, ONNXSliceOp>(op);
+}
+
+// True if `value` flows only into constant computation that is re-quantized
+// (or reaches a graph output) -- never into a non-constant op. This confines
+// the DequantizeLinear fold to constant islands (e.g. a constant MatMul chain)
+// and leaves ordinary quantized weights, which feed real activations, intact.
+static bool onlyFeedsConstantIsland(Value value) {
+  for (Operation *user : value.getUsers()) {
+    if (isa<ONNXQuantizeLinearOp>(user))
+      continue;
+    if (user->hasTrait<OpTrait::IsTerminator>())
+      continue;
+    if (!isConstIslandPureOp(user))
+      return false;
+    for (Value operand : user->getOperands()) {
+      if (operand == value || isNoneValue(operand))
+        continue;
+      if (!isConstantOrDequantizeOfConstant(operand))
+        return false;
+    }
+    for (Value result : user->getResults())
+      if (!onlyFeedsConstantIsland(result))
+        return false;
+  }
+  return true;
+}
+
+// Fold DequantizeLinear on constants to `(x - x_zero_point) * x_scale`, the
+// inverse of ConstFoldQuantizeLinearOnConst (same enableQuantConstFold gate).
+// Per-tensor and per-axis are handled; blocked quantization is out of scope.
+// Confined to constant islands (onlyFeedsConstantIsland) so quantized weights
+// are not dequantized.
+class ConstFoldDequantizeLinearOnConst
+    : public OpRewritePattern<ONNXDequantizeLinearOp> {
+public:
+  using OpRewritePattern<ONNXDequantizeLinearOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXDequantizeLinearOp dqOp, PatternRewriter &rewriter) const override {
+    // Blocked quantization is out of scope.
+    if (dqOp.getBlockSize() != 0)
+      return rewriter.notifyMatchFailure(dqOp, "blocked quantization");
+
+    // The input and quantization parameters must all be constants.
+    ElementsAttr xElems = getDenseOrDisposableConstLikeElements(dqOp.getX());
+    if (!xElems)
+      return rewriter.notifyMatchFailure(dqOp, "x is not a constant");
+
+    ElementsAttr scaleElems =
+        getDenseOrDisposableConstLikeElements(dqOp.getXScale());
+    if (!scaleElems)
+      return rewriter.notifyMatchFailure(dqOp, "x_scale is not a constant");
+
+    Value zpValue = dqOp.getXZeroPoint();
+    bool hasZeroPoint = !isNoneValue(zpValue);
+    ElementsAttr zpElems;
+    if (hasZeroPoint) {
+      zpElems = getDenseOrDisposableConstLikeElements(zpValue);
+      if (!zpElems)
+        return rewriter.notifyMatchFailure(
+            dqOp, "x_zero_point is not a constant");
+    }
+
+    auto floatType = dyn_cast<FloatType>(getElementTypeOrSelf(dqOp.getY()));
+    if (!floatType)
+      return rewriter.notifyMatchFailure(dqOp, "non-floating-point output");
+
+    // Only fold inside a constant island, not ordinary quantized weights.
+    if (!onlyFeedsConstantIsland(dqOp.getY()))
+      return rewriter.notifyMatchFailure(
+          dqOp, "not confined to a constant island");
+
+    auto xType = cast<ShapedType>(dqOp.getX().getType());
+    if (!xType.hasStaticShape())
+      return rewriter.notifyMatchFailure(dqOp, "x has dynamic shape");
+    int64_t xRank = xType.getRank();
+    ArrayRef<int64_t> xShape = xType.getShape();
+
+    int64_t scaleElemCount =
+        cast<ShapedType>(scaleElems.getType()).getNumElements();
+    int64_t zpElemCount =
+        hasZeroPoint ? cast<ShapedType>(zpElems.getType()).getNumElements() : 1;
+    bool isPerAxis = scaleElemCount > 1 || zpElemCount > 1;
+
+    int64_t axis = dqOp.getAxis();
+    if (isPerAxis) {
+      if (axis < 0)
+        axis += xRank;
+      if (axis < 0 || axis >= xRank)
+        return rewriter.notifyMatchFailure(dqOp, "axis out of range");
+
+      auto isFoldablePerAxisParam = [&](ElementsAttr elems,
+                                        int64_t count) -> bool {
+        if (count == 1)
+          return true; // Scalar broadcasts trivially.
+        auto type = cast<ShapedType>(elems.getType());
+        return type.getRank() == 1 && count == xShape[axis];
+      };
+      if (!isFoldablePerAxisParam(scaleElems, scaleElemCount) ||
+          (hasZeroPoint && !isFoldablePerAxisParam(zpElems, zpElemCount)))
+        return rewriter.notifyMatchFailure(
+            dqOp, "unsupported per-axis scale/zp");
+    }
+
+    FloatType f64Type = rewriter.getF64Type();
+    OnnxElementsAttrBuilder elementsBuilder(rewriter.getContext());
+
+    // Reshape a per-axis scale/zp (1-D of length xShape[axis]) so it
+    // broadcasts against x's shape; per-tensor (scalar) needs no reshape.
+    auto broadcastToX = [&](ElementsAttr elems) -> ElementsAttr {
+      auto type = cast<ShapedType>(elems.getType());
+      int64_t numElems = type.getNumElements();
+      if (numElems == 1)
+        return elems; // Per-tensor: scalar broadcasts trivially.
+      SmallVector<int64_t> bcastShape(xRank, 1);
+      bcastShape[axis] = numElems;
+      return elementsBuilder.reshape(elems, bcastShape);
+    };
+
+    ShapedType combinedType = cast<ShapedType>(
+        elementsBuilder.castToFPElementType(xElems, f64Type).getType());
+
+    // shifted = x - zero_point (both in f64).
+    ElementsAttr xF64 = elementsBuilder.castToFPElementType(xElems, f64Type);
+    ElementsAttr shifted = xF64;
+    if (hasZeroPoint) {
+      ElementsAttr zpF64 =
+          broadcastToX(elementsBuilder.castToFPElementType(zpElems, f64Type));
+      shifted = elementsBuilder.combine(
+          xF64, zpF64, combinedType, subCombiner(f64Type));
+    }
+
+    // dequantized = (x - zero_point) * scale (still in f64).
+    ElementsAttr scaleF64 =
+        broadcastToX(elementsBuilder.castToFPElementType(scaleElems, f64Type));
+    ElementsAttr dequantizedF64 = elementsBuilder.combine(shifted, scaleF64,
+        combinedType, elementwiseBinaryOpCombiner<ONNXMulOp>(f64Type));
+
+    // Cast down to the DequantizeLinear result's floating-point type.
+    ElementsAttr dequantized =
+        elementsBuilder.castToFPElementType(dequantizedF64, floatType);
+
+    rewriter.replaceOp(
+        dqOp, createReplacingConstantOp(rewriter, dqOp.getY(), dequantized));
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Code to manage the pass.
 //===----------------------------------------------------------------------===//
@@ -2353,7 +2521,8 @@ void onnx_mlir::getConstPropONNXToONNXPatterns(RewritePatternSet &patterns,
         RemoveQDQForConst<ONNXSqueezeOp>, RemoveQDQForConst<ONNXUnsqueezeOp>,
         RemoveQDQForConst<ONNXGatherOp>>(patterns.getContext());
   if (enableQuantConstFold)
-    patterns.add<ConstFoldQuantizeLinearOnConst>(patterns.getContext());
+    patterns.add<ConstFoldQuantizeLinearOnConst,
+        ConstFoldDequantizeLinearOnConst>(patterns.getContext());
 }
 
 void onnx_mlir::configureConstPropONNXToONNXPass(bool roundFPToInt,

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -2299,28 +2299,16 @@ static bool isConstantOrDequantizeOfConstant(Value v) {
   return isNoneValue(zp) || getDenseOrDisposableConstLikeElements(zp);
 }
 
-// Ops that may take part in a constant island. MatMul is included so that a
-// MatMul of two constants folds; a MatMul (or Conv/Gemm) with a real weight is
-// not dequantized because onlyFeedsConstantIsland separately requires every
-// other operand of the consumer to be constant.
-static bool isConstIslandPureOp(Operation *op) {
-  return isa<ONNXMatMulOp, ONNXTransposeOp, ONNXConcatOp, ONNXReshapeOp,
-      ONNXSqueezeOp, ONNXUnsqueezeOp, ONNXExpandOp, ONNXGatherOp, ONNXFlattenOp,
-      ONNXSliceOp>(op);
-}
-
-// True if `value` flows only into constant computation that is re-quantized
-// (or reaches a graph output) -- never into a non-constant op. This confines
-// the DequantizeLinear fold to constant islands (e.g. a constant MatMul chain)
-// and leaves ordinary quantized weights, which feed real activations, intact.
+// True if `value` is only consumed by constant computation ending at a
+// QuantizeLinear or graph output -- never by an op with a non-constant operand.
+// This keeps the fold off ordinary quantized weights (whose consumer mixes in a
+// non-constant activation).
 static bool onlyFeedsConstantIsland(Value value) {
   for (Operation *user : value.getUsers()) {
     if (isa<ONNXQuantizeLinearOp>(user))
       continue;
     if (user->hasTrait<OpTrait::IsTerminator>())
       continue;
-    if (!isConstIslandPureOp(user))
-      return false;
     for (Value operand : user->getOperands()) {
       if (operand == value || isNoneValue(operand))
         continue;

--- a/test/mlir/onnx/onnx_constprop_dq_fold.mlir
+++ b/test/mlir/onnx/onnx_constprop_dq_fold.mlir
@@ -100,7 +100,7 @@ func.func @fold_dq_bf16() -> tensor<2xbf16> {
 
 // -----
 
-// End-to-end (the PSGT rotary_emb pattern): a MatMul whose operands both come
+// End-to-end: a MatMul whose operands both come
 // from a DequantizeLinear-on-const folds all the way to a single Constant once
 // the DQ folder turns each operand into a Constant.
 // a = [[1,2],[3,4]] (scale 0.5 on [[2,4],[6,8]]), b = [[1,2],[3,4]] (scale 1.0).

--- a/test/mlir/onnx/onnx_constprop_dq_fold.mlir
+++ b/test/mlir/onnx/onnx_constprop_dq_fold.mlir
@@ -193,19 +193,41 @@ func.func @no_fold_weight_via_transpose(%act: tensor<2x2xf32>) -> tensor<2x2xf32
 
 // -----
 
-// Scoping: a DequantizeLinear-on-const feeding a Reduce (not a const-island
-// pure op) must NOT be folded. This is the pattern that previously fed a float
-// constant into the DMAC reduce-shielding pass and crashed it.
-func.func @no_fold_dq_into_reduce() -> tensor<1x1xf32> {
-  %x = onnx.Constant dense<[[2, 4]]> : tensor<1x2xui8>
-  %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
-  %zp = onnx.Constant dense<0> : tensor<ui8>
-  %dq = "onnx.DequantizeLinear"(%x, %scale, %zp) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
-  %axes = onnx.Constant dense<[1]> : tensor<1xi64>
-  %r = "onnx.ReduceSum"(%dq, %axes) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2xf32>, tensor<1xi64>) -> tensor<1x1xf32>
-  return %r : tensor<1x1xf32>
+// A constant Add folds too: no op type is special-cased, so Add(const, const)
+// inside an island collapses just like MatMul. [[1,2],[3,4]] + [[1,1],[1,1]].
+func.func @fold_add_of_dq_consts() -> tensor<2x2xf32> {
+  %a = onnx.Constant dense<[[2, 4], [6, 8]]> : tensor<2x2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+
+  %b = onnx.Constant dense<[[1, 1], [1, 1]]> : tensor<2x2xui8>
+  %b_scale = onnx.Constant dense<1.000000e+00> : tensor<f32>
+  %b_zp = onnx.Constant dense<0> : tensor<ui8>
+  %b_dq = "onnx.DequantizeLinear"(%b, %b_scale, %b_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+
+  %add = "onnx.Add"(%a_dq, %b_dq) : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %add : tensor<2x2xf32>
 }
 
-// CHECK-LABEL: @no_fold_dq_into_reduce
+// CHECK-LABEL: @fold_add_of_dq_consts
+// CHECK-NOT: onnx.DequantizeLinear
+// CHECK-NOT: onnx.Add
+// CHECK: onnx.Constant dense<{{\[}}[2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00]]> : tensor<2x2xf32>
+
+// -----
+
+// A constant added to a non-constant activation must NOT be dequantized -- the
+// operand check (not an op list) is what protects it.
+func.func @no_fold_const_into_add(%act: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %b = onnx.Constant dense<[[1, 2], [3, 4]]> : tensor<2x2xui8>
+  %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %zp = onnx.Constant dense<0> : tensor<ui8>
+  %b_dq = "onnx.DequantizeLinear"(%b, %scale, %zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+  %add = "onnx.Add"(%act, %b_dq) : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %add : tensor<2x2xf32>
+}
+
+// CHECK-LABEL: @no_fold_const_into_add
 // CHECK: onnx.DequantizeLinear
-// CHECK: onnx.ReduceSum
+// CHECK: onnx.Add

--- a/test/mlir/onnx/onnx_constprop_dq_fold.mlir
+++ b/test/mlir/onnx/onnx_constprop_dq_fold.mlir
@@ -1,0 +1,211 @@
+// RUN: onnx-mlir-opt --split-input-file %s -constprop-onnx=enable-quant-const-fold | FileCheck %s
+// RUN: onnx-mlir-opt --split-input-file %s -constprop-onnx | FileCheck %s --check-prefix=DISABLED
+
+//===----------------------------------------------------------------------===//
+// Positive cases.
+//===----------------------------------------------------------------------===//
+
+// Per-tensor, zero point = 0. (2-0)*0.5=1, (4-0)*0.5=2, (6-0)*0.5=3.
+// The fold is gated behind enable-quant-const-fold, so it is off by default.
+func.func @fold_dq_per_tensor() -> tensor<3xf32> {
+  %x = onnx.Constant dense<[2, 4, 6]> : tensor<3xui8>
+  %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %zp = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%x, %scale, %zp) {axis = 1 : si64, block_size = 0 : si64} : (tensor<3xui8>, tensor<f32>, tensor<ui8>) -> tensor<3xf32>
+  return %dq : tensor<3xf32>
+}
+
+// CHECK-LABEL: @fold_dq_per_tensor
+// CHECK-NOT: onnx.DequantizeLinear
+// CHECK: onnx.Constant dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>
+
+// DISABLED-LABEL: @fold_dq_per_tensor
+// DISABLED: onnx.DequantizeLinear
+
+// -----
+
+// Per-tensor with a non-zero zero point. (18-10)*0.5=4, (10-10)*0.5=0.
+func.func @fold_dq_with_zp() -> tensor<2xf32> {
+  %x = onnx.Constant dense<[18, 10]> : tensor<2xui8>
+  %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %zp = onnx.Constant dense<10> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%x, %scale, %zp) {axis = 1 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2xf32>
+  return %dq : tensor<2xf32>
+}
+
+// CHECK-LABEL: @fold_dq_with_zp
+// CHECK-NOT: onnx.DequantizeLinear
+// CHECK: onnx.Constant dense<[4.000000e+00, 0.000000e+00]> : tensor<2xf32>
+
+// -----
+
+// Signed input with a negative value. (-3-(-1))*0.25 = -0.5, (5-(-1))*0.25 = 1.5.
+func.func @fold_dq_signed() -> tensor<2xf32> {
+  %x = onnx.Constant dense<[-3, 5]> : tensor<2xi8>
+  %scale = onnx.Constant dense<2.500000e-01> : tensor<f32>
+  %zp = onnx.Constant dense<-1> : tensor<i8>
+  %dq = "onnx.DequantizeLinear"(%x, %scale, %zp) {axis = 1 : si64, block_size = 0 : si64} : (tensor<2xi8>, tensor<f32>, tensor<i8>) -> tensor<2xf32>
+  return %dq : tensor<2xf32>
+}
+
+// CHECK-LABEL: @fold_dq_signed
+// CHECK-NOT: onnx.DequantizeLinear
+// CHECK: onnx.Constant dense<[-5.000000e-01, 1.500000e+00]> : tensor<2xf32>
+
+// -----
+
+// Per-axis along axis 0: row 0 uses scale 0.5, row 1 uses scale 0.25.
+// row0: [(4-0)*0.5, (8-0)*0.5] = [2, 4]; row1: [(4-0)*0.25, (8-0)*0.25] = [1, 2].
+func.func @fold_dq_per_axis() -> tensor<2x2xf32> {
+  %x = onnx.Constant dense<[[4, 8], [4, 8]]> : tensor<2x2xui8>
+  %scale = onnx.Constant dense<[5.000000e-01, 2.500000e-01]> : tensor<2xf32>
+  %zp = onnx.Constant dense<[0, 0]> : tensor<2xui8>
+  %dq = "onnx.DequantizeLinear"(%x, %scale, %zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<2xf32>, tensor<2xui8>) -> tensor<2x2xf32>
+  return %dq : tensor<2x2xf32>
+}
+
+// CHECK-LABEL: @fold_dq_per_axis
+// CHECK-NOT: onnx.DequantizeLinear
+// CHECK: onnx.Constant dense<{{\[}}[2.000000e+00, 4.000000e+00], [1.000000e+00, 2.000000e+00]]> : tensor<2x2xf32>
+
+// -----
+
+// No zero point operand (None). (4-0)*0.5 = 2.
+func.func @fold_dq_no_zp() -> tensor<1xf32> {
+  %x = onnx.Constant dense<[4]> : tensor<1xi8>
+  %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %none = "onnx.NoValue"() {value} : () -> none
+  %dq = "onnx.DequantizeLinear"(%x, %scale, %none) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1xi8>, tensor<f32>, none) -> tensor<1xf32>
+  return %dq : tensor<1xf32>
+}
+
+// CHECK-LABEL: @fold_dq_no_zp
+// CHECK-NOT: onnx.DequantizeLinear
+// CHECK: onnx.Constant dense<2.000000e+00> : tensor<1xf32>
+
+// -----
+
+// bf16 output: scale and result are bf16. (2-0)*0.5=1, (4-0)*0.5=2 (both exact in bf16).
+func.func @fold_dq_bf16() -> tensor<2xbf16> {
+  %x = onnx.Constant dense<[2, 4]> : tensor<2xui8>
+  %scale = onnx.Constant dense<5.000000e-01> : tensor<bf16>
+  %zp = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%x, %scale, %zp) {axis = 1 : si64, block_size = 0 : si64} : (tensor<2xui8>, tensor<bf16>, tensor<ui8>) -> tensor<2xbf16>
+  return %dq : tensor<2xbf16>
+}
+
+// CHECK-LABEL: @fold_dq_bf16
+// CHECK-NOT: onnx.DequantizeLinear
+// CHECK: onnx.Constant dense<[1.000000e+00, 2.000000e+00]> : tensor<2xbf16>
+
+// -----
+
+// End-to-end (the PSGT rotary_emb pattern): a MatMul whose operands both come
+// from a DequantizeLinear-on-const folds all the way to a single Constant once
+// the DQ folder turns each operand into a Constant.
+// a = [[1,2],[3,4]] (scale 0.5 on [[2,4],[6,8]]), b = [[1,2],[3,4]] (scale 1.0).
+// [[1,2],[3,4]] . [[1,2],[3,4]] = [[7,10],[15,22]].
+func.func @fold_matmul_of_dq_consts() -> tensor<2x2xf32> {
+  %a = onnx.Constant dense<[[2, 4], [6, 8]]> : tensor<2x2xui8>
+  %a_scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %a_zp = onnx.Constant dense<0> : tensor<ui8>
+  %a_dq = "onnx.DequantizeLinear"(%a, %a_scale, %a_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+
+  %b = onnx.Constant dense<[[1, 2], [3, 4]]> : tensor<2x2xui8>
+  %b_scale = onnx.Constant dense<1.000000e+00> : tensor<f32>
+  %b_zp = onnx.Constant dense<0> : tensor<ui8>
+  %b_dq = "onnx.DequantizeLinear"(%b, %b_scale, %b_zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+
+  %mm = "onnx.MatMul"(%a_dq, %b_dq) : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %mm : tensor<2x2xf32>
+}
+
+// CHECK-LABEL: @fold_matmul_of_dq_consts
+// CHECK-NOT: onnx.DequantizeLinear
+// CHECK-NOT: onnx.MatMul
+// CHECK: onnx.Constant dense<{{\[}}[7.000000e+00, 1.000000e+01], [1.500000e+01, 2.200000e+01]]> : tensor<2x2xf32>
+
+//===----------------------------------------------------------------------===//
+// Negative cases.
+//===----------------------------------------------------------------------===//
+
+// -----
+
+// Input is not a constant (function argument): DQ must remain.
+func.func @no_fold_non_const(%arg0: tensor<3xui8>) -> tensor<3xf32> {
+  %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %zp = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%arg0, %scale, %zp) {axis = 1 : si64, block_size = 0 : si64} : (tensor<3xui8>, tensor<f32>, tensor<ui8>) -> tensor<3xf32>
+  return %dq : tensor<3xf32>
+}
+
+// CHECK-LABEL: @no_fold_non_const
+// CHECK: onnx.DequantizeLinear
+
+// -----
+
+// Blocked quantization (block_size != 0): DQ must remain.
+func.func @no_fold_blocked() -> tensor<4xf32> {
+  %x = onnx.Constant dense<[1, 2, 3, 4]> : tensor<4xui8>
+  %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %zp = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%x, %scale, %zp) {axis = 0 : si64, block_size = 2 : si64} : (tensor<4xui8>, tensor<f32>, tensor<ui8>) -> tensor<4xf32>
+  return %dq : tensor<4xf32>
+}
+
+// CHECK-LABEL: @no_fold_blocked
+// CHECK: onnx.DequantizeLinear
+
+// -----
+
+// Scoping: a quantized weight feeding a real MatMul (with a non-constant
+// activation) must NOT be dequantized -- it is not a constant island.
+func.func @no_fold_weight_into_matmul(%act: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %w = onnx.Constant dense<[[1, 2], [3, 4]]> : tensor<2x2xui8>
+  %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %zp = onnx.Constant dense<0> : tensor<ui8>
+  %w_dq = "onnx.DequantizeLinear"(%w, %scale, %zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+  %mm = "onnx.MatMul"(%act, %w_dq) : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %mm : tensor<2x2xf32>
+}
+
+// CHECK-LABEL: @no_fold_weight_into_matmul
+// CHECK: onnx.DequantizeLinear
+// CHECK: onnx.MatMul
+
+// -----
+
+// Scoping: a quantized weight that is transposed before a real MatMul must NOT
+// be dequantized -- the transitive consumer mixes in a non-constant activation.
+func.func @no_fold_weight_via_transpose(%act: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %w = onnx.Constant dense<[[1, 2], [3, 4]]> : tensor<2x2xui8>
+  %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %zp = onnx.Constant dense<0> : tensor<ui8>
+  %w_dq = "onnx.DequantizeLinear"(%w, %scale, %zp) {axis = 0 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+  %wt = "onnx.Transpose"(%w_dq) {perm = [1, 0]} : (tensor<2x2xf32>) -> tensor<2x2xf32>
+  %mm = "onnx.MatMul"(%act, %wt) : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %mm : tensor<2x2xf32>
+}
+
+// CHECK-LABEL: @no_fold_weight_via_transpose
+// CHECK: onnx.DequantizeLinear
+// CHECK: onnx.Transpose
+
+// -----
+
+// Scoping: a DequantizeLinear-on-const feeding a Reduce (not a const-island
+// pure op) must NOT be folded. This is the pattern that previously fed a float
+// constant into the DMAC reduce-shielding pass and crashed it.
+func.func @no_fold_dq_into_reduce() -> tensor<1x1xf32> {
+  %x = onnx.Constant dense<[[2, 4]]> : tensor<1x2xui8>
+  %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
+  %zp = onnx.Constant dense<0> : tensor<ui8>
+  %dq = "onnx.DequantizeLinear"(%x, %scale, %zp) {axis = 1 : si64, block_size = 0 : si64} : (tensor<1x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<1x2xf32>
+  %axes = onnx.Constant dense<[1]> : tensor<1xi64>
+  %r = "onnx.ReduceSum"(%dq, %axes) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2xf32>, tensor<1xi64>) -> tensor<1x1xf32>
+  return %r : tensor<1x1xf32>
+}
+
+// CHECK-LABEL: @no_fold_dq_into_reduce
+// CHECK: onnx.DequantizeLinear
+// CHECK: onnx.ReduceSum

--- a/test/mlir/onnx/onnx_constprop_qdq_fold.mlir
+++ b/test/mlir/onnx/onnx_constprop_qdq_fold.mlir
@@ -100,7 +100,8 @@ func.func @fold_q_no_zp() -> tensor<1xi8> {
 
 // -----
 
-// End-to-end: Const(fp) -> Q -> DQ collapses to Const(int) -> DQ.
+// End-to-end: Const(fp) -> Q -> DQ collapses all the way to a Const(fp), since
+// both the Q and DQ folders are enabled by enable-quant-const-fold.
 func.func @fold_q_then_dq() -> tensor<3xf32> {
   %x = onnx.Constant dense<[1.0, 2.0, 3.0]> : tensor<3xf32>
   %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>
@@ -112,8 +113,8 @@ func.func @fold_q_then_dq() -> tensor<3xf32> {
 
 // CHECK-LABEL: @fold_q_then_dq
 // CHECK-NOT: onnx.QuantizeLinear
-// CHECK: onnx.Constant dense<[2, 4, 6]> : tensor<3xui8>
-// CHECK: onnx.DequantizeLinear
+// CHECK-NOT: onnx.DequantizeLinear
+// CHECK: onnx.Constant dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>
 
 // -----
 


### PR DESCRIPTION
## Summary

Adds a constant-folding pattern for `onnx.DequantizeLinear` on constant inputs, the inverse of the existing `ConstFoldQuantizeLinearOnConst`. Gated behind the same `enable-quant-const-fold` option.

This unblocks folding of compile-time-constant subgraphs that were previously left as live compute. Since folders like `MatMulOfConsts` / `TransposeofConst` / `ConcatofConst` require their operands to be dense-constant-like, a `DequantizeLinear` result blocked them; folding the DQ to a constant lets the whole subgraph collapse. For example, a constant `MatMul` whose operands come from `DequantizeLinear`-of-constant (plus surrounding `Transpose`/`Concat`, and even `Cos`/`Sin` of a constant) folds to a single precomputed constant.

## Details

- `ConstFoldDequantizeLinearOnConst` computes `(x - x_zero_point) * x_scale` in f64 and casts to the op's float result type (f32/bf16). Handles per-tensor and per-axis quantization; blocked quantization (`block_size != 0`) is out of scope.
- The fold is scoped by `onlyFeedsConstantIsland`: a DQ is folded only if its value is consumed exclusively by constant computation that ends at a `QuantizeLinear` (re-quantization) or a graph output — never by an op that also takes a non-constant operand. No op type is special-cased; safety comes purely from the requirement that every other operand of each consumer is constant. This keeps ordinary quantized weights integer, since a weight feeds a real Conv/MatMul whose activation operand is not constant.

## Tests

- New `onnx_constprop_dq_fold.mlir`: per-tensor / per-axis / signed / no-zero-point / bf16 folds; end-to-end `MatMul`-of-dequantized-consts and `Add`-of-dequantized-consts folds; negative cases (non-constant input, blocked quantization, quantized weight into a real `MatMul`, weight via `Transpose` into a real `MatMul`, constant added to a non-constant activation).
- Updated `onnx_constprop_qdq_fold.mlir`: `fold_q_then_dq` now folds all the way to a float constant.

