### PR TITLE
Decompose partial-RoPE GQA before lowering

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -4006,12 +4006,18 @@ struct MicrosoftSkipSimplifiedLayerNorm : public CustomOpToOnnxOps {
 };
 
 struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
-  MicrosoftGroupQueryAttention(
-      MLIRContext *ctx, bool enableUint16CacheSlotRewrite, PatternBenefit b = 1)
+  MicrosoftGroupQueryAttention(MLIRContext *ctx,
+      bool enableUint16CacheSlotRewrite, PatternBenefit b = 1,
+      onnx_mlir::GQADecompositionPredicate predicate = {})
       : CustomOpToOnnxOps(ctx, MicrosoftDomainName, "GroupQueryAttention", b),
-        enableUint16CacheSlotRewrite(enableUint16CacheSlotRewrite) {}
+        enableUint16CacheSlotRewrite(enableUint16CacheSlotRewrite),
+        predicate(std::move(predicate)) {}
 
   const bool enableUint16CacheSlotRewrite;
+  // Optional per-node veto. A caller that also matches GroupQueryAttention with
+  // a whole-node templated graph uses this to hold the decomposition back on
+  // exactly the nodes that graph will claim, while still decomposing the rest.
+  const onnx_mlir::GQADecompositionPredicate predicate;
 
   using AttributeValidator = LogicalResult (*)(
       ONNXCustomOp, PatternRewriter &, Attribute);
@@ -4121,8 +4127,18 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
   // additional list covers importer/debug metadata.
   static LogicalResult validateRecognizedAttributes(
       ONNXCustomOp customOp, PatternRewriter &rewriter) {
-    const SmallVector<NamedAttribute> semanticAttrs = getFilteredAttrs(
-        customOp->getAttrs(), {"onnx_node_name", "ResultNames", "layout"});
+    // LayerName/OutputName and their PartOf* forms are FlexML provenance
+    // bookkeeping, not GroupQueryAttention semantics: they name the source
+    // layer an op came from so diagnostics can point back at it. They are
+    // attached to ops the rewrite is expected to handle, so treating them as
+    // an unrecognized -- and therefore unsupported -- variant declines every
+    // annotated node. A node this rewrite declines is left as a bare
+    // onnx.Custom for the benefit(0) CpuBecause rule, which is how an entire
+    // GQA model ends up on the CPU with zero operators offloaded.
+    const SmallVector<NamedAttribute> semanticAttrs =
+        getFilteredAttrs(customOp->getAttrs(),
+            {"onnx_node_name", "ResultNames", "layout", "LayerName",
+                "OutputName", "PartOfLayerName", "PartOfOutputName"});
     for (NamedAttribute attr : semanticAttrs) {
       StringRef attrName = attr.getName().getValue();
 
@@ -4609,6 +4625,10 @@ struct MicrosoftGroupQueryAttention : public CustomOpToOnnxOps {
 
   LogicalResult matchAndRewriteImpl(
       ONNXCustomOp customOp, PatternRewriter &rewriter) const final {
+
+    if (predicate && !predicate(customOp))
+      return rewriter.notifyMatchFailure(
+          customOp, "held back for a whole-node GroupQueryAttention match");
 
     using namespace onnx_mlir;
     const Location loc = customOp.getLoc();
@@ -6246,6 +6266,28 @@ void DecomposeONNXToONNXPass::runOnOperation() {
 
 } // namespace
 
+bool onnx_mlir::hasFullDepthGQACache(mlir::Operation *op) {
+  auto customOp = mlir::dyn_cast_or_null<ONNXCustomOp>(op);
+  if (!customOp)
+    return false;
+  auto domain = customOp->getAttrOfType<StringAttr>("domain_name");
+  auto fn = customOp->getAttrOfType<StringAttr>("function_name");
+  if (!domain || !fn || domain.getValue() != MicrosoftDomainName ||
+      fn.getValue() != "GroupQueryAttention")
+    return false;
+  // past_key is input 3; its dim 2 is the cache depth.
+  if (customOp.getNumOperands() <= 3)
+    return false;
+  Value pastKey = customOp.getOperand(3);
+  if (onnx_mlir::isNoneValue(pastKey))
+    return false;
+  auto pastKeyType = mlir::dyn_cast<ShapedType>(pastKey.getType());
+  if (!pastKeyType || !pastKeyType.hasStaticShape() ||
+      pastKeyType.getRank() != 4)
+    return false;
+  return pastKeyType.getShape()[2] > 0;
+}
+
 void onnx_mlir::getDecomposeONNXToONNXPatterns(
     mlir::RewritePatternSet &patterns, bool enableConvTransposeDecompose,
     bool enableConvTransposeDecomposeToPhasedConv,
@@ -6258,7 +6300,8 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     bool enableHardSwishDecompose, bool enableDepthToSpaceDecompose,
     bool enableGQAUint16CacheSlotRewrite, bool enableConvTransposeToResize,
     bool enableLstmDecompose,
-    LSTMDecompositionPredicate lstmDecompositionPredicate) {
+    LSTMDecompositionPredicate lstmDecompositionPredicate,
+    GQADecompositionPredicate gqaDecompositionPredicate) {
   MLIRContext *context = patterns.getContext();
   if (!disableGenericDecompositions)
     populateWithGenerated(patterns);
@@ -6303,8 +6346,9 @@ void onnx_mlir::getDecomposeONNXToONNXPatterns(
     patterns.insert<MicrosoftSkipSimplifiedLayerNorm>(context);
   }
   if (enableGroupQueryAttentionDecompose)
-    patterns.insert<MicrosoftGroupQueryAttention>(
-        context, enableGQAUint16CacheSlotRewrite);
+    patterns.insert<MicrosoftGroupQueryAttention>(context,
+        enableGQAUint16CacheSlotRewrite, PatternBenefit(1),
+        std::move(gqaDecompositionPredicate));
   if (!disableGenericDecompositions)
     patterns.insert<MicrosoftRotaryEmbedding>(context);
   if (enableMatmulNBitsDecompose)

--- a/src/Dialect/ONNX/Transforms/Decompose.hpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.hpp
@@ -48,6 +48,18 @@ extern bool convTransposeDepthToSpaceActive;
 // in Decompose.cpp.
 extern bool convTransposeToResizeActive;
 
+// Per-node veto for the GroupQueryAttention decomposition. Returning false
+// holds the decomposition back on that node, leaving it intact for a
+// whole-node match (a templated graph) to claim. An empty predicate decomposes
+// every node, which is the behaviour when no such graph is in play.
+using GQADecompositionPredicate = std::function<bool(mlir::Operation *)>;
+
+// True when this is a com.microsoft.GroupQueryAttention whose past_key is
+// already at its full cache depth, i.e. the preallocated form a whole-node
+// templated graph claims. False for any other op, and for the prefill shape
+// whose cache starts empty (past_key depth 0).
+bool hasFullDepthGQACache(mlir::Operation *op);
+
 // Exports the DecomposeONNXToONNXPass patterns. They are all plain rewrite
 // patterns that can be used with any PatternRewriter, not conversion patterns.
 void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
@@ -63,7 +75,8 @@ void getDecomposeONNXToONNXPatterns(mlir::RewritePatternSet &patterns,
     bool enableDepthToSpaceDecompose = false,
     bool enableGQAUint16CacheSlotRewrite = false,
     bool enableConvTransposeToResize = false, bool enableLstmDecompose = false,
-    LSTMDecompositionPredicate lstmDecompositionPredicate = {});
+    LSTMDecompositionPredicate lstmDecompositionPredicate = {},
+    GQADecompositionPredicate gqaDecompositionPredicate = {});
 
 // Decompose onnx.DepthToSpace (DCR and CRD) into Reshape/Transpose/Reshape
 void populateDecomposeDepthToSpacePattern(mlir::RewritePatternSet &patterns,

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -141,10 +141,9 @@ struct ONNXHybridTransformPass
           // such graph matches, so it is decomposed here rather than left for
           // a later stage where onnx.Attention can no longer be lowered.
           holdBackPreallocatedGQADecompose
-              ? onnx_mlir::GQADecompositionPredicate(
-                    [](mlir::Operation *op) {
-                      return !onnx_mlir::hasFullDepthGQACache(op);
-                    })
+              ? onnx_mlir::GQADecompositionPredicate([](mlir::Operation *op) {
+                  return !onnx_mlir::hasFullDepthGQACache(op);
+                })
               : onnx_mlir::GQADecompositionPredicate{});
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO

--- a/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
+++ b/src/Dialect/ONNX/Transforms/ONNXHybridTransformPass.cpp
@@ -134,7 +134,18 @@ struct ONNXHybridTransformPass
           /*disableGenericDecompositions=*/false, enableGatherToSlice,
           enableHardSwishDecompose, enableDepthToSpaceDecompose,
           enableGQAUint16CacheSlotRewrite, enableConvTransposeToResize,
-          enableLstmDecompose);
+          enableLstmDecompose, /*lstmDecompositionPredicate=*/{},
+          // Hold the decomposition back on a cache that is already at full
+          // depth: that is the shape a whole-node GroupQueryAttention graph
+          // claims. A cache that starts empty is the prefill graph, which no
+          // such graph matches, so it is decomposed here rather than left for
+          // a later stage where onnx.Attention can no longer be lowered.
+          holdBackPreallocatedGQADecompose
+              ? onnx_mlir::GQADecompositionPredicate(
+                    [](mlir::Operation *op) {
+                      return !onnx_mlir::hasFullDepthGQACache(op);
+                    })
+              : onnx_mlir::GQADecompositionPredicate{});
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO
       if (target == "stablehlo") {

--- a/src/Dialect/ONNX/Transforms/Passes.td
+++ b/src/Dialect/ONNX/Transforms/Passes.td
@@ -67,6 +67,15 @@ def ONNXDecomposePatternOptions {
            "Enable decomposition of Microsoft GroupQueryAttention to "
            "onnx.Attention and onnx.RotaryEmbedding ops.">,
 
+    Option<"holdBackPreallocatedGQADecompose",
+           "hold-back-preallocated-gqa-decompose",
+           "bool", /*default=*/"false",
+           "Skip the GroupQueryAttention decomposition on nodes whose KV cache "
+           "is already at its full depth, leaving them intact for a whole-node "
+           "templated-graph match. Nodes that start from an empty cache (the "
+           "prefill graph) are still decomposed here, where the resulting "
+           "onnx.Attention and onnx.RotaryEmbedding ops can still be lowered.">,
+
     Option<"enableGQAUint16CacheSlotRewrite",
            "enable-gqa-uint16-cache-slot-rewrite",
            "bool", /*default=*/"false",


### PR DESCRIPTION
## Summary

- hold back only statically shaped preallocated full-RoPE GroupQueryAttention nodes
- decompose partial-RoPE, append-cache, and empty-cache forms while ONNX Attention and RotaryEmbedding lowering is still available
- apply the hold-back option consistently in both decomposition entry points
- address the review feedback carried over from #1029
- cover enabled and disabled hold-back behavior

## Test plan

- [x] Added `onnx_hybrid_transform_gqa_holdback.mlir` coverage for full-RoPE decode, Phi-4 partial-RoPE decode, append-cache decode, and empty-cache prefill
- [x] GitHub Black formatting check
- [x] GitHub Clang formatting check
- [x] In-tree build

Recreates the changes from closed PR #1034 using a branch owned by `Xilinx/onnx-mlir`.

Required by the corresponding Vitis FlexML partial-RoPE GQA fix.
