### PR TITLE
[ONNX] ScatterElements verify: iterate raw APInt, not per-element IntegerAttr

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Math/Scatter.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/Scatter.cpp
@@ -83,9 +83,11 @@ LogicalResult ONNXScatterElementsOp::verify() {
         return success(); // Return success to allow the parsing of MLIR with
                           // elided attributes
       }
-      for (IntegerAttr value : valueAttribute.getValues<IntegerAttr>()) {
+      // Iterate the raw APInt values instead of materializing an IntegerAttr
+      // per element to reduce processing time.
+      for (const APInt &value : valueAttribute.getValues<APInt>()) {
         if (indicesAreUnsigned) {
-          uint64_t index = value.getValue().getZExtValue();
+          uint64_t index = value.getZExtValue();
           if (index < (uint64_t)dataDimAtAxis)
             continue;
 
@@ -93,7 +95,7 @@ LogicalResult ONNXScatterElementsOp::verify() {
               *this->getOperation(), "indices", (int64_t)index,
               onnx_mlir::Diagnostic::Range<int64_t>(0, dataDimAtAxis - 1));
         }
-        int64_t index = value.getInt();
+        int64_t index = value.getSExtValue();
         if (index >= -dataDimAtAxis && index < dataDimAtAxis)
           continue;
 


### PR DESCRIPTION

`ONNXScatterElementsOp::verify()` bounds-checks the index constant by iterating `valueAttribute.getValues<IntegerAttr>()`. For a `DisposableElementsAttr`, that materializes and uniques a fresh `IntegerAttr` (hashing an `APInt`) for every element of the indices tensor. On networks with a large index constant this per-element attribute uniquing dominates compile time — in a VAIML get-capability profile it accounted for ~90% of the whole run (StorageUniquer::get / llvm hash_short), because the module verifier re-runs it after every pass.

Iterate the raw values with `getValues<APInt>()` instead and read them via `getZExtValue()` / `getSExtValue()`. This performs the identical range check with no per-element attribute uniquing. `getValues<APInt>()` is already the idiomatic accessor elsewhere in the dialect (OneHot, PaddingOp, Clip, ElementsAttrHelper).

Measured on bevfusion-camera: get-capability wall time drops from ~46 min to ~2 min (~24x), same output, maxRSS unchanged. No functional change: same bounds check, same diagnostics on out-of-range indices.