### PR TITLE
Do not fold DQ across a weight requantize boundary

### DIFF
--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -2033,14 +2033,35 @@ static bool isConstantOrDequantizeOfConstant(Value v) {
   return isNoneValue(zp) || getDenseOrDisposableConstLikeElements(zp);
 }
 
-// True if `value` is only consumed by constant computation ending at a
-// QuantizeLinear or graph output -- never by an op with a non-constant operand.
-// This keeps the fold off ordinary quantized weights (whose consumer mixes in a
-// non-constant activation).
+// True if `q` is a weight requantize boundary: Q -> DQ -> Op(activation, ...),
+// not the end of a constant island.
+static bool requantizeFeedsNonConstantConsumer(ONNXQuantizeLinearOp q) {
+  for (Operation *qUser : q.getY().getUsers()) {
+    auto dq = dyn_cast<ONNXDequantizeLinearOp>(qUser);
+    if (!dq)
+      continue;
+    for (Operation *dqUser : dq.getY().getUsers())
+      for (Value operand : dqUser->getOperands()) {
+        // Skip the island path itself and None operands.
+        if (operand == dq.getY() || isNoneValue(operand))
+          continue;
+        if (!isConstantOrDequantizeOfConstant(operand))
+          return true;
+      }
+  }
+  return false;
+}
+
+// True if `value` is only consumed by constant computation (no op with a
+// non-constant operand), so it is safe to dequantize.
 static bool onlyFeedsConstantIsland(Value value) {
   for (Operation *user : value.getUsers()) {
-    if (isa<ONNXQuantizeLinearOp>(user))
+    if (auto q = dyn_cast<ONNXQuantizeLinearOp>(user)) {
+      // A QuantizeLinear ends the island unless it is a weight requantize.
+      if (requantizeFeedsNonConstantConsumer(q))
+        return false;
       continue;
+    }
     if (user->hasTrait<OpTrait::IsTerminator>())
       continue;
     for (Value operand : user->getOperands()) {

--- a/src/Dialect/ONNX/Transforms/ConstProp.cpp
+++ b/src/Dialect/ONNX/Transforms/ConstProp.cpp
@@ -2033,21 +2033,48 @@ static bool isConstantOrDequantizeOfConstant(Value v) {
   return isNoneValue(zp) || getDenseOrDisposableConstLikeElements(zp);
 }
 
-// True if `q` is a weight requantize boundary: Q -> DQ -> Op(activation, ...),
-// not the end of a constant island.
-static bool requantizeFeedsNonConstantConsumer(ONNXQuantizeLinearOp q) {
-  for (Operation *qUser : q.getY().getUsers()) {
-    auto dq = dyn_cast<ONNXDequantizeLinearOp>(qUser);
-    if (!dq)
-      continue;
-    for (Operation *dqUser : dq.getY().getUsers())
-      for (Value operand : dqUser->getOperands()) {
-        // Skip the island path itself and None operands.
-        if (operand == dq.getY() || isNoneValue(operand))
-          continue;
-        if (!isConstantOrDequantizeOfConstant(operand))
+// Pure shape/movement ops that carry a value through a re-quantization boundary
+// unchanged, so a constant flowing through them is still the same constant.
+static bool isValuePreservingMovementOp(Operation *op) {
+  return isa<ONNXTransposeOp, ONNXReshapeOp, ONNXSqueezeOp, ONNXUnsqueezeOp,
+      ONNXFlattenOp, ONNXSliceOp, ONNXGatherOp>(op);
+}
+
+// Following `value` through movement ops, true if it reaches an op that also
+// takes a non-constant operand (real activation compute consuming it).
+static bool feedsNonConstantConsumer(Value value) {
+  for (Operation *user : value.getUsers()) {
+    if (isValuePreservingMovementOp(user)) {
+      for (Value result : user->getResults())
+        if (feedsNonConstantConsumer(result))
           return true;
-      }
+      continue;
+    }
+    for (Value operand : user->getOperands()) {
+      if (operand == value || isNoneValue(operand))
+        continue;
+      if (!isConstantOrDequantizeOfConstant(operand))
+        return true;
+    }
+  }
+  return false;
+}
+
+// True if `requantized` (a QuantizeLinear result) is a weight requantize
+// boundary: following it through movement ops to a DequantizeLinear, and that
+// DQ's result on through movement ops, reaches an op with a non-constant
+// operand -- rather than the end of a purely-constant island.
+static bool requantizeFeedsNonConstantConsumer(Value requantized) {
+  for (Operation *user : requantized.getUsers()) {
+    if (isValuePreservingMovementOp(user)) {
+      for (Value result : user->getResults())
+        if (requantizeFeedsNonConstantConsumer(result))
+          return true;
+      continue;
+    }
+    auto dq = dyn_cast<ONNXDequantizeLinearOp>(user);
+    if (!dq || feedsNonConstantConsumer(dq.getY()))
+      return true;
   }
   return false;
 }
@@ -2058,7 +2085,7 @@ static bool onlyFeedsConstantIsland(Value value) {
   for (Operation *user : value.getUsers()) {
     if (auto q = dyn_cast<ONNXQuantizeLinearOp>(user)) {
       // A QuantizeLinear ends the island unless it is a weight requantize.
-      if (requantizeFeedsNonConstantConsumer(q))
+      if (requantizeFeedsNonConstantConsumer(q.getY()))
         return false;
       continue;
     }

--- a/test/mlir/onnx/onnx_constprop_dq_fold.mlir
+++ b/test/mlir/onnx/onnx_constprop_dq_fold.mlir
@@ -231,3 +231,28 @@ func.func @no_fold_const_into_add(%act: tensor<2x2xf32>) -> tensor<2x2xf32> {
 // CHECK-LABEL: @no_fold_const_into_add
 // CHECK: onnx.DequantizeLinear
 // CHECK: onnx.Add
+
+// -----
+
+// Scoping: a weight requantize boundary -- Const<ui8> -> DQ -> QuantizeLinear
+// <ui16> -> DQ -> MatMul(activation, weight) -- must NOT be folded. Folding the
+// leading DQ would collapse the chain up to the QuantizeLinear and materialize a
+// quantized weight, pre-empting the backend's requantization/narrowing of it.
+func.func @no_fold_weight_requantize_into_matmul(%act: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %w = onnx.Constant dense<[[10, 20], [30, 40]]> : tensor<2x2xui8>
+  %s1 = onnx.Constant dense<2.500000e-03> : tensor<f32>
+  %z1 = onnx.Constant dense<122> : tensor<ui8>
+  %w_dq = "onnx.DequantizeLinear"(%w, %s1, %z1) {axis = 1 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+  %s2 = onnx.Constant dense<8.900000e-06> : tensor<f32>
+  %z2 = onnx.Constant dense<35358> : tensor<ui16>
+  %q = "onnx.QuantizeLinear"(%w_dq, %s2, %z2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x2xf32>, tensor<f32>, tensor<ui16>) -> tensor<2x2xui16>
+  %rq_dq = "onnx.DequantizeLinear"(%q, %s2, %z2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<2x2xui16>, tensor<f32>, tensor<ui16>) -> tensor<2x2xf32>
+  %mm = "onnx.MatMul"(%act, %rq_dq) : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %mm : tensor<2x2xf32>
+}
+
+// CHECK-LABEL: @no_fold_weight_requantize_into_matmul
+// CHECK: onnx.Constant dense<{{\[}}[10, 20], [30, 40]]> : tensor<2x2xui8>
+// CHECK: onnx.DequantizeLinear
+// CHECK: onnx.QuantizeLinear
+// CHECK: onnx.MatMul

--- a/test/mlir/onnx/onnx_constprop_dq_fold.mlir
+++ b/test/mlir/onnx/onnx_constprop_dq_fold.mlir
@@ -234,10 +234,57 @@ func.func @no_fold_const_into_add(%act: tensor<2x2xf32>) -> tensor<2x2xf32> {
 
 // -----
 
-// Scoping: a weight requantize boundary -- Const<ui8> -> DQ -> QuantizeLinear
-// <ui16> -> DQ -> MatMul(activation, weight) -- must NOT be folded. Folding the
-// leading DQ would collapse the chain up to the QuantizeLinear and materialize a
-// quantized weight, pre-empting the backend's requantization/narrowing of it.
+// A movement op between the QuantizeLinear and DequantizeLinear (Const<ui8> ->
+// DQ -> Q<ui16> -> Reshape -> DQ -> MatMul) is still a weight requantize
+// boundary: the DQ must not be folded.
+func.func @no_fold_weight_requantize_reshape(%act: tensor<4xf32>) -> tensor<4xf32> {
+  %w = onnx.Constant dense<[10, 20, 30, 40]> : tensor<4xui8>
+  %s1 = onnx.Constant dense<2.500000e-03> : tensor<f32>
+  %z1 = onnx.Constant dense<122> : tensor<ui8>
+  %w_dq = "onnx.DequantizeLinear"(%w, %s1, %z1) {axis = 0 : si64, block_size = 0 : si64} : (tensor<4xui8>, tensor<f32>, tensor<ui8>) -> tensor<4xf32>
+  %s2 = onnx.Constant dense<8.900000e-06> : tensor<f32>
+  %z2 = onnx.Constant dense<35358> : tensor<ui16>
+  %q = "onnx.QuantizeLinear"(%w_dq, %s2, %z2) {axis = 0 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<4xf32>, tensor<f32>, tensor<ui16>) -> tensor<4xui16>
+  %shape = onnx.Constant dense<[4]> : tensor<1xi64>
+  %r = "onnx.Reshape"(%q, %shape) {allowzero = 0 : si64} : (tensor<4xui16>, tensor<1xi64>) -> tensor<4xui16>
+  %rq_dq = "onnx.DequantizeLinear"(%r, %s2, %z2) {axis = 0 : si64, block_size = 0 : si64} : (tensor<4xui16>, tensor<f32>, tensor<ui16>) -> tensor<4xf32>
+  %mm = "onnx.Mul"(%act, %rq_dq) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  return %mm : tensor<4xf32>
+}
+
+// CHECK-LABEL: @no_fold_weight_requantize_reshape
+// CHECK: onnx.Constant dense<[10, 20, 30, 40]> : tensor<4xui8>
+// CHECK: onnx.QuantizeLinear
+
+// -----
+
+// A movement op after the DequantizeLinear (... -> Q<ui16> -> DQ -> Transpose ->
+// MatMul(activation, weight)) is still a weight requantize boundary reached
+// through the Transpose: the DQ must not be folded.
+func.func @no_fold_weight_requantize_transpose(%act: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %w = onnx.Constant dense<[[10, 20], [30, 40]]> : tensor<2x2xui8>
+  %s1 = onnx.Constant dense<2.500000e-03> : tensor<f32>
+  %z1 = onnx.Constant dense<122> : tensor<ui8>
+  %w_dq = "onnx.DequantizeLinear"(%w, %s1, %z1) {axis = 1 : si64, block_size = 0 : si64} : (tensor<2x2xui8>, tensor<f32>, tensor<ui8>) -> tensor<2x2xf32>
+  %s2 = onnx.Constant dense<8.900000e-06> : tensor<f32>
+  %z2 = onnx.Constant dense<35358> : tensor<ui16>
+  %q = "onnx.QuantizeLinear"(%w_dq, %s2, %z2) {axis = 1 : si64, block_size = 0 : si64, output_dtype = 0 : si64, saturate = 1 : si64} : (tensor<2x2xf32>, tensor<f32>, tensor<ui16>) -> tensor<2x2xui16>
+  %rq_dq = "onnx.DequantizeLinear"(%q, %s2, %z2) {axis = 1 : si64, block_size = 0 : si64} : (tensor<2x2xui16>, tensor<f32>, tensor<ui16>) -> tensor<2x2xf32>
+  %t = "onnx.Transpose"(%rq_dq) {perm = [1, 0]} : (tensor<2x2xf32>) -> tensor<2x2xf32>
+  %mm = "onnx.MatMul"(%act, %t) : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %mm : tensor<2x2xf32>
+}
+
+// CHECK-LABEL: @no_fold_weight_requantize_transpose
+// CHECK: onnx.Constant dense<{{\[}}[10, 20], [30, 40]]> : tensor<2x2xui8>
+// CHECK: onnx.QuantizeLinear
+
+// -----
+
+// A weight requantize boundary (Const<ui8> -> DQ -> QuantizeLinear<ui16> -> DQ
+// -> MatMul(activation, weight)) must NOT be folded: folding the leading DQ
+// collapses the chain up to the QuantizeLinear and materializes a quantized
+// weight, pre-empting the backend's requantization/narrowing of it.
 func.func @no_fold_weight_requantize_into_matmul(%act: tensor<2x2xf32>) -> tensor<2x2xf32> {
   %w = onnx.Constant dense<[[10, 20], [30, 40]]> : tensor<2x2xui8>
   %s1 = onnx.Constant dense<2.500000e-03> : tensor<f32>
@@ -253,6 +300,5 @@ func.func @no_fold_weight_requantize_into_matmul(%act: tensor<2x2xf32>) -> tenso
 
 // CHECK-LABEL: @no_fold_weight_requantize_into_matmul
 // CHECK: onnx.Constant dense<{{\[}}[10, 20], [30, 40]]> : tensor<2x2xui8>
-// CHECK: onnx.DequantizeLinear
 // CHECK: onnx.QuantizeLinear
 // CHECK: onnx.MatMul


### PR DESCRIPTION

`onlyFeedsConstantIsland` treated the `QuantizeLinear` as an unconditional island terminator, so the fold collapsed the chain up to it into a quantized-weight constant. That materialized a re-quantization the backend normally rewrites (e.g. narrows back to the weight's native precision) and removed the `Q -> DQ` structure those passes match on. The result was weights silently changing integer width and picking up the requantize's scale/zero-point instead of their calibrated ones.