### PR TITLE
Let a caller hold the GQA decomposition back per node

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -4006,12 +4006,18 @@ struct MicrosoftSkipSimplifiedLayerNorm : public CustomOpToOnnxOps {
 };
 
 struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
-  MicrosoftGroupQueryAttention(
-      MLIRContext *ctx, bool enableUint16CacheSlotRewrite, PatternBenefit b = 1)
+  MicrosoftGroupQueryAttention(MLIRContext *ctx,
+      bool enableUint16CacheSlotRewrite, PatternBenefit b = 1,
+      onnx_mlir::GQADecompositionPredicate predicate = {})
       : CustomOpToOnnxOps(ctx, MicrosoftDomainName, "GroupQueryAttention", b),
-        enableUint16CacheSlotRewrite(enableUint16CacheSlotRewrite) {}
+        enableUint16CacheSlotRewrite(enableUint16CacheSlotRewrite),
+        predicate(std::move(predicate)) {}
 
   const bool enableUint16CacheSlotRewrite;
+  // Optional per-node veto. A caller that also matches GroupQueryAttention with
+  // a whole-node templated graph uses this to hold the decomposition back on
+  // exactly the nodes that graph will claim, while still decomposing the rest.
+  const onnx_mlir::GQADecompositionPredicate predicate;
 
   using AttributeValidator = LogicalResult (*)(
       ONNXCustomOp, PatternRewriter &, Attribute);
@@ -4121,8 +4127,18 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
   // additional list covers importer/debug metadata.
   static LogicalResult validateRecognizedAttributes(
       ONNXCustomOp customOp, PatternRewriter &rewriter) {
-    const SmallVector<NamedAttribute> semanticAttrs = getFilteredAttrs(
-        customOp->getAttrs(), {"onnx_node_name", "ResultNames", "layout"});
+    // LayerName/OutputName and their PartOf* forms are FlexML provenance
+    // bookkeeping, not GroupQueryAttention semantics: they name the source
+    // layer an op came from so diagnostics can point back at it. They are
+    // attached to ops the rewrite is expected to handle, so treating them as
+    // an unrecognized -- and therefore unsupported -- variant declines every
+    // annotated node. A node this rewrite declines is left as a bare
+    // onnx.Custom for the benefit(0) CpuBecause rule, which is how an entire
+    // GQA model ends up on the CPU with zero operators offloaded.
+    const SmallVector<NamedAttribute> semanticAttrs =
+        getFilteredAttrs(customOp->getAttrs(),
+            {"onnx_node_name", "ResultNames", "layout", "LayerName",
+                "OutputName", "PartOfLayerName", "PartOfOutputName"});
     for (NamedAttribute attr : semanticAttrs) {
       StringRef attrName = attr.getName().getValue();
 
@@ -4609,6 +4625,10 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
 
   LogicalResult matchAndRewriteImpl(
       ONNXCustomOp customOp, PatternRewriter &rewriter) const final {
+
+    if (predicate && !predicate(customOp))
+      return rewriter.notifyMatchFailure(
+          customOp, "held back for a whole-node GroupQueryAttention match");
 
     using namespace onnx_mlir;
     const Location loc = customOp.getLoc();
@@ -6246,6 +6266,28 @@ void DecomposeONNXToONNXPass::runOnOperation() {
 
 } // namespace
 
+bool onnx_mlir::hasFullDepthGQACache(mlir::Operation *op) {
+  auto customOp = mlir::dyn_cast_or_null<ONNXCustomOp>(op);
+  if (!customOp)
+    return false;
+  auto domain = customOp->getAttrOfType<StringAttr>("domain_name");
+  auto fn = customOp->getAttrOfType<StringAttr>("function_name");
+  if (!domain || !fn || domain.getValue() != MicrosoftDomainName ||
+      fn.getValue() != "GroupQueryAttention")
+    return false;
+  // past_key is input 3; its dim 2 is the cache depth.
+  if (customOp.getNumOperands() <= 3)
+    return false;
+  Value pastKey = customOp.getOperand(3);
+  if (onnx_mlir::isNoneValue(pastKey))
+    return false;
+  auto pastKeyType = mlir::dyn_cast<ShapedType>(pastKey.getType());
+  if (!pastKeyType || !pastKeyType.hasStaticShape() ||
+      pastKeyType.getRank() != 4)
+    return false;
+  return pastKeyType.getShape()[2] > 0;
+}
+
 void onnx_mlir::getDecomposeONNXToONNXPatterns(
     mlir::RewritePatternSet &patterns, bool enableConvTransposeDecompose,
     bool enableConvTransposeDecomposeToPhasedConv,
@@ -6258,7 +6300,8 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     bool enableHardSwishDecompose, bool enableDepthToSpaceDecompose,
     bool enableGQAUint16CacheSlotRewrite, bool enableConvTransposeToResize,
     bool enableLstmDecompose,
-    LSTMDecompositionPredicate lstmDecompositionPredicate) {
+    LSTMDecompositionPredicate lstmDecompositionPredicate,
+    GQADecompositionPredicate gqaDecompositionPredicate) {
   MLIRContext *context = patterns.getContext();
   if (!disableGenericDecompositions)
     populateWithGenerated(patterns);
@@ -6303,8 +6346,9 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     patterns.insert<MicrosoftSkipSimplifiedLayerNorm>(context);
   }
   if (enableGroupQueryAttentionDecompose)
-    patterns.insert<MicrosoftGroupQueryAttention>(
-        context, enableGQAUint16CacheSlotRewrite);
+    patterns.insert<MicrosoftGroupQueryAttention>(context,
+        enableGQAUint16CacheSlotRewrite, PatternBenefit(1),
+        std::move(gqaDecompositionPredicate));
   if (!disableGenericDecompositions)
     patterns.insert<MicrosoftRotaryEmbedding>(context);
   if (enableMatmulNBitsDecompose)

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -48,6 +48,18 @@ extern bool convTransposeDepthToSpaceActive;
 // in Decompose.cpp.
 extern bool convTransposeToResizeActive;
 
+// Per-node veto for the GroupQueryAttention decomposition. Returning false
+// holds the decomposition back on that node, leaving it intact for a
+// whole-node match (a templated graph) to claim. An empty predicate decomposes
+// every node, which is the behaviour when no such graph is in play.
+using GQADecompositionPredicate = std::function<bool(mlir::Operation *)>;
+
+// True when this is a com.microsoft.GroupQueryAttention whose past_key is
+// already at its full cache depth, i.e. the preallocated form a whole-node
+// templated graph claims. False for any other op, and for the prefill shape
+// whose cache starts empty (past_key depth 0).
+bool hasFullDepthGQACache(mlir::Operation *op);
+
 // Exports the DecomposeONNXToONNXPass patterns. They are all plain rewrite
 // patterns that can be used with any PatternRewriter, not conversion patterns.
 void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
@@ -63,7 +75,8 @@ void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableDepthToSpaceDecompose = false,
     bool enableGQAUint16CacheSlotRewrite = false,
     bool enableConvTransposeToResize = false, bool enableLstmDecompose = false,
-    LSTMDecompositionPredicate lstmDecompositionPredicate = {});
+    LSTMDecompositionPredicate lstmDecompositionPredicate = {},
+    GQADecompositionPredicate gqaDecompositionPredicate = {});
 
 // Decompose onnx.DepthToSpace (DCR and CRD) into Reshape/Transpose/Reshape
 void populateDecomposeDepthToSpacePattern(mlir::RewritePatternSet &patterns,

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -141,10 +141,9 @@ struct ONNXHybridTransformPass
           // such graph matches, so it is decomposed here rather than left for
           // a later stage where onnx.Attention can no longer be lowered.
           holdBackPreallocatedGQADecompose
-              ? onnx_mlir::GQADecompositionPredicate(
-                    [](mlir::Operation *op) {
-                      return !onnx_mlir::hasFullDepthGQACache(op);
-                    })
+              ? onnx_mlir::GQADecompositionPredicate([](mlir::Operation *op) {
+                  return !onnx_mlir::hasFullDepthGQACache(op);
+                })
               : onnx_mlir::GQADecompositionPredicate{});
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -134,7 +134,18 @@ struct ONNXHybridTransformPass
           /*disableGenericDecompositions=*/false, enableGatherToSlice,
           enableHardSwishDecompose, enableDepthToSpaceDecompose,
           enableGQAUint16CacheSlotRewrite, enableConvTransposeToResize,
-          enableLstmDecompose);
+          enableLstmDecompose, /*lstmDecompositionPredicate=*/{},
+          // Hold the decomposition back on a cache that is already at full
+          // depth: that is the shape a whole-node GroupQueryAttention graph
+          // claims. A cache that starts empty is the prefill graph, which no
+          // such graph matches, so it is decomposed here rather than left for
+          // a later stage where onnx.Attention can no longer be lowered.
+          holdBackPreallocatedGQADecompose
+              ? onnx_mlir::GQADecompositionPredicate(
+                    [](mlir::Operation *op) {
+                      return !onnx_mlir::hasFullDepthGQACache(op);
+                    })
+              : onnx_mlir::GQADecompositionPredicate{});
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
       if (target == "stablehlo") {

--- a/src/Dialect/ONNX/Transforms/Passes.td
+++ b/src/Dialect/ONNX/Transforms/Passes.td
@@ -67,6 +67,15 @@ def ONNXDecomposePatternOptions {
            "Enable decomposition of Microsoft GroupQueryAttention to "
            "onnx.Attention and onnx.RotaryEmbedding ops.">,
 
+    Option<"holdBackPreallocatedGQADecompose",
+           "hold-back-preallocated-gqa-decompose",
+           "bool", /*default=*/"false",
+           "Skip the GroupQueryAttention decomposition on nodes whose KV cache "
+           "is already at its full depth, leaving them intact for a whole-node "
+           "templated-graph match. Nodes that start from an empty cache (the "
+           "prefill graph) are still decomposed here, where the resulting "
+           "onnx.Attention and onnx.RotaryEmbedding ops can still be lowered.">,
+
     Option<"enableGQAUint16CacheSlotRewrite",
            "enable-gqa-uint16-cache-slot-rewrite",
            "bool", /*default=*/"false",


### PR DESCRIPTION
## Summary

Two changes to the `com.microsoft.GroupQueryAttention` decomposition, both driven by FlexML work where a templated graph (`GQATokenDecodeAdf`) claims a whole GQA node on the token-decode path. They are independent and can be reviewed separately.

### 1. Let a caller hold the decomposition back per node

A caller that also matches GroupQueryAttention with a whole-node graph needs the nodes that graph will claim to reach it undecomposed, while every other node is still decomposed **here**.

Turning `enableGroupQueryAttentionDecompose` off for the whole run is too blunt. It leaves the nodes the graph does *not* match intact as bare `onnx.Custom`, and decomposing them later is too late: the ONNX-stage passes that lower `onnx.Attention` and `onnx.RotaryEmbedding` have already run, so the ops arrive with nothing left to lower them and get sent to the CPU.

This adds:

- `GQADecompositionPredicate` — an optional per-node veto on `MicrosoftGroupQueryAttention`, following the existing `LSTMDecompositionPredicate`.
- `hasFullDepthGQACache(Operation *)` — true when `past_key` (operand 3) is a static rank-4 type whose dim 2 is non-zero, i.e. the preallocated cache such a graph claims.
- `hold-back-preallocated-gqa-decompose` on the hybrid transform, which builds that predicate.

Both default off, so behaviour is unchanged for every existing caller.

### 2. Do not reject a node for carrying provenance attributes

`validateRecognizedAttributes` treats any attribute not in its map as an unsupported variant and declines the node. FlexML annotates ops with `LayerName` / `OutputName` / `PartOfLayerName` / `PartOfOutputName`, which name the source layer an op came from and say nothing about GroupQueryAttention semantics.

The effect was that **every** annotated node was declined — all 32 in the model under test — and each was then claimed by a low-priority fallback that wraps unsupported ops for the CPU, so the model offloaded zero operators. This filters them alongside the `onnx_node_name` / `ResultNames` / `layout` carrier attrs already filtered there.

This half is a standalone bug fix and is useful independently of the predicate above.

## Verification

Verified end to end through the FlexML compile of `AMD-OLMo-1B-SFT-DPO_E2E` (VE2 / VEK385), with the token-decode graph enabled:

| | before | after |
|---|---|---|
| GQA nodes sent to CPU | 32 | 0 |
| decode submodel | declined | 16 nodes claimed by `GQATokenDecodeAdf` |
| prefill submodel | bare `onnx.Custom` | decomposed to 16 `onnx.Attention` + 32 `onnx.RotaryEmbedding` |
| compile result | fails, 0 operators offloaded | 112 MB artifact produced |

The prefill result matches, op for op, what the same model produces on the path that does not use the graph at all — which is the behaviour this is meant to preserve.

Note the zero-sized `past_key` (`tensor<1x16x0x128xf32>`) is **not** what was breaking it; the working reference compile carries the same tensor. The difference is only *where* the decomposition runs.

## Reviewer notes

- I have not run the onnx-mlir lit suite on this; verification was through the downstream compile. Please flag if a test is expected for the new option.
- `hasFullDepthGQACache` tests `shape[2] > 0`. The FlexML-side matcher expresses the same contract as `cache_depth >= 16` (from the kernel metadata, which declares min 16 / step 16). I kept the generic `> 0` here rather than hardcoding a kernel constant into onnx-mlir, but that is two encodings of one contract and could drift — opinions welcome.
- The paired FlexML change is `FaaSApps/vitis_flexml` commit `fe3ff53c92b`; the submodule pin there is bumped once this lands.
