### PR TITLE
Gate DequantizeLinear const fold behind enable-dequant-const-fold

### DIFF
--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -2057,10 +2057,10 @@ static bool onlyFeedsConstantIsland(Value value) {
 }
 
 // Fold DequantizeLinear on constants to `(x - x_zero_point) * x_scale`, the
-// inverse of ConstFoldQuantizeLinearOnConst (same enableQuantConstFold gate).
-// Per-tensor and per-axis are handled; blocked quantization is out of scope.
-// Confined to constant islands (onlyFeedsConstantIsland) so quantized weights
-// are not dequantized.
+// inverse of ConstFoldQuantizeLinearOnConst, gated by
+// enable-dequant-const-fold. Per-tensor and per-axis are handled; blocked
+// quantization is out of scope. Confined to constant islands
+// (onlyFeedsConstantIsland) so quantized weights are not dequantized.
 class ConstFoldDequantizeLinearOnConst
     : public OpRewritePattern<ONNXDequantizeLinearOp> {
 public:
@@ -2190,15 +2190,19 @@ struct ConstPropONNXToONNXPass
   Option<bool> enableQuantConstFold{
       *this, "enable-quant-const-fold", llvm::cl::init(false)};
 
+  Option<bool> enableDequantConstFold{
+      *this, "enable-dequant-const-fold", llvm::cl::init(false)};
+
   Option<int64_t> maxLoopUnrollCount{*this, "max-loop-unroll-count",
       llvm::cl::desc("Maximum constant onnx.Loop trip count to unroll."),
       llvm::cl::init(64)};
 
-  ConstPropONNXToONNXPass(
-      bool enableQDQ, bool enableQuantConstFold, int64_t maxLoopUnrollCount) {
+  ConstPropONNXToONNXPass(bool enableQDQ, bool enableQuantConstFold,
+      int64_t maxLoopUnrollCount, bool enableDequantConstFold) {
     this->enableQDQ = enableQDQ;
     this->enableQuantConstFold = enableQuantConstFold;
     this->maxLoopUnrollCount = maxLoopUnrollCount;
+    this->enableDequantConstFold = enableDequantConstFold;
   }
 
   ConstPropONNXToONNXPass(const ConstPropONNXToONNXPass &other) {
@@ -2219,8 +2223,8 @@ void ConstPropONNXToONNXPass::runOnOperation() {
   MLIRContext *context = &getContext();
 
   RewritePatternSet patterns(context);
-  getConstPropONNXToONNXPatterns(
-      patterns, enableQDQ, enableQuantConstFold, maxLoopUnrollCount);
+  getConstPropONNXToONNXPatterns(patterns, enableQDQ, enableQuantConstFold,
+      maxLoopUnrollCount, enableDequantConstFold);
   onnx_mlir::ResultNamesUpdater rnUpdater;
   if (failed(applyPatternsGreedily(function, std::move(patterns),
           GreedyRewriteConfig{.listener = &rnUpdater})))
@@ -2230,7 +2234,8 @@ void ConstPropONNXToONNXPass::runOnOperation() {
 } // end anonymous namespace.
 
 void onnx_mlir::getConstPropONNXToONNXPatterns(RewritePatternSet &patterns,
-    bool enableQDQ, bool enableQuantConstFold, int64_t maxLoopUnrollCount) {
+    bool enableQDQ, bool enableQuantConstFold, int64_t maxLoopUnrollCount,
+    bool enableDequantConstFold) {
   if (isConstantPropagationDisabled())
     return;
   populateWithGenerated(patterns);
@@ -2253,9 +2258,9 @@ void onnx_mlir::getConstPropONNXToONNXPatterns(RewritePatternSet &patterns,
         patterns.getContext());
   }
   if (enableQuantConstFold)
-    patterns
-        .add<ConstFoldQuantizeLinearOnConst, ConstFoldDequantizeLinearOnConst>(
-            patterns.getContext());
+    patterns.add<ConstFoldQuantizeLinearOnConst>(patterns.getContext());
+  if (enableDequantConstFold)
+    patterns.add<ConstFoldDequantizeLinearOnConst>(patterns.getContext());
 }
 
 void onnx_mlir::configureConstPropONNXToONNXPass(bool roundFPToInt,
@@ -2273,7 +2278,8 @@ void onnx_mlir::configureConstPropONNXToONNXPass(bool roundFPToInt,
  * Create a ConstPropONNX pass.
  */
 std::unique_ptr<mlir::Pass> onnx_mlir::createConstPropONNXToONNXPass(
-    bool enableQDQ, bool enableQuantConstFold, int64_t maxLoopUnrollCount) {
-  return std::make_unique<ConstPropONNXToONNXPass>(
-      enableQDQ, enableQuantConstFold, maxLoopUnrollCount);
+    bool enableQDQ, bool enableQuantConstFold, int64_t maxLoopUnrollCount,
+    bool enableDequantConstFold) {
+  return std::make_unique<ConstPropONNXToONNXPass>(enableQDQ,
+      enableQuantConstFold, maxLoopUnrollCount, enableDequantConstFold);
 }

--- a/src/Dialect/ONNX/Transforms/ConstProp.hpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.hpp
@@ -14,7 +14,7 @@ namespace onnx_mlir {
 // Exports the ConstPropONNXToONNXPass patterns.
 void getConstPropONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableQDQ = false, bool enableQuantConstFold = false,
-    int64_t maxLoopUnrollCount = 64);
+    int64_t maxLoopUnrollCount = 64, bool enableDequantConstFold = false);
 
 } // namespace onnx_mlir
 #endif

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -80,7 +80,7 @@ void configureGatherElementsTileCanonicalization(
 
 std::unique_ptr<mlir::Pass> createConstPropONNXToONNXPass(
     bool enableQDQ = false, bool enableQuantConstFold = false,
-    int64_t maxLoopUnrollCount = 64);
+    int64_t maxLoopUnrollCount = 64, bool enableDequantConstFold = false);
 
 std::unique_ptr<mlir::Pass> createQDQCanonicalizePass(bool removeBinary = false,
     bool removeQDQAroundOps = false, int64_t maxRoundTripDiff = 0);

--- a/test/mlir/onnx/onnx_constprop_dq_fold.mlir
+++ b/test/mlir/onnx/onnx_constprop_dq_fold.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --split-input-file %s -constprop-onnx=enable-quant-const-fold | FileCheck %s
+// RUN: onnx-mlir-opt --split-input-file %s -constprop-onnx=enable-dequant-const-fold | FileCheck %s
 // RUN: onnx-mlir-opt --split-input-file %s -constprop-onnx | FileCheck %s --check-prefix=DISABLED
 
 //===----------------------------------------------------------------------===//
@@ -6,7 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 // Per-tensor, zero point = 0. (2-0)*0.5=1, (4-0)*0.5=2, (6-0)*0.5=3.
-// The fold is gated behind enable-quant-const-fold, so it is off by default.
+// The fold is gated behind enable-dequant-const-fold, so it is off by default.
 func.func @fold_dq_per_tensor() -> tensor<3xf32> {
   %x = onnx.Constant dense<[2, 4, 6]> : tensor<3xui8>
   %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>

--- a/test/mlir/onnx/onnx_constprop_qdq_fold.mlir
+++ b/test/mlir/onnx/onnx_constprop_qdq_fold.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --split-input-file %s -constprop-onnx=enable-quant-const-fold | FileCheck %s
+// RUN: onnx-mlir-opt --split-input-file %s -constprop-onnx="enable-quant-const-fold enable-dequant-const-fold" | FileCheck %s
 // RUN: onnx-mlir-opt --split-input-file %s -constprop-onnx | FileCheck %s --check-prefix=DISABLED
 
 //===----------------------------------------------------------------------===//
@@ -101,7 +101,7 @@ func.func @fold_q_no_zp() -> tensor<1xi8> {
 // -----
 
 // End-to-end: Const(fp) -> Q -> DQ collapses all the way to a Const(fp), since
-// both the Q and DQ folders are enabled by enable-quant-const-fold.
+// the Q and DQ folders are enabled (enable-quant-const-fold + enable-dequant-const-fold).
 func.func @fold_q_then_dq() -> tensor<3xf32> {
   %x = onnx.Constant dense<[1.0, 2.0, 3.0]> : tensor<3xf32>
   %scale = onnx.Constant dense<5.000000e-01> : tensor<f32>


### PR DESCRIPTION
## Summary

Splits `DequantizeLinear`-on-const folding out of `enable-quant-const-fold` into its own opt-in flag, `enable-dequant-const-fold` (default off).

## Motivation

The DQ const fold can fold a quantized compute subgraph (e.g. a constant `MatMul`/`Concat`, and transcendentals like `Cos`/`Sin`) into a precomputed constant. While correct, this replaces the on-device quantized computation with a host float computation, which diverges from the quantized reference and was observed to cause an accuracy regression. Gating it behind a separate flag lets the Q-fold stay enabled while the DQ-fold is opt-in and off by default, so pipelines control it explicitly rather than inheriting it.
